### PR TITLE
[SID:3496] fix: submit() early-return ignores reapproval_required — permanent resubmit lockout

### DIFF
--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -933,6 +933,13 @@ async def submit_channel_post_draft(
         and not schedule_changed
         and not media_changed
         and existing.status in ("pending", "approved")
+        # story #3496(site_posts.py와 동형 결함, 페드루 실측 2026-09-05) — reapproval_
+        # required도 판정 축이다. 승인 뒤 편집(approved→pending+reapproval_required=
+        # True)한 뒤 submit 없이 또 편집하면 재봉인 훅이 sealed_*를 최신으로 동기화
+        # 하면서도 reapproval_required는 그대로 True로 남긴다 — 그 상태에서 이 조기
+        # return이 content/schedule/media만 보고 "이미 봉인돼 있다"로 넘기면 게이트
+        # 재승인 가드가 절대 안 풀리는 영구 막다른 길이 된다.
+        and not existing.reapproval_required
     ):
         return existing, target.id
 

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -680,6 +680,16 @@ async def submit_site_post_draft(
         # "이미 이 정확한 상태로 봉인돼 있다"가 아니다 — 재봉인(아래)을 타야 한다.
         and existing.sealed_destination_connection_id == draft.connection_id
         and existing.status in ("pending", "approved")
+        # story #3496(페드루 실측 2026-09-05) — reapproval_required도 판정 축이다. 승인
+        # 뒤 편집(approved→pending+reapproval_required=True, sealed는 옛 버전 보존)한
+        # 뒤 **submit 없이** 또 편집하면 `_reseal_gate_on_new_version`의 pending 분기가
+        # sealed_content_*·sealed_destination을 최신으로 동기화하면서도 reapproval_
+        # required는 그대로 True로 둔다(그 필드는 이 훅의 관할이 아니다) — 그 상태에서
+        # submit()이 sha·destination만 보고 "이미 봉인돼 있다"로 조기 return하면 gates.py
+        # 의 재승인 가드(SITE_POST_RESUBMIT_REQUIRED)가 절대 안 풀리는 영구 막다른 길이
+        # 된다(사람이 본문을 한 글자라도 바꿔야만 풀림 — 안내 없는 사고). "이미 이 정확한
+        # 상태로 봉인돼 있다"는 재승인 요구가 없을 때만 참이다.
+        and not existing.reapproval_required
     ):
         return existing, target.id  # 이미 이 정확한 내용+목적지로 봉인돼 있다 — 재봉인하지 않는다(불변).
 

--- a/backend/tests/test_3367_site_post_submit_gate_seal.py
+++ b/backend/tests/test_3367_site_post_submit_gate_seal.py
@@ -471,6 +471,127 @@ async def test_approve_after_edit_is_blocked_until_resubmit_seals_new_version():
 
 
 @pytest.mark.anyio
