### PR TITLE
[SID:3492] feat: 붙여넣기 채널 연결 자격 제자리 교체(PATCH .../credentials)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2145,7 +2145,11 @@
     "channelConnectPastedSecretPendingCta": "Connecting…",
     "channelConnectPastedSecretHintWordpress": "Create this in WordPress under Users → Application Passwords, then paste it here.",
     "channelConnectPastedSecretHintWebhook": "Create this on the receiving server's side (the value it will use to verify requests), then paste it here.",
-    "channelConnectPastedSecretRewriteNote": "You won't be able to see this again after saving — paste a new value to change it."
+    "channelConnectPastedSecretRewriteNote": "You won't be able to see this again after saving — paste a new value to change it.",
+    "channelConnectSecretHintLabel": "Current credential: ****{hint}",
+    "channelConnectReplaceCredentialAction": "Replace credential",
+    "channelConnectReplaceCredentialSubmitAction": "Replace",
+    "channelConnectReplaceCredentialPendingCta": "Replacing…"
   },
   "content": {
     "title": "Content",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2104,7 +2104,7 @@
     "channelTestOk": "OK · {account}",
     "channelTestFailed": "Failed · {error}",
     "channelLastErrorToggle": "View server response",
-    "channelOwnerOnlyReason": "Only owners can do this.",
+    "channelOwnerOnlyReason": "Only owners and admins can do this.",
     "channelConfigIncompleteReason": "App credentials must be set up before you can start connecting.",
     "channelExpiringInfoNote": "This renews automatically.",
     "channelExpiringActionNote": "This does not renew automatically — you'll need to reconnect it yourself.",
@@ -2146,7 +2146,7 @@
     "channelConnectPastedSecretHintWordpress": "Create this in WordPress under Users → Application Passwords, then paste it here.",
     "channelConnectPastedSecretHintWebhook": "Create this on the receiving server's side (the value it will use to verify requests), then paste it here.",
     "channelConnectPastedSecretRewriteNote": "You won't be able to see this again after saving — paste a new value to change it.",
-    "channelConnectSecretHintLabel": "Current credential: ****{hint}",
+    "channelConnectSecretHintLabel": "Current credential ends in {hint}",
     "channelConnectReplaceCredentialAction": "Replace credential",
     "channelConnectReplaceCredentialSubmitAction": "Replace",
     "channelConnectReplaceCredentialPendingCta": "Replacing…"

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2145,7 +2145,11 @@
     "channelConnectPastedSecretPendingCta": "연결하는 중…",
     "channelConnectPastedSecretHintWordpress": "WordPress 관리자 → 사용자 → 애플리케이션 비밀번호에서 만들어 붙여넣습니다.",
     "channelConnectPastedSecretHintWebhook": "받는 서버가 검증에 쓸 비밀값을 그쪽 설정에서 만들어 붙여넣습니다.",
-    "channelConnectPastedSecretRewriteNote": "저장한 뒤에는 다시 볼 수 없습니다 — 바꾸려면 새로 붙여넣습니다."
+    "channelConnectPastedSecretRewriteNote": "저장한 뒤에는 다시 볼 수 없습니다 — 바꾸려면 새로 붙여넣습니다.",
+    "channelConnectSecretHintLabel": "현재 자격: ****{hint}",
+    "channelConnectReplaceCredentialAction": "자격 바꾸기",
+    "channelConnectReplaceCredentialSubmitAction": "바꾸기",
+    "channelConnectReplaceCredentialPendingCta": "바꾸는 중…"
   },
   "content": {
     "title": "글 관리",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2104,7 +2104,7 @@
     "channelTestOk": "정상 · {account}",
     "channelTestFailed": "실패 · {error}",
     "channelLastErrorToggle": "서버 응답 보기",
-    "channelOwnerOnlyReason": "owner만 할 수 있는 작업입니다.",
+    "channelOwnerOnlyReason": "이 작업은 owner·admin만 할 수 있습니다.",
     "channelConfigIncompleteReason": "먼저 앱 자격을 설정해야 연결을 시작할 수 있습니다.",
     "channelExpiringInfoNote": "자동 갱신됩니다.",
     "channelExpiringActionNote": "자동으로 갱신되지 않습니다 — 직접 다시 연결해야 합니다.",
@@ -2146,7 +2146,7 @@
     "channelConnectPastedSecretHintWordpress": "WordPress 관리자 → 사용자 → 애플리케이션 비밀번호에서 만들어 붙여넣습니다.",
     "channelConnectPastedSecretHintWebhook": "받는 서버가 검증에 쓸 비밀값을 그쪽 설정에서 만들어 붙여넣습니다.",
     "channelConnectPastedSecretRewriteNote": "저장한 뒤에는 다시 볼 수 없습니다 — 바꾸려면 새로 붙여넣습니다.",
-    "channelConnectSecretHintLabel": "현재 자격: ****{hint}",
+    "channelConnectSecretHintLabel": "현재 자격 끝 4자리 {hint}",
     "channelConnectReplaceCredentialAction": "자격 바꾸기",
     "channelConnectReplaceCredentialSubmitAction": "바꾸기",
     "channelConnectReplaceCredentialPendingCta": "바꾸는 중…"

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -138,7 +138,7 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
     await mount('member');
     const disconnectBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '해제');
     expect(disconnectBtn).toBeUndefined();
-    expect(container.textContent).toContain('owner만 할 수 있는 작업입니다');
+    expect(container.textContent).toContain('이 작업은 owner·admin만 할 수 있습니다');
   });
 
   it('member도 연결 시험은 할 수 있다', async () => {
@@ -280,7 +280,7 @@ describe('OrganizationChannelsPage — 앱 자격(AC2, story #3376)', () => {
     await mount('member');
     const registerBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '우리 조직 앱을 쓰려면 등록');
     expect(registerBtn).toBeUndefined();
-    expect(container.textContent).toContain('owner만 할 수 있는 작업입니다');
+    expect(container.textContent).toContain('이 작업은 owner·admin만 할 수 있습니다');
   });
 });
 
