### PR TITLE
[SID:3487] feat: external_publish 게이트 승인 통지 문구를 실동작으로

### DIFF
--- a/backend/alembic/versions/0330_preset_gate_verdict_gate_id_field.py
+++ b/backend/alembic/versions/0330_preset_gate_verdict_gate_id_field.py
@@ -1,0 +1,104 @@
+"""story #3487(Phase1·마케팅운영·소형, 페드루 PO 決定 2026-09-05) — preset.gate.verdict
+payload_schema에 gate_id(선택) 필드를 연다.
+
+[[no-pr-for-data]] 게이트 — 프리셋 표현/스키마 변경(0251/0301/0303/0309 선례와 동일 규칙,
+병합 전 선생님 확認 필요할 수 있음).
+
+배경(페드루 PO 決定, 2026-09-05) — story #3478(gate.scope_key)이 착지하면 같은 work_item
+에 목적지가 다른 external_publish 게이트가 둘 이상 있을 수 있다. `_render_gate_verdict_
+message`(events.py)의 기존 게이트 재조회(`(org_id, work_item_id, work_item_type,
+gate_type, status==verdict)` + `order_by(resolved_at desc).limit(1)`)는 그런 상황에서
+"가장 최근 resolved"인 게이트 하나만 골라 그 문맥(draft_id·목적지)을 보여준다 — 지금
+막 승인/반려된 그 게이트가 아니라 다른 게이트의 정보가 섞일 수 있다. 이벤트가 판정된
+그 gate_id를 직접 들고 오면 렌더가 그 행만 정확히 읽을 수 있다(재조회 자체가 불요해진다).
+
+payload_schema는 `additionalProperties: false`라 이 필드가 스키마에 없으면 발행 자체가
+422로 거부된다 — 0303/0309 선례와 동일한 additive-only 변경(선택 필드, required엔
+안 넣는다 — 이 발행 호출부는 항상 채우지만, 스키마 자체는 과거 이력 호환을 위해
+필수로 강제하지 않는다).
+
+Revision ID: 0330
+Revises: 0329
+Create Date: 2026-09-05
+
+⚠️번호 재부여 — 최초 0329로 열었으나 미르코군 #3836(story #3475, 발행 계측 API)이
+같은 번호를 먼저 잡아(페드루 PO 조정으로 0329는 #3836 소유) 0330으로 재부여했다
+(0309 선례와 동형 사고 — 도메인이 달라 순서 자체는 무의미, 체인만 선형으로 맞춘다)."""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0330"
+down_revision = "0329"
+branch_labels = None
+depends_on = None
+
+_KEY = "preset.gate.verdict"
+
+# 0309 이후 현행 그대로(무손실 보존, 0301/0303/0309와 동일 스타일 — 전체 리터럴 교체로
+# 드리프트 방지).
+_OLD_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "gate_type", "verdict"],
+    "properties": {
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "work_item_title": {"type": ["string", "null"]},
+        "gate_type": {"type": "string"},
+        "verdict": {"type": "string", "enum": ["approved", "rejected"]},
+        "resolver_member_id": {"type": "string", "format": "uuid"},
+        "resolution_note": {"type": ["string", "null"]},
+        "gate_requester_member_id": {"type": "string", "format": "uuid"},
+        "gate_draft_author_member_id": {"type": "string", "format": "uuid"},
+    },
+}
+
+_NEW_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "gate_type", "verdict"],
+    "properties": {
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "work_item_title": {"type": ["string", "null"]},
+        "gate_type": {"type": "string"},
+        "verdict": {"type": "string", "enum": ["approved", "rejected"]},
+        "resolver_member_id": {"type": "string", "format": "uuid"},
+        "resolution_note": {"type": ["string", "null"]},
+        "gate_requester_member_id": {"type": "string", "format": "uuid"},
+        "gate_draft_author_member_id": {"type": "string", "format": "uuid"},
+        # story #3487 — 선택 필드(required엔 안 넣는다, 0303/0309와 동일 원칙). 판정된
+        # 그 gate 행을 정확히 재조회하기 위한 축(story #3478 dual-destination 이후
+        # (work_item, gate_type)만으로는 게이트가 더 이상 유일하지 않다).
+        "gate_id": {"type": "string", "format": "uuid"},
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE event_definitions "
+            "SET payload_schema = :payload_schema, version = version + 1 "
+            "WHERE org_id IS NULL AND key = :key"
+        ),
+        {"payload_schema": json.dumps(_NEW_PAYLOAD_SCHEMA), "key": _KEY},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE event_definitions "
+            "SET payload_schema = :payload_schema, version = version - 1 "
+            "WHERE org_id IS NULL AND key = :key"
+        ),
+        {"payload_schema": json.dumps(_OLD_PAYLOAD_SCHEMA), "key": _KEY},
+    )

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1318,14 +1318,27 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
 
     draft_doc_ref: str | None = None
     draft_id: str | None = None