+async def test_double_edit_without_resubmit_between_still_requires_and_allows_resubmit():
+    """story #3496(페드루 실측 2026-09-05, #3835 3ee55a847 코드 읽기 중 발견) — 승인 뒤
+    편집(v2, reapproval_required=True)까지는 위 테스트와 같지만, **submit() 없이 또
+    편집(v3)**하면 `_reseal_gate_on_new_version`의 pending 분기가 sealed_content_*·
+    sealed_destination을 v3로 동기화하면서도 reapproval_required는 그대로 True로
+    남긴다(그 필드는 그 훅의 관할이 아니다). 그 상태에서 submit()을 호출하면 sealed
+    sha·destination이 이미 target(v3)과 일치해 "이미 이 정확한 상태로 봉인돼 있다"는
+    조기 return 조건에 걸린다 — reapproval_required를 안 보던 옛 조건이면 게이트가
+    조용히 무변한 채 반환되고, 이어지는 승인 시도가 여전히(그리고 영원히) 409
+    SITE_POST_RESUBMIT_REQUIRED로 막힌다(재상신해도 다시 이 자리로 돌아오는 막다른
+    길 — 사람이 본문을 한 글자라도 또 바꿔야만 빠져나간다, 안내 없는 사고).
+
+    수정 後 기대값 — submit()이 조기 return을 안 타고 reapproval_required=False까지
+    재봉인해, 그 뒤 승인이 200으로 통과한다."""
+    from app.main import app
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.services.member_resolver import ResolvedMember
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+        async with Session() as s:
+            await _approve_gate_directly(s, gate_id)
+
+        # v2 — 승인 뒤 편집. pending+reapproval_required=True로 재오픈(위 테스트와 동일).
+        async with _client_for(app) as client:
+            r_edit_v2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, title="2호 글(수정 v2)"),
+            )
+        assert r_edit_v2.status_code == 201, r_edit_v2.text
+
+        # v3 — submit() 재호출 없이 또 편집. pending 분기가 sealed를 v3로 동기화하되
+        # reapproval_required는 손 안 댄다(True 그대로) — 이게 이 스토리의 재현 핵심.
+        async with _client_for(app) as client:
+            r_edit_v3 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, title="2호 글(수정 v3, submit 안 거침)"),
+            )
+        assert r_edit_v3.status_code == 201, r_edit_v3.text
+        v3_sha256 = r_edit_v3.json()["body_sha256"]
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+        assert gate.status == "pending"
+        assert gate.sealed_content_sha256 == v3_sha256, "pending 재봉인 훅이 v3로 동기화되지 않았다(그라운딩 전제 확인)"
+        assert gate.reapproval_required is True, "reapproval_required가 편집 훅에서 조용히 풀렸다(그라운딩 전제 확인)"
+
+        # submit() 재호출 — v3는 이미 봉인돼 있다(sha·destination 둘 다 동일) → 옛 조건이면
+        # 조기 return으로 reapproval_required=True가 그대로 남는다.
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_resubmit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r_resubmit.status_code == 200, r_resubmit.text
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+        assert gate.reapproval_required is False, (
+            "submit() 재호출이 이미-봉인 조기 return을 타 reapproval_required가 안 풀렸다"
+            " — 승인이 영구히 409로 막히는 사고"
+        )
+
+        # 이제 승인이 통과해야 한다(막다른 길이 아니어야).
+        approver = ResolvedMember(
+            id=uuid.uuid4(), user_id=uuid.uuid4(), name="approver", type="human",
+            role="owner", org_id=org_id,
+        )
+
+        class _FakeAuth:
+            user_id = str(approver.user_id)
+            claims: dict = {"app_metadata": {"org_id": str(org_id)}}
+
+        from fastapi import BackgroundTasks
+        from unittest.mock import AsyncMock, patch
+        import app.routers.gates as gates_mod
+
+        async with Session() as s:
+            with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=approver)), \
+                 patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
+                # story #2027 고위험 게이트 사유 강제(신규 org=기본 posture=high risk_grade
+                # 추정) — 이 테스트의 관심사(SITE_POST_RESUBMIT_REQUIRED 해소)와 무관한
+                # 별도 가드라 note를 채워 지나간다(위 test_approve_after_edit_...는 그
+                # 가드 前에 409로 끝나 이 자리에 안 닿았을 뿐, 신규 요구사항이 아니다).
+                approved = await transition_gate_endpoint(
+                    id=gate_id, body=GateTransitionRequest(status="approved", note="재검토 완료", evidence_viewed=True),
+                    background_tasks=BackgroundTasks(), session=s, org_id=org_id, auth=_FakeAuth(),
+                )
+        assert approved.status == "approved", "재봉인이 정상 처리됐는데도 승인이 막혔다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_publish_with_content_diverged_from_sealed_hash_returns_409_and_keeps_old_public_body():
     """AC6의 실제 갭 — 기존 POST /site-posts는 임의 body(title/slug/body_md 등)를 그대로
     받는다(초안/버전 시스템과 무관하게 호출 가능, S1 이전부터 있던 계약). 게이트가 approved인

--- a/backend/tests/test_3374_channel_posts.py
+++ b/backend/tests/test_3374_channel_posts.py
@@ -443,6 +443,110 @@ async def test_approve_after_edit_is_blocked_until_resubmit_seals_new_version():
 
 
 @pytest.mark.anyio
+async def test_double_edit_without_resubmit_between_still_requires_and_allows_resubmit():
+    """story #3496(site_posts.py::test_double_edit_without_resubmit_between_...와
+    동형, 페드루 실측 2026-09-05) — 승인 뒤 편집(v2)까지는 위 테스트와 같지만,
+    **submit() 없이 또 편집(v3)**하면 재봉인 훅이 sealed_*를 v3로 동기화하면서도
+    reapproval_required는 True로 남긴다. submit()의 조기 return 조건이
+    reapproval_required를 안 보면, sealed sha·schedule·media가 이미 v3와 일치해
+    "이미 봉인돼 있다"로 조용히 넘어가 승인이 영구히 409 SITE_POST_RESUBMIT_REQUIRED
+    로 막힌다."""
+    from app.main import app
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.services.member_resolver import ResolvedMember
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+            )
+        gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+        async with Session() as s:
+            await _approve_gate_directly(s, gate_id)
+
+        # v2 — 승인 뒤 편집.
+        async with _client_for(app) as client:
+            r_edit_v2 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id, text="채널 포스트 v2."),
+            )
+        assert r_edit_v2.status_code == 201, r_edit_v2.text
+
+        # v3 — submit() 없이 또 편집.
+        async with _client_for(app) as client:
+            r_edit_v3 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id, text="채널 포스트 v3(submit 안 거침)."),
+            )
+        assert r_edit_v3.status_code == 201, r_edit_v3.text
+        v3_sha256 = r_edit_v3.json()["body_sha256"]
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+        assert gate.status == "pending"
+        assert gate.sealed_content_sha256 == v3_sha256, "pending 재봉인 훅이 v3로 동기화되지 않았다(그라운딩 전제 확인)"
+        assert gate.reapproval_required is True, "reapproval_required가 편집 훅에서 조용히 풀렸다(그라운딩 전제 확인)"
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_resubmit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r_resubmit.status_code == 200, r_resubmit.text
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+        assert gate.reapproval_required is False, (
+            "submit() 재호출이 이미-봉인 조기 return을 타 reapproval_required가 안 풀렸다"
+            " — 승인이 영구히 409로 막히는 사고"
+        )
+
+        approver = ResolvedMember(
+            id=uuid.uuid4(), user_id=uuid.uuid4(), name="approver", type="human", role="owner", org_id=org_id,
+        )
+
+        class _FakeAuth:
+            user_id = str(approver.user_id)
+            claims: dict = {"app_metadata": {"org_id": str(org_id)}}
+
+        from fastapi import BackgroundTasks
+        from unittest.mock import AsyncMock, patch
+        import app.routers.gates as gates_mod
+
+        async with Session() as s:
+            with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=approver)), \
+                 patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
+                approved = await transition_gate_endpoint(
+                    id=gate_id, body=GateTransitionRequest(status="approved", note="재검토 완료", evidence_viewed=True),
+                    background_tasks=BackgroundTasks(), session=s, org_id=org_id, auth=_FakeAuth(),
+                )
+        assert approved.status == "approved", "재봉인이 정상 처리됐는데도 승인이 막혔다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_resubmit_after_approved_edit_reseals_to_new_version():
     """AC5 QA 뮤테이션 대상 — gate_seal.compute_seal_hash가 payload 내용과 무관한 상수를
     내면(공용 헬퍼가 깨진 것과 동형), 편집 전/후 버전이 "같은 해시"로 보여 이 재상신이