@@ -312,7 +312,7 @@ describe('OrganizationChannelsPage — available-channels 목록 기반 렌더(s
     stubFetch({ connections: [], availableChannels: AVAILABLE_WITH_SANDBOX });
     await mount('member');
     expect(container.querySelector('[data-testid="channel-connect-sandbox-button"]')).toBeNull();
-    expect(container.textContent).toContain('owner만 할 수 있는 작업입니다');
+    expect(container.textContent).toContain('이 작업은 owner·admin만 할 수 있습니다');
   });
 
   it('⭐sandbox 「연결 만들기」를 누르면 BFF POST 성공 뒤 리로드 없이 새 연결 행이 추가된다', async () => {
@@ -429,7 +429,7 @@ describe('OrganizationChannelsPage — pasted_secret 자리 채움(story #3450 F
       availableChannels: WORDPRESS_AVAILABLE,
     });
     await mount('owner');
-    expect(container.querySelector('[data-testid="channel-connect-secret-hint-conn-wp-1"]')?.textContent).toBe('현재 자격: ****1234');
+    expect(container.querySelector('[data-testid="channel-connect-secret-hint-conn-wp-1"]')?.textContent).toBe('현재 자격 끝 4자리 1234');
     expect(container.querySelector('[data-testid="channel-connect-replace-credential-button-conn-wp-1"]')).not.toBeNull();
   });
 
@@ -476,6 +476,12 @@ describe('OrganizationChannelsPage — pasted_secret 자리 채움(story #3450 F
     const openBtn = container.querySelector('[data-testid="channel-connect-replace-credential-button-conn-wp-1"]') as HTMLButtonElement;
     await act(async () => { openBtn.click(); });
     await flush();
+
+    // 유나 정본 §2④(페드루 PO 차단, PR#3841 리뷰) — 「이 자격이 어디서 오나」 필드-위
+    // 도움말이 폼을 열면 보여야 한다(생성 폼과 같은 다섯 규격).
+    expect(
+      container.querySelector('[data-testid="channel-connect-replace-credential-hint-conn-wp-1"]')?.textContent,
+    ).toContain('애플리케이션 비밀번호');
 
     const pwInput = container.querySelector('#conn-wp-1-app_password') as HTMLInputElement;
     const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -397,7 +397,7 @@ describe('OrganizationChannelsPage — pasted_secret 자리 채움(story #3450 F
     expect(container.textContent).toContain(koMessages.channelConnect.channelOwnerOnlyReason);
   });
 
