### PR TITLE
[SID:3488] fix: test_2078 outbox dispatcher flake — wait on DB state, not the publish signal

### DIFF
--- a/backend/tests/test_2078_event_outbox_realdb.py
+++ b/backend/tests/test_2078_event_outbox_realdb.py
@@ -215,11 +215,26 @@ async def test_outbox_dispatcher_publishes_pending_rows_and_marks_published(monk
             s.add(EventOutbox(org_id=org_id, target="org", target_id=org_id, event_type="x", payload={}))
             await s.commit()
 
+        # story #3488(플레이키 근본원인, 2026-09-05 실측) — dispatcher 루프는
+        # `_publish_outbox_batch`(Redis publish, 이 fake가 `published`에 append하는
+        # 그 지점)와 `_finalize_outbox_published`(published_at UPDATE+commit, 별도
+        # 세션)이 서로 다른 await 구간이다(event_broker.py:646-647). `published`가
+        # 비었다가 채워진 순간 바로 task.cancel()하면, publish는 끝났지만 finalize의
+        # DB 커밋은 아직 시작도 안 했을 수 있는 창이 생긴다 — CI에서 간헐적으로
+        # `published_at is None`으로 관측된 원인이 정확히 이것이었다(CancelledError가
+        # finalize의 `await session.commit()` 진입 前에 그 태스크를 끊음). "발행됨"과
+        # "커밋됨"을 같은 순간으로 착각한 시간 기반 대기가 문제라 — 대기 조건을
+        # 상태(DB에 published_at이 실제로 찍혔는지)로 바꾼다(sleep 늘리기 아님).
         task = asyncio.create_task(eb.outbox_dispatcher_loop())
-        for _ in range(50):  # 최대 ~0.5s 대기 — dispatcher가 첫 배치를 처리할 때까지
+        finalized = False
+        for _ in range(200):  # 최대 ~2s 대기 — publish+finalize(별도 커밋)까지.
             await asyncio.sleep(0.01)
             if published:
-                break
+                async with Session() as s:
+                    row = (await s.execute(select(EventOutbox))).scalars().first()
+                if row is not None and row.published_at is not None:
+                    finalized = True
+                    break
         task.cancel()
         try:
             await task
@@ -227,6 +242,7 @@ async def test_outbox_dispatcher_publishes_pending_rows_and_marks_published(monk
             pass
 
         assert len(published) == 1
+        assert finalized, "publish는 됐는데 finalize(published_at 커밋)가 취소 前에 안 끝났다"
 
         async with Session() as s:
             rows = (await s.execute(select(EventOutbox))).scalars().all()


### PR DESCRIPTION
[SID:3488]

## Summary
근본원인(테스트 쪽, 옵션2 확定) — `outbox_dispatcher_loop`(event_broker.py:646-647)은 `_publish_outbox_batch`(Redis publish — 이 테스트의 fake client가 `published`에 append하는 그 지점)와 `_finalize_outbox_published`(published_at UPDATE, **별도 세션·별도 commit**)이 서로 다른 await 구간이다. 테스트는 `published`가 비었다가 채워진 순간 바로 `task.cancel()`했는데, 그 시점엔 finalize가 아직 시작도 안 했을 수 있는 창이 있다 — `CancelledError`가 finalize의 `await session.commit()` 진입 前에 그 태스크를 끊으면 `published_at`이 `None`으로 남는다(CI에서 간헐 관측된 증상과 정확히 일치, #3825·#3829 x2).

"발행됨"과 "커밋됨"을 같은 순간으로 착각한 시간 기반 대기가 문제 — 대기 조건을 시간이 아니라 **DB의 실제 상태**(published_at이 실제로 찍혔는지, 최대 2s 폴링)로 바꾼다. sleep을 늘린 게 아니다.

## Evidence
- **처방 적용 후**: 100/100 로컬 실행 green(단독 프로세스 20회 + 배치 80회, 매번 fresh disposable Postgres).
- **뮤테이션(옛 대기 조건으로 되돌림)**: 30회 재실행 중 1회 `published_at is None`으로 실패 재현(정확히 관측된 증상) — 처방 원복 뒤 재확인.
- 관련 파일 전체(`test_2078_event_outbox_realdb.py`, 8건) 회귀 green.

## Note(범위 밖 — 기록만)
cancel이 publish 뒤·finalize 前에 끊기면 그 outbox 행은 pending으로 남아 다음 tick에 다시 publish된다(at-least-once). 소비자 멱등 전제가 문서/코드에 명시돼 있는지는 별도 확認 항목.

🤖 Generated with [Claude Code](https://claude.com/claude-code)