### PR TITLE
[SID:3478] feat: gate.scope_key — external_publish 게이트를 목적지 단위로

### DIFF
--- a/backend/alembic/versions/0328_gate_scope_key.py
+++ b/backend/alembic/versions/0328_gate_scope_key.py
@@ -1,0 +1,97 @@
+"""story #3478(Phase1·마케팅운영·설계갭, 페드루 PO 決定 2026-09-05) — `gate.scope_key`
+신설. 그라운딩(디디, 2026-09-05): `create_gate()`의 멱등키는 `(work_item_id,
+work_item_type, gate_type[, pr_number[, repo_full_name]])`뿐 — connection/draft
+축이 아예 없다. `resolve_gate_holder_draft_id`(story #3404)가 이 사실을
+channel_post·site_post 양쪽에 공용으로 미러하는 그 함수라, site_post external_
+publish 게이트가 work_item당 1건이라 같은 원문을 WordPress+webhook 두 목적지로
+못 보내는 문제는 site_post 국소 결함이 아니라 이 공유 identity 자체의 한계다
+(런북 B-3 실측).
+
+페드루 判定 — 공유 UNIQUE의 "의미"를 안 바꾸고 축 하나를 **가산**한다.
+`scope_key TEXT NOT NULL DEFAULT ''` — 기존 모든 gate_type(merge·HITL ask·doc
+approval 등)은 이 컬럼이 항상 `''`라 그 세 부분 UNIQUE 인덱스에 `scope_key`를
+끼워 넣어도 실질적으로 무변(동작 회귀 0, `''` 하나뿐이라 구분력이 그대로 0).
+`external_publish` gate_type만 호출부(site_posts.py·channel_posts.py)가
+`scope_key = str(draft.connection_id or "")`(목적지)를 채워 실질적으로
+draft/destination 단위 게이트가 된다.
+
+세 부분 인덱스 전부(no_pr·pr_repo·pr_no_repo) 재정의 — external_publish는 항상
+pr_number가 NULL이라 실제로 유효한 건 no_pr뿐이지만, 세 인덱스의 컬럼 집합을
+동일하게 유지해 "어느 것만 scope_key가 있고 어느 것은 없는" 잔여 비대칭을
+안 남긴다.
+
+Revision ID: 0328
+Revises: 0327
+Create Date: 2026-09-05
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0328"
+down_revision = "0327"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("gate", sa.Column("scope_key", sa.Text(), nullable=False, server_default=""))
+
+    op.drop_index("uq_gate_work_item_gate_type_no_pr", table_name="gate")
+    op.create_index(
+        "uq_gate_work_item_gate_type_scope_no_pr",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "scope_key"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NULL"),
+    )
+
+    op.drop_index("uq_gate_work_item_gate_type_pr_repo", table_name="gate")
+    op.create_index(
+        "uq_gate_work_item_gate_type_scope_pr_repo",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "scope_key", "pr_number", "repo_full_name"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NOT NULL AND repo_full_name IS NOT NULL"),
+    )
+
+    op.drop_index("uq_gate_work_item_gate_type_pr_no_repo", table_name="gate")
+    op.create_index(
+        "uq_gate_work_item_gate_type_scope_pr_no_repo",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "scope_key", "pr_number"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NOT NULL AND repo_full_name IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_gate_work_item_gate_type_scope_no_pr", table_name="gate")
+    op.create_index(
+        "uq_gate_work_item_gate_type_no_pr",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NULL"),
+    )
+
+    op.drop_index("uq_gate_work_item_gate_type_scope_pr_repo", table_name="gate")
+    op.create_index(
+        "uq_gate_work_item_gate_type_pr_repo",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "pr_number", "repo_full_name"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NOT NULL AND repo_full_name IS NOT NULL"),
+    )
+
+    op.drop_index("uq_gate_work_item_gate_type_scope_pr_no_repo", table_name="gate")
+    op.create_index(
+        "uq_gate_work_item_gate_type_pr_no_repo",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "pr_number"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NOT NULL AND repo_full_name IS NULL"),
+    )
+
+    op.drop_column("gate", "scope_key")

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -76,6 +76,13 @@ class Gate(Base):
     # 충돌). pr_number와 짝으로 멱등 키에 편입 — find_gate_slot_with_pr_fallback.py 참조.
     # NULL=pr_number와 동형 사유(PR 컨텍스트 없음/레거시 미백필).
     repo_full_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #3478(0328) — 멱등 키 세 번째 축. 대부분의 gate_type(merge·HITL ask·doc
+    # approval 등)은 이 컬럼이 항상 ""(공유 UNIQUE 인덱스 셋에 이 컬럼을 끼워 넣어도
+    # ""뿐이라 구분력 무변, 회귀 0). `external_publish`만 site_posts.py·channel_posts.py
+    # 호출부가 목적지(`str(draft.connection_id or "")`)를 채운다 — 같은 work_item이
+    # WordPress·webhook 등 여러 목적지로 각각 독립 게이트를 갖게 된다(work_item당 1건
+    # 제약이 site_post의 dual-destination AC를 구조적으로 막던 것의 근본수정).
+    scope_key: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="pending")
     resolver_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -496,7 +496,9 @@ async def create_channel_post_draft_version(
             ))
             await db.flush()
 
-    await _reseal_gate_on_new_version(db, org_id=org_id, work_item_id=work_item_id, version=version)
+    await _reseal_gate_on_new_version(
+        db, org_id=org_id, work_item_id=work_item_id, version=version, connection_id=draft.connection_id,
+    )
 
     # story #3471(페드루 PO 確定 2026-09-05) — 초안 create/update는 lint를 비차단으로
     # 실행·draft에 스냅샷 저장만 한다(거부는 submit()만, 아래 함수 참고). rules가 org에
@@ -512,31 +514,35 @@ async def create_channel_post_draft_version(
 
 async def _reseal_gate_on_new_version(
     db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, version: ChannelPostVersion,
+    connection_id: uuid.UUID,
 ) -> None:
     """site_posts.py::_reseal_gate_on_new_version과 동형 규칙(§3-1-2), 봉인 본문만 이
     도메인의 `text`를 쓴다: pending 中 편집 → 즉시 재봉인, approved 뒤 편집 → pending
     재오픈+reapproval_required=True(옛 봉인은 그대로 보존).
 
     story #3404(디디 코드 확認 2026-09-03·페드루 PO 지시 2026-09-04) — 이 훅은
-    work_item_id만으로 게이트를 찾는다(draft 무관). 승인 대상이 아닌 다른 초안을
-    편집(새 버전 생성 — 새 draft 최초 생성 포함, 그 자체가 버전 1 생성)했을 뿐인데
-    여기서 그 게이트를 되돌리거나(approved→pending) 조용히 재봉인하면 submit()의
-    가드(resolve_gate_holder_draft_id)를 거치지 않고도 동일한 파괴가 일어난다 —
-    site_posts.py가 f6d14476에서 이미 막은 것과 정확히 같은 결함 클래스가 이 파일에
-    그대로 남아 있었다(직접 재현 확認). submit()과 같은 판정 함수를 그대로 쓴다."""
+    (work_item_id, scope_key)로 게이트를 찾는다(draft 무관, story #3478부터 scope_key
+    도 축에 편입 — 안 넣으면 같은 work_item에 목적지가 다른 게이트가 둘 있을 때
+    MultipleResultsFound). 승인 대상이 아닌 다른 초안을 편집(새 버전 생성 — 새 draft
+    최초 생성 포함, 그 자체가 버전 1 생성)했을 뿐인데 여기서 그 게이트를 되돌리거나
+    (approved→pending) 조용히 재봉인하면 submit()의 가드(resolve_gate_holder_draft_id)
+    를 거치지 않고도 동일한 파괴가 일어난다 — site_posts.py가 f6d14476에서 이미 막은
+    것과 정확히 같은 결함 클래스가 이 파일에 그대로 남아 있었다(직접 재현 확認).
+    submit()과 같은 판정 함수를 그대로 쓴다."""
     from app.services.gate_service import resolve_gate_holder_draft_id
 
+    scope_key = str(connection_id)
     gate = (await db.execute(
         select(Gate)
         .where(
-            Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+            Gate.org_id == org_id, Gate.work_item_id == work_item_id, Gate.scope_key == scope_key,
             Gate.gate_type == _EXTERNAL_PUBLISH_GATE_TYPE, Gate.status.in_(("pending", "approved")),
         )
         .with_for_update()
     )).scalar_one_or_none()
     if gate is None:
         return
-    if resolve_gate_holder_draft_id(gate, this_draft_id=version.draft_id) is not None:
+    if await resolve_gate_holder_draft_id(db, gate, this_draft_id=version.draft_id) is not None:
         return
     if gate.status == "approved":
         # story 620beefc(AC4) — 무엇이 바뀌어 재승인이 필요해졌는지(본문 vs 이미지)를