-  it('⭐(AC5) 이미 연결된 WordPress 행에 secret 값·끝 4자리 어느 것도 안 그려진다 — BFF 응답(ChannelConnectionResponse)에 그 필드가 없다', async () => {
+  it('⭐(AC5, story #3492로 secret_hint 부재 시로 범위 재확定) 응답에 secret_hint가 없으면 마스킹 흔적도 없다', async () => {
     stubFetch({
       connections: [{
         id: 'conn-wp-1', channel: 'wordpress', account_id: 'https://blog.example.com', account_label: 'admin',
@@ -410,10 +410,89 @@ describe('OrganizationChannelsPage — pasted_secret 자리 채움(story #3450 F
     await mount('owner');
     // 계정 라벨(username)만 보이고(ConnectionRow는 account_label이 있으면 account_id
     // 대신 그것만 그린다, 정상 기존 동작) — app_password류 흔적(마스킹 문자열 포함)이
-    // 어디에도 없다. 스키마 자체가 그 필드를 안 주므로(types.ts) 이 화면이 지어낼 값
-    // 자체가 없다.
+    // 어디에도 없다. secret_hint 필드 자체가 응답에 없으면(구버전 BFF·null) 이 화면이
+    // 지어낼 값이 없다(story #3492 이전 AC5 원문 그대로, "필드 자체가 없던" 시절 대신
+    // 지금은 "필드가 null·부재인" 케이스로 범위가 좁아졌을 뿐 — 있으면 다음 테스트처럼
+    // 끝 4자리를 보여주는 게 정상 동작으로 바뀌었다).
     expect(container.textContent).toContain('admin');
     expect(container.textContent).not.toMatch(/•{2,}|\*{2,}/);
+  });
+
+  it('⭐story #3492 — secret_hint가 있으면 owner는 끝 4자리 힌트와 「자격 바꾸기」 버튼을 본다(원문은 절대 안 보인다)', async () => {
+    stubFetch({
+      connections: [{
+        id: 'conn-wp-1', channel: 'wordpress', account_id: 'https://blog.example.com', account_label: 'admin',
+        credential_kind: 'pasted_secret', status: 'active', token_expires_at: null, last_refreshed_at: null,
+        last_error: null, can_auto_refresh: false, connected_by: 'member-1',
+        created_at: '2026-09-01T00:00:00Z', updated_at: '2026-09-01T00:00:00Z', secret_hint: '1234',
+      }],
+      availableChannels: WORDPRESS_AVAILABLE,
+    });
+    await mount('owner');
+    expect(container.querySelector('[data-testid="channel-connect-secret-hint-conn-wp-1"]')?.textContent).toBe('현재 자격: ****1234');
+    expect(container.querySelector('[data-testid="channel-connect-replace-credential-button-conn-wp-1"]')).not.toBeNull();
+  });
+
+  it('story #3492 — member는 힌트도 「자격 바꾸기」 버튼도 안 보이고 owner 전용 사유만 본다', async () => {
+    stubFetch({
+      connections: [{
+        id: 'conn-wp-1', channel: 'wordpress', account_id: 'https://blog.example.com', account_label: 'admin',
+        credential_kind: 'pasted_secret', status: 'active', token_expires_at: null, last_refreshed_at: null,
+        last_error: null, can_auto_refresh: false, connected_by: 'member-1',
+        created_at: '2026-09-01T00:00:00Z', updated_at: '2026-09-01T00:00:00Z', secret_hint: '1234',
+      }],
+      availableChannels: WORDPRESS_AVAILABLE,
+    });
+    await mount('member');
+    expect(container.querySelector('[data-testid="channel-connect-secret-hint-conn-wp-1"]')).toBeNull();
+    expect(container.querySelector('[data-testid="channel-connect-replace-credential-button-conn-wp-1"]')).toBeNull();
+  });
+
+  it('story #3492 — owner가 「자격 바꾸기」 폼을 열고 제출하면 목록이 재조회되고 폼이 닫힌다', async () => {
+    let patchCalled = false;
+    let patchBody: unknown = null;
+    const connectionWithHint = {
+      id: 'conn-wp-1', channel: 'wordpress', account_id: 'https://blog.example.com', account_label: 'admin',
+      credential_kind: 'pasted_secret', status: 'active', token_expires_at: null, last_refreshed_at: null,
+      last_error: null, can_auto_refresh: false, connected_by: 'member-1',
+      created_at: '2026-09-01T00:00:00Z', updated_at: '2026-09-01T00:00:00Z', secret_hint: '1234',
+    };
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes('/channel-connections/available-channels')) {
+        return { ok: true, status: 200, json: async () => ({ data: WORDPRESS_AVAILABLE }) } as Response;
+      }
+      if (url.includes('/credentials') && init?.method === 'PATCH') {
+        patchCalled = true;
+        patchBody = init.body ? JSON.parse(init.body as string) : null;
+        return { ok: true, status: 200, json: async () => ({ data: { ...connectionWithHint, secret_hint: '9999' } }) } as Response;
+      }
+      if (url.includes('/channel-connections')) {
+        return { ok: true, status: 200, json: async () => ({ data: [connectionWithHint] }) } as Response;
+      }
+      return { ok: false, status: 404, json: async () => ({ data: null, error: { code: 'NOT_FOUND' } }) } as Response;
+    }));
+    await mount('owner');
+
+    const openBtn = container.querySelector('[data-testid="channel-connect-replace-credential-button-conn-wp-1"]') as HTMLButtonElement;
+    await act(async () => { openBtn.click(); });
+    await flush();
+
+    const pwInput = container.querySelector('#conn-wp-1-app_password') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(pwInput, 'new-app-password-9999');
+      pwInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flush();
+
+    const submitBtn = container.querySelector('[data-testid="channel-connect-replace-credential-submit-conn-wp-1"]') as HTMLButtonElement;
+    await act(async () => { submitBtn.click(); });
+    await flush();
+
+    expect(patchCalled).toBe(true);
+    expect((patchBody as { app_password?: string })?.app_password).toBe('new-app-password-9999');
+    // 폼이 닫히고(재입력 필드가 사라지고) 목록 재조회로 새 힌트가 반영된다.
+    expect(container.querySelector('[data-testid="channel-connect-replace-credential-form-conn-wp-1"]')).toBeNull();
   });
 });
 

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -15,6 +15,7 @@ import { ChannelStatusChip } from '@/components/channel-connect/channel-status-c
 import { deriveChannelConnectionStatus, worstChannelConnectionStatus } from '@/components/channel-connect/connection-status';
 import { AppCredentialsCard } from '@/components/channel-connect/app-credentials-card';
 import { PastedSecretConnectCard } from '@/components/channel-connect/pasted-secret-connect-card';
+import { ReplaceCredentialCard } from '@/components/channel-connect/replace-credential-card';
 import { connectErrorLabelKey } from '@/components/channel-connect/connect-error';
 import type { AppCredentialsStatusResponse, ChannelConnectionResponse, TestConnectionResponse } from '@/components/channel-connect/types';
 
@@ -160,6 +161,19 @@ function ConnectionRow({
           <span className="text-xs text-muted-foreground">{t('channelOwnerOnlyReason')}</span>
         )}
       </div>
+      {/* story #3492 — 붙여넣기(pasted_secret) 연결만 「자격 바꾸기」를 갖는다(해제→
+          재연결 대신 id 불변 제자리 교체). oauth 연결은 위 재인증 버튼이 그 역할). */}
+      {conn.credential_kind === 'pasted_secret' ? (
+        <ReplaceCredentialCard
+          channel={conn.channel}
+          connectionId={conn.id}
+          secretHint={conn.secret_hint}
+          isOwner={isOwner}
+          orgId={orgId}
+          onReplaced={onDisconnected}
+          t={t}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/app/api/organizations/[id]/channel-connections/[channel]/credentials/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-connections/[channel]/credentials/route.ts
@@ -1,0 +1,16 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; channel: string }> };
+
+// story #3492 — 붙여넣기(pasted_secret) 자격 「제자리 교체」. disconnect/route.ts와 동형
+// 이유로 폴더명은 `[channel]`이지만 실제 값은 connection_id(UUID) — 형제 동적 세그먼트
+// 슬러그 이름 통일 제약(Next.js) 그대로.
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const { id, channel: connectionId } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request, '/api/v2/organizations/[id]/channel-connections/[connectionId]/credentials', { id, connectionId },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/components/channel-connect/replace-credential-card.tsx
+++ b/apps/web/src/components/channel-connect/replace-credential-card.tsx
@@ -33,6 +33,16 @@ const REPLACE_FIELDS: Record<string, ReplaceField[]> = {
   ],
 };
 