+    # story #3487(0329) — payload에 gate_id가 있으면(이 함수의 유일한 발행부는 항상
+    # 채운다) 그 행만 정확히 읽는다. story #3478(gate.scope_key) 이후 같은 work_item에
+    # 목적지가 다른 external_publish 게이트가 둘 이상일 수 있어, 아래 (work_item_id,
+    # gate_type, status) 재조회+`order_by(resolved_at desc).limit(1)`는 "가장 최근
+    # resolved"인 게이트를 고르는 것이지 "지금 이 이벤트가 말하는" 그 게이트가 아니다
+    # — 옛 payload(gate_id 없음, 레거시 큐 재생 등)에 대한 하위호환 폴백으로만 유지.
+    gate_id_raw = payload.get("gate_id")
     if work_item_type and work_item_id is not None and gate_type:
-        gate_row = (await db.execute(
-            select(Gate).where(
-                Gate.org_id == org_id, Gate.work_item_id == work_item_id,
-                Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
-                Gate.status == verdict,
-            ).order_by(Gate.resolved_at.desc()).limit(1)
-        )).scalar_one_or_none()
+        if gate_id_raw:
+            try:
+                gate_row = await db.get(Gate, uuid.UUID(str(gate_id_raw)))
+            except (ValueError, TypeError, AttributeError):
+                gate_row = None
+        else:
+            gate_row = (await db.execute(
+                select(Gate).where(
+                    Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+                    Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
+                    Gate.status == verdict,
+                ).order_by(Gate.resolved_at.desc()).limit(1)
+            )).scalar_one_or_none()
         if gate_row is not None:
             facts = gate_row.neutral_facts or {}
             token = facts.get("draft_doc_reference_token")
@@ -1355,7 +1368,34 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
     # 없앤다).
     if gate_type == "external_publish":
         if verdict == "approved":