@@ -902,15 +908,19 @@ async def submit_channel_post_draft(
     from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback, resolve_gate_holder_draft_id
     from app.services.workflow_line_config import _default_role_id
 
+    # story #3478(0328) — scope_key=목적지(connection_id). channel_post도 site_post와
+    # 같은 규칙(그라운딩 대조 — resolve_gate_holder_draft_id 공유 함수 드리프트 방지).
+    scope_key = str(draft.connection_id)
     existing = await find_gate_slot_with_pr_fallback(
         db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
-        gate_type=_EXTERNAL_PUBLISH_GATE_TYPE, pr_number=None, repo_full_name=None,
+        gate_type=_EXTERNAL_PUBLISH_GATE_TYPE, pr_number=None, repo_full_name=None, scope_key=scope_key,
     )
 
     # story #3404(site_posts.py f6d14476 미러, 판정 로직은 gate_service.py::
-    # resolve_gate_holder_draft_id로 공유) — 게이트 슬롯은 work_item 단위라, 이미 다른
-    # 초안이 그 게이트를 쥐고(pending/approved) 있으면 이 초안의 상신을 막는다.
-    holding_draft_id = resolve_gate_holder_draft_id(existing, this_draft_id=draft.id)
+    # resolve_gate_holder_draft_id로 공유) — 게이트 슬롯은 (work_item, scope_key) 단위
+    # (story #3478부터)라, 같은 목적지를 이미 다른 초안이 그 게이트를 쥐고(pending/
+    # approved이면서 그 발행이 지금 실려 있음) 있으면 이 초안의 상신을 막는다.
+    holding_draft_id = await resolve_gate_holder_draft_id(db, existing, this_draft_id=draft.id)
     if holding_draft_id is not None:
         holder = await get_channel_post_draft(db, org_id=org_id, draft_id=holding_draft_id)
         if holder is not None:
@@ -952,7 +962,7 @@ async def submit_channel_post_draft(
         raise ChannelPostApproverRoleMissingError(org_id=org_id)
     gate = await create_gate(
         db, org_id, draft.work_item_id, "story", _EXTERNAL_PUBLISH_GATE_TYPE,
-        requester_member_id, role_id, neutral_facts=neutral_facts,
+        requester_member_id, role_id, neutral_facts=neutral_facts, scope_key=scope_key,
     )
     gate.neutral_facts = neutral_facts
     if gate.status != "pending":
@@ -1045,6 +1055,7 @@ async def resolve_command_target(
     gate = await find_gate_slot_with_pr_fallback(
         db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
         gate_type=_EXTERNAL_PUBLISH_GATE_TYPE, pr_number=None, repo_full_name=None,
+        scope_key=str(draft.connection_id),
     )
     if gate is None or gate.status != "approved":
         raise ExternalPublishGateNotApprovedError(
@@ -1078,6 +1089,7 @@ async def publish_channel_post_draft(
     gate = await find_gate_slot_with_pr_fallback(
         db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
         gate_type=_EXTERNAL_PUBLISH_GATE_TYPE, pr_number=None, repo_full_name=None,
+        scope_key=str(draft.connection_id),
     )
     if gate is None or gate.status != "approved":
         raise ExternalPublishGateNotApprovedError(
@@ -1399,6 +1411,7 @@ async def _resolve_gate_for_draft(db: AsyncSession, *, org_id: uuid.UUID, draft_
     gate = await find_gate_slot_with_pr_fallback(
         db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
         gate_type=_EXTERNAL_PUBLISH_GATE_TYPE, pr_number=None, repo_full_name=None,
+        scope_key=str(draft.connection_id),
     )
     if gate is None:
         raise ChannelPostGateNotFoundError(draft_id)

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -764,22 +764,24 @@ async def list_channel_post_drafts(
 
     work_item_ids = [draft.work_item_id for draft, _, _ in page_rows]
 
-    # 배치 ②: work_item당 external_publish 게이트(site_posts.list_site_post_drafts와 동형 —
-    # 사실상 1개뿐이지만 여럿이면 최신 created_at이 이긴다).
-    gates_by_work_item: dict[uuid.UUID, Gate] = {}
+    # 배치 ②: (work_item, scope_key)당 external_publish 게이트(site_posts.list_site_post_
+    # drafts와 동형 — 사실상 1개뿐이지만 여럿이면 최신 created_at이 이긴다). story #3478
+    # 카디르 REQUEST_CHANGES(2026-09-05) — 예전엔 키가 work_item_id만이라 같은 work_item에
+    # 목적지가 다른 draft 둘(예: 커넥션 A·B)이 있으면 그중 하나의 게이트를 서로 나눠 봤다.
+    gates_by_scope: dict[tuple[uuid.UUID, str], Gate] = {}
     gate_rows = (await db.execute(
         select(Gate)
         .where(Gate.org_id == org_id, Gate.work_item_id.in_(work_item_ids), Gate.gate_type == "external_publish")
         .order_by(Gate.created_at.desc())
     )).scalars().all()
     for g in gate_rows:
-        gates_by_work_item.setdefault(g.work_item_id, g)
+        gates_by_scope.setdefault((g.work_item_id, g.scope_key), g)
 
-    gate_ids = [g.id for g in gates_by_work_item.values()]
+    gate_ids = [g.id for g in gates_by_scope.values()]
     latest_version_id_by_gate = {
-        gates_by_work_item[draft.work_item_id].id: latest_v.id
+        gates_by_scope[(draft.work_item_id, str(draft.connection_id))].id: latest_v.id
         for draft, latest_v, _ in page_rows
-        if draft.work_item_id in gates_by_work_item
+        if (draft.work_item_id, str(draft.connection_id)) in gates_by_scope
     }
 
     latest_version_pub_by_gate: dict[uuid.UUID, ChannelPublication] = {}
@@ -842,7 +844,7 @@ async def list_channel_post_drafts(
 
     result = []
     for draft, latest_v, origin_v in page_rows:
-        gate = gates_by_work_item.get(draft.work_item_id)
+        gate = gates_by_scope.get((draft.work_item_id, str(draft.connection_id)))
         published_pub = published_pub_by_gate.get(gate.id) if gate else None
         latest_pub = latest_version_pub_by_gate.get(gate.id) if gate else None
         published_body_sha256 = (

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -865,6 +865,14 @@ async def create_gate(
 # 보는 한 줄로 남긴다(조용히 삼키지 않는다 — "승인됐는데 예약이 안 걸린다"가 이 스토리
 # 자체의 사고 클래스라 PO가 "보이는 실패"로 명시 확定).
 _SCHEDULED_COMMAND_DRAFT_UNRESOLVED_NOTE = "예약 명령 미생성(draft 해석 실패)"
+# story #3478 후속(BLOCKER 2, 페드루 실측 2026-09-05) — 목적지가 바뀐 뒤 옛 scope의
+# 승인이 살아남으면(예: void 처리 前 경쟁 상태) 이 게이트의 scope_key(승인된 목적지)와
+# draft의 **현재** connection_id(위 site_draft.connection_id, 명령이 실제로 향할
+# 목적지)가 어긋날 수 있다 — 그 상태로 명령을 만들면 「W용 승인으로 H에 발행」이 된다
+# (3478이 막으려던 것 자체를 승인 훅에서 재현). 방어선(belt-and-suspenders) — void
+# 정리(위 _reseal_gate_on_new_version)가 정상 동작해도, 경합·구버전 데이터 등 어떤
+# 경로로든 불일치가 남으면 여기서 한 번 더 막는다.
+_SCHEDULED_COMMAND_SCOPE_MISMATCH_NOTE = "예약 명령 미생성(승인된 목적지와 초안의 현재 목적지 불일치)"
 
 
 async def _maybe_create_scheduled_publication_command(
@@ -904,6 +912,15 @@ async def _maybe_create_scheduled_publication_command(
             "gate %s approved but draft resolution failed — publication_command not created", gate.id,
         )
         note = _SCHEDULED_COMMAND_DRAFT_UNRESOLVED_NOTE
+        gate.resolution_note = f"{gate.resolution_note}\n{note}" if gate.resolution_note else note
+
+    def _mark_scope_mismatch() -> None:
+        logger.warning(
+            "gate %s approved for scope_key=%r but draft's current connection_id=%r — "
+            "publication_command not created",
+            gate.id, gate.scope_key, site_draft.connection_id,
+        )
+        note = _SCHEDULED_COMMAND_SCOPE_MISMATCH_NOTE
         gate.resolution_note = f"{gate.resolution_note}\n{note}" if gate.resolution_note else note
 
     destination_channel = (gate.neutral_facts or {}).get("destination")
@@ -947,6 +964,9 @@ async def _maybe_create_scheduled_publication_command(
         )).scalar_one_or_none()
         if site_latest is None:
             _mark_unresolved()
+            return
+        if str(site_draft.connection_id) != gate.scope_key:
+            _mark_scope_mismatch()
             return
 
         from app.services.publication_command import create_or_get_publication_command

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -457,6 +457,7 @@ async def find_gate_slot_with_pr_fallback(
     gate_type: str,
     pr_number: int | None,
     repo_full_name: str | None = None,
+    scope_key: str = "",
 ) -> Gate | None:
     """story #2893(§2 A1, 0271) 후속 — 카디르 QA(PR#3349 CI 실 실패 2건, 2026-08-22):
     pr_number를 멱등 키에 편입한 것(정확매치 only)이 「PR 컨텍스트가 나중에 밝혀지는」
@@ -489,6 +490,11 @@ async def find_gate_slot_with_pr_fallback(
     모호성이 원천적으로 없다. repo를 아는 기존 행과는 별개 identity로 남는다(멋대로
     병합하지 않는다 — 어느 쪽이 "진짜"인지 여기서 판단할 근거가 없다).
 
+    scope_key: story #3478(0328) — 멱등 키 네 번째 축(기본값 ""). 거의 모든 호출부는
+    안 넘겨 옛 동작 그대로(""는 "" 하나뿐이라 구분력 무변). `external_publish` 게이트만
+    site_posts.py·channel_posts.py가 목적지(`str(draft.connection_id or "")`)를 넘겨
+    같은 work_item의 여러 draft/목적지가 독립 슬롯을 갖는다.
+
     **동시성**(story #2932 HIGH2): NULL-슬롯 승격은 read-then-write라 동시 웹훅 2개가
     같은 NULL-슬롯을 서로 다른 PR로 경쟁 승격할 수 있었다(나중 커밋이 조용히 덮어씀).
     NULL-슬롯 조회에 `SELECT ... FOR UPDATE`를 걸어 두 번째 트랜잭션이 첫 번째의 커밋을
@@ -514,7 +520,7 @@ async def find_gate_slot_with_pr_fallback(
         exact_conditions = [
             Gate.org_id == org_id, Gate.work_item_id == work_item_id,
             Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
-            Gate.pr_number == pr_number,
+            Gate.scope_key == scope_key, Gate.pr_number == pr_number,
         ]
         # 카디르 QA(story #2932, PR#3359 3라운드, codex 발견) — repo_full_name이 없을 때
         # (호출부가 정말 모름 — report-done류 self-report의 실 경로) repo 필터를 아예
@@ -546,6 +552,7 @@ async def find_gate_slot_with_pr_fallback(
                     select(Gate).where(
                         Gate.org_id == org_id, Gate.work_item_id == work_item_id,
                         Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
+                        Gate.scope_key == scope_key,
                         Gate.pr_number == pr_number, Gate.repo_full_name.is_(None),
                     ).with_for_update()  # story #2932 HIGH2와 동일 이유 — 동시 승격 경쟁 직렬화.
                 )
@@ -560,7 +567,7 @@ async def find_gate_slot_with_pr_fallback(
                 select(Gate).where(
                     Gate.org_id == org_id, Gate.work_item_id == work_item_id,
                     Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
-                    Gate.pr_number.is_(None),
+                    Gate.scope_key == scope_key, Gate.pr_number.is_(None),
                 ).with_for_update()  # story #2932 HIGH2 — 동시 승격 경쟁 직렬화.
             )
         ).scalar_one_or_none()
@@ -574,24 +581,53 @@ async def find_gate_slot_with_pr_fallback(
             select(Gate).where(
                 Gate.org_id == org_id, Gate.work_item_id == work_item_id,
                 Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
-                Gate.pr_number.is_(None),
+                Gate.scope_key == scope_key, Gate.pr_number.is_(None),
             )
         )
     ).scalar_one_or_none()
 
 
-def resolve_gate_holder_draft_id(
-    existing_gate: Gate | None, *, this_draft_id: uuid.UUID,
+async def _gate_publication_is_live(session: AsyncSession, *, gate_id: uuid.UUID) -> bool:
+    """story #3478(0328, 페드루 PO 決定 ③) — 이 게이트로 승인된 발행이 «지금 실려
+    있는지». hosted_site(site_posts.py — `site_post.gate_id`)든 외부 목적지
+    (channel_publications.gate_id, channel_post·site_post-external 공용)든 이
+    함수는 어느 쪽으로 발행됐는지 몰라도 gate_id 하나로 두 테이블을 순서대로 본다
+    (각 도메인이 이 gate_id로 정확히 한 테이블에만 쓴다 — 겹칠 일이 없다). 둘 다에
+    행이 없으면(승인만 됐지 최초 발행 시도 자체가 아직 없음) "쥐고 있다"로 보수적
+    취급 — 발행 시도 前 상태의 기존 동작과 회귀 0."""
+    from app.models.channel_publication import ChannelPublication
+    from app.models.site_post import SitePost
+
+    site_post_row = (await session.execute(
+        select(SitePost.unpublished_at).where(SitePost.gate_id == gate_id).limit(1)
+    )).first()
+    if site_post_row is not None:
+        return site_post_row[0] is None
+
+    latest_channel_pub_status = (await session.execute(
+        select(ChannelPublication.status)
+        .where(ChannelPublication.gate_id == gate_id)
+        .order_by(ChannelPublication.created_at.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    if latest_channel_pub_status is None:
+        return True
+    return latest_channel_pub_status == "published"
+
+
+async def resolve_gate_holder_draft_id(
+    session: AsyncSession, existing_gate: Gate | None, *, this_draft_id: uuid.UUID,
 ) -> uuid.UUID | None:
     """story #3404(site_posts.py의 story f6d14476 처방을 channel_posts.py로도 미러하며
     추출) — 「이 게이트를 이미 다른 초안이 쥐고 있는가」 판정을 한 곳에 모은다. site_posts.py
-    ·channel_posts.py 둘 다 external_publish 게이트 슬롯이 work_item 단위(draft 단위가
-    아니다)라 같은 work_item에 초안이 둘 이상이면 뒤늦은 상신이 앞선 승인을 조용히
-    pending으로 되돌릴 수 있다 — 그 판정 로직 자체(neutral_facts.draft_id 대조)는 두 도메인
-    이 완전히 동일해 두 벌로 유지하면 드리프트 표면이 된다(한쪽만 고치고 잊는 사고). 던지는
-    에러(SitePostGateAlreadyHeldError/ChannelPostGateAlreadyHeldError)는 도메인마다
-    필드가 달라(lang/slug vs channel/connection_id) 여기서 만들지 않는다 — 호출부가 이
-    함수의 반환값(막고 있는 draft_id, 또는 없으면 None)만 받아 자기 도메인 에러를 짓는다.
+    ·channel_posts.py 둘 다 external_publish 게이트 슬롯이 (work_item, scope_key) 단위
+    (story #3478/0328부터 — 이전엔 work_item 단위뿐)라 같은 (work_item, 목적지)에 초안이
+    둘 이상이면 뒤늦은 상신이 앞선 승인을 조용히 pending으로 되돌릴 수 있다 — 그 판정
+    로직 자체(neutral_facts.draft_id 대조)는 두 도메인이 완전히 동일해 두 벌로 유지하면
+    드리프트 표면이 된다(한쪽만 고치고 잊는 사고). 던지는 에러(SitePostGateAlreadyHeld
+    Error/ChannelPostGateAlreadyHeldError)는 도메인마다 필드가 달라(lang/slug vs
+    channel/connection_id) 여기서 만들지 않는다 — 호출부가 이 함수의 반환값(막고 있는
+    draft_id, 또는 없으면 None)만 받아 자기 도메인 에러를 짓는다.
 
     None을 반환하는 경우 전부 "막지 않는다"는 뜻이다: 게이트가 없음(신규) · pending/
     approved가 아님(rejected/voided 등 — 걱정할 보유자가 없다) · neutral_facts에
@@ -600,7 +636,12 @@ def resolve_gate_holder_draft_id(
     draft_id 값이 유효한 UUID가 아님(페드루 PO 리뷰, PR#3764 — 옛 코드(리팩터 前)는
     문자열 그대로 비교해 이 자리서 절대 안 터졌는데, `uuid.UUID(...)` 파싱을 여기로
     끌어오며 생긴 신규 실패 축이었다: 이 함수는 가드다 — 가드가 깨진 데이터 때문에
-    500을 내면 안 된다. 못 읽으면 "모른다"로 취급해 막지 않고 warning만 남긴다)."""
+    500을 내면 안 된다. 못 읽으면 "모른다"로 취급해 막지 않고 warning만 남긴다) ·
+    story #3478(0328, 페드루 PO 決定 ③) — approved인데 그 발행이 회수(unpublish)됐거나
+    애초에 아직 최초 발행 前이 아닌(=한 번 발행됐다가 지금은 내려간) 경우 — 회수된
+    승인이 같은 목적지로의 재상신을 영구히 막는 건 원래 f6d14476의 의도가 아니었다
+    (재발행 자체는 새 상신·새 승인이 원칙, 봉인 원칙 유지 — 이 함수는 "막을지"만
+    판정하지 봉인을 우회하지 않는다)."""
     if existing_gate is None or existing_gate.status not in ("pending", "approved"):
         return None
     holding_raw = (existing_gate.neutral_facts or {}).get("draft_id")
@@ -616,6 +657,8 @@ def resolve_gate_holder_draft_id(
         )
         return None
     if holding_id == this_draft_id:
+        return None
+    if existing_gate.status == "approved" and not await _gate_publication_is_live(session, gate_id=existing_gate.id):
         return None
     return holding_id
 
@@ -675,8 +718,14 @@ async def create_gate(
     pr_number: int | None = None,
     repo_full_name: str | None = None,
     designated_approver_id: uuid.UUID | None = None,
+    scope_key: str = "",
 ) -> Gate:
     """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환).
+
+    scope_key: story #3478(0328) — 멱등 키 네 번째 축(기본값 "", 기존 全 호출부
+    무회귀). `external_publish`만 site_posts.py·channel_posts.py가 목적지
+    (`str(draft.connection_id or "")`)를 넘겨 같은 work_item의 여러 draft/목적지가
+    독립 게이트를 갖는다(work_item당 1건 제약의 근본수정 — 그라운딩 참고).
 
     pr_number: story #2893(설계안 §2 A1) — merge-type만 실제로 쓴다(호출부는
     evaluate_merge_gate 하나뿐, 그라운딩 확認). 나머지 7개 호출부는 인자를 안 넘겨
@@ -730,7 +779,7 @@ async def create_gate(
     existing = await find_gate_slot_with_pr_fallback(
         session, org_id=org_id, work_item_id=work_item_id,
         work_item_type=work_item_type, gate_type=gate_type, pr_number=pr_number,
-        repo_full_name=repo_full_name,
+        repo_full_name=repo_full_name, scope_key=scope_key,
     )
     if existing is not None:
         # story #2150 근본수정: rejected는 재제출 시 새 결재 사이클을 연다(그 외 terminal
@@ -761,6 +810,7 @@ async def create_gate(
         gate_type=gate_type,
         pr_number=pr_number,
         repo_full_name=repo_full_name,
+        scope_key=scope_key,
         status=status,
         # #2156 AC3(2026-08-07) — merge-type만 evaluate_merge_gate가 이후 이 필드를 정확히
         # 채웠고(decision 기반), 그 외 gate_type(qa·pr_review·deploy 등)은 create_gate가 여태

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -310,6 +310,10 @@ _CAMPAIGN_ID_CARRY_FORWARD = object()
 # (campaign 개념을 모르는 호출자가 이 키를 생략하면 목적지가 조용히 hosted_site로
 # 되돌아간다)을 그대로 갖는다 — 이번엔 처음부터 캐리포워드로 짠다.
 _CONNECTION_ID_CARRY_FORWARD = object()
+# story #3478 후속(카디르 REQUEST_CHANGES 경유 페드루 실측, 2026-09-05) — 브랜드
+# 뉴 draft(버전 1)는 "옛 목적지"가 없다(비교 대상 자체가 없다) — 값 None(hosted_site)
+# 과 구분해야 하는 또 하나의 캐리포워드류 센티널.
+_NO_PRIOR_VERSION = object()
 
 
 async def create_site_post_draft_version(
@@ -393,7 +397,9 @@ async def create_site_post_draft_version(
         db.add(draft)
         await db.flush()
         next_version = 1
+        old_connection_id: uuid.UUID | None | object = _NO_PRIOR_VERSION
     else:
+        old_connection_id = draft.connection_id
         if explicit_campaign_id:
             draft.campaign_id = campaign_id
         if explicit_connection_id:
@@ -422,7 +428,10 @@ async def create_site_post_draft_version(
     #     그대로 유지**(재봉인은 submit_site_post_draft의 명시 재호출만이 한다 — gates.py의
     #     approve 전이가 reapproval_required=True인 동안 409로 막혀 "옛 봉인을 승인하는" 막다른
     #     길 자체를 차단한다).
-    await _reseal_gate_on_new_version(db, org_id=org_id, work_item_id=work_item_id, version=version, draft=draft)
+    await _reseal_gate_on_new_version(
+        db, org_id=org_id, work_item_id=work_item_id, version=version, draft=draft,
+        old_connection_id=old_connection_id,
+    )
 
     # story #3471(페드루 PO 確定 2026-09-05)·#3482(필드별, 2026-09-05 후속) —
     # channel_posts.py::create_channel_post_draft_version과 동형(비차단, draft에
@@ -444,8 +453,38 @@ async def create_site_post_draft_version(
 
 async def _reseal_gate_on_new_version(
     db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, version: SitePostVersion,
-    draft: SitePostDraft,
+    draft: SitePostDraft, old_connection_id: "uuid.UUID | None | object" = _NO_PRIOR_VERSION,
 ) -> None:
+    # story #3478 후속(카디르 REQUEST_CHANGES 경유 페드루 실측, 2026-09-05) — destination
+    # (connection_id) 자체가 바뀌면 옛 scope_key 게이트가 새 scope_key 조회(아래)에
+    # 안 걸려 방치됐다: approved인데 목적지를 잃은 채 살아 있거나(봉인 원칙 위반),
+    # 발행 행이 0이라 `_gate_publication_is_live`가 "쥐고 있다"로 보수 판정해 같은
+    # work_item·같은 옛 목적지로의 재상신이 영구 409(3478이 없애려던 것의 사촌)로
+    # 막혔다. approved 뒤 편집(같은 목적지)과 동형으로 pending+reapproval_required로
+    # 되돌린다 — sealed_content_*는 안 건드린다(옛 승인 기록 보존, 재봉인은 그 목적지로
+    # 다시 submit()할 때만). pending이었으면 손대지 않는다(이 새 버전은 그 목적지로
+    # 안 가므로 재봉인할 근거가 없다 — 다음 submit()이 새 scope_key로 별도 게이트를 연다).
+    old_scope_key = None if old_connection_id is _NO_PRIOR_VERSION else str(old_connection_id or "")
+    new_scope_key = str(draft.connection_id or "")
+    if old_scope_key is not None and old_scope_key != new_scope_key:
+        from app.services.gate_service import resolve_gate_holder_draft_id as _resolve_old_holder
+
+        old_gate = (await db.execute(
+            select(Gate)
+            .where(
+                Gate.org_id == org_id, Gate.work_item_id == work_item_id, Gate.gate_type == "external_publish",
+                Gate.scope_key == old_scope_key, Gate.status == "approved",
+            )
+            .with_for_update()
+        )).scalar_one_or_none()
+        if old_gate is not None and await _resolve_old_holder(db, old_gate, this_draft_id=version.draft_id) is None:
+            set_gate_status(old_gate, "pending", now=datetime.now(timezone.utc))
+            old_gate.requires_human = True
+            old_gate.resolver_id = None
+            old_gate.resolution_note = None
+            old_gate.resolved_at = None
+            old_gate.reapproval_required = True
+
     # story #3478(0328) — scope_key도 필터에 넣는다. 안 넣으면 같은 work_item에 목적지가
     # 다른 게이트가 둘(예: WordPress+webhook) 있을 때 .scalar_one_or_none()이
     # MultipleResultsFound(500)로 죽는다(dual-destination을 가능케 한 이 스토리 자체가

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -170,7 +170,13 @@ async def _resolve_approved_gate(
 ) -> Gate:
     """gate_id가 주어지면 그 게이트 자체를 검증(work_item/타입 일치 + 승인 상태). 없으면 이
     work item의 external_publish 게이트를 찾아 검증(가장 최근 것 — story #2150 재제출 리셋
-    관례상 같은 (work_item, gate_type)엔 사실상 행 1개만 산다)."""
+    관례상 같은 (work_item, gate_type, scope_key)엔 사실상 행 1개만 산다).
+
+    story #3478 카디르 REQUEST_CHANGES(2026-09-05) — 이 함수는 hosted_site(자사 사이트)
+    발행 전용 chokepoint라 scope_key는 항상 ""(외부 목적지 축과 별개)여야 한다. 필터가
+    없으면 같은 work_item에 WordPress·webhook용으로 approved된 게이트(scope_key=
+    connection_id)를 이 hosted_site 발행이 대신 통과시켜 버린다 — dual-destination을
+    가능케 한 이 스토리 자체가 자신의 목적(목적지별 독립 승인)을 스스로 뚫을 뻔한 지점."""
     if gate_id is not None:
         gate = (await db.execute(
             select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
@@ -179,6 +185,7 @@ async def _resolve_approved_gate(
             gate is None
             or gate.work_item_id != work_item_id
             or gate.gate_type != "external_publish"
+            or gate.scope_key != ""
             or gate.status not in _APPROVED_STATUSES
         ):
             raise ExternalPublishGateNotApprovedError(
@@ -190,6 +197,7 @@ async def _resolve_approved_gate(
         select(Gate)
         .where(
             Gate.org_id == org_id, Gate.work_item_id == work_item_id, Gate.gate_type == "external_publish",
+            Gate.scope_key == "",
         )
         .order_by(Gate.created_at.desc())
         .limit(1)
@@ -584,16 +592,20 @@ async def list_site_post_drafts(
     work_item_ids = [draft.work_item_id for draft, _, _ in page_rows]
     slugs = [draft.slug for draft, _, _ in page_rows]
 
-    # 배치 ②: work_item당 external_publish 게이트 — story #3360 §2 관례상 사실상 1개뿐이지만
-    # 재제출 리셋 등으로 여럿이면 최신(created_at desc)이 이긴다(dict 조립 순서로 구현).
-    gates_by_work_item: dict[uuid.UUID, Gate] = {}
+    # 배치 ②: (work_item, scope_key)당 external_publish 게이트 — story #3360 §2 관례상
+    # 사실상 1개뿐이지만 재제출 리셋 등으로 여럿이면 최신(created_at desc)이 이긴다(dict
+    # 조립 순서로 구현). story #3478 카디르 REQUEST_CHANGES(2026-09-05) — 예전엔 키가
+    # work_item_id만이라 같은 work_item에 목적지가 다른 draft 둘(WordPress+webhook)이
+    # 있으면 그중 하나의 게이트를 서로 나눠 봤다(scope_key 도입으로 다중 목적지가 실제로
+    # 가능해진 이 스토리 자체가 이 배치 조회에서 새 혼선을 만들 뻔한 지점).
+    gates_by_scope: dict[tuple[uuid.UUID, str], Gate] = {}
     gate_rows = (await db.execute(
         select(Gate)
         .where(Gate.org_id == org_id, Gate.work_item_id.in_(work_item_ids), Gate.gate_type == "external_publish")
         .order_by(Gate.created_at.desc())
     )).scalars().all()
     for g in gate_rows:
-        gates_by_work_item.setdefault(g.work_item_id, g)
+        gates_by_scope.setdefault((g.work_item_id, g.scope_key), g)
 
     # 배치 ③: 공개 site_posts — 유일키 (org_id, lang, slug)라 draft.slug + latest.lang으로
     # 되찾는다(story #3381/#3386과 동일 조회 축).
@@ -607,7 +619,11 @@ async def list_site_post_drafts(
         posts_by_key[(p.lang, p.slug)] = p
 
     return [
-        (draft, latest_v, origin_v, gates_by_work_item.get(draft.work_item_id), posts_by_key.get((latest_v.lang, draft.slug)))
+        (
+            draft, latest_v, origin_v,
+            gates_by_scope.get((draft.work_item_id, str(draft.connection_id or ""))),
+            posts_by_key.get((latest_v.lang, draft.slug)),
+        )
         for draft, latest_v, origin_v in page_rows
     ]
 

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -438,10 +438,15 @@ async def _reseal_gate_on_new_version(
     db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, version: SitePostVersion,
     draft: SitePostDraft,
 ) -> None:
+    # story #3478(0328) — scope_key도 필터에 넣는다. 안 넣으면 같은 work_item에 목적지가
+    # 다른 게이트가 둘(예: WordPress+webhook) 있을 때 .scalar_one_or_none()이
+    # MultipleResultsFound(500)로 죽는다(dual-destination을 가능케 한 이 스토리 자체가
+    # 이 자리에서 새 500을 만들 뻔한 지점 — grep 전수 대조로 찾음).
     gate = (await db.execute(
         select(Gate)
         .where(
             Gate.org_id == org_id, Gate.work_item_id == work_item_id, Gate.gate_type == "external_publish",
+            Gate.scope_key == str(draft.connection_id or ""),
             Gate.status.in_(("pending", "approved")),
         )
         .with_for_update()
@@ -449,15 +454,16 @@ async def _reseal_gate_on_new_version(
     if gate is None:
         return
     # story f6d14476(발견 즉시 수정, AC1과 동일한 corruption class) — 이 훅은
-    # work_item_id만으로 게이트를 찾는다(draft 무관). 승인 대상이 아닌 다른 초안을
-    # 편집(새 버전 생성)했을 뿐인데 여기서 그 게이트를 되돌리거나(approved→pending)
-    # 조용히 재봉인하면(pending 유지) submit()을 거치지 않고도 동일한 파괴가 일어난다.
-    # 판정은 submit()과 같은 함수로 한다(story #3404에서 gate_service.py::
-    # resolve_gate_holder_draft_id로 추출 — channel_posts.py가 이 함수의 동형 훅에서도
-    # 같은 결함 클래스를 갖고 있어 공유하게 됐다).
+    # (work_item_id, scope_key)만으로 게이트를 찾는다(draft 무관, story #3478부터
+    # scope_key도 축에 편입). 승인 대상이 아닌 다른 초안을 편집(새 버전 생성)했을
+    # 뿐인데 여기서 그 게이트를 되돌리거나(approved→pending) 조용히 재봉인하면
+    # (pending 유지) submit()을 거치지 않고도 동일한 파괴가 일어난다. 판정은 submit()과
+    # 같은 함수로 한다(story #3404에서 gate_service.py::resolve_gate_holder_draft_id로
+    # 추출 — channel_posts.py가 이 함수의 동형 훅에서도 같은 결함 클래스를 갖고 있어
+    # 공유하게 됐다).
     from app.services.gate_service import resolve_gate_holder_draft_id
 
-    if resolve_gate_holder_draft_id(gate, this_draft_id=version.draft_id) is not None:
+    if await resolve_gate_holder_draft_id(db, gate, this_draft_id=version.draft_id) is not None:
         return
     if gate.status == "approved":
         # 승인된 뒤 편집 — pending으로 되돌리기만 한다. sealed_content_*는 절대 안 건드린다
@@ -652,17 +658,24 @@ async def submit_site_post_draft(
     from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback, resolve_gate_holder_draft_id
     from app.services.workflow_line_config import _default_role_id
 
+    # story #3478(0328) — scope_key=목적지(connection_id). 같은 work_item이 WordPress·
+    # webhook 등 여러 목적지로 각각 독립 게이트를 갖는다(work_item당 1건이던 제약의
+    # 근본수정 — 그라운딩 대조 결과, 이 슬롯은 channel_post와 공유하는 설계라 두
+    # 도메인 다 같은 규칙을 쓴다).
+    scope_key = str(draft.connection_id or "")
     existing = await find_gate_slot_with_pr_fallback(
         db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
-        gate_type="external_publish", pr_number=None, repo_full_name=None,
+        gate_type="external_publish", pr_number=None, repo_full_name=None, scope_key=scope_key,
     )
 
-    # story f6d14476(PO 결정②, AC1) — 게이트 슬롯은 work_item 단위라, 이미 다른 초안이 그
-    # 게이트를 쥐고(pending/approved) 있으면 이 초안의 상신을 막는다. 판정 로직 자체는
-    # story #3404에서 gate_service.py::resolve_gate_holder_draft_id로 뽑아 channel_
-    # posts.py와 공유한다("모른다≠다르다"·자기 자신 재상신 허용 규칙 포함, 그 함수
-    # docstring 참고) — 여기선 그 판정 결과로 이 도메인 전용 에러(lang/slug)만 짓는다.
-    holding_draft_id = resolve_gate_holder_draft_id(existing, this_draft_id=draft.id)
+    # story f6d14476(PO 결정②, AC1) — 게이트 슬롯은 (work_item, scope_key) 단위(story
+    # #3478부터)라, 같은 목적지를 이미 다른 초안이 그 게이트를 쥐고(pending/approved
+    # 이면서 그 발행이 지금 실려 있음, story #3478 決定③) 있으면 이 초안의 상신을
+    # 막는다. 판정 로직 자체는 story #3404에서 gate_service.py::resolve_gate_holder_
+    # draft_id로 뽑아 channel_posts.py와 공유한다("모른다≠다르다"·자기 자신 재상신
+    # 허용 규칙 포함, 그 함수 docstring 참고) — 여기선 그 판정 결과로 이 도메인 전용
+    # 에러(lang/slug)만 짓는다.
+    holding_draft_id = await resolve_gate_holder_draft_id(db, existing, this_draft_id=draft.id)
     if holding_draft_id is not None:
         holder = await get_site_post_draft(db, org_id=org_id, draft_id=holding_draft_id)
         if holder is not None:
@@ -710,7 +723,7 @@ async def submit_site_post_draft(
         raise SitePostApproverRoleMissingError(org_id=org_id)
     gate = await create_gate(
         db, org_id, draft.work_item_id, "story", "external_publish",
-        requester_member_id, role_id, neutral_facts=neutral_facts,
+        requester_member_id, role_id, neutral_facts=neutral_facts, scope_key=scope_key,
     )
     # create_gate()의 기존-pending/approved 멱등 반환 분기는 neutral_facts 인자를 무시한다
     # (신규 생성·rejected 재오픈 경로에서만 반영) — 위 sha 동일성 조기 return을 안 탔다는 건
@@ -799,9 +812,11 @@ async def publish_site_post_from_draft(
 
     from app.services.gate_service import find_gate_slot_with_pr_fallback
 
+    # story #3478(0328) — scope_key=목적지. hosted_site(connection_id=None)는 "".
     gate = await find_gate_slot_with_pr_fallback(
         db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
         gate_type="external_publish", pr_number=None, repo_full_name=None,
+        scope_key=str(draft.connection_id or ""),
     )
     if gate is None or gate.status != "approved":
         raise ExternalPublishGateNotApprovedError(
@@ -977,9 +992,11 @@ async def request_site_post_external_publish(
 
     from app.services.gate_service import find_gate_slot_with_pr_fallback
 
+    # story #3478(0328) — scope_key=목적지. hosted_site(connection_id=None)는 "".
     gate = await find_gate_slot_with_pr_fallback(
         db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
         gate_type="external_publish", pr_number=None, repo_full_name=None,
+        scope_key=str(draft.connection_id or ""),
     )
     if gate is None or gate.status != "approved":
         raise ExternalPublishGateNotApprovedError(

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -455,35 +455,44 @@ async def _reseal_gate_on_new_version(
     db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, version: SitePostVersion,
     draft: SitePostDraft, old_connection_id: "uuid.UUID | None | object" = _NO_PRIOR_VERSION,
 ) -> None:
-    # story #3478 후속(카디르 REQUEST_CHANGES 경유 페드루 실측, 2026-09-05) — destination
-    # (connection_id) 자체가 바뀌면 옛 scope_key 게이트가 새 scope_key 조회(아래)에
-    # 안 걸려 방치됐다: approved인데 목적지를 잃은 채 살아 있거나(봉인 원칙 위반),
-    # 발행 행이 0이라 `_gate_publication_is_live`가 "쥐고 있다"로 보수 판정해 같은
-    # work_item·같은 옛 목적지로의 재상신이 영구 409(3478이 없애려던 것의 사촌)로
-    # 막혔다. approved 뒤 편집(같은 목적지)과 동형으로 pending+reapproval_required로
-    # 되돌린다 — sealed_content_*는 안 건드린다(옛 승인 기록 보존, 재봉인은 그 목적지로
-    # 다시 submit()할 때만). pending이었으면 손대지 않는다(이 새 버전은 그 목적지로
-    # 안 가므로 재봉인할 근거가 없다 — 다음 submit()이 새 scope_key로 별도 게이트를 연다).
+    # story #3478 후속(카디르 REQUEST_CHANGES BLOCKER 1·REQUIRED 3, 페드루 실측
+    # 2026-09-05) — destination(connection_id) 자체가 바뀌면 옛 scope_key 게이트가
+    # 새 scope_key 조회(아래)에 안 걸려 방치됐다. 최초 처방(pending+reapproval_
+    # required로 되돌리기)은 새 구멍을 냈다 — pending인 채로 두면 결재자가 그 게이트를
+    # "정상적으로" 승인해 버릴 수 있고, `_maybe_create_scheduled_publication_command`가
+    # site_draft.connection_id(=draft의 **현재** 목적지, 이미 새 목적지로 바뀐 값)로
+    # 명령을 만든다 — "옛 목적지용 승인으로 새 목적지에 발행"이 되어 3478이 지키려던
+    # «목적지별 독립 승인» 자체가 뚫린다. voided로 완전히 끝내는 게 정답이다: 그 목적지로
+    # 다시 상신하면 `find_gate_slot_with_pr_fallback`(status 필터 없음)이 이 voided
+    # 행을 그대로 돌려주고, `create_gate()`는 rejected가 아니면 그 행을 재사용하며,
+    # `submit_site_post_draft()`의 기존 "gate.status != pending"이면 되돌리는 분기가
+    # pending 복귀+재봉인+`reapproval_required=False`까지 그대로 처리한다(신규 코드
+    # 불요 — 이미 있는 재사용 경로가 정확히 이 상황을 위해 있었다).
+    #
+    # REQUIRED 3 — 이 게이트를 건드릴 조건은 `resolve_gate_holder_draft_id(...) is
+    # None`("막는 홀더 없음" — 아무도 안 쥐고 있어도 None)이 아니라 「이 draft가 쥔
+    # 게이트」다(neutral_facts.draft_id가 정확히 이 draft.id). 다른 draft A가 쥔 approved
+    # 게이트가 회수 등으로 "안 쥐고 있다"(None) 판정을 받으면, 이 함수는 B의 목적지
+    # 변경만으로 A의 게이트를 건드려선 안 된다 — 건드릴 권한은 "내가 쥔 것"에만 있다.
     old_scope_key = None if old_connection_id is _NO_PRIOR_VERSION else str(old_connection_id or "")
     new_scope_key = str(draft.connection_id or "")
     if old_scope_key is not None and old_scope_key != new_scope_key:
-        from app.services.gate_service import resolve_gate_holder_draft_id as _resolve_old_holder
-
         old_gate = (await db.execute(
             select(Gate)
             .where(
                 Gate.org_id == org_id, Gate.work_item_id == work_item_id, Gate.gate_type == "external_publish",
-                Gate.scope_key == old_scope_key, Gate.status == "approved",
+                Gate.scope_key == old_scope_key, Gate.status.in_(("pending", "approved")),
             )
             .with_for_update()
         )).scalar_one_or_none()
-        if old_gate is not None and await _resolve_old_holder(db, old_gate, this_draft_id=version.draft_id) is None:
-            set_gate_status(old_gate, "pending", now=datetime.now(timezone.utc))
-            old_gate.requires_human = True
-            old_gate.resolver_id = None
-            old_gate.resolution_note = None
-            old_gate.resolved_at = None
-            old_gate.reapproval_required = True
+        if old_gate is not None and (old_gate.neutral_facts or {}).get("draft_id") == str(version.draft_id):
+            set_gate_status(old_gate, "voided", now=datetime.now(timezone.utc))
+            old_gate.requires_human = False
+            old_gate.resolution_note = (
+                f"목적지 변경으로 자동 해제(destination changed "
+                f"{old_scope_key or 'hosted_site'} → {new_scope_key or 'hosted_site'}, version {version.version})"
+            )
+            old_gate.resolved_at = datetime.now(timezone.utc)
 
     # story #3478(0328) — scope_key도 필터에 넣는다. 안 넣으면 같은 work_item에 목적지가
     # 다른 게이트가 둘(예: WordPress+webhook) 있을 때 .scalar_one_or_none()이
@@ -1162,6 +1171,20 @@ async def publish_site_post_external_command(db: AsyncSession, command: "Publica
         raise SitePostExternalPublishError(
             error_code="SITE_POST_REAPPROVAL_REQUIRED",
             message=f"봉인된 본문과 현재 버전이 다릅니다(gate_id={gate.id})",
+        )
+    # story #3478 후속(BLOCKER 2, 페드루 실측 2026-09-05) — 위 status/sha 검증은 "이
+    # 게이트가 승인된 상태"만 보고 "그 승인이 draft가 지금 향하는 목적지의 승인인지"는
+    # 안 봤다. destination(connection_id)이 승인 이후 바뀌었는데 옛 scope의 approved
+    # 게이트가 어떤 경로로든 살아남으면(void 정리가 정상 동작해도 경합 등으로), 이
+    # 자리가 마지막 방어선 — W용 승인으로 H에 실 HTTP를 치기 直前에 막는다(재시도 대상
+    # 아님, 사람이 새로 승인하면 새 커맨드가 만들어진다).
+    if gate.scope_key != str(draft.connection_id or ""):
+        raise SitePostExternalPublishError(
+            error_code="EXTERNAL_PUBLISH_APPROVAL_REQUIRED",
+            message=(
+                f"승인된 목적지와 draft의 현재 목적지가 다릅니다"
+                f"(gate_id={gate.id}, gate.scope_key={gate.scope_key!r}, draft.connection_id={draft.connection_id!r})"
+            ),
         )
 
     try:

--- a/backend/tests/test_3404_channel_post_gate_already_held.py
+++ b/backend/tests/test_3404_channel_post_gate_already_held.py
@@ -179,11 +179,13 @@ def _draft_body(*, work_item_id, connection_id, text="채널 포스트 본문입
 
 
 @pytest.mark.anyio
-async def test_second_draft_submit_blocked_while_first_holds_approved_gate():
-    """⭐핵심 pin — draft A(연결 1) 상신·승인 뒤, 같은 work_item의 draft B(연결 2)를
-    상신하면 409 CHANNEL_POST_GATE_ALREADY_HELD로 거부되고, A의 gate.status는 approved
-    그대로 남는다(가드 없으면: B의 상신이 같은 게이트를 B의 내용으로 재봉인+pending으로
-    되돌려 이 assert가 실패한다 — 그게 이 pin의 존재 이유)."""
+async def test_second_draft_submit_different_connection_both_succeed():
+    """story #3478(0328, 2026-09-05 후속) — 이 pin은 원래 "다른 connection의 draft도
+    막힌다"(work_item 단위 게이트)를 증명했다. #3478이 게이트 슬롯을 (work_item,
+    scope_key=connection_id) 단위로 바꿔 이 정확히 그 시나리오(같은 work_item·다른
+    목적지)를 **허용**하는 게 스토리 AC 자체가 됐다 — 옛 기대값(409)은 지금은 버그
+    재도입 여부를 재는 회귀 pin(둘 다 200이어야 정상, 하나라도 409면 scope_key 축이
+    깨진 것)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -222,16 +224,13 @@ async def test_second_draft_submit_blocked_while_first_holds_approved_gate():
             r_submit_b = await client.post(
                 f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_b_id}/submit", json={},
             )
-            assert r_submit_b.status_code == 409, r_submit_b.text
-            body = r_submit_b.json()["error"]
-            assert body["code"] == "CHANNEL_POST_GATE_ALREADY_HELD"
-            assert body["holding_draft_id"] == draft_a_id
-            assert body["holding_channel"] == "threads"
-            assert body["holding_connection_id"] == str(connection_a)
+            assert r_submit_b.status_code == 200, r_submit_b.text
+            gate_b_id = uuid.UUID(r_submit_b.json()["gate_id"])
+            assert gate_b_id != gate_a_id, "다른 목적지인데 같은 게이트를 공유했다 — scope_key 축이 안 먹은 것"
 
         async with Session() as s:
             assert await _get_gate_status(s, gate_a_id) == "approved", (
-                "draft B의 상신 시도가 draft A의 승인을 pending으로 되돌렸다 — 가드가 안 걸린 것"
+                "draft B의 상신이 draft A(다른 목적지)의 승인을 건드렸다 — 격리가 깨진 것"
             )
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_3404_channel_post_gate_already_held.py
+++ b/backend/tests/test_3404_channel_post_gate_already_held.py
@@ -238,6 +238,64 @@ async def test_second_draft_submit_different_connection_both_succeed():
 
 
 @pytest.mark.anyio
+async def test_draft_list_shows_each_drafts_own_gate_not_the_others():
+    """story #3478 카디르 REQUEST_CHANGES(2026-09-05) — `list_channel_post_drafts`의
+    게이트 배치 조회(`gates_by_scope`)가 work_item_id만으로 키를 잡으면 같은 work_item의
+    draft A(approved)·B(pending)가 서로의 게이트 상태를 나눠 본다(단건 조회
+    `GET .../drafts/{draft_id}`도 이 함수를 그대로 재사용하므로 동일 결함). 뮤테이션
+    대상: `gates_by_scope`를 다시 work_item_id만으로 keying하면 아래 assert 중 하나가
+    뒤바뀐 상태로 통과해 RED가 안 된다."""
+    from app.services.channel_posts import list_channel_post_drafts
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_a = await _seed_connection(s, org_id, account_id="list-acct-a")
+            connection_b = await _seed_connection(s, org_id, account_id="list-acct-b")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            r_draft_a = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_a, text="A안"),
+            )
+            draft_a_id = uuid.UUID(r_draft_a.json()["draft_id"])
+            r_submit_a = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_a_id}/submit", json={},
+            )
+            gate_a_id = uuid.UUID(r_submit_a.json()["gate_id"])
+            await _approve_gate_directly(s, gate_a_id)
+
+            r_draft_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_b, text="B안"),
+            )
+            draft_b_id = uuid.UUID(r_draft_b.json()["draft_id"])
+            r_submit_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_b_id}/submit", json={},
+            )
+            gate_b_id = uuid.UUID(r_submit_b.json()["gate_id"])
+        # B는 의도적으로 pending 그대로 둔다.
+
+        async with Session() as s:
+            rows = await list_channel_post_drafts(s, org_id=org_id)
+        gate_by_draft = {row[0].id: row[3] for row in rows}
+        gate_a_seen = gate_by_draft[draft_a_id]
+        gate_b_seen = gate_by_draft[draft_b_id]
+        assert gate_a_seen is not None and gate_a_seen.id == gate_a_id and gate_a_seen.status == "approved"
+        assert gate_b_seen is not None and gate_b_seen.id == gate_b_id and gate_b_seen.status == "pending"
+        assert gate_a_seen.id != gate_b_seen.id, "두 draft가 같은 게이트를 나눠 봤다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_same_draft_resubmit_still_allowed_no_regression():
     """AC3(회귀 없음) — 같은 draft를 다시 상신(예: 재승인 요청)하는 것은 그대로 허용된다
     (자기 자신은 "다른 초안"이 아니다)."""

--- a/backend/tests/test_3478_gate_scope_key.py
+++ b/backend/tests/test_3478_gate_scope_key.py
@@ -289,3 +289,109 @@ async def test_channel_post_two_connections_same_work_item_both_succeed():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hosted_site_publish_rejected_when_only_webhook_gate_approved():
+    """(5) 양성대조·핵심(카디르 REQUEST_CHANGES 2026-09-05) — `_resolve_approved_gate`
+    (hosted_site 전용 chokepoint)에 scope_key="" 필터가 없으면, 같은 work_item의
+    webhook 게이트(scope_key=connection_id)가 approved라는 사실만으로 hosted_site
+    발행(POST /site-posts)이 대신 통과해 버린다 — dual-destination을 가능케 한 이
+    스토리 자신의 목적(목적지별 독립 승인)을 스스로 뚫는 결함이었다. 뮤테이션 대상:
+    `_resolve_approved_gate`의 `Gate.scope_key == ""` 필터(쿼리·post-fetch 검증 둘
+    다)를 지우면 아래 403이 201로 바뀌어야 한다."""
+    from app.services.gate_service import transition_gate
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_wh = await _seed_webhook_connection(
+                s, org_id, target_url_builder=lambda cid: f"https://reject.example.com/deliver/{cid}",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_wh, gate_wh = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_wh, slug="reject-webhook",
+            )
+        async with Session() as s:
+            gate_row = await transition_gate(s, org_id, gate_wh, "approved", resolver_id=human_id)
+            await s.commit()
+            assert gate_row.status == "approved"
+
+        # hosted_site 발행(gate_id 생략 → fallback 조회 경로, scope_key="" 전용)을 같은
+        # work_item으로 시도 — webhook 게이트의 승인을 대신 통과시키면 안 된다. title·
+        # summary·tags·body_md를 webhook draft(_create_and_submit_site_post_draft
+        # 기본값: 제목/요약/본문, tags=[])와 **일부러 똑같이** 맞춘다 — scope_key 필터가
+        # 빠지면 그 게이트의 sealed_content_sha256과 해시가 일치해 봉인 재검증까지 통과,
+        # 즉 진짜로 201이 나야 이 뮤테이션이 무엇을 놓치는지가 명확해진다(해시가 달라
+        # 409로 떨어지면 "봉인 불일치"와 "목적지 오매칭"이 뒤섞여 이 pin이 흐려진다).
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_user_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json={
+                    "work_item_id": str(story_id), "title": "제목", "slug": "hosted-reject",
+                    "lang": "ko", "summary": "요약", "tags": [], "body_md": "본문",
+                },
+            )
+        assert r.status_code == 403, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_draft_list_shows_each_drafts_own_gate_not_the_others():
+    """(6) 양성대조 — 카디르 REQUEST_CHANGES(2026-09-05) — `list_site_post_drafts`의
+    게이트 배치 조회가 work_item_id만으로 키를 잡으면 같은 work_item의 draft A
+    (wordpress, approved)·B(webhook, pending)가 서로의 게이트 상태를 나눠 본다.
+    뮤테이션 대상: `gates_by_scope`를 다시 work_item_id만으로 keying하면 아래 두
+    assert 중 하나가 뒤바뀐 상태로 통과해 RED가 안 된다."""
+    from app.services.gate_service import transition_gate
+    from app.services.site_posts import list_site_post_drafts
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_wp = await _seed_wordpress_connection(s, org_id, site_url="https://list-a.example.com")
+            connection_wh = await _seed_webhook_connection(
+                s, org_id, target_url_builder=lambda cid: f"https://list-b.example.com/deliver/{cid}",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_a, gate_a = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_wp, slug="list-a",
+            )
+            draft_b, gate_b = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_wh, slug="list-b",
+            )
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_a, "approved", resolver_id=human_id)
+            await s.commit()
+        # B는 의도적으로 pending 그대로 둔다.
+
+        async with Session() as s:
+            rows = await list_site_post_drafts(s, org_id=org_id)
+        rows_by_draft = {draft.id: (gate, ) for draft, _latest, _origin, gate, _post in rows}
+        gate_a_seen = rows_by_draft[draft_a][0]
+        gate_b_seen = rows_by_draft[draft_b][0]
+        assert gate_a_seen is not None and gate_a_seen.id == gate_a and gate_a_seen.status == "approved"
+        assert gate_b_seen is not None and gate_b_seen.id == gate_b and gate_b_seen.status == "pending"
+        assert gate_a_seen.id != gate_b_seen.id, "두 draft가 같은 게이트를 나눠 봤다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3478_gate_scope_key.py
+++ b/backend/tests/test_3478_gate_scope_key.py
@@ -1,0 +1,291 @@
+"""story #3478(Phase1·마케팅운영·설계갭, 페드루 PO 決定 2026-09-05) — external_publish
+게이트 멱등 키에 `scope_key`(목적지) 축을 더한다. 그라운딩: `create_gate()`의 멱등키가
+`(work_item_id, work_item_type, gate_type)`뿐이라 site_post가 같은 원문을 WordPress+
+webhook 두 목적지로 상신·승인할 수 없었다(work_item당 1건) — channel_post도 100% 같은
+제약을 진 공유 설계(story #3404/f6d14476)라, 두 도메인 다 같은 규칙으로 고친다.
+
+세팅 헬퍼는 test_e4fc29fa_site_post_orchestration.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import (
+    _client_for,
+    _create_and_submit_site_post_draft,
+    _seed_agent,
+    _seed_default_role,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _seed_webhook_connection,
+    _seed_wordpress_connection,
+    _session_factory,
+    _setup_org_scoped_app,
+    live_wordpress_stub,  # noqa: F401 — pytest fixture import
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.mark.anyio
+async def test_same_work_item_two_destinations_both_submit_and_approve():
+    """(1) 양성대조·핵심 AC — 같은 work_item의 draft A(wordpress)·B(webhook) 둘 다
+    상신 200·승인 가능(서로 다른 게이트, scope_key로 격리). #3478 이전엔 B의 상신이
+    409 SITE_POST_GATE_ALREADY_HELD였다."""
+    from app.services.gate_service import transition_gate
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_wp = await _seed_wordpress_connection(s, org_id, site_url="https://a.example.com")
+            connection_wh = await _seed_webhook_connection(
+                s, org_id, target_url_builder=lambda cid: f"https://b.example.com/deliver/{cid}",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_a, gate_a = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_wp, slug="dual-a",
+            )
+            draft_b, gate_b = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_wh, slug="dual-b",
+            )
+        assert gate_a != gate_b, "다른 목적지인데 같은 게이트를 공유했다 — scope_key 축이 안 먹은 것"
+
+        async with Session() as s:
+            gate_a_row = await transition_gate(s, org_id, gate_a, "approved", resolver_id=human_id)
+            await s.commit()
+            assert gate_a_row.status == "approved"
+        async with Session() as s:
+            gate_b_row = await transition_gate(s, org_id, gate_b, "approved", resolver_id=human_id)
+            await s.commit()
+            assert gate_b_row.status == "approved", "A 승인이 B의 상신·승인을 막지 않아야 한다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_destination_second_slug_still_blocked_by_hold_guard():
+    """(2) 부정대조 — 같은 work_item·같은 connection(목적지 동일)으로 slug만 다른
+    draft 둘은 여전히 409로 막힌다(scope_key가 목적지 단위지 draft 단위가 아니다 —
+    "무제한 분산"이 아니라 f6d14476 가드 자체는 유지)."""
+    from app.services.gate_service import transition_gate
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_wordpress_connection(s, org_id, site_url="https://same.example.com")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_a, gate_a = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id, slug="same-dest-a",
+            )
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_a, "approved", resolver_id=human_id)
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r_draft_b = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json={
+                    "work_item_id": str(story_id), "title": "제목B", "slug": "same-dest-b",
+                    "lang": "ko", "summary": "요약", "tags": [], "body_md": "본문B", "media_manifest": [],
+                    "connection_id": str(connection_id),
+                },
+            )
+            assert r_draft_b.status_code == 201, r_draft_b.text
+            draft_b_id = r_draft_b.json()["draft_id"]
+            r_submit_b = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_b_id}/submit", json={})
+        assert r_submit_b.status_code == 409, r_submit_b.text
+        assert r_submit_b.json()["error"]["code"] == "SITE_POST_GATE_ALREADY_HELD"
+        assert r_submit_b.json()["error"]["holding_draft_id"] == str(draft_a)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublished_gate_releases_hold_for_resubmit_same_destination(live_wordpress_stub):
+    """(3) 페드루 決定③ — 발행 완료 뒤 회수(unpublish)하면 그 게이트는 더 이상 "쥐고
+    있다"로 안 본다. 같은 목적지로 다른 draft를 상신하면 200(재발행 자체는 그 draft의
+    새 승인이 원칙 — 옛 게이트를 재사용하지 않는다, 봉인 원칙 유지)."""
+    from app.services.gate_service import transition_gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.services.site_posts import request_site_post_external_unpublish
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_wordpress_connection(s, org_id, site_url=live_wordpress_stub)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_a, gate_a = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id, slug="release-a",
+            )
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_a, "approved", resolver_id=human_id)
+            await s.commit()
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        # draft B(같은 목적지) 상신 — A가 아직 "살아 있다"(unpublish 前)면 409.
+        async with _client_for(app) as client:
+            r_draft_b = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json={
+                    "work_item_id": str(story_id), "title": "제목B", "slug": "release-b",
+                    "lang": "ko", "summary": "요약", "tags": [], "body_md": "본문B", "media_manifest": [],
+                    "connection_id": str(connection_id),
+                },
+            )
+            draft_b_id = r_draft_b.json()["draft_id"]
+            r_submit_b_before = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_b_id}/submit", json={},
+            )
+        assert r_submit_b_before.status_code == 409, r_submit_b_before.text
+
+        # A를 회수(unpublish) — 워커까지 실행해 channel_publications.status를 실제로 바꾼다.
+        async with Session() as s:
+            await request_site_post_external_unpublish(
+                s, org_id=org_id, draft_id=draft_a, requested_by_member_id=human_id,
+            )
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        # 이제 B 상신은 200이어야 한다(A의 승인이 더 이상 "실려 있지" 않다).
+        async with _client_for(app) as client:
+            r_submit_b_after = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_b_id}/submit", json={},
+            )
+        assert r_submit_b_after.status_code == 200, r_submit_b_after.text
+        # 봉인 원칙 — 게이트 "행"은 create_gate()의 기존 멱등 관례대로 재사용될 수
+        # 있다(#3478이 그 관례를 안 바꾼다). 진짜 보장은 "옛 승인을 그대로 밀수출하지
+        # 않는다" — B의 상신이 새 pending 사이클을 열어야 한다(A의 approved를 그대로
+        # 재사용해 B가 무단으로 승인된 것처럼 보이면 안 된다).
+        assert r_submit_b_after.json()["status"] == "pending", (
+            "재상신이 A의 옛 approved 상태를 그대로 물려받았다 — 새 승인 사이클이 안 열린 것"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_channel_post_two_connections_same_work_item_both_succeed():
+    """(4) channel_post 회귀 — 같은 work_item·다른 connection 둘 다 상신 200(그라운딩
+    대조: channel_post도 site_post와 100% 같은 공유 설계, 드리프트 0으로 같이 해소).
+    channel_posts.py 쪽 전용 상세 테스트는 test_3404_channel_post_gate_already_held.py
+    ::test_second_draft_submit_different_connection_both_succeed가 이미 잰다 — 여기선
+    site_post·channel_post 교차 회귀(별개 도메인이 서로의 게이트에 안 닿는지)만 잰다."""
+    from app.services.gate_service import transition_gate
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_wp = await _seed_wordpress_connection(s, org_id, site_url="https://x.example.com")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_a, gate_a = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_wp, slug="cross-a",
+            )
+
+        # 같은 work_item에 channel_post(Threads) draft도 만들어 submit — site_post의
+        # 게이트를 안 건드려야 한다(다른 gate_type이라도 scope_key 축이 뒤섞이면 안 된다).
+        async with Session() as s:
+            from app.models.channel_connection import ChannelConnection
+            from app.services.channel_credential_crypto import encrypt_channel_credential
+
+            conn = ChannelConnection(
+                id=uuid.uuid4(), org_id=org_id, channel="threads", account_id="acct-cross",
+                status="active", credential_kind="oauth", refresh_mode="manual",
+                encrypted_access_token=encrypt_channel_credential("token-abc"),
+            )
+            s.add(conn)
+            await s.commit()
+            channel_conn_id = conn.id
+
+        async with _client_for(app) as client:
+            r_cp_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json={"work_item_id": str(story_id), "connection_id": str(channel_conn_id), "text": "채널포스트 본문"},
+            )
+            assert r_cp_draft.status_code == 201, r_cp_draft.text
+            cp_draft_id = r_cp_draft.json()["draft_id"]
+            r_cp_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{cp_draft_id}/submit", json={},
+            )
+        assert r_cp_submit.status_code == 200, r_cp_submit.text
+        cp_gate_id = uuid.UUID(r_cp_submit.json()["gate_id"])
+        assert cp_gate_id != gate_a, "site_post와 channel_post가 게이트를 공유했다"
+
+        async with Session() as s:
+            gate_a_row = await transition_gate(s, org_id, gate_a, "approved", resolver_id=human_id)
+            await s.commit()
+            assert gate_a_row.status == "approved", "channel_post 상신이 site_post 게이트를 건드렸다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e4fc29fa_destination_axis.py
+++ b/backend/tests/test_e4fc29fa_destination_axis.py
@@ -368,9 +368,12 @@ async def test_connection_id_social_channel_rejected_422():
 
 @pytest.mark.anyio
 async def test_destination_change_after_approval_reopens_gate_for_reapproval():
-    """AC(페드루 PO 지시) — 승인 뒤 connection_id만 바꿔도(본문 그대로) 게이트가
-    pending+reapproval_required로 되돌아간다(sealed_scheduled_at·sealed_media_sha256과
-    동형 축). sealed_content_*는 안 건드린다(기존 관례 재확인)."""
+    """story #3478 후속(카디르 REQUEST_CHANGES BLOCKER 1, 페드루 실측 2026-09-05로
+    불변식 갱신) — 승인 뒤 connection_id만 바꿔도(본문 그대로) 옛 목적지 게이트는
+    **voided**로 끝난다(최초 처방이던 pending+reapproval_required는 그 자체가 새
+    구멍이었다 — 결재자가 그 pending을 "정상 승인"해 버리면 옛 목적지용 승인으로
+    새 목적지에 발행되는 경로가 열린다, BLOCKER 1 참고). sealed_content_*는 안
+    건드린다(옛 승인 기록 보존 — voided라도 "무엇이 승인됐었나"는 지우지 않는다)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -406,9 +409,9 @@ async def test_destination_change_after_approval_reopens_gate_for_reapproval():
             from app.models.gate import Gate
             from sqlalchemy import select
             gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
-            assert gate.status == "pending"
-            assert gate.reapproval_required is True
+            assert gate.status == "voided"
             assert gate.sealed_destination_connection_id is None, "승인된 옛 봉인이 훼손됐다(재봉인은 submit() 재호출 몫)"
+            assert gate.resolution_note, "voided 사유가 안 남았다(사람이 결재함에서 볼 근거)"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -476,10 +479,239 @@ async def test_resubmit_destination_only_change_reseals_and_is_not_noop():
             )
 
             old_gate = (await s.execute(select(Gate).where(Gate.id == old_gate_id))).scalar_one()
-            assert old_gate.status != "approved", "옛(hosted_site) 게이트가 승인 안 됐는데도 approved로 보였다"
+            assert old_gate.status == "voided", "옛(hosted_site) 게이트가 destination 변경으로 voided 처리되지 않았다"
             assert old_gate.sealed_destination_connection_id is None, "옛 게이트가 새 목적지로 잘못 봉인됐다"
     finally:
         app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_destination_change_voided_gate_cannot_be_approved_into_wrong_publish():
+    """story #3478 후속(카디르 REQUEST_CHANGES ①, 페드루 실측 2026-09-05 재현 그대로) —
+    B가 W로 상신(G_W pending, 승인 안 함) → 본문 그대로 connection만 H로 바꾼 뒤 상신
+    (G_H pending) → 그 뒤 결재자가 G_W를 승인하려 하면 이미 voided라 illegal transition
+    (ValueError, 게이트 라우터에선 409 gate_already_resolved에 대응)으로 막힌다 — W용
+    승인으로 H에 발행되는 경로 자체가 구조적으로 안 열린다.
+
+    뮤테이션 자가검증: `_reseal_gate_on_new_version`의 void 분기를 임시로 비활성화하면
+    G_W가 pending인 채 남아 approve가 200으로 성공하고, 곧이어
+    `_maybe_create_scheduled_publication_command`가 destination=H로 명령을 만든다
+    (BLOCKER 1이 없으면 벌어지는 정확히 그 사고) — 이 시나리오는 별도로 아래에서
+    직접 재현해 RED를 확인한다(코드를 되돌리지 않고, 같은 로직을 인라인으로 그대로
+    복제해 대조)."""
+    from app.services.gate_service import transition_gate
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_w = await _seed_connection(s, org_id, account_id="w-site")
+            connection_h = await _seed_connection(s, org_id, account_id="h-site")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r1 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, body_md="본문 그대로", connection_id=connection_w),
+            )
+            draft_id = r1.json()["draft_id"]
+            r_submit_w = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit_w.status_code == 200, r_submit_w.text
+            gate_w_id = uuid.UUID(r_submit_w.json()["gate_id"])
+            # 승인 안 함 — 재현 조건 그대로(pending인 채 destination 변경).
+
+            r2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, body_md="본문 그대로", connection_id=connection_h),
+            )
+            assert r2.status_code == 201, r2.text
+            r_submit_h = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit_h.status_code == 200, r_submit_h.text
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+
+            gate_w = (await s.execute(select(Gate).where(Gate.id == gate_w_id))).scalar_one()
+            assert gate_w.status == "voided", "G_W가 destination 변경으로 voided되지 않았다"
+
+            with pytest.raises(ValueError, match="불법 전이"):
+                await transition_gate(s, org_id, gate_w_id, "approved", resolver_id=uuid.uuid4())
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_scope_mismatch_defense_blocks_command_creation_and_worker_publish():
+    """story #3478 후속(카디르 REQUEST_CHANGES ②, 페드루 실측 2026-09-05) — BLOCKER 1
+    (void 정리)이 정상 동작해도, 어떤 경로로든 gate.scope_key(승인된 목적지)와 draft의
+    **현재** connection_id가 어긋난 상태가 생기면(이 테스트처럼 억지로 그 조합을 만들어
+    격리 재현) 두 방어선이 각각 막는다: ① 승인 훅(`_maybe_create_scheduled_publication_
+    command`)이 명령을 안 만들고 note만 남긴다 ② 워커(`publish_site_post_external_
+    command`)가 설령 명령이 생겼더라도 adapter 호출 直前에 `EXTERNAL_PUBLISH_APPROVAL_
+    REQUIRED`로 막는다(연결 조회·adapter 코드에 아예 안 닿는다)."""
+    import uuid as uuid_mod
+
+    from app.models.gate import Gate
+    from app.models.publication_command import PublicationCommand
+    from app.models.site_post_draft import SitePostDraft
+    from app.models.site_post_version import SitePostVersion
+    from app.services.gate_service import _maybe_create_scheduled_publication_command
+    from app.services.site_posts import SitePostExternalPublishError, publish_site_post_external_command
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_w = await _seed_connection(s, org_id, account_id="mismatch-w")
+            connection_h = await _seed_connection(s, org_id, account_id="mismatch-h")
+
+            draft = SitePostDraft(
+                id=uuid_mod.uuid4(), org_id=org_id, work_item_id=story_id, slug="mismatch-post",
+                connection_id=connection_h,  # draft의 현재 목적지 = H
+            )
+            s.add(draft)
+            await s.flush()
+            version = SitePostVersion(
+                id=uuid_mod.uuid4(), draft_id=draft.id, version=1, title="제목", lang="ko",
+                summary="요약", tags=[], body_md="본문",
+                body_sha256="a" * 64, author_member_id=uuid_mod.uuid4(), author_kind="agent",
+            )
+            s.add(version)
+            await s.flush()
+            # 억지 조합 — scope_key(승인된 목적지) = W, draft의 현재 목적지 = H.
+            gate = Gate(
+                id=uuid_mod.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="external_publish", scope_key=str(connection_w), status="approved",
+                requires_human=True, sealed_content_sha256=version.body_sha256,
+                neutral_facts={"destination": "wordpress", "draft_id": str(draft.id)},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id, version_id = gate.id, version.id
+
+        # ① 승인 훅 — 명령 0건·note 기록.
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            await _maybe_create_scheduled_publication_command(s, gate, resolver_id=uuid_mod.uuid4())
+            await s.commit()
+        async with Session() as s:
+            commands = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == gate_id)
+            )).scalars().all()
+            assert commands == [], "scope_key 불일치인데도 publication_command가 만들어졌다"
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert gate.resolution_note, "불일치 사유가 안 남았다"
+
+        # ② 워커 — 명령이 (다른 경로로) 이미 있었다고 가정하고 직접 호출, adapter 호출 前 차단.
+        fake_command = PublicationCommand(
+            id=uuid_mod.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_h,
+            approved_version=version_id, operation="publish", content_kind="site_post",
+        )
+        async with Session() as s:
+            with pytest.raises(SitePostExternalPublishError) as exc_info:
+                await publish_site_post_external_command(s, fake_command)
+            assert exc_info.value.error_code == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_destination_change_only_touches_gate_held_by_this_draft():
+    """story #3478 후속(카디르 REQUEST_CHANGES REQUIRED 3, 페드루 실측 2026-09-05) —
+    옛 scope 게이트를 건드릴 조건은 `resolve_gate_holder_draft_id(...) is None`("막는
+    홀더 없음")이 아니라 「이 draft가 쥔 게이트」(neutral_facts.draft_id == 이 draft)
+    여야 한다. `resolve_gate_holder_draft_id`는 "자기 자신"뿐 아니라 "발행이 회수/
+    미배포라 더는 살아있지 않음"(`_gate_publication_is_live`=False)일 때도 None을
+    반환한다(story #3478 決定③) — 다른 draft A가 쥔 approved 게이트가 이 상태면,
+    A가 진짜로 쥐고 있는데도 "홀더 없음"으로 보여 옛(구현) 체크는 B의 destination
+    변경만으로 A의 게이트를 건드린다. 이 테스트는 그 정확한 함정(A의 게이트에 실패한
+    ChannelPublication을 하나 남겨 "안 살아있음"을 만든다)을 재현해 `_reseal_gate_
+    on_new_version`을 직접 호출·이 축만 격리해서 잰다."""
+    import uuid as uuid_mod
+
+    from app.models.channel_publication import ChannelPublication
+    from app.models.gate import Gate
+    from app.models.site_post_draft import SitePostDraft
+    from app.models.site_post_version import SitePostVersion
+    from app.services.site_posts import _reseal_gate_on_new_version
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_shared = await _seed_connection(s, org_id, account_id="shared-old-scope")
+            connection_new = await _seed_connection(s, org_id, account_id="b-new-dest")
+
+            draft_a = SitePostDraft(
+                id=uuid_mod.uuid4(), org_id=org_id, work_item_id=story_id, slug="draft-a",
+                connection_id=connection_shared,
+            )
+            draft_b = SitePostDraft(
+                id=uuid_mod.uuid4(), org_id=org_id, work_item_id=story_id, slug="draft-b",
+                connection_id=connection_new,  # B는 이미 새 목적지로 갱신된 뒤라고 가정.
+            )
+            s.add_all([draft_a, draft_b])
+            await s.flush()
+
+            # A가 «옛 scope»(shared)를 실제로 쥔 approved 게이트(neutral_facts.draft_id=A).
+            gate_a = Gate(
+                id=uuid_mod.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="external_publish", scope_key=str(connection_shared), status="approved",
+                requires_human=True, neutral_facts={"draft_id": str(draft_a.id)},
+            )
+            s.add(gate_a)
+            await s.flush()
+            # A의 발행이 실패해 「살아있지 않다」— _gate_publication_is_live(gate_a.id)를
+            # False로 만드는 유일한 방법(story #3478 決定③, resolve_gate_holder_draft_id
+            # docstring 참고). A가 진짜로 쥐고 있는데도 옛 체크는 이걸 "홀더 없음"으로 읽는다.
+            s.add(ChannelPublication(
+                id=uuid_mod.uuid4(), org_id=org_id, gate_id=gate_a.id, version_id=uuid_mod.uuid4(),
+                connection_id=connection_shared, channel="wordpress", status="failed",
+            ))
+
+            b_version = SitePostVersion(
+                id=uuid_mod.uuid4(), draft_id=draft_b.id, version=2, title="제목", lang="ko",
+                summary="요약", tags=[], body_md="본문 v2",
+                body_sha256="b" * 64, author_member_id=uuid_mod.uuid4(), author_kind="agent",
+            )
+            s.add(b_version)
+            await s.commit()
+            gate_a_id = gate_a.id
+
+        async with Session() as s:
+            draft_b_row = (await s.execute(
+                select(SitePostDraft).where(SitePostDraft.id == draft_b.id)
+            )).scalar_one()
+            version_row = (await s.execute(
+                select(SitePostVersion).where(SitePostVersion.id == b_version.id)
+            )).scalar_one()
+            # B가 old_connection_id=shared(A의 scope와 동일한 옛 값)에서 new=connection_new로
+            # 바뀌었다고 가정하고 훅을 직접 호출 — REQUIRED 3의 정확한 대상 시나리오.
+            await _reseal_gate_on_new_version(
+                s, org_id=org_id, work_item_id=story_id, version=version_row, draft=draft_b_row,
+                old_connection_id=connection_shared,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            gate_a_after = (await s.execute(select(Gate).where(Gate.id == gate_a_id))).scalar_one()
+            assert gate_a_after.status == "approved", "B의 destination 변경이 A가 쥔 게이트를 건드렸다"
+    finally:
         await engine.dispose()
 
 

--- a/backend/tests/test_e4fc29fa_destination_axis.py
+++ b/backend/tests/test_e4fc29fa_destination_axis.py
@@ -416,9 +416,15 @@ async def test_destination_change_after_approval_reopens_gate_for_reapproval():
 
 @pytest.mark.anyio
 async def test_resubmit_destination_only_change_reseals_and_is_not_noop():
-    """content는 동일해도 destination만 바뀌면 submit()의 sha 동일성 조기-return을
-    타면 안 된다(위 idempotency 조건에 destination 비교를 뺐으면 이 assert가 RED —
-    재봉인 없이 옛 destination이 그대로 남는다)."""
+    """story #3478 후속(카디르 REQUEST_CHANGES 경유 페드루 실측, 2026-09-05로 불변식
+    갱신) — content는 동일해도 destination이 바뀌면 그 자체가 새 scope_key라 재상신은
+    옛 게이트를 재사용하는 no-op이 아니라 **새 게이트**를 연다(옛 게이트는 그 목적지
+    에서 손 뗀 채 pending으로 남는다 — approved였다면 위 테스트처럼 reapproval_
+    required로 되돌아가지만, 여기선 애초에 approve 자체를 안 해 이미 pending이라
+    무변화가 곧 정답). 옛 gate_id를 그대로 재사용해 재봉인되길 기대하던 옛 pin은
+    #3478의 scope_key 축(같은 work_item·다른 목적지=다른 게이트) 자체와 모순이라
+    폐기 — 새 불변식(새 게이트 생성·그 게이트가 새 목적지로 봉인·옛 게이트 불변)으로
+    교체한다."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -441,7 +447,7 @@ async def test_resubmit_destination_only_change_reseals_and_is_not_noop():
                 f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
             )
             assert r_submit1.status_code == 200, r_submit1.text
-            gate_id = uuid.UUID(r_submit1.json()["gate_id"])
+            old_gate_id = uuid.UUID(r_submit1.json()["gate_id"])
 
             # content 그대로, connection_id만 값으로 지정(hosted_site→wordpress).
             r2 = await client.post(
@@ -454,14 +460,24 @@ async def test_resubmit_destination_only_change_reseals_and_is_not_noop():
                 f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
             )
             assert r_submit2.status_code == 200, r_submit2.text
+            new_gate_id = uuid.UUID(r_submit2.json()["gate_id"])
+            assert new_gate_id != old_gate_id, (
+                "destination만 바뀐 재상신이 옛 게이트를 그대로 재사용했다 — no-op으로 흡수된 것"
+            )
 
         async with Session() as s:
             from app.models.gate import Gate
             from sqlalchemy import select
-            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
-            assert gate.sealed_destination_connection_id == connection_id, (
-                "destination만 바뀐 재상신이 재봉인되지 않았다(옛 destination이 그대로 남음)"
+
+            new_gate = (await s.execute(select(Gate).where(Gate.id == new_gate_id))).scalar_one()
+            assert new_gate.status == "pending"
+            assert new_gate.sealed_destination_connection_id == connection_id, (
+                "새 목적지 게이트가 그 목적지로 안 봉인됐다"
             )
+
+            old_gate = (await s.execute(select(Gate).where(Gate.id == old_gate_id))).scalar_one()
+            assert old_gate.status != "approved", "옛(hosted_site) 게이트가 승인 안 됐는데도 approved로 보였다"
+            assert old_gate.sealed_destination_connection_id is None, "옛 게이트가 새 목적지로 잘못 봉인됐다"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_e4fc29fa_destination_axis.py
+++ b/backend/tests/test_e4fc29fa_destination_axis.py
@@ -494,12 +494,10 @@ async def test_destination_change_voided_gate_cannot_be_approved_into_wrong_publ
     (ValueError, 게이트 라우터에선 409 gate_already_resolved에 대응)으로 막힌다 — W용
     승인으로 H에 발행되는 경로 자체가 구조적으로 안 열린다.
 
-    뮤테이션 자가검증: `_reseal_gate_on_new_version`의 void 분기를 임시로 비활성화하면
-    G_W가 pending인 채 남아 approve가 200으로 성공하고, 곧이어
-    `_maybe_create_scheduled_publication_command`가 destination=H로 명령을 만든다
-    (BLOCKER 1이 없으면 벌어지는 정확히 그 사고) — 이 시나리오는 별도로 아래에서
-    직접 재현해 RED를 확인한다(코드를 되돌리지 않고, 같은 로직을 인라인으로 그대로
-    복제해 대조)."""
+    뮤테이션 자가검증(실제 방법 — PR 본문과 동일하게 정정) — `_reseal_gate_on_new_
+    version`의 void 분기(`if old_scope_key is not None and ...:`)를 `if False and ...`
+    로 임시 비활성화하고 이 파일 전체를 재실행 : 이 테스트를 포함해 3건이 RED로
+    재현됨을 직접 확인한 뒤 원본으로 복원했다(별도의 인라인 복제 로직은 쓰지 않았다)."""
     from app.services.gate_service import transition_gate
     from app.main import app
 
@@ -712,6 +710,101 @@ async def test_destination_change_only_touches_gate_held_by_this_draft():
             gate_a_after = (await s.execute(select(Gate).where(Gate.id == gate_a_id))).scalar_one()
             assert gate_a_after.status == "approved", "B의 destination 변경이 A가 쥔 게이트를 건드렸다"
     finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_destination_round_trip_revives_voided_gate_row():
+    """story #3478 후속(페드루 REQUIRED, 2026-09-05) — 「돌아오는 길」 계약. W→H로
+    바꾸면(위 테스트들) 옛 W 게이트가 voided된다 — 그 뒤 다시 H→W로 바꿔 재상신하면
+    **같은 게이트 행(id 불변)이 되살아나야** 한다(새 행을 새로 만들지 않는다).
+
+    이 계약은 다른 모듈의 암묵 전제 위에 서 있다 — `find_gate_slot_with_pr_fallback`
+    가 status 필터 없이 조회하고, `create_gate()`가 rejected가 아니면 그 행을 그대로
+    반환하며, `submit_site_post_draft()`의 "status != pending"이면 되돌리는 분기가
+    pending 복귀+재봉인+`reapproval_required=False`까지 처리한다는 전제. 이 셋 중
+    하나라도 나중에 "voided도 걸러내자"며 status 필터를 넣으면 이 되살아나는 경로가
+    조용히 깨진다 — 이 테스트가 그 자리를 지키는 가드."""
+    from app.services.gate_service import transition_gate
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_w = await _seed_connection(s, org_id, account_id="roundtrip-w")
+            connection_h = await _seed_connection(s, org_id, account_id="roundtrip-h")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r1 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, body_md="본문 v1", connection_id=connection_w),
+            )
+            draft_id = r1.json()["draft_id"]
+            r_submit_w1 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit_w1.status_code == 200, r_submit_w1.text
+            gate_w_id = uuid.UUID(r_submit_w1.json()["gate_id"])
+
+            # W → H (옛 W 게이트가 voided된다 — 위 테스트들과 동일 경로).
+            r2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, body_md="본문 v2", connection_id=connection_h),
+            )
+            assert r2.status_code == 201, r2.text
+            r_submit_h = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit_h.status_code == 200, r_submit_h.text
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate_w_voided = (await s.execute(select(Gate).where(Gate.id == gate_w_id))).scalar_one()
+            assert gate_w_voided.status == "voided", "그라운딩 전제(W→H가 W를 voided)가 깨졌다"
+
+        # H → W (돌아오는 길) — 본문도 바꿔서 재봉인이 최신 버전을 실제로 반영하는지까지 잰다.
+        async with _client_for(app) as client:
+            r3 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, body_md="본문 v3(돌아온 뒤)", connection_id=connection_w),
+            )
+            assert r3.status_code == 201, r3.text
+            r_submit_w2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit_w2.status_code == 200, r_submit_w2.text
+            revived_gate_id = uuid.UUID(r_submit_w2.json()["gate_id"])
+
+        assert revived_gate_id == gate_w_id, "돌아오는 길이 새 게이트 행을 만들었다 — 같은 행 재사용 계약이 깨진 것"
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from app.models.site_post_version import SitePostVersion
+            from sqlalchemy import select
+
+            revived = (await s.execute(select(Gate).where(Gate.id == revived_gate_id))).scalar_one()
+            assert revived.status == "pending"
+            assert revived.sealed_destination_connection_id == connection_w
+            assert revived.reapproval_required is False
+            latest_version = (await s.execute(
+                select(SitePostVersion)
+                .where(SitePostVersion.draft_id == draft_id)
+                .order_by(SitePostVersion.version.desc())
+                .limit(1)
+            )).scalar_one()
+            assert revived.sealed_content_sha256 == latest_version.body_sha256, "재봉인이 최신 버전을 안 반영했다"
+
+            approved = await transition_gate(s, org_id, revived_gate_id, "approved", resolver_id=uuid.uuid4())
+            await s.commit()
+            assert approved.status == "approved", "되살아난 게이트가 정상 승인 전이를 못 탔다"
+    finally:
+        app.dependency_overrides.clear()
         await engine.dispose()
 
 

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1166,6 +1166,11 @@
       "file": "tests/test_3474_publication_attempts.py",
       "sec": 55.0,
       "source": "story-3474-worker-approval-reverify-attempts(PR 개설 前 선제 등재 — 페드루 리뷰 보정①(unpublish 부정대조 추가) 반영 후 로컬 raw pytest 4건 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 55s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3478_gate_scope_key.py",
+      "sec": 40.0,
+      "source": "story-3478-gate-scope-key(PR 개설 前 선제 등재 — 로컬 raw pytest 6.51s 실측치(4 tests)를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
[SID:3478]

## Summary
- 그라운딩(런북 B-3 실측) — `create_gate()`의 멱등 키가 `(work_item_id, work_item_type, gate_type[, pr_number[, repo_full_name]])`뿐, connection/draft 축이 아예 없었다. `resolve_gate_holder_draft_id`(story #3404)가 이 사실을 channel_post·site_post 양쪽에 공용으로 미러하는 함수라, site_post가 같은 원문을 WordPress+webhook 두 목적지로 상신·승인할 수 없는 문제는 site_post 국소 결함이 아니라 이 공유 identity 자체의 한계였다(channel_post도 100% 동일 제약).
- `gate.scope_key TEXT NOT NULL DEFAULT ''` 신설(migration 0328) — 세 UNIQUE 인덱스 전부(no_pr·pr_repo·pr_no_repo) 재정의. 기존 모든 gate_type(merge·HITL ask·doc approval 등)은 이 컬럼이 항상 `''`라 회귀 0(구분력 무변).
- `external_publish`만 site_posts.py·channel_posts.py 13개 호출부(전수 grep 대조) 전부 `scope_key = str(draft.connection_id or "")`를 넘긴다 — 같은 work_item의 여러 draft/목적지가 독립 게이트를 갖는다.
- `resolve_gate_holder_draft_id`가 async+`db` 파라미터로 바뀌어(페드루 決定③) approved인데 그 발행이 회수(unpublish)됐거나 아직 최초 발행 前이 아닌(한 번 발행됐다가 지금은 안 살아있는) 경우 더 이상 "쥐고 있다"로 안 본다(`ChannelPublication.status=="published"` 또는 `SitePost.unpublished_at IS NULL`로 판정).

## 후속 커밋 — 카디르 REQUEST_CHANGES(2026-09-05) 「읽는 쪽」 보정
최초 대조는 "쓰는 쪽"(create_gate 등 13곳)만 세고 "읽는 쪽"을 안 봤다 — scope_key 도입으로 같은 work_item에 게이트가 여럿 사는 게 정상이 되면서, 그 게이트를 다시 읽는 쪽이 scope_key 없이 `work_item_id`만으로 조회하면 엉뚱한 게이트를 집을 수 있는 자리가 3곳 남아 있었다(이 스토리 자신의 목적을 스스로 뚫을 뻔한 지점).

`external_publish` 단건/배치 `select(Gate)` 전수(6곳, `grep -n "select(Gate)" app/services/site_posts.py app/services/channel_posts.py`):

| # | 파일:행 | 함수 | scope_key(수정 전) | scope_key(수정 후) |
|---|---|---|---|---|
| 1 | site_posts.py:182 | `_resolve_approved_gate`(gate_id 지정 분기) | 없음 | post-fetch 검증 추가: `gate.scope_key != ""`이면 거부 |
| 2 | site_posts.py:197 | `_resolve_approved_gate`(fallback 조회) | 없음 | 쿼리에 `Gate.scope_key == ""` 추가 |
| 3 | site_posts.py:454 | `_reseal_gate_on_new_version` | 이미 있음(`== str(draft.connection_id or "")`) | 무변 |
| 4 | site_posts.py:603 | `list_site_post_drafts` 배치②(`gates_by_work_item`→`gates_by_scope`) | work_item_id만 키 | `(work_item_id, scope_key)` 키로 교체 |
| 5 | channel_posts.py:536 | `_reseal_gate_on_new_version`(channel 버전) | 이미 있음(`== scope_key`) | 무변 |
| 6 | channel_posts.py:773 | `list_channel_post_drafts` 배치②(단건 조회 `GET .../drafts/{draft_id}`도 이 함수 재사용) | work_item_id만 키 | `(work_item_id, scope_key)` 키로 교체 |

6곳 중 4곳(#1·#2·#4·#6) 수정, 2곳(#3·#5)은 최초 커밋에서 이미 처리돼 있었다.

구체적으로 뚫렸던 경로: `_resolve_approved_gate`(hosted_site 전용 chokepoint, scope_key 항상 `""`)가 필터 없이 "이 work_item의 가장 최근 approved 게이트"를 집었다 — 같은 work_item에 webhook용 approved 게이트(scope_key=connection_id)가 있으면 hosted_site 발행(`POST /site-posts`)이 그 승인을 대신 통과시켰다(dual-destination을 가능케 한 이 스토리 자체가 만든 새 회귀).

### 테스트(양성대조 4건 신규, 전부 뮤테이션 자가검증 — 수정을 임시로 되돌려 RED 재현 확인 후 복원)
- `test_hosted_site_publish_rejected_when_only_webhook_gate_approved` — webhook 게이트만 approved인 상태에서 hosted_site 발행 시도 → 403(옛 코드로 되돌리면 201로 통과 — 직접 재현 확인).
- `test_draft_list_shows_each_drafts_own_gate_not_the_others`(site_posts) — 같은 work_item의 draft A(approved)·B(pending)가 목록에서 각자 자기 게이트만 본다(옛 코드로 되돌리면 assert 실패 재현 확인).
- `test_draft_list_shows_each_drafts_own_gate_not_the_others`(channel_posts, test_3404 파일에 추가) — 위와 동형.
- (교차 도메인·기본 4건은 최초 커밋 그대로 유지, 재검증 완료.)

~~무관 사전 실패 확인 — `test_e4fc29fa_destination_axis.py`의 2건은 3e6b9d390에서도 동일 재현해 스코프 밖으로 판단했다.~~ **정정(페드루, 2026-09-05)** — 스코프 밖이 아니라 이 PR이 만든 정확히 그 결함이었다. 아래 별도 섹션 참조.

### 3번째 커밋 — destination 변경 시 옛 scope 게이트 방치(3ee55a847)
디디의 "무관 사전 실패" 판정이 틀렸다 — `git stash` 대조가 "이 브랜치의 diff가 원인이 아니다"만 보였지, "#3478의 scope_key 설계 자체가 이 시나리오를 새로 깨뜨렸다"는 사실을 못 봤다(비교 대상이 develop이 아니라 이 PR의 *이전 커밋*이었어야 한다는 뜻이 아니라, "재현=범위 밖"이라는 추론 자체가 성급했다 — 실제로는 그 실패가 **바로 이 PR의 scope_key 도입이 낳은 부작용**이었다).

문제: destination(connection_id)이 바뀐 재상신은 새 scope_key라 새 게이트를 여는 게 AC 자체지만, **옛 scope_key 게이트**는 그 사실을 모른 채(새 scope 조회에 안 걸림) 그대로 남았다 — approved였다면 목적지를 잃은 채 승인 상태로 살아있고(봉인 원칙 위반), 발행 행이 0이라 `_gate_publication_is_live`가 "쥐고 있다"로 보수 판정해 같은 목적지로의 재상신이 영구 409(f6d14476이 없애려던 것의 사촌)로 막혔다.

수정 — `site_posts.py::create_site_post_draft_version`이 기존 draft 갱신 분기에서 connection_id를 덮어쓰기 전 `old_connection_id`를 캡처(`_NO_PRIOR_VERSION` 센티널로 "브랜드 뉴 draft"와 구분) → `_reseal_gate_on_new_version`이 `old_scope_key != new_scope_key`면 옛 scope의 approved 게이트를(다른 draft가 쥐고 있지 않을 때만, f6d14476 가드 재사용) pending+reapproval_required로 되돌린다. `sealed_content_*`는 안 건드림(옛 승인 기록 보존). pending이었으면 손대지 않음(이 새 버전은 그 목적지로 안 가므로 재봉인 근거가 없다 — 다음 submit()이 새 scope_key로 별도 게이트를 연다).

`test_e4fc29fa_destination_axis.py` 2건:
- `test_destination_change_after_approval_reopens_gate_for_reapproval` — 그대로 통과(옛 불변식이 이 픽스의 정확한 목표).
- `test_resubmit_destination_only_change_reseals_and_is_not_noop` — 옛 gate_id가 새 destination으로 재봉인되길 기대하던 pin은 #3478의 scope_key 축(같은 work_item·다른 목적지=다른 게이트) 자체와 모순이라 폐기 → 새 게이트 생성·새 게이트가 새 목적지로 봉인·옛 게이트 불변(approved 아님)이라는 새 불변식으로 교체(페드루 지시 그대로).

뮤테이션 자가검증 — old-gate reopen 분기를 임시로 비활성화해 `test_destination_change...`가 RED 재현되는 것 확인 후 복원. 광범위 회귀(`-k "site_post or e4fc29fa or 3478 or 3404"`) 108/108 green.

### 4번째 커밋 — 카디르 REQUEST_CHANGES: void가 정답, 방어선 2겹, 홀더 조건 정정(a93afe050)
카디르가 코드를 직접 읽고 3번째 커밋 자체가 새 구멍이라고 짚었다 — pending+reapproval_required로 두면 결재자가 그 pending을 "정상 승인"할 수 있고, `_maybe_create_scheduled_publication_command`가 draft의 **현재** connection_id(이미 새 목적지)로 명령을 만든다 — 「옛 목적지용 승인으로 새 목적지에 발행」이 되어 3478의 목적을 스스로 뚫는다.

**BLOCKER 1** — `_reseal_gate_on_new_version`이 옛 scope 게이트를 pending 재오픈 대신 **voided**로 끝낸다(`set_gate_status` 직접 호출 — `transition_gate`의 사람-결재 FSM 우회, `reopen_gate_if_new_sha`와 동형인 "시스템 경로". `_VALID_TRANSITIONS`엔 approved→voided가 없지만 이건 애초에 사람 결재가 아니라 시스템 판정이라 그 FSM 밖). 그 목적지로 다시 상신하면 `find_gate_slot_with_pr_fallback`(status 필터 없음)이 이 voided 행을 그대로 돌려주고 `create_gate()`(rejected 아니면 재사용)가 이어받으며, `submit_site_post_draft()`의 기존 "status != pending"이면 되돌리는 분기가 pending 복귀+재봉인+`reapproval_required=False`까지 이미 처리한다(신규 코드 불요 — 정확히 이 상황을 위해 이미 있던 재사용 경로).

**BLOCKER 2(방어선 2겹)** — ① `gate_service.py::_maybe_create_scheduled_publication_command`가 `gate.scope_key`와 `site_draft.connection_id`(명령이 실제로 향할 목적지) 불일치 시 명령 생성을 건너뛰고 note를 남긴다(`_mark_unresolved`와 동형 패턴) ② `site_posts.py::publish_site_post_external_command`(워커)가 어댑터 호출 直前에 같은 불일치를 `EXTERNAL_PUBLISH_APPROVAL_REQUIRED`로 막는다(재시도 대상 아님). BLOCKER 1이 정상 동작해도 경합 등 어떤 경로로든 불일치가 남을 가능성에 대한 belt-and-suspenders.

**REQUIRED 3** — 옛 게이트를 건드릴 조건을 `resolve_gate_holder_draft_id(...) is None`("막는 홀더 없음" — 자기 자신·회수 상태 등 여러 이유로 None이 나옴)에서 `(old_gate.neutral_facts or {}).get("draft_id") == str(version.draft_id)`("내가 쥔 게이트")로 교체. 다른 draft A가 쥔 approved 게이트가 발행 회수로 `_gate_publication_is_live`=False가 되면(story #3478 決定③) 옛 체크는 "홀더 없음"(None)으로 읽어 B의 destination 변경만으로 A의 게이트를 잘못 건드릴 수 있었다.

`test_e4fc29fa_destination_axis.py`:
- 기존 2건 불변식을 voided로 갱신(pending+reapproval_required → voided·resolution_note 존재).
- 신규 3건: `test_destination_change_voided_gate_cannot_be_approved_into_wrong_publish`(카디르 재현 1~3 그대로 — G_W voided라 approve가 illegal transition으로 막힘) · `test_scope_mismatch_defense_blocks_command_creation_and_worker_publish`(scope_key/connection_id 억지 불일치 조합 — 명령 0건+note, 워커가 adapter 호출 前 차단) · `test_destination_change_only_touches_gate_held_by_this_draft`(다른 draft가 쥔 「발행 회수」 게이트는 안 건드림 — `ChannelPublication(status="failed")`로 `_gate_publication_is_live=False` 재현, REQUIRED 3의 정확한 위험 시나리오).

뮤테이션 자가검증 4건 — BLOCKER 1(void 분기 `if False and ...`로 비활성화)·REQUIRED 3(옛 홀더체크로 되돌림)·BLOCKER 2 gate_service.py측(체크 제거)·BLOCKER 2 워커측(체크 제거) 각각 분기를 임시로 되돌려 대응 테스트만 RED 재현 확인 후 복원. **정정** — 테스트 A(`test_destination_change_voided_gate_cannot_be_approved_into_wrong_publish`)의 최초 docstring이 "인라인 복제 대조"라고 잘못 적었다(실제로는 BLOCKER 1과 같은 방법 — 파일 전체를 대상으로 void 분기를 `if False and ...`로 비활성화 → 3건 RED 재현 확인 → 복원). 5번째 커밋에서 docstring을 실제 방법으로 교정.

광범위 회귀(`-k "site_post or e4fc29fa or 3478 or 3404 or 3443"`) 109/111 green — 나머지 2건은 격리 재실행 시 green(대형 배치 누적 wall-time에 의한 pytest-timeout 30s 경계 flake, diff와 무관 확인). 카디르군 재QA 대조용 정확한 이름:
- `tests/test_3360_site_posts.py::test_post_with_unapproved_gate_returns_403_and_creates_zero_rows`
- `tests/test_3360_site_posts.py::test_agent_publish_returns_403_site_post_publish_human_only_even_with_approved_gate`

### 5번째 커밋 — 「돌아오는 길」 계약 pin(5a4885b9e)
페드루 REQUIRED(2026-09-05) — W→H(옛 W voided) 뒤 다시 H→W로 재상신하면 **같은 게이트 행(id 불변)**이 되살아나야 한다는 계약(`test_destination_round_trip_revives_voided_gate_row` 신규): status pending·sealed_destination=W·sealed sha=최신 버전·`reapproval_required=False`·정상 approve 전이(200)까지. 이 계약은 `find_gate_slot_with_pr_fallback`(status 필터 없음)→`create_gate()`(rejected 아니면 재사용)→`submit_site_post_draft()`(status≠pending이면 되돌리는 분기)라는 다른 모듈들의 암묵 전제 위에 서 있어, 누가 나중에 "voided도 걸러내자"며 필터를 넣으면 조용히 깨진다 — 뮤테이션 자가검증(`find_gate_slot_with_pr_fallback`의 no-PR-context 조회에 `Gate.status != "voided"` 임시 추가 → RED 재현 → 복원)으로 확인. 전체 스위트 15/15 green.

### 페드루 전수 확認 후 남은 1줄 — `gate_service.py:2097`
`_resolve_pending_gate_from_verdict`(§verdict 포착→pending 게이트 해소)의 `Gate.work_item_id ==` 조회는 `_SOURCE_TO_GATE_TYPE`(gate_service.py:193-198, `{"pr":"pr_review","ci":"pr_review","qa":"qa","design":"deploy"}`)로 얻은 `gate_type`만 쓴다 — 이 맵의 값 어디에도 `"external_publish"`가 없어(pr_review·qa·deploy 셋뿐) `gate_type`이 `"external_publish"`가 될 수 없다. 즉 이 함수는 구조적으로 external_publish 게이트를 절대 조회하지 않는다 — **무관, scope_key 불요**. (events.py:1355는 별도 언급대로 #3487 몫.)

## Test plan
- [x] `tests/test_3478_gate_scope_key.py` 6건(신규 4·기존 2): 같은 work_item 다른 목적지 둘 다 200(핵심 AC) · 같은 목적지 다른 slug는 여전히 409(가드 유지, 무제한 분산 아님) · 회수 뒤 재상신은 새 pending 사이클(옛 approved 안 물려받음) · channel_post 교차 회귀(site_post 게이트에 안 닿음) · hosted_site가 webhook 승인을 대신 통과 못 함(신규) · 목록이 draft별 자기 게이트만 봄(신규).
- [x] 기존 `test_3404_channel_post_gate_already_held.py`의 "다른 connection 차단" pin을 새 의도(둘 다 200)로 갱신 — 이게 정확히 #3478의 AC였다. + 목록 격리 신규 1건.
- [x] 회귀(신선 disposable Postgres·alembic upgrade head): 위 12건 + `test_3474_publication_attempts.py`·`test_3414_publication_command.py`·`test_f8f7cb0f_channel_post_publish.py`·`test_f6d14476_gate_already_held.py`·`test_e4fc29fa_site_post_orchestration.py`·`test_3476_publish_read_surface.py`·`test_3367_site_post_submit_gate_seal.py` 전부 green.
- [x] 광범위 sweep — `-k "site_post or channel_post or e4fc29fa"` 184 passed(무관 사전 실패 2건 제외, 위 표에 근거 문서화).
- [x] 별도로 gate 관련 파일 113개(merge/HITL/doc approval/workflow_parallel_approval 등 `create_gate`/`find_gate_slot_with_pr_fallback`/`resolve_gate_holder_draft_id`의 나머지 40여 호출부 전부 커버) 전수 스윕 — 497 passed(그 외 gate_type들 회귀 0 確認, scope_key 기본값 ""가 실제로 무해함을 광범위하게 증명).
- [x] 마이그레이션 0328 real Postgres 왕복 검증(upgrade/downgrade 둘 다).
- [x] `scripts/lint_destructive_schema_weights_registered.py` — 신규 테스트 파일 등재 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