+// 유나 정본(3653a18c §2 "이 다섯은 pasted_secret 연결 폼에도 그대로 걸린다" ④ —
+// "이 자격이 어디서 오나" 필드-위 한 줄) — pasted-secret-connect-card.tsx의
+// PASTED_SECRET_HINT_KEY와 동형(같은 채널·같은 문구, 재입력 폼이라고 다른 말을
+// 쓸 이유가 없다). 페드루 PO 차단(2026-09-05, PR#3841 리뷰④) — 이 카드에 그동안
+// 이 줄 자체가 없었다.
+const REPLACE_SECRET_HINT_KEY: Record<string, string> = {
+  wordpress: 'channelConnectPastedSecretHintWordpress',
+  webhook: 'channelConnectPastedSecretHintWebhook',
+};
+
 export function ReplaceCredentialCard({
   channel, connectionId, secretHint, isOwner, orgId, onReplaced, t,
 }: {
@@ -111,6 +121,10 @@ export function ReplaceCredentialCard({
               <AlertDescription>{error}</AlertDescription>
             </Alert>
           ) : null}
+          {/* 유나 정본 §2④ — 도움말 두 줄 중 필드-위(어디서 오나, 넣기 전에 읽는다). */}
+          <p className="text-xs text-muted-foreground" data-testid={`channel-connect-replace-credential-hint-${connectionId}`}>
+            {t(REPLACE_SECRET_HINT_KEY[channel])}
+          </p>
           {fields.map((f) => (
             <div key={f.name} className="space-y-1">
               <label className="text-xs font-medium text-muted-foreground" htmlFor={`${connectionId}-${f.name}`}>

--- a/apps/web/src/components/channel-connect/replace-credential-card.tsx
+++ b/apps/web/src/components/channel-connect/replace-credential-card.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { fetchWithAuth } from '@/lib/db/client';
+import { connectErrorLabelKey } from '@/components/channel-connect/connect-error';
+
+/**
+ * story #3492(Phase1·마케팅운영·소형, 페드루 PO 決定 2026-09-05) — 붙여넣기(pasted_
+ * secret) 연결 「자격 제자리 교체」. pasted-secret-connect-card.tsx(생성 폼)와 §2 동형
+ * 원칙 그대로 — secret류 필드는 제출 직후 무조건 비우고(§2 "다시 못 봄"), 재입력은
+ * 덮어쓰기다. 다른 점은 site_url/target_url 등 목적지 필드가 없다(id·계정 축은
+ * 불변 — 이 폼은 자격만 바꾼다) 뿐.
+ *
+ * §2 규격 3 — 재방문 시 원문은 절대 안 보이고 끝 4자리(secret_hint)만 표시한다.
+ */
+interface ReplaceField {
+  name: string;
+  labelKey: string;
+  type: 'text' | 'password';
+  required: boolean;
+}
+
+const REPLACE_FIELDS: Record<string, ReplaceField[]> = {
+  wordpress: [
+    { name: 'username', labelKey: 'channelConnectFieldUsername', type: 'text', required: false },
+    { name: 'app_password', labelKey: 'channelConnectFieldAppPassword', type: 'password', required: true },
+  ],
+  webhook: [
+    { name: 'secret', labelKey: 'channelConnectFieldSecret', type: 'password', required: true },
+  ],
+};
+
+export function ReplaceCredentialCard({
+  channel, connectionId, secretHint, isOwner, orgId, onReplaced, t,
+}: {
+  channel: string;
+  connectionId: string;
+  secretHint: string | null;
+  isOwner: boolean;
+  orgId: string;
+  onReplaced: () => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const fields = REPLACE_FIELDS[channel];
+  const [editing, setEditing] = useState(false);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!fields) return null;
+
+  // §5 정본과 동형 — 비owner/admin은 버튼 자체를 안 그리고 사유 한 줄만.
+  if (!isOwner) {
+    return <p className="text-xs text-muted-foreground">{t('channelOwnerOnlyReason')}</p>;
+  }
+
+  const allFilled = fields.every((f) => !f.required || (values[f.name] ?? '').trim().length > 0);
+
+  const handleSubmit = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth(`/api/organizations/${orgId}/channel-connections/${connectionId}/credentials`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      // §2 "다시 못 봄" — 성공/실패 무관하게 여기서 비운다.
+      setValues({});
+      if (res.ok) {
+        setEditing(false);
+        onReplaced();
+      } else {
+        const body = (await res.json().catch(() => null)) as { error?: { code?: string } } | null;
+        const code = body?.error?.code;
+        setError(t(code ? connectErrorLabelKey(code, isOwner) : 'channelConnectErrorGeneric'));
+      }
+    } catch {
+      setValues({});
+      setError(t('channelConnectErrorGeneric'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col items-start gap-2">
+      {!editing ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {secretHint ? (
+            <span className="text-xs text-muted-foreground" data-testid={`channel-connect-secret-hint-${connectionId}`}>
+              {t('channelConnectSecretHintLabel', { hint: secretHint })}
+            </span>
+          ) : null}
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setEditing(true)}
+            data-testid={`channel-connect-replace-credential-button-${connectionId}`}
+          >
+            {t('channelConnectReplaceCredentialAction')}
+          </Button>
+        </div>
+      ) : (
+        <div className="w-full space-y-2" data-testid={`channel-connect-replace-credential-form-${connectionId}`}>
+          {error ? (
+            <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+          {fields.map((f) => (
+            <div key={f.name} className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor={`${connectionId}-${f.name}`}>
+                {t(f.labelKey)}
+              </label>
+              <input
+                id={`${connectionId}-${f.name}`}
+                type={f.type}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+                value={values[f.name] ?? ''}
+                onChange={(e) => setValues((v) => ({ ...v, [f.name]: e.target.value }))}
+                autoComplete="off"
+              />
+            </div>
+          ))}
+          <p className="text-xs text-muted-foreground" data-testid={`channel-connect-replace-credential-rewrite-note-${connectionId}`}>
+            {t('channelConnectPastedSecretRewriteNote')}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={() => void handleSubmit()}
+              disabled={saving || !allFilled}
+              data-testid={`channel-connect-replace-credential-submit-${connectionId}`}
+            >
+              {saving ? t('channelConnectReplaceCredentialPendingCta') : t('channelConnectReplaceCredentialSubmitAction')}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => { setEditing(false); setValues({}); setError(null); }}
+            >
+              {t('appCredentialsCancelAction')}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/channel-connect/types.ts
+++ b/apps/web/src/components/channel-connect/types.ts
@@ -16,6 +16,9 @@ export interface ChannelConnectionResponse {
   connected_by: string | null;
   created_at: string;
   updated_at: string;
+  // story #3492 — 붙여넣기(pasted_secret) 자격 재방문 표시(끝 4자리). oauth 채널은
+  // null(§2 규격 3, app_id_suffix와 동형).
+  secret_hint: string | null;
 }
 
 export interface AuthorizeResponse {

--- a/backend/alembic/versions/0331_channel_connection_secret_hint.py
+++ b/backend/alembic/versions/0331_channel_connection_secret_hint.py
@@ -1,0 +1,37 @@
+"""story #3492(Phase1·마케팅운영·소형, 페드루 PO 決定 2026-09-05) —
+`channel_connections.secret_hint` 신설.
+
+유나 10회차 #3823 E 관찰 — 붙여넣기(pasted_secret) 연결(WordPress·webhook)은 지금
+해제→새로 연결뿐이라 자격을 바꿀 때마다 connection_id가 갈려 draft·발행 이력·
+external_publish 게이트 scope_key(story #3478, connection_id 단위)가 끊긴다.
+「제자리 교체」(PATCH .../credentials, id 불변)를 열면서, 3653a18c §2 규격 3(재방문
+시 끝 4자리만 표시)의 근거 컬럼을 신설한다 — `app_id_suffix`(channel_connections.py
+::_app_id_suffix)와 동형으로 원문은 저장하지 않고 끝 4자리만 저장·반환한다.
+
+oauth 채널(Threads 등)은 이 값을 안 쓴다(NULL 그대로, credential_kind="pasted_secret"
+경로만 채운다).
+
+Revision ID: 0331
+Revises: 0330
+Create Date: 2026-09-05
+
+⚠️0330(#3837)이 아직 develop 미착지 — 스택(#3829→#3835→#3836→#3837) 순서대로
+착지된 뒤 이 마이그가 체인의 다음 자리를 잇는다(0327/#3474 이후 이 세션 전체가
+써 온 관례와 동일 — 열린 PR의 alembic/versions까지가 SSOT)."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0331"
+down_revision = "0330"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("channel_connections", sa.Column("secret_hint", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("channel_connections", "secret_hint")

--- a/backend/app/models/channel_connection.py
+++ b/backend/app/models/channel_connection.py
@@ -50,3 +50,7 @@ class ChannelConnection(Base, TimestampMixin, OrgScopedMixin):
     # 유나 화면설계 §8②(PO 채택) — 갱신 실패 사유를 화면이 보여줄 수 있게(토큰 자체는 절대 아님).
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
     connected_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # story #3492(0331) — 붙여넣기(pasted_secret) 자격 「제자리 교체」의 재방문 표시용
+    # (§2 규격 3, app_id_suffix와 동형 — 원문은 절대 저장/반환하지 않는다, 끝 4자리뿐).
+    # oauth 채널은 이 값을 안 씀(NULL 그대로).
+    secret_hint: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -30,6 +30,7 @@ from app.services.channel_connection import (
     decrypt_for_use,
     get_channel_connection,
     list_channel_connections,
+    replace_channel_connection_credential,
     revoke_channel_connection,
     upsert_channel_connection,
 )
@@ -137,6 +138,9 @@ class ChannelConnectionResponse(BaseModel):
     image_width_max: int = 0
     image_color_space: str = ""
     image_max_count: int = 0
+    # story #3492 — 붙여넣기(pasted_secret) 재방문 표시(§2 규격 3, app_id_suffix와
+    # 동형). oauth 채널은 항상 null(secret_hint 자체를 안 씀).
+    secret_hint: str | None = None
 
 
 def _to_response(row) -> ChannelConnectionResponse:
@@ -169,6 +173,7 @@ def _to_response(row) -> ChannelConnectionResponse:
         image_width_max=adapter.image_width_max if adapter is not None else 0,
         image_color_space=adapter.image_color_space if adapter is not None else "",
         image_max_count=adapter.image_max_count if adapter is not None else 0,
+        secret_hint=row.secret_hint,
     )
 
 
@@ -596,6 +601,80 @@ async def create_pasted_secret_channel_connection(
         status_code=404,
         detail={"code": "CHANNEL_NOT_PASTED_SECRET", "message": f"channel={channel!r}는 아직 지원하지 않습니다."},
     )
+
+
+class ReplaceCredentialsRequest(BaseModel):
+    """story #3492 — WordPress는 `username?`(생략 시 무변)+`app_password`, webhook은
+    `secret`. create 쪽(CreatePastedSecretConnectionRequest)과 동형으로 한 모델에
+    Optional로 얹고 라우터가 channel별 필수 필드를 검사한다."""
+    username: str | None = None
+    app_password: str | None = None
+    secret: str | None = None
+
+
+@router.patch(
+    "/{org_id}/channel-connections/{connection_id}/credentials", response_model=ChannelConnectionResponse,
+)
+async def replace_channel_connection_credentials(
+    org_id: uuid.UUID,
+    connection_id: uuid.UUID,
+    body: ReplaceCredentialsRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelConnectionResponse:
+    """story #3492(PO 決定 2026-09-05) — 붙여넣기 자격 「제자리 교체」(id 불변). 지금까지는
+    해제→새로 연결뿐이라 자격을 바꿀 때마다(예: WordPress 앱 비밀번호 정기 회전) 새
+    connection_id가 생겨 draft·발행 이력·external_publish 게이트 scope_key(story
+    #3478, connection_id 단위)가 끊겼다.
+
+    owner/admin(create_pasted_secret_channel_connection과 동형 폭). oauth 채널
+    (credential_kind != "pasted_secret")은 애초에 이 경로 대상이 아니다(404) —
+    OAuth 자격은 authorize/callback이 갱신하는 축이지 붙여넣기가 아니다."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    resolved = await _require_owner_or_admin(db, auth, org_id)
+
+    row = await get_channel_connection(db, org_id=org_id, connection_id=connection_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"channel connection을 찾을 수 없습니다: {connection_id}")
+    if row.credential_kind != "pasted_secret":
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "CHANNEL_NOT_PASTED_SECRET",
+                "message": "붙여넣기형 연결만 자격을 바꿀 수 있습니다.",
+            },
+        )
+
+    if row.channel == "wordpress":
+        if not body.app_password:
+            raise HTTPException(
+                status_code=422,
+                detail={"code": "WORDPRESS_FIELDS_REQUIRED", "message": "app_password가 필요합니다."},
+            )
+        new_secret, account_label = body.app_password, body.username
+    elif row.channel == "webhook":
+        if not body.secret:
+            raise HTTPException(
+                status_code=422,
+                detail={"code": "WEBHOOK_FIELDS_REQUIRED", "message": "secret이 필요합니다."},
+            )
+        new_secret, account_label = body.secret, None
+    else:
+        # story e4fc29fa(조각⑤)의 fail-closed 관례 그대로 — 현재 pasted_secret 채널은
+        # wordpress/webhook 둘뿐. 새 pasted_secret 채널이 추가되고 이 분기가 안 늘면
+        # 조용히 새지 않고 여기로 떨어진다.
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "CHANNEL_NOT_PASTED_SECRET", "message": f"channel={row.channel!r}는 아직 지원하지 않습니다."},
+        )
+
+    updated = await replace_channel_connection_credential(
+        db, org_id=org_id, connection_id=connection_id, new_secret=new_secret,
+        updated_by=resolved.id, account_label=account_label,
+    )
+    return _to_response(updated)
 
 
 @router.post("/{org_id}/channel-connections/{connection_id}/disconnect", response_model=ChannelConnectionResponse)

--- a/backend/app/services/channel_connection.py
+++ b/backend/app/services/channel_connection.py
@@ -70,6 +70,9 @@ async def upsert_channel_connection(
 
     encrypted_access_token = encrypt_channel_credential(access_token) if access_token else None
     encrypted_refresh_token = encrypt_channel_credential(refresh_token) if refresh_token else None
+    # story #3492 — pasted_secret 채널만 재방문 표시용 힌트를 남긴다(oauth는 이 개념이
+    # 없다, §2 규격 3).
+    secret_hint = _secret_hint(access_token) if access_token and credential_kind == "pasted_secret" else None
 
     if existing is None:
         row = ChannelConnection(
@@ -77,7 +80,7 @@ async def upsert_channel_connection(
             account_label=account_label, credential_kind=credential_kind,
             encrypted_access_token=encrypted_access_token, encrypted_refresh_token=encrypted_refresh_token,
             token_expires_at=token_expires_at, refresh_mode=refresh_mode, scopes=scopes,
-            status="active", connected_by=connected_by,
+            status="active", connected_by=connected_by, secret_hint=secret_hint,
         )
         db.add(row)
     else:
@@ -91,7 +94,50 @@ async def upsert_channel_connection(
         existing.status = "active"
         existing.last_error = None
         existing.connected_by = connected_by
+        existing.secret_hint = secret_hint
         row = existing
+
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+def _secret_hint(secret: str) -> str:
+    """channel_connections.py::_app_id_suffix와 동형(끝 4자리) — story #3492."""
+    return secret[-4:] if len(secret) >= 4 else secret
+
+
+async def replace_channel_connection_credential(
+    db: AsyncSession, *, org_id: uuid.UUID, connection_id: uuid.UUID,
+    new_secret: str, updated_by: uuid.UUID, account_label: str | None = None,
+) -> ChannelConnection:
+    """story #3492(PO 決定 2026-09-05) — 붙여넣기(pasted_secret) 자격 「제자리 교체」.
+    `upsert_channel_connection`과 의도적으로 다른 함수다 — 그쪽은 (org, channel,
+    account_id) 키로 새 행을 만들거나 찾아 갱신하지만(account_id가 바뀌면 새 행),
+    이 함수는 `connection_id` 하나로 정확히 그 행만 찾아 자격만 바꾼다(id·account_id·
+    channel 전부 불변 — draft·발행 이력·external_publish 게이트 scope_key(story
+    #3478, connection_id 단위)가 안 끊긴다는 것이 이 스토리의 존재 이유).
+
+    `account_label`은 WordPress만 갱신 대상(username이 바뀔 수 있다 — webhook은
+    label 개념이 없어 호출부가 안 넘긴다). `status`는 시험 성공 前에도 그대로
+    active로 남는다(PO 明示 — pending_verify 같은 신규 상태를 만들지 않는다,
+    「연결 시험」이 검증 축). 기존 last_error는 지운다(새 자격이 이전 실패를
+    고쳤을 수 있다 — 사람이 다시 시험 눌러 실제로 확인)."""
+    row = (await db.execute(
+        select(ChannelConnection).where(
+            ChannelConnection.id == connection_id, ChannelConnection.org_id == org_id,
+        ).with_for_update()
+    )).scalar_one_or_none()
+    if row is None:
+        raise ChannelConnectionNotFoundError(connection_id)
+
+    row.encrypted_access_token = encrypt_channel_credential(new_secret)
+    row.secret_hint = _secret_hint(new_secret)
+    if account_label is not None:
+        row.account_label = account_label
+    row.status = "active"
+    row.last_error = None
+    row.connected_by = updated_by
 
     await db.commit()
     await db.refresh(row)

--- a/backend/app/services/channel_connection.py
+++ b/backend/app/services/channel_connection.py
@@ -102,9 +102,16 @@ async def upsert_channel_connection(
     return row
 
 
-def _secret_hint(secret: str) -> str:
-    """channel_connections.py::_app_id_suffix와 동형(끝 4자리) — story #3492."""
-    return secret[-4:] if len(secret) >= 4 else secret
+def _secret_hint(secret: str) -> str | None:
+    """channel_connections.py::_app_id_suffix와 동형(끝 4자리) — story #3492.
+
+    페드루 PO 차단(2026-09-05, PR#3841 리뷰·유나 Design FAIL) — 이전엔 3자 이하
+    secret이면 원문 통째를 그대로 돌려줬다(`len(secret) >= 4`가 아니면 else 분기가
+    `secret` 자체). 그 값이 DB `secret_hint` 컬럼(평문)·목록 응답(member까지)·화면
+    「****ab」로 그대로 샌다 — 짧은 secret일수록 오히려 더 많이 새는 역설. 8자
+    미만이면 힌트 자체를 안 만든다(None, 화면은 `secretHint ? … : null`이라 이미
+    null-safe — 무변경)."""
+    return secret[-4:] if len(secret) >= 8 else None
 
 
 async def replace_channel_connection_credential(

--- a/backend/tests/test_3492_credential_replace.py
+++ b/backend/tests/test_3492_credential_replace.py
@@ -1,0 +1,320 @@
+"""story #3492(Phase1·마케팅운영·소형, 페드루 PO 決定 2026-09-05) — 붙여넣기(pasted_
+secret) 채널 연결(WordPress·webhook) 자격 「제자리 교체」. 유나 10회차 #3823 E 관찰
+— 지금은 해제→새로 연결뿐이라 자격을 바꿀 때마다 connection_id가 갈려 draft·발행
+이력·external_publish 게이트 scope_key(story #3478)가 끊긴다.
+
+세팅 헬퍼는 test_e4fc29fa_channel_connection_creation.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_e4fc29fa_channel_connection_creation import (
+    _client_for,
+    _seed_agent,
+    _seed_human,
+    _seed_org,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _create_wordpress_connection(client, org_id, *, site_url="https://customer-blog.example.com"):
+    r = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-connections/wordpress",
+        json={"site_url": site_url, "username": "editor", "app_password": "app-pw-original-1234"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+async def _create_webhook_connection(client, org_id, *, target_url="https://customer-target.example.com/hook"):
+    r = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-connections/webhook",
+        json={"target_url": target_url, "secret": "original-secret-abcd"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+@pytest.mark.anyio
+async def test_owner_replaces_wordpress_app_password_id_unchanged(dns_stub):
+    """핵심 AC — id 불변으로 자격만 바뀐다(해제→재연결이 아니다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            created = await _create_wordpress_connection(client, org_id)
+            connection_id = created["id"]
+
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}/channel-connections/{connection_id}/credentials",
+                json={"username": "new-editor", "app_password": "app-pw-rotated-5678"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["id"] == connection_id, "자격 교체가 새 connection_id를 만들었다 — 제자리 교체가 아니다"
+        assert body["account_id"] == created["account_id"], "account_id(site_url)는 자격 교체 대상이 아니다"
+        assert body["account_label"] == "new-editor"
+        assert body["status"] == "active"
+        # story #3373 AC6과 동형 — 응답에 자격 원문이 어떤 필드로도 안 실린다.
+        assert "app_password" not in body and "encrypted_access_token" not in body
+        # §2 규격 3 — 끝 4자리 힌트만.
+        assert body["secret_hint"] == "5678"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_admin_replaces_webhook_secret(dns_stub):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="admin")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            created = await _create_webhook_connection(client, org_id)
+            connection_id = created["id"]
+
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}/channel-connections/{connection_id}/credentials",
+                json={"secret": "rotated-secret-wxyz"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["id"] == connection_id
+        assert body["secret_hint"] == "wxyz"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_replaced_credential_is_actually_used_for_next_publish(dns_stub):
+    """AC — 바꾼 뒤 발행이 새 자격으로 나간다(스텁의 Basic 인증 헤더 실측). 뮤테이션
+    대상: replace_channel_connection_credential이 encrypted_access_token을 안
+    갱신하면 이 assert가 옛 비밀번호로도 200을 내 RED가 안 된다(스텁이 자격을 검사
+    안 하면 이 테스트 자체가 무의미해지므로, 스텁이 검사하는지도 간접 확인)."""
+    from app.services.channel_credential_crypto import decrypt_channel_credential
+    from app.models.channel_connection import ChannelConnection
+    from sqlalchemy import select
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            created = await _create_wordpress_connection(client, org_id)
+            connection_id = created["id"]
+
+            await client.patch(
+                f"/api/v2/organizations/{org_id}/channel-connections/{connection_id}/credentials",
+                json={"app_password": "app-pw-rotated-9999"},
+            )
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(ChannelConnection).where(ChannelConnection.id == uuid.UUID(connection_id))
+            )).scalar_one()
+            assert decrypt_channel_credential(row.encrypted_access_token) == "app-pw-rotated-9999"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_forbidden(dns_stub):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="owner")
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            created = await _create_wordpress_connection(client, org_id)
+            connection_id = created["id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}/channel-connections/{connection_id}/credentials",
+                json={"app_password": "x"},
+            )
+        assert r.status_code == 403, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_CONNECTION_HUMAN_ONLY"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_member_forbidden(dns_stub):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            member_id = await _seed_human(s, org_id, role="member")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id, agent=False)
+        async with _client_for(app) as client:
+            created = await _create_wordpress_connection(client, org_id)
+            connection_id = created["id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=member_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}/channel-connections/{connection_id}/credentials",
+                json={"app_password": "x"},
+            )
+        assert r.status_code == 403, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_CONNECTION_OWNER_OR_ADMIN_ONLY"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_missing_secret_field_rejected(dns_stub):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            created = await _create_wordpress_connection(client, org_id)
+            connection_id = created["id"]
+
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}/channel-connections/{connection_id}/credentials",
+                json={"username": "new-editor"},
+            )
+        assert r.status_code == 422, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "WORDPRESS_FIELDS_REQUIRED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_oauth_channel_rejected(dns_stub):
+    """threads는 credential_kind="oauth" — 이 붙여넣기 교체 엔드포인트 대상이 아니다."""
+    from app.services.channel_connection import upsert_channel_connection
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="owner")
+            row = await upsert_channel_connection(
+                s, org_id=org_id, channel="threads", account_id="acct-1", account_label=None,
+                credential_kind="oauth", access_token="tok", refresh_token=None,
+                token_expires_at=None, refresh_mode="manual", scopes=[], connected_by=human_id,
+            )
+            connection_id = str(row.id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}/channel-connections/{connection_id}/credentials",
+                json={"app_password": "x"},
+            )
+        assert r.status_code == 404, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_NOT_PASTED_SECRET"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_other_org_connection_returns_404(dns_stub):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a, project_a = await _seed_org(s)
+            owner_a = await _seed_human(s, org_a, role="owner")
+            org_b, project_b = await _seed_org(s)
+            owner_b = await _seed_human(s, org_b, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_a, user_id=owner_a, agent=False)
+        async with _client_for(app) as client:
+            created = await _create_wordpress_connection(client, org_a)
+            connection_id = created["id"]
+
+        _setup_org_scoped_app(app, Session, org_b, user_id=owner_b, agent=False)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_b}/channel-connections/{connection_id}/credentials",
+                json={"app_password": "x"},
+            )
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3492_credential_replace.py
+++ b/backend/tests/test_3492_credential_replace.py
@@ -318,3 +318,35 @@ async def test_other_org_connection_returns_404(dns_stub):
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_short_secret_produces_no_hint_not_the_full_secret(dns_stub):
+    """페드루 PO 차단(2026-09-05, PR#3841 리뷰①·유나 Design FAIL) — 8자 미만 secret은
+    끝 4자리를 만들 수 없다(원문과 같아지거나 원문 자체가 나간다). 옛 코드는
+    `len(secret) >= 4`가 아니면 원문 통째를 그대로 돌려줬다 — DB 컬럼(평문)·목록
+    응답(member까지)·화면에 새는 경로였다. 지금은 None(화면은 null-safe라 무변경)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            created = await _create_wordpress_connection(client, org_id)
+            connection_id = created["id"]
+
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}/channel-connections/{connection_id}/credentials",
+                json={"app_password": "short12"},  # 7자 — 8자 미만.
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["secret_hint"] is None, "7자 secret인데 원문(또는 그 일부)이 secret_hint로 샜다"
+        assert "short12" not in str(body), "원문 secret이 응답 어디에도 없어야 한다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -349,6 +349,13 @@ _ID_MUTATION_FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "(→_require_human)가 org 멤버십+role(owner)을 검증한다 — project 스코프 검증이 "
         "애초에 무의미(labels/organizations/org_members류와 동일 ORG_ONLY 결)."
     ),
+    "app.routers.channel_connections:replace_channel_connection_credentials": (
+        "story #3492 — 바로 위 set_channel_app_credentials와 자구 동형. path의 "
+        "{connection_id}는 channel_connections 행(org_id+channel+account_id UNIQUE·"
+        "project_id 컬럼 자체가 없음, org-level 리소스). _require_owner_or_admin이 org "
+        "멤버십+role(owner|admin)을 검증하고 get_channel_connection(org_id, connection_id) "
+        "선조회로 org 스코프를 이미 강제한다 — project 스코프 검증이 애초에 무의미."
+    ),
     # 실 가드가 있으나 v1 정적스캔이 인라인/1-hop 헬퍼를 미인식(guarded 확認)
     "app.routers.open_api_keys:revoke_project_api_key": "resolves ProjectApiKey→key.project_id!=path project_id 인라인 체크(v1 스캔 miss)",
     "app.routers.project_access:delete_project_access": "_require_owner_or_admin→has_project_role(admin) on path project_id(1-hop miss)",

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1153,6 +1153,11 @@
       "source": "story-e4fc29fa-channel-connection-creation(조각⑤, PR 개설 前 선제 등재 — 로컬 raw pytest 15.01s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 90s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3492_credential_replace.py",
+      "sec": 85.0,
+      "source": "story-3492-channel-connection-credential-replace(PR 개설 前 선제 등재 — 로컬 raw pytest 13.93s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 85s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3471_org_content_rules_lint.py",
       "sec": 40.0,
       "source": "story-3471-org-content-rules-lint(PR 개설 前 선제 등재 — 로컬 raw pytest 7.34s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## 요약
story #3492(Phase1·마케팅운영·소형, 페드루 PO 決定 2026-09-05) — WordPress·webhook(pasted_secret) 연결은 지금까지 해제→새로 연결뿐이라 자격을 바꿀 때마다 connection_id가 갈려 draft·발행 이력·external_publish 게이트 scope_key(story #3478, connection_id 단위)가 끊겼다. id 불변으로 자격만 바꾸는 경로를 새로 연다.

## 변경
- `PATCH /organizations/{org_id}/channel-connections/{connection_id}/credentials` — owner/admin(휴먼만, 에이전트 403 `CHANNEL_CONNECTION_HUMAN_ONLY`), WordPress=`{username?, app_password}`·webhook=`{secret}`, id·account_id·channel·status(active 복귀) 불변. 응답에 자격 원문은 어떤 필드로도 안 실린다.
- `replace_channel_connection_credential()`(신규) — `connection_id`로 직접 조회해 `encrypted_access_token`·`secret_hint`만 갱신. `upsert_channel_connection()`과 의도적으로 분리(그쪽은 `(org, channel, account_id)` 재매칭 축이라 이 경로 대상이 아님).
- `channel_connections.secret_hint`(migration 0331) — 재방문 시 원문은 절대 저장/반환하지 않고 끝 4자리만(`_app_id_suffix`와 동형). oauth 채널은 NULL. `upsert_channel_connection()`도 pasted_secret 경로에서 이 값을 채우도록 함께 갱신(생성 시점부터 일관).
- FE: 연결 행에 「자격 바꾸기」 인라인 폼(`replace-credential-card.tsx`, `pasted-secret-connect-card.tsx`와 §2 동형 원칙 — secret류는 제출 직후 성공/실패 무관 항상 비움). 힌트는 `현재 자격: ****{끝4자리}`로 표시.
- 감사 축 — 기존 `connected_by`(actor)+`updated_at`(TimestampMixin, 시각) 재사용. 이 라우터의 disconnect/create 어느 쪽도 별도 audit_log 테이블을 쓰지 않는 기존 관례 그대로 유지했다 — `permission_audit_logs`는 `action` 값이 `member_added`/`member_removed`/`role_changed`로 닫혀 있어(팀멤버 라우터 주석) 이 mutation의 대상이 아니다. 별도 감사 테이블이 필요하다고 판단되면 PO 재량으로 후속 스토리 분리를 제안한다.

## 마이그레이션 순서 주의
`0331_channel_connection_secret_hint.py`의 `down_revision="0330"`은 #3837(story #3487)의 `preset_gate_verdict_gate_id_field` 마이그다 — 아직 develop 미착지. 스택(#3829✅→#3835→#3836→#3837) 순서대로 착지된 뒤 이 PR의 마이그가 체인 다음 자리를 잇는다. 로컬 검증은 각 sibling 브랜치에서 파일을 임시로 fetch해(커밋에는 없음) 0326→0331 전체 upgrade/downgrade round-trip으로 확인했다(아래 테스트 계획).

## 테스트 계획
- [x] BE `tests/test_3492_credential_replace.py`(신규 8) — owner WordPress 교체(id 불변·secret_hint=끝4자리)·admin webhook 교체·교체된 자격이 실제로 다음 발행에 쓰임(DB round-trip으로 복호화 검증)·agent 403(`CHANNEL_CONNECTION_HUMAN_ONLY`)·member 403(`CHANNEL_CONNECTION_OWNER_OR_ADMIN_ONLY`)·필수 필드 누락 422·oauth 채널 404(`CHANNEL_NOT_PASTED_SECRET`)·타 org 404 — 로컬 disposable Postgres 8/8 PASS
- [x] BE 회귀 — `test_e4fc29fa_channel_connection_creation.py`(기존 생성 플로우) 10/10 PASS·`-k channel_connection -m destructive_schema` 47/47 PASS
- [x] BE 마이그 — 임시 fetch(0327~0330)로 0326→0331 전체 upgrade 성공 확인 + `downgrade -1`로 `secret_hint` 컬럼 정상 제거 확인(round-trip), 이후 sibling 파일은 커밋 전 삭제
- [x] `scripts/lint_destructive_schema_weights_registered.py` — 신규 파일 등재 확인(OK, 미등재 0건)
- [x] FE `page.test.tsx`(4개 신규: secret_hint 없을 때 무흔적·있을 때 힌트+버튼·member 비노출·폼 열기→제출→PATCH 호출+재조회) 포함 전체 30/30 PASS
- [x] `pnpm --filter web type-check` 클린·`node scripts/check-i18n-keys.js` 클린(ko/en 키 동기화)