-            lines.append("- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.")
+            # story #3487(PO 실측 2026-09-05) — 옛 문구("발행은 휴먼이 화면에서 합니다")는
+            # site_post(외부 목적지·hosted_site 공통)의 실동작과 어긋난다: 승인 훅이
+            # publication_command를 즉시 만들고 **다음 워커 tick(최대 1분)이 어댑터를
+            # 호출**한다 — 휴먼 화면의 발행 버튼은 이미 completed된 command를 멱등
+            # 반환할 뿐(회수만 화면 액션이 실제로 필요). channel_post(예약 상신)는
+            # scheduled_at 시각에 발행되는 게 이미 맞는 문구라 무변(회귀 pin, AC2).
+            # draft_id가 site_post_drafts에 있는지로 도메인을 가른다 — destination
+            # 문자열(hosted_site/wordpress/webhook vs threads)에 기대는 것보다
+            # 채널 목록이 늘어나도 안 깨지는 축이다.
+            is_site_post = False
+            if draft_id:
+                try:
+                    draft_uuid = uuid.UUID(draft_id)
+                except (ValueError, TypeError, AttributeError):
+                    draft_uuid = None
+                if draft_uuid is not None:
+                    from app.models.site_post_draft import SitePostDraft
+                    is_site_post = (await db.execute(
+                        select(SitePostDraft.id).where(SitePostDraft.id == draft_uuid)
+                    )).scalar_one_or_none() is not None
+            if is_site_post:
+                lines.append(
+                    "- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 "
+                    "tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 "
+                    "확認합니다."
+                )
+            else:
+                lines.append("- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.")
         elif verdict == "rejected":
             # AC3 — 사유에 «폐기/중단» 신호가 있으면 다음 행동 자체를 비운다(침묵도
             # 문구다). 재상신을 권하면 카드가 사람의 결정과 정면으로 반대되는 행동을

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -2057,6 +2057,10 @@ async def _publish_gate_verdict_notification(
             "gate_type": gate.gate_type,
             "verdict": new_status,
             "resolver_member_id": str(resolver_id),
+            # story #3487(0329) — 지금 판정된 그 게이트 행 자체(story #3478 dual-
+            # destination 이후 (work_item, gate_type)만으로는 유일하지 않다). 렌더
+            # (_render_gate_verdict_message)가 이 값이 있으면 재조회 없이 이 행만 읽는다.
+            "gate_id": str(gate.id),
             # story #3330 AC2 — 반려 사유 문구. 필드 자체는 #2791 스키마에 이미 있었으나
             # (payload_schema.resolution_note) 값이 한 번도 채워진 적이 없었다.
             "resolution_note": gate.resolution_note,

--- a/backend/tests/test_3330_gate_verdict_notification.py
+++ b/backend/tests/test_3330_gate_verdict_notification.py
@@ -162,10 +162,16 @@ _PRESET_GATE_VERDICT_SCHEMA = {
     "properties": {
         "work_item_type": {"type": "string"},
         "work_item_id": {"type": "string", "format": "uuid"},
+        "work_item_title": {"type": ["string", "null"]},
         "gate_type": {"type": "string"},
         "verdict": {"type": "string", "enum": ["approved", "rejected"]},
         "resolver_member_id": {"type": "string", "format": "uuid"},
         "resolution_note": {"type": ["string", "null"]},
+        "gate_requester_member_id": {"type": "string", "format": "uuid"},
+        "gate_draft_author_member_id": {"type": "string", "format": "uuid"},
+        # story #3487(0330) — 판정된 그 게이트 행 식별(dual-destination 이후 재조회
+        # 대신 이 값으로 exact fetch).
+        "gate_id": {"type": "string", "format": "uuid"},
     },
 }
 _PRESET_GATE_VERDICT_ROUTING = {

--- a/backend/tests/test_3340_gate_verdict_notify_reach.py
+++ b/backend/tests/test_3340_gate_verdict_notify_reach.py
@@ -149,6 +149,10 @@ _PRESET_GATE_VERDICT_SCHEMA = {
         "resolution_note": {"type": ["string", "null"]},
         # story #3340 — 이 스토리가 여는 신규 선택 필드(migration 0303).
         "gate_requester_member_id": {"type": "string", "format": "uuid"},
+        "gate_draft_author_member_id": {"type": "string", "format": "uuid"},
+        # story #3487(0330) — 판정된 그 게이트 행 식별(dual-destination 이후 재조회
+        # 대신 이 값으로 exact fetch).
+        "gate_id": {"type": "string", "format": "uuid"},
     },
 }
 _WORK_ITEM_STAKEHOLDERS_ROUTING = {

--- a/backend/tests/test_3370_gate_notify_recipients.py
+++ b/backend/tests/test_3370_gate_notify_recipients.py
@@ -167,6 +167,9 @@ _PRESET_GATE_VERDICT_SCHEMA = {
         "gate_requester_member_id": {"type": "string", "format": "uuid"},
         # story #3370 — 이 스토리가 여는 신규 선택 필드(migration 0308).
         "gate_draft_author_member_id": {"type": "string", "format": "uuid"},
+        # story #3487(0330) — 판정된 그 게이트 행 식별(dual-destination 이후 재조회
+        # 대신 이 값으로 exact fetch).
+        "gate_id": {"type": "string", "format": "uuid"},
     },
 }
 _WORK_ITEM_STAKEHOLDERS_ROUTING = {

--- a/backend/tests/test_3387_gate_verdict_agent_next_action.py
+++ b/backend/tests/test_3387_gate_verdict_agent_next_action.py
@@ -24,8 +24,9 @@ def anyio_backend():
 
 
 class _FakeGateRow:
-    def __init__(self, neutral_facts: dict | None):
+    def __init__(self, neutral_facts: dict | None, *, id_=None):
         self.neutral_facts = neutral_facts
+        self.id = id_ or uuid.uuid4()
 
 
 class _FakeResult:
@@ -36,20 +37,38 @@ class _FakeResult:
         return self._row
 
 
-def _fake_db(gate_row=None):
+def _fake_db(gate_row=None, *, site_post_draft_exists: bool = False):
+    """story #3487 — 두 번째 db.execute 호출(SitePostDraft 존재 확인, verdict==
+    approved·draft_id 있을 때만 일어난다)을 첫 번째(Gate 조회)와 다르게 응답해야
+    한다 — 호출 순서로 가른다(이 함수의 유일한 소비자가 순서를 그렇게 고정한다).
+    `db.get(Gate, ...)`(gate_id 있는 신규 경로)도 같은 gate_row를 돌려준다."""
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_FakeResult(gate_row))
+    call_count = {"n": 0}
+
+    async def _execute(*_args, **_kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _FakeResult(gate_row)
+        return _FakeResult(uuid.uuid4() if site_post_draft_exists else None)
+
+    db.execute = AsyncMock(side_effect=_execute)
+    db.get = AsyncMock(return_value=gate_row)
     return db
 
 
-def _payload(*, gate_type: str, verdict: str, resolution_note: str | None = None) -> dict:
-    return {
+def _payload(
+    *, gate_type: str, verdict: str, resolution_note: str | None = None, gate_id: str | None = None,
+) -> dict:
+    payload = {
         "work_item_type": "story",
         "work_item_id": str(uuid.uuid4()),
         "gate_type": gate_type,
         "verdict": verdict,
         "resolution_note": resolution_note,
     }
+    if gate_id:
+        payload["gate_id"] = gate_id
+    return payload
 
 
 @pytest.fixture(autouse=True)
@@ -62,10 +81,12 @@ def _stub_work_item_ref(monkeypatch):
     monkeypatch.setattr(events_module, "_render_event_notification_work_item_ref", _fake_ref)
 
 
-async def _render(payload: dict, gate_row=None) -> str:
+async def _render(payload: dict, gate_row=None, *, site_post_draft_exists: bool = False) -> str:
     from app.routers.events import _render_gate_verdict_message
 
-    return await _render_gate_verdict_message(_fake_db(gate_row), org_id=uuid.uuid4(), payload=payload)
+    return await _render_gate_verdict_message(
+        _fake_db(gate_row, site_post_draft_exists=site_post_draft_exists), org_id=uuid.uuid4(), payload=payload,
+    )
 
 
 class TestExternalPublishAgentNextAction:
@@ -90,6 +111,49 @@ class TestExternalPublishAgentNextAction:
             gate_type="external_publish", verdict="rejected", resolution_note="제목 오타 수정 필요",
         ))
         assert "- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다." in text
+
+    async def test_site_post_approved_says_worker_tick_not_human_screen(self):
+        """story #3487 — site_post(외부 목적지·hosted_site 공통)는 승인 즉시 워커가
+        다음 tick에 발행한다(실동작). draft_id가 site_post_drafts에 있으면 새 문구."""
+        draft_id = str(uuid.uuid4())
+        gate_row = _FakeGateRow({"draft_id": draft_id})
+        text = await _render(
+            _payload(gate_type="external_publish", verdict="approved"),
+            gate_row=gate_row, site_post_draft_exists=True,
+        )
+        assert "발행은 휴먼이 화면에서 합니다" not in text
+        assert "다음 워커 tick" in text
+        assert "발행 결과" in text
+
+    async def test_channel_post_approved_keeps_old_text_regression(self):
+        """AC2 회귀 0 — channel_post(예약 상신)는 draft_id가 있어도(channel_posts.py도
+        neutral_facts.draft_id를 stamp한다) site_post_drafts엔 없으므로 옛 문구 그대로."""
+        draft_id = str(uuid.uuid4())
+        gate_row = _FakeGateRow({"draft_id": draft_id})
+        text = await _render(
+            _payload(gate_type="external_publish", verdict="approved"),
+            gate_row=gate_row, site_post_draft_exists=False,
+        )
+        assert "- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다." in text
+        assert "다음 워커 tick" not in text
+
+    async def test_gate_id_in_payload_fetches_exact_row_not_reconstructed(self):
+        """story #3487 AC3(페드루 決定, story #3478 dual-destination 대비) — payload에
+        gate_id가 있으면 db.get으로 그 행만 읽는다(재조회 쿼리를 아예 안 탄다). 뮤테이션
+        대상: db.get 호출을 지우면 이 테스트가 db.execute만 호출되는 옛 경로로 빠져
+        site_post_draft_exists=True를 반영 못 하고 RED가 된다."""
+        draft_id = str(uuid.uuid4())
+        gate_row = _FakeGateRow({"draft_id": draft_id}, id_=uuid.uuid4())
+        db = _fake_db(gate_row, site_post_draft_exists=True)
+        from app.routers.events import _render_gate_verdict_message
+
+        text = await _render_gate_verdict_message(
+            db, org_id=uuid.uuid4(),
+            payload=_payload(gate_type="external_publish", verdict="approved", gate_id=str(gate_row.id)),
+        )
+        db.get.assert_awaited_once()
+        assert "다음 워커 tick" in text
+        assert f"- draft_id: {draft_id}" in text
 
     async def test_rejected_signal_is_keyword_based_not_a_blanket_reason_suppression(self):
         # "제목 오타 수정 필요"는 신호가 없어 문구가 뜬다(위 테스트) — "중단"이 들어간


### PR DESCRIPTION
[SID:3487]

**⚠️ merge 순서: #3829 → #3835(3478) → #3836(3475, 마이그 0329 소유) 착지 뒤 이 PR의 base를 develop으로 전환. 지금 base는 #3835(3478) 브랜치 위, migration 0330(down_revision=0329, #3836 소유) 예정.**

## Summary
- `_render_gate_verdict_message`(events.py) approved 분기 — site_post(외부 목적지·hosted_site 공통)는 옛 문구("발행은 휴먼이 화면에서 합니다")가 실동작과 어긋난다: 승인 훅이 즉시 publication_command를 만들고 다음 워커 tick(최대 1분)이 어댑터를 호출한다. draft_id가 `site_post_drafts`에 있는지로 도메인을 갈라 새 문구를 낸다. channel_post(예약 상신, scheduled_at 시각에 발행)는 무변(회귀 pin).
- migration 0330 — `preset.gate.verdict` payload_schema에 `gate_id`(선택) 필드 additive 추가(0303/0309 선례 동일 패턴). `gate_service.py::_publish_gate_verdict_notification`이 항상 채운다.
- AC3(페드루 決定, story #3478 dual-destination 대비) — 렌더가 payload의 `gate_id`로 `db.get(Gate, ...)` exact fetch를 우선한다. 기존 `(work_item_id, gate_type, status).order_by(resolved_at desc).limit(1)` 재조회는 gate_id 없는 레거시 payload 전용 폴백으로 남긴다 — #3478 이후 같은 work_item에 목적지가 다른 게이트가 둘 이상이면 "가장 최근 resolved" 하나만 고르는 그 재조회가 다른 게이트의 문맥을 섞어 보여줄 수 있었다.
- `test_3330_gate_verdict_notification.py`/`test_3340_gate_verdict_notify_reach.py`/`test_3370_gate_notify_recipients.py`의 하드코딩된(alembic 비경유) `_PRESET_GATE_VERDICT_SCHEMA` 픽스처 3곳에 `gate_id`(+ 누락돼 있던 `work_item_title`/`gate_requester_member_id`/`gate_draft_author_member_id`) 동기화 — 없으면 새 payload가 422로 거부돼 CI가 그 자리에서 깨진다(diff 밖 grep 대조로 발견).

## Test plan
- [x] `test_3387_gate_verdict_agent_next_action.py` 신규 3건: site_post 승인 → 새 문구(옛 문구 부재) · channel_post(draft_id 있어도 site_post_drafts엔 없음) → 옛 문구 무변(AC2) · payload에 gate_id 있으면 db.get으로 exact fetch(뮤테이션 대상 — db.get 호출 지우면 RED).
- [x] 회귀: `test_3387`(12건, mock 기반) + `test_3330`/`test_3340`/`test_3370`(24건, realdb) 전부 local green.
- [x] 마이그레이션 0330 real Postgres 왕복 검증(0327→0328→0329(임시)→0330 전체 체인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)