### PR DESCRIPTION
## 요약
페드루 실측(2026-09-05, #3835 3ee55a847 코드 읽기 중 발견) — site_post/channel_post 상신의 「이미 이 정확한 상태로 봉인돼 있다」 조기 return 조건이 `reapproval_required`를 안 봐, 승인 뒤 두 번 편집(사이에 submit() 없이)하면 재승인이 영구히 409로 막히는 막다른 길이 있었다.

## 재현 경로 (5단계, 그대로)
1. v1 submit → approve(approved, sealed v1)
2. 편집 v2 → `_reseal_gate_on_new_version` approved 분기 → pending+`reapproval_required=True`(sealed v1 보존)
3. **submit 없이** 편집 v3 → 같은 함수 pending 분기(status만 봄) → sealed=v3로 동기화(`reapproval_required`는 True 그대로 — 그 필드는 이 훅의 관할이 아님)
4. submit v3 → sealed==target·destination/schedule/media 동일·status pending → 조기 return(게이트 무변, `reapproval_required=True` 그대로)
5. approve → gates.py 가드 409 `SITE_POST_RESUBMIT_REQUIRED` → 재상신해도 4로 되돌아가는 영구 막다른 길(사람이 본문을 한 글자라도 또 바꿔야만 풀림, 안내 없음)

## 변경 前 / 後 조건 (파일:줄, 요청된 명시)
- `backend/app/services/site_posts.py::submit_site_post_draft`(조기 return 조건, 변경 전 라인 675-684)
  - 前: `existing is not None and existing.sealed_content_sha256 == target.body_sha256 and existing.sealed_destination_connection_id == draft.connection_id and existing.status in ("pending", "approved")`
  - 後: 위 조건에 `and not existing.reapproval_required` 추가.
- `backend/app/services/channel_posts.py::submit_channel_post_draft`(조기 return 조건, 변경 전 라인 930-936)
  - 前: `existing is not None and not content_changed and not schedule_changed and not media_changed and existing.status in ("pending", "approved")`
  - 後: 위 조건에 `and not existing.reapproval_required` 추가.

pending 분기 재봉인(`_reseal_gate_on_new_version`)에서 `reapproval_required`를 지우는 방향은 채택 안 함 — 명시 submit() 없이 승인 가능해져 story #3367 S2 설계(승인 뒤 편집은 반드시 재상신을 거쳐야 한다) 위반이 된다.

## 테스트 계획
- [x] `test_3367_site_post_submit_gate_seal.py::test_double_edit_without_resubmit_between_still_requires_and_allows_resubmit`(신규) — 위 1~5 재현, 수정 前 직접 RED 확인(뮤테이션 자가검증: `and not existing.reapproval_required` 제거 → RED 재현 → 복원) → 수정 後 GREEN(`reapproval_required=False`로 재봉인·승인 200).
- [x] `test_3374_channel_posts.py::test_double_edit_without_resubmit_between_still_requires_and_allows_resubmit`(동형 신규) — 위와 동일 패턴(channel_post), 뮤테이션 자가검증 동일하게 확인.
- [x] AC4 — 기존 `test_e4fc29fa_destination_axis.py`·site_post 봉인 테스트(`test_3367_site_post_submit_gate_seal.py` 나머지 전체) 무회귀.
- [x] 광범위 회귀 — `-k "site_post or channel_post or e4fc29fa or 3404 or 3443"` 184/184 green.
- [x] `scripts/lint_destructive_schema_weights_registered.py` — 신규 destructive-schema 파일 0건(기존 파일에 테스트 추가뿐), 등재 상태 무변 확인.

## 참고
site_posts.py의 이 자리는 #3478(PR#3835, scope_key)의 diff(`_resolve_approved_gate`·`list_site_post_drafts`·`_reseal_gate_on_new_version`)와 겹치지 않는다(다른 함수) — base는 plain `develop`, #3835 착지를 기다리지 않고 병행 진행.