### PR TITLE
[SID:3498] feat: 생성 비용 한도(크레딧 게이트) — budget 봉인 축 + 서버 거부

### DIFF
--- a/backend/alembic/versions/0333_gate_sealed_estimated_cost_minor.py
+++ b/backend/alembic/versions/0333_gate_sealed_estimated_cost_minor.py
@@ -1,0 +1,28 @@
+"""story #3498(Phase2·마케팅운영, 페드루 PO 決定 2026-09-05) — `gate.sealed_estimated_
+cost_minor` 신설(additive, nullable). 블루프린트 v3 §2 「생성 비용 한도(크레딧 게이트)」·
+§1 구조적 차단 3(승인 시 예산 봉인) — gate.py 자신이 이미 예고해 둔 「목적지·버전·예약·
+예산」 4축 봉인 중 "예산" 축의 실제 구현.
+
+`org_content_rules.rules.generation_budget`·evidence.payload.cost_minor 쪽은 신규 컬럼이
+필요 없다(기존 JSONB 슬롯 확장 — additive, 별도 마이그 불요). 이 컬럼 하나가 이 스토리의
+유일한 스키마 변경.
+
+down_revision=0332는 story #3497(#3844)의 마이그 — 이 스토리 착수 시점에 develop 미착지
+였다(gh pr list로 실물 확인, 스택 관례 그대로)."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0333"
+down_revision = "0332"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("gate", sa.Column("sealed_estimated_cost_minor", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("gate", "sealed_estimated_cost_minor")

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -151,6 +151,15 @@ class Gate(Base):
     sealed_destination_connection_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
+    # story #3498(Phase2·마케팅운영, 페드루 PO 決定 2026-09-05, migration 0333) —
+    # external_publish 전용 다섯 번째 봉인 축(위 네 축과 같은 공유-nullable 관례).
+    # submit()이 실은 예상 생성비용 추정치 — "승인 후 값 변경=재승인, 사유=BUDGET_
+    # CHANGED"를 content/schedule/media/destination 축과 독립적으로 판정한다(블루프린트
+    # §2 「목적지·불변 버전·예약 시각·예산을 참조 — 승인 후 변경 시 무효화」의 "예산"
+    # 축 — gate.py 자신의 이 예고가 이 스토리 전까지 미구현이었다). `_reseal_gate_
+    # on_new_version`(편집 훅)은 이 필드를 절대 안 건드린다 — submit() 재호출만이
+    # 재봉인 권한을 갖는다(sealed_content_*와 동일 "무엇이 승인됐었나 보존" 원칙).
+    sealed_estimated_cost_minor: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # 승인 후 수정으로 시스템이 되돌린 pending인지(사람이 처음 상신한 pending과 구분 — S4가
     # "재승인 필요" 배지를 그릴 신호) — 새 명시 submit()이 재봉인하면 False로 복귀한다.
     reapproval_required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -68,6 +68,7 @@ from app.services.channel_post_images import (
     get_channel_post_image_for_version,
     public_url_for_object_path,
 )
+from app.services.generation_budget import GenerationBudgetExceededError
 from app.services.member_resolver import resolve_member
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["channel-posts"])
@@ -297,6 +298,9 @@ class SubmitChannelPostDraftRequest(BaseModel):
     # v3 §3). 생략/null=즉시. 승인 뒤 이 값만 바꿔도(본문은 그대로) 재승인이 필요하다 —
     # submit_channel_post_draft가 그 판정을 한다(신규 엔드포인트 없음).
     scheduled_at: datetime | None = None
+    # story #3498(페드루 PO 決定 2026-09-05) — site_posts.py와 동형(submit 전용, draft
+    # 컬럼 아님). 생략/null=검사 없음(AC2).
+    estimated_cost_minor: int | None = None
 
     @field_validator("scheduled_at")
     @classmethod
@@ -817,7 +821,18 @@ async def submit_channel_post_draft_endpoint(
         gate, version_id = await submit_channel_post_draft(
             db, org_id=org_id, draft_id=draft_id, version_id=body.version_id,
             requester_member_id=uuid.UUID(auth.user_id), scheduled_at=body.scheduled_at,
+            estimated_cost_minor=body.estimated_cost_minor,
         )
+    except GenerationBudgetExceededError as exc:
+        # story #3498(AC2) — site_posts.py와 동형 4값 detail.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "GENERATION_BUDGET_EXCEEDED",
+                "limit_minor": exc.limit_minor, "spent_minor": exc.spent_minor,
+                "estimated_cost_minor": exc.estimated_cost_minor, "remaining_minor": exc.remaining_minor,
+            },
+        ) from exc
     except ChannelPostDraftNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ChannelPostVersionNotFoundError as exc:
@@ -1004,6 +1019,22 @@ async def publish_channel_post_draft_endpoint(
         raise HTTPException(
             status_code=403,
             detail=_with_command_state({"code": "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "message": str(exc)}),
+        ) from exc
+    except GenerationBudgetExceededError as exc:
+        # story #3498(AC4) — 위 EXTERNAL_PUBLISH_APPROVAL_REQUIRED와 동형 처리(adapter
+        # 미호출, 원장 기록만 추가·재시도/종결 정책 변경 없음).
+        await _record_this_attempt(approval_check="budget_exceeded", adapter_called=False, result_code=None)
+        await apply_command_failure(
+            db, command, error_code="GENERATION_BUDGET_EXCEEDED", last_error=str(exc), now=now,
+        )
+        await db.commit()
+        raise HTTPException(
+            status_code=422,
+            detail=_with_command_state({
+                "code": "GENERATION_BUDGET_EXCEEDED",
+                "limit_minor": exc.limit_minor, "spent_minor": exc.spent_minor,
+                "estimated_cost_minor": exc.estimated_cost_minor, "remaining_minor": exc.remaining_minor,
+            }),
         ) from exc
     except ChannelTextTooLongError as exc:
         # 페드루 PO 확定(2026-09-03) — 발행 시점 재검사(UTM 태그된 링크가 붙은 실제 전송

--- a/backend/app/routers/content_rules.py
+++ b/backend/app/routers/content_rules.py
@@ -12,7 +12,7 @@ import uuid
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -53,7 +53,10 @@ class GenerationBudgetRule(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    limit_minor: int
+    # 페드루 PO REQUIRED(2026-09-05, PR#3847 리뷰③) — limit_minor 음수는 "정지"보다
+    # 더 이상한 상태(잔량이 시작부터 음수)라 애초에 저장을 막는다. currency/period는
+    # Literal이 이미 422를 강제(3종 검증 테스트로 확認).
+    limit_minor: int = Field(ge=0)
     currency: Literal["KRW", "USD"] = "KRW"
     period: Literal["month"] = "month"
 

--- a/backend/app/routers/content_rules.py
+++ b/backend/app/routers/content_rules.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import uuid
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.services.content_rules import get_org_content_rules, put_org_content_rules
+from app.services.generation_budget import compute_generation_budget_status
 from app.services.member_resolver import resolve_member
 from app.services.project_auth import assert_target_in_caller_org
 
@@ -43,6 +46,18 @@ class ContentRulesResponse(BaseModel):
     version: int
 
 
+class GenerationBudgetRule(BaseModel):
+    """story #3498(페드루 PO 決定 2026-09-05) — 생성 비용 한도 정책값(Sprintable
+    결제 원장과 무접촉, 3471 슬롯 확장). limit_minor=0은 "정지"(모든 추정치가 즉시
+    거부) — 필드 자체가 없음(«규칙 없음»)과는 다른 신호(generation_budget.py 참고)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    limit_minor: int
+    currency: Literal["KRW", "USD"] = "KRW"
+    period: Literal["month"] = "month"
+
+
 class ContentRulesFields(BaseModel):
     """페드루 PO 리뷰 보정(2026-09-05, PR#3825) — `rules: dict`가 무형식이라
     `banned_terms`에 문자열 "spam"을 그대로 넣으면 `lint_content()`의
@@ -58,6 +73,7 @@ class ContentRulesFields(BaseModel):
     taxonomy: list[str] = []
     channel_priority: list[str] = []
     brand_kit: dict | None = None
+    generation_budget: GenerationBudgetRule | None = None
 
 
 class PutContentRulesRequest(BaseModel):
@@ -109,3 +125,44 @@ async def put_content_rules_endpoint(
         db, org_id=org_id, rules=validated.model_dump(), updated_by_member_id=resolved.id,
     )
     return ContentRulesResponse(org_id=row.org_id, rules=row.rules, version=row.version)
+
+
+class GenerationBudgetStatusResponse(BaseModel):
+    """story #3498 조각①(미르코 FE 3500 그라운딩, 페드루 PO 決定 2026-09-05) — 잔량
+    조회. limit_minor가 null이면(«규칙 없음») 전부 null — 지어내지 않는다(compute_
+    generation_budget_status()가 None을 돌려주는 그 신호를 그대로 반영)."""
+
+    limit_minor: int | None
+    currency: str | None
+    period: str | None
+    period_start: str | None
+    period_end: str | None
+    spent_minor: int | None
+    remaining_minor: int | None
+
+
+@router.get("/{org_id}/generation-budget", response_model=GenerationBudgetStatusResponse)
+async def get_generation_budget_endpoint(
+    org_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> GenerationBudgetStatusResponse:
+    """content-rules GET과 동일 권한 축(org 멤버 누구나 — 휴먼·에이전트 모두, write
+    없음). compute_generation_budget_status() 그대로 재사용(submit/발행 체크포인트와
+    같은 계산 함수 — 화면이 보는 값과 서버가 실제로 거부 판정에 쓰는 값이 항상
+    같다는 보장)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    status = await compute_generation_budget_status(db, org_id=org_id)
+    if status is None:
+        return GenerationBudgetStatusResponse(
+            limit_minor=None, currency=None, period=None, period_start=None, period_end=None,
+            spent_minor=None, remaining_minor=None,
+        )
+    return GenerationBudgetStatusResponse(
+        limit_minor=status["limit_minor"], currency=status["currency"], period=status["period"],
+        period_start=status["period_start"].isoformat(), period_end=status["period_end"].isoformat(),
+        spent_minor=status["spent_minor"], remaining_minor=status["remaining_minor"],
+    )

--- a/backend/app/routers/evidence.py
+++ b/backend/app/routers/evidence.py
@@ -199,6 +199,55 @@ async def _attach_artifact_denorm(
     return out
 
 
+_GENERATION_COST_KIND = "generation_cost"
+
+
+async def _validate_and_normalize_evidence_payload(
+    session: AsyncSession, *, org_id: uuid.UUID, payload: dict | None, caller_type: str,
+) -> dict | None:
+    """story #3498(페드루 PO REQUIRED, PR#3847 리뷰) — client-writable payload를 연
+    대가로 두 가지를 서버가 강제한다.
+
+    ① `recorded_by`는 클라이언트 값을 항상 버리고 서버가 채운다(caller_type 그대로
+    — "platform" 표식은 이 경로로 절대 못 나온다, insight_snapshots.py 내부 서비스
+    호출만이 그 표식을 쓸 수 있다). evidence.py의 어떤 payload든 이 축은 위조 불가.
+
+    ② `kind="generation_cost"`(생성 비용 자기 보고, 3498 §2 spent 합산의 유일한
+    입력)면 `cost_minor`는 int·0 이상이어야 한다(음수 cost로 잔량을 부풀려 한도를
+    뚫는 걸 여기서 원천 차단 — generation_budget.py의 합산 스킵은 두 번째 겹).
+    `currency`는 조직에 generation_budget 정책이 설정돼 있으면 그 통화와 정확히
+    일치해야 한다(정책 자체가 없으면 비교 대상이 없어 통과 — «규칙 없음»과 같은
+    원칙). 위반은 422 EVIDENCE_PAYLOAD_INVALID."""
+    if payload is None:
+        return None
+    payload = dict(payload)
+    payload["recorded_by"] = caller_type
+
+    if payload.get("kind") == _GENERATION_COST_KIND:
+        cost_minor = payload.get("cost_minor")
+        if not isinstance(cost_minor, int) or isinstance(cost_minor, bool) or cost_minor < 0:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "EVIDENCE_PAYLOAD_INVALID",
+                    "message": "generation_cost evidence의 cost_minor는 0 이상의 정수여야 합니다.",
+                },
+            )
+        from app.services.content_rules import get_org_content_rules
+
+        rule_row = await get_org_content_rules(session, org_id=org_id)
+        policy_currency = ((rule_row.rules or {}).get("generation_budget") or {}).get("currency") if rule_row else None
+        if policy_currency is not None and payload.get("currency") != policy_currency:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "EVIDENCE_PAYLOAD_INVALID",
+                    "message": f"currency는 조직 정책 통화({policy_currency})와 일치해야 합니다.",
+                },
+            )
+    return payload
+
+
 @router.post("", response_model=EvidenceResponse, status_code=201)
 async def create_evidence(
     body: EvidenceCreateRequest,
@@ -223,6 +272,10 @@ async def create_evidence(
             session, body.artifact_id, org_id, project_id
         )
 
+    payload = await _validate_and_normalize_evidence_payload(
+        session, org_id=org_id, payload=body.payload, caller_type=caller.type,
+    )
+
     evidence = Evidence(
         id=uuid.uuid4(),
         org_id=org_id,
@@ -233,7 +286,7 @@ async def create_evidence(
         ref=body.ref,
         source=body.source,
         note=body.note,
-        payload=body.payload,
+        payload=payload,
         created_by=caller.id,
     )
     session.add(evidence)

--- a/backend/app/routers/evidence.py
+++ b/backend/app/routers/evidence.py
@@ -34,6 +34,12 @@ class EvidenceCreateRequest(BaseModel):
     # 않는다 — "그 시각의 latest"를 서버가 항상 resolve해 고정한다(③pin 시점 규칙, 클라
     # 위임 시 취지가 샌다).
     artifact_id: uuid.UUID | None = None
+    # story #3498(페드루 PO 決定 2026-09-05) — evidence API가 "지출 기록" 정본이 되려면
+    # 클라이언트가 payload를 실을 수 있어야 한다(이전엔 insight_snapshots.py 등 내부
+    # 서비스만 이 컬럼을 썼다). 스키마는 여기서 강제 안 함(content_rules.py::lint_content
+    # 관례와 동형 — type="metric"·payload.kind="generation_cost"·cost_minor 규약은
+    # generation_budget.py가 읽는 쪽에서만 본다).
+    payload: dict | None = None
 
     @field_validator("work_item_type")
     @classmethod
@@ -76,6 +82,9 @@ class EvidenceResponse(BaseModel):
     # story #3497 — nullable(모델과 동형). None=행위자 없는 시스템 기록(인사이트
     # 스냅샷 evidence 등, payload.recorded_by="platform"이 그 표식).
     created_by: uuid.UUID | None
+    # story #3498 — 생성 시 받은 payload를 그대로 되돌려준다(모델·#3497 payload 컬럼과
+    # 동형, 이전엔 응답에 아예 없었다 — 내부 서비스만 쓰던 컬럼이라 노출 자체가 불요했음).
+    payload: dict | None = None
     created_at: Any
     resolved_story_id: uuid.UUID | None = None
     """story #2314 AC3② — embed 칩이 evidence의 «담긴 곳»으로 한 번에 건너뛸 자리.
@@ -224,6 +233,7 @@ async def create_evidence(
         ref=body.ref,
         source=body.source,
         note=body.note,
+        payload=body.payload,
         created_by=caller.id,
     )
     session.add(evidence)

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -17,6 +17,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.services.member_resolver import resolve_member
 from app.routers.insight_snapshots import InsightSnapshotView
+from app.services.generation_budget import GenerationBudgetExceededError
 from app.services.insight_snapshots import get_latest_insight_snapshot
 from app.services.site_posts import (
     CampaignNotFoundError,
@@ -142,6 +143,10 @@ class SitePostDraftListItem(BaseModel):
 
 class SubmitSitePostDraftRequest(BaseModel):
     version_id: uuid.UUID | None = None
+    # story #3498(페드루 PO 決定 2026-09-05) — 예상 생성비용 제시(에이전트가 채운다).
+    # 생략/null=검사 없음(AC2). 게이트 budget 축(sealed_estimated_cost_minor)에 그대로
+    # 봉인된다 — channel_posts.py의 scheduled_at과 동형(submit 전용, draft 컬럼 아님).
+    estimated_cost_minor: int | None = None
 
 
 class SubmitSitePostDraftResponse(BaseModel):
@@ -480,7 +485,18 @@ async def submit_site_post_draft_endpoint(
         gate, version_id = await submit_site_post_draft(
             db, org_id=org_id, draft_id=draft_id, version_id=body.version_id,
             requester_member_id=uuid.UUID(auth.user_id),
+            estimated_cost_minor=body.estimated_cost_minor,
         )
+    except GenerationBudgetExceededError as exc:
+        # story #3498(AC2) — 4값 detail(story 確定 그대로).
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "GENERATION_BUDGET_EXCEEDED",
+                "limit_minor": exc.limit_minor, "spent_minor": exc.spent_minor,
+                "estimated_cost_minor": exc.estimated_cost_minor, "remaining_minor": exc.remaining_minor,
+            },
+        ) from exc
     except SitePostDraftNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SitePostVersionNotFoundError as exc:
@@ -656,6 +672,16 @@ async def publish_site_post_from_draft_endpoint(
         )
     except SitePostDraftNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except GenerationBudgetExceededError as exc:
+        # story #3498(AC4) — 발행 直前 재검사 실패(재시도 아님·사유 코드).
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "GENERATION_BUDGET_EXCEEDED",
+                "limit_minor": exc.limit_minor, "spent_minor": exc.spent_minor,
+                "estimated_cost_minor": exc.estimated_cost_minor, "remaining_minor": exc.remaining_minor,
+            },
+        ) from exc
     except ExternalPublishGateNotApprovedError as exc:
         raise HTTPException(
             status_code=403,

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -867,6 +867,7 @@ async def submit_channel_post_draft(
     version_id: uuid.UUID | None,
     requester_member_id: uuid.UUID,
     scheduled_at: datetime | None = None,
+    estimated_cost_minor: int | None = None,
 ) -> tuple[Gate, uuid.UUID]:
     """초안 버전을 external_publish 게이트에 상신 — site_posts.submit_site_post_draft와
     1:1 대응(AC3). **에이전트도 호출 가능**(AC1, 2026-09-03 dev 실측 정정 — site S2와 동일
@@ -907,6 +908,11 @@ async def submit_channel_post_draft(
             rules_version=rule_row.version if rule_row else 0, violations=submit_violations,
         )
 
+    # story #3498(AC2, 페드루 PO 決定 2026-09-05) — site_posts.py와 동형(게이트
+    # mutations 전에 판정 — 잔량 초과면 반쪽 봉인 없이 즉시 422).
+    from app.services.generation_budget import check_generation_budget_or_raise
+    await check_generation_budget_or_raise(db, org_id=org_id, estimated_cost_minor=estimated_cost_minor)
+
     from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback, resolve_gate_holder_draft_id
     from app.services.workflow_line_config import _default_role_id
 
@@ -939,11 +945,15 @@ async def submit_channel_post_draft(
     # 기존 두 축의 판정·no-op short-circuit 조건은 손대지 않는다(회귀 0) — media_changed는
     # short-circuit 조건에도 추가로 들어가 "이미지만 바뀐" 재상신도 더는 no-op되지 않는다.
     media_changed = existing is None or existing.sealed_media_sha256 != target.image_sha256
+    # story #3498(AC3) — 네 번째 축. 위 세 축과 나란히 두되 기존 판정·short-circuit
+    # 조건은 손대지 않는다(회귀 0) — budget만 바뀐 재상신도 더는 no-op되지 않는다.
+    budget_changed = existing is None or existing.sealed_estimated_cost_minor != estimated_cost_minor
     if (
         existing is not None
         and not content_changed
         and not schedule_changed
         and not media_changed
+        and not budget_changed
         and existing.status in ("pending", "approved")
         # story #3496(site_posts.py와 동형 결함, 페드루 실측 2026-09-05) — reapproval_
         # required도 판정 축이다. 승인 뒤 편집(approved→pending+reapproval_required=
@@ -985,6 +995,7 @@ async def submit_channel_post_draft(
     gate.sealed_content_body = target.text
     gate.sealed_scheduled_at = scheduled_at
     gate.sealed_media_sha256 = target.image_sha256
+    gate.sealed_estimated_cost_minor = estimated_cost_minor
     gate.reapproval_required = False
 
     if was_approved:
@@ -999,7 +1010,10 @@ async def submit_channel_post_draft(
         reason_code = (
             "CONTENT_CHANGED" if content_changed
             else "SCHEDULE_CHANGED" if schedule_changed
-            else "MEDIA_CHANGED"
+            else "MEDIA_CHANGED" if media_changed
+            # story #3498(AC3) — 다섯 번째 우선순위(가장 낮음, media_changed와 동일
+            # 원칙 — 앞 세 축이 전부 그대로일 때만 이 사유가 뜬다).
+            else "BUDGET_CHANGED"
         )
         await void_pending_commands_for_gate(db, gate_id=gate.id, reason_code=reason_code)
 
@@ -1116,6 +1130,14 @@ async def publish_channel_post_draft(
         raise ChannelPostSealMissingError(gate_id=gate.id)
     if gate.sealed_content_sha256 != latest.body_sha256:
         raise ChannelPostReapprovalRequiredError(gate_id=gate.id)
+
+    # story #3498(AC4, 페드루 PO 決定 2026-09-05) — 발행 直前 예산 재검사(승인 뒤 다른
+    # 지출로 잔량이 줄었을 수 있다). site_posts.py와 동형 위치(다른 재검증 바로 옆,
+    # adapter 호출 前).
+    from app.services.generation_budget import check_generation_budget_or_raise
+    await check_generation_budget_or_raise(
+        db, org_id=org_id, estimated_cost_minor=gate.sealed_estimated_cost_minor,
+    )
 
     # 멱등 — 이미 완료된 발행이면 새 POST 없이 그대로 반환(뮤테이션 대상: 이 UNIQUE
     # 조회를 제거하면 같은 버전 재요청이 Threads에 두 번 POST된다).

--- a/backend/app/services/generation_budget.py
+++ b/backend/app/services/generation_budget.py
@@ -78,9 +78,16 @@ async def compute_generation_budget_status(
     spent_minor = 0
     for payload in rows:
         try:
-            spent_minor += int((payload or {}).get("cost_minor") or 0)
+            cost = int((payload or {}).get("cost_minor") or 0)
         except (TypeError, ValueError):
             continue  # 기형 payload(비-숫자 cost_minor) — 지출로 안 잡는다(관대한 reader).
+        # 페드루 PO REQUIRED(2026-09-05, PR#3847 리뷰①) — 두 겹 방어의 두 번째 겹.
+        # 쓰기 시점(evidence.py::create_evidence)이 이미 음수를 422로 막지만, 이
+        # 합산 자체도 음수를 무시한다 — 어느 한쪽이 우회돼도(예: 과거 데이터·내부
+        # 서비스 직접 insert) 음수 cost로 잔량을 부풀려 한도를 뚫을 수 없다.
+        if cost < 0:
+            continue
+        spent_minor += cost
 
     return {
         "limit_minor": limit_minor, "currency": currency, "period": period,

--- a/backend/app/services/generation_budget.py
+++ b/backend/app/services/generation_budget.py
@@ -1,0 +1,110 @@
+"""story #3498(Phase2·마케팅운영, 페드루 PO 決定 2026-09-05) — 생성 비용 한도(크레딧
+게이트). 블루프린트 v3 §2 「생성 비용 한도」·§PO-3 댄 걸린 자리 4·10.
+
+잔량은 저장하지 않고 매번 계산한다(PO 決定②) — Sprintable 결제 원장(lab_credit_minor·
+billing_ledger)과 무접촉이다: 생성 비용은 고객이 자기 AI 공급자에 쓰는 돈이라 조직의
+«정책값»(`org_content_rules.rules.generation_budget`)일 뿐이다. `limit_minor`에서
+evidence(type=metric·payload.kind=generation_cost·기간 내)의 cost_minor 합을 뺀 값이
+잔량이다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.evidence import Evidence
+from app.services.content_rules import get_org_content_rules
+
+_GENERATION_COST_KIND = "generation_cost"
+_SUPPORTED_PERIODS = frozenset({"month"})
+
+
+class GenerationBudgetExceededError(Exception):
+    """AC2·AC4의 공용 거부 신호 — submit 시점·발행 직전 재검사 둘 다 이 예외 하나로
+    통일한다(호출부 라우터가 각자 상황에 맞는 HTTP status로 감싼다). detail 4값은
+    story 確定 그대로(limit·spent·estimated·remaining)."""
+
+    def __init__(self, *, limit_minor: int, spent_minor: int, estimated_cost_minor: int, remaining_minor: int):
+        self.limit_minor = limit_minor
+        self.spent_minor = spent_minor
+        self.estimated_cost_minor = estimated_cost_minor
+        self.remaining_minor = remaining_minor
+        super().__init__(
+            f"generation budget exceeded: limit={limit_minor} spent={spent_minor} "
+            f"estimated={estimated_cost_minor} remaining={remaining_minor}"
+        )
+
+
+def _period_window(period: str, now: datetime) -> tuple[datetime, datetime]:
+    """"month"만 지원(story 確定 — period 값은 지금 이거 하나, 다른 값은 규칙 저장
+    시점에 이미 422로 막힌다·이 함수는 방어적으로만 raise). UTC 달력 월 경계 —
+    evidence.created_at 자체가 UTC라 그 축에 그대로 맞춘다(org timezone 무관)."""
+    if period not in _SUPPORTED_PERIODS:
+        raise ValueError(f"unsupported generation_budget period: {period}")
+    start = now.replace(hour=0, minute=0, second=0, microsecond=0, day=1)
+    end = start.replace(year=start.year + 1, month=1) if start.month == 12 else start.replace(month=start.month + 1)
+    return start, end
+
+
+async def compute_generation_budget_status(
+    db: AsyncSession, *, org_id: uuid.UUID, now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """규칙 자체가 없으면(«규칙 없음») None — 호출자는 이걸 "검사 없음"으로 읽는다.
+    「규칙 없음」과 「0 한도(정지)」를 가르는 유일한 신호가 이 반환값이다: None=규칙
+    없음(검사 스킵) · dict(limit_minor=0, ...)=정지(0보다 큰 어떤 추정치도 거부)."""
+    row = await get_org_content_rules(db, org_id=org_id)
+    if row is None:
+        return None
+    budget = (row.rules or {}).get("generation_budget")
+    if not budget:
+        return None
+    limit_minor = int(budget["limit_minor"])
+    currency = budget.get("currency", "KRW")
+    period = budget.get("period", "month")
+
+    now = now or datetime.now(timezone.utc)
+    start, end = _period_window(period, now)
+
+    rows = (await db.execute(
+        select(Evidence.payload).where(
+            Evidence.org_id == org_id, Evidence.type == "metric",
+            Evidence.payload["kind"].astext == _GENERATION_COST_KIND,
+            Evidence.created_at >= start, Evidence.created_at < end,
+        )
+    )).scalars().all()
+    spent_minor = 0
+    for payload in rows:
+        try:
+            spent_minor += int((payload or {}).get("cost_minor") or 0)
+        except (TypeError, ValueError):
+            continue  # 기형 payload(비-숫자 cost_minor) — 지출로 안 잡는다(관대한 reader).
+
+    return {
+        "limit_minor": limit_minor, "currency": currency, "period": period,
+        # story #3498 조각①(미르코 FE 그라운딩 후속, 페드루 PO 決定) — GET /generation-
+        # budget 조회 응답이 그대로 쓰는 경계값(FE가 "이번 기간" 문구를 조립할 수
+        # 있게, 서버가 계산한 값 그대로 — FE 재조립 0).
+        "period_start": start, "period_end": end,
+        "spent_minor": spent_minor, "remaining_minor": limit_minor - spent_minor,
+    }
+
+
+async def check_generation_budget_or_raise(
+    db: AsyncSession, *, org_id: uuid.UUID, estimated_cost_minor: int | None, now: datetime | None = None,
+) -> None:
+    """AC2·AC4의 공용 판정 지점 — submit 시점·발행 직전 둘 다 이 함수 하나를 부른다
+    (story #3414/#3478의 "판정 지점 하나" 관례 그대로). estimated_cost_minor가 None이면
+    검사 자체를 안 한다(호출자가 이 축을 아예 안 실었다는 뜻 — AC2 "미설정이면 통과")."""
+    if estimated_cost_minor is None:
+        return
+    status = await compute_generation_budget_status(db, org_id=org_id, now=now)
+    if status is None:
+        return
+    if estimated_cost_minor > status["remaining_minor"]:
+        raise GenerationBudgetExceededError(
+            limit_minor=status["limit_minor"], spent_minor=status["spent_minor"],
+            estimated_cost_minor=estimated_cost_minor, remaining_minor=status["remaining_minor"],
+        )

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -74,7 +74,12 @@ _TRANSIENT_CODES = frozenset({"CHANNEL_PUBLISH_PROVIDER_ERROR", "CHANNEL_RATE_LI
 # 아니라 "재시도라는 개념 자체가 안 맞는" 종류: 사람이 다시 승인해야 새 커맨드가
 # 생긴다). 기존 'voided'(재승인으로 무효화)와 같은 결의 신규 terminal 상태.
 STATUS_BLOCKED_UNAPPROVED = "blocked_unapproved"
-_GATE_REVERIFY_ERROR_CODES = frozenset({"EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "SITE_POST_REAPPROVAL_REQUIRED"})
+_GATE_REVERIFY_ERROR_CODES = frozenset({
+    "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "SITE_POST_REAPPROVAL_REQUIRED",
+    # story #3498(AC4) — 예산 재검사도 이 워커 재검증 묶음에 낀다(adapter 호출 0
+    # 방어선이 이 자리 하나라, 새 방어선을 안 늘리고 기존 방어선을 확장한다).
+    "GENERATION_BUDGET_EXCEEDED",
+})
 
 
 async def record_publication_attempt(
@@ -256,6 +261,7 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
         get_channel_post_draft,
         publish_channel_post_draft,
     )
+    from app.services.generation_budget import GenerationBudgetExceededError
 
     error_code: str | None = None
     last_error: str | None = None
@@ -328,6 +334,17 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
         command.status = STATUS_BLOCKED_UNAPPROVED
         command.last_error = str(exc)[:2000]
         return
+    except GenerationBudgetExceededError as exc:
+        # story #3498(AC4) — site_post 쪽의 GENERATION_BUDGET_EXCEEDED 처리와 동형
+        # (adapter 호출 0, 재시도 대상 아님).
+        await record_publication_attempt(
+            db, command=command, approval_check="budget_exceeded", adapter_called=False,
+            started_at=attempt_started_at, finished_at=now, result_code=None,
+        )
+        command.status = STATUS_BLOCKED_UNAPPROVED
+        command.reason_code = "GENERATION_BUDGET_EXCEEDED"
+        command.last_error = str(exc)[:2000]
+        return
     except ChannelPostSealMissingError as exc:
         error_code, last_error = "SITE_POST_SEAL_MISSING", str(exc)
     except ChannelTextTooLongError as exc:
@@ -398,16 +415,26 @@ async def _process_one_site_post_command(db: AsyncSession, command: PublicationC
             # story #3474 — adapter는 안 불렸다(게이트 재검증에서 막혔다). 재시도
             # 백오프(apply_command_failure) 대상이 아니라 즉시 종결 — 사람이 다시
             # 승인해야 새 커맨드가 생긴다(channel_post 쪽과 동형 처리).
-            approval_check = "missing" if error_code == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED" else "version_mismatch"
+            # story #3498(AC4, 페드루 PO 決定) — 예산 초과도 같은 결(재시도 개념
+            # 자체가 안 맞는다, 지출이 안 줄면 재시도해도 똑같다)이지만 사유가
+            # 다르다(승인 자체는 유효·잔량만 부족) — 별도 approval_check 값으로
+            # 구분한다.
+            approval_check = (
+                "missing" if error_code == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED"
+                else "budget_exceeded" if error_code == "GENERATION_BUDGET_EXCEEDED"
+                else "version_mismatch"
+            )
             await record_publication_attempt(
                 db, command=command, approval_check=approval_check, adapter_called=False,
                 started_at=attempt_started_at, finished_at=now, result_code=None,
             )
-            if approval_check == "missing":
-                command.status = STATUS_BLOCKED_UNAPPROVED
-            else:
+            if approval_check == "version_mismatch":
                 command.status = "voided"
                 command.reason_code = "CONTENT_CHANGED"
+            else:
+                command.status = STATUS_BLOCKED_UNAPPROVED
+                if approval_check == "budget_exceeded":
+                    command.reason_code = "GENERATION_BUDGET_EXCEEDED"
             command.last_error = last_error[:2000]
             return
     except Exception as exc:  # noqa: BLE001 — 미분류 실패도 이 command 하나만 막는다.

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -692,6 +692,7 @@ async def submit_site_post_draft(
     draft_id: uuid.UUID,
     version_id: uuid.UUID | None,
     requester_member_id: uuid.UUID,
+    estimated_cost_minor: int | None = None,
 ) -> tuple[Gate, uuid.UUID]:
     """story #3365(Phase0 S2) — 초안 버전을 external_publish 게이트에 상신. 대상 버전(생략 시
     최신)의 content_sha256·content_version·본문 스냅샷을 게이트에 봉인(sealed_content_*)한다.
@@ -727,6 +728,12 @@ async def submit_site_post_draft(
         raise ContentRuleViolationError(
             rules_version=rule_row.version if rule_row else 0, violations=submit_violations,
         )
+
+    # story #3498(AC2, 페드루 PO 決定 2026-09-05) — 상신 시점 예산 거부. content-rule
+    # lint와 같은 자리(게이트 mutations 전) — 잔량 초과면 게이트를 손대지 않고 422로
+    # 즉시 거부한다(반쪽 봉인 상태를 만들지 않는다).
+    from app.services.generation_budget import check_generation_budget_or_raise
+    await check_generation_budget_or_raise(db, org_id=org_id, estimated_cost_minor=estimated_cost_minor)
 
     from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback, resolve_gate_holder_draft_id
     from app.services.workflow_line_config import _default_role_id
@@ -765,6 +772,9 @@ async def submit_site_post_draft(
         # sha256과 동형, AC "판정 축 세분화"). content가 그대로여도 destination이 바뀌었으면
         # "이미 이 정확한 상태로 봉인돼 있다"가 아니다 — 재봉인(아래)을 타야 한다.
         and existing.sealed_destination_connection_id == draft.connection_id
+        # story #3498(AC3) — budget 축도 판정 대상이다. content/destination이 그대로여도
+        # estimated_cost_minor가 바뀌면 "이미 이 정확한 상태로 봉인돼 있다"가 아니다.
+        and existing.sealed_estimated_cost_minor == estimated_cost_minor
         and existing.status in ("pending", "approved")
         # story #3496(페드루 실측 2026-09-05) — reapproval_required도 판정 축이다. 승인
         # 뒤 편집(approved→pending+reapproval_required=True, sealed는 옛 버전 보존)한
@@ -825,6 +835,10 @@ async def submit_site_post_draft(
     # story e4fc29fa(조각③a) — 목적지 봉인도 여기서 명시적으로 (재)봉인한다(위 sha+
     # destination 동일성 조기 return을 안 탔다는 건 둘 중 하나가 달라졌거나 신규라는 뜻).
     gate.sealed_destination_connection_id = draft.connection_id
+    # story #3498(AC3) — budget 축 (재)봉인. 위 sha+destination+budget 동일성 조기
+    # return을 안 탔다는 건 셋 중 하나가 달라졌거나 신규라는 뜻(_reseal_gate_on_new_
+    # version은 이 필드를 절대 안 건드린다 — submit() 재호출만이 재봉인 권한을 갖는다).
+    gate.sealed_estimated_cost_minor = estimated_cost_minor
     gate.reapproval_required = False
     await db.commit()
     await db.refresh(gate)
@@ -925,6 +939,14 @@ async def publish_site_post_from_draft(
         raise SitePostSealMissingError(gate_id=gate.id)
     if gate.sealed_content_sha256 != latest.body_sha256:
         raise SitePostReapprovalRequiredError(gate_id=gate.id)
+
+    # story #3498(AC4, 페드루 PO 決定 2026-09-05) — hosted_site도 발행 直前 재검사
+    # (승인 뒤 다른 지출로 잔량이 줄었을 수 있다). 라우터가 GenerationBudgetExceededError
+    # 를 422로 감싼다.
+    from app.services.generation_budget import check_generation_budget_or_raise
+    await check_generation_budget_or_raise(
+        db, org_id=org_id, estimated_cost_minor=gate.sealed_estimated_cost_minor,
+    )
 
     post = await hosted_site_publish.publish(
         db, org_id=org_id, work_item_id=draft.work_item_id, gate_id=gate.id,
@@ -1227,6 +1249,17 @@ async def publish_site_post_external_command(db: AsyncSession, command: "Publica
                 f"(gate_id={gate.id}, gate.scope_key={gate.scope_key!r}, draft.connection_id={draft.connection_id!r})"
             ),
         )
+
+    # story #3498(AC4, 페드루 PO 決定 2026-09-05) — 승인 뒤 다른 지출로 잔량이 줄었을
+    # 수 있다(승인 시점엔 통과했어도 지금은 아닐 수 있음) — module.publish() 호출
+    # (아래) 直前에 다시 잰다. 어댑터 호출 0(위 승인/봉인 재검증과 같은 방어선).
+    from app.services.generation_budget import GenerationBudgetExceededError, check_generation_budget_or_raise
+    try:
+        await check_generation_budget_or_raise(
+            db, org_id=command.org_id, estimated_cost_minor=gate.sealed_estimated_cost_minor,
+        )
+    except GenerationBudgetExceededError as exc:
+        raise SitePostExternalPublishError(error_code="GENERATION_BUDGET_EXCEEDED", message=str(exc)) from exc
 
     try:
         connection = await _get_active_blog_connection(db, org_id=command.org_id, connection_id=draft.connection_id)

--- a/backend/tests/test_3498_generation_budget.py
+++ b/backend/tests/test_3498_generation_budget.py
@@ -120,6 +120,44 @@ async def _create_channel_post_draft_submit(
     return draft_id, r_submit
 
 
+async def _grant_project_access(session, *, project_id, member_id):
+    """evidence.py::_assert_work_item_access가 최종적으로 부르는 has_project_access의
+    agent 분기(project_auth.py::_project_access_predicate)는 team_member_branch가
+    TeamMember.type=="human" 전용이라 에이전트를 안 본다 — 에이전트는 이 명시 grant
+    (ProjectAccess.member_id, permission="granted")로만 통과한다(test_e_verify_v0_
+    s1_evidence_realdb.py의 확립된 시딩과 동형)."""
+    from app.models.project_access import ProjectAccess
+    import uuid as _uuid
+
+    grant = ProjectAccess(
+        id=_uuid.uuid4(), project_id=project_id, member_id=member_id, permission="granted", role="member",
+    )
+    session.add(grant)
+    await session.commit()
+
+
+async def _seed_evidence_agent(session, org_id, project_id, *, name="Evidence Agent"):
+    """evidence.py 경로 전용 — create_evidence()가 resolve_member()(레거시 경로,
+    member_ssot_resolver_shadow 기본 False)와 has_project_access를 **둘 다** 부른다.
+    실측(2026-09-05) — 실 alembic-migrated DB(realdb류 테스트)에서는 `team_members`가
+    `members`(+project_access) 위의 VIEW라 Member 하나만 심어도 양쪽에서 다 보이지만,
+    이 파일은 destructive_schema(`Base.metadata.create_all`)라 `team_members`가 그
+    VIEW 대신 독립된 빈 테이블로 만들어진다 — Member만 심으면 resolve_member의
+    TeamMember 조회가 0행(`Team member not found`, 400). 그래서 여기선 **같은 id로
+    Member+TeamMember 둘 다** 명시적으로 심는다(같은 신원의 두 그림자, 이 create_all
+    한정 우회 — 실 DB에서는 자동으로 성립하는 것을 여기서만 손으로 맞춘다)."""
+    from app.models.member import Member
+    from app.models.team import TeamMember
+    import uuid as _uuid
+
+    member_id = _uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org_id, type="agent", name=name, is_active=True))
+    session.add(TeamMember(id=member_id, org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True))
+    await session.commit()
+    await _grant_project_access(session, project_id=project_id, member_id=member_id)
+    return member_id
+
+
 async def _approve_gate_directly(session, gate_id):
     from app.models.gate import Gate
     from sqlalchemy import select
@@ -571,6 +609,235 @@ async def test_get_generation_budget_endpoint_all_null_when_rule_absent():
             "limit_minor": None, "currency": None, "period": None,
             "period_start": None, "period_end": None, "spent_minor": None, "remaining_minor": None,
         }
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 조각⑤(페드루 PO REQUIRED, PR#3847 리뷰) — payload 검증·recorded_by 강제 ───────
+
+
+@pytest.mark.anyio
+async def test_create_evidence_generation_cost_negative_cost_minor_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            agent_id = await _seed_evidence_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "metric", "ref": "self-report",
+                "payload": {"kind": "generation_cost", "cost_minor": -1, "currency": "KRW"},
+            })
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "EVIDENCE_PAYLOAD_INVALID"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_evidence_generation_cost_non_int_cost_minor_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            agent_id = await _seed_evidence_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "metric", "ref": "self-report",
+                "payload": {"kind": "generation_cost", "cost_minor": "500", "currency": "KRW"},
+            })
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "EVIDENCE_PAYLOAD_INVALID"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_evidence_generation_cost_currency_mismatch_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            agent_id = await _seed_evidence_agent(s, org_id, project_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=100000, currency="KRW")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "metric", "ref": "self-report",
+                "payload": {"kind": "generation_cost", "cost_minor": 500, "currency": "USD"},
+            })
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "EVIDENCE_PAYLOAD_INVALID"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_evidence_generation_cost_currency_check_skipped_when_no_policy():
+    """정책 자체가 없으면(«규칙 없음») 비교 대상이 없어 통과 — currency 값이 뭐든
+    거부 안 함(존재하지 않는 정책과 비교할 수 없다는 원칙, generation_budget.py의
+    «규칙 없음=None» 신호와 동형)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            agent_id = await _seed_evidence_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "metric", "ref": "self-report",
+                "payload": {"kind": "generation_cost", "cost_minor": 500, "currency": "USD"},
+            })
+        assert r.status_code == 201, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_evidence_client_recorded_by_ignored_server_overwrites_with_caller_type():
+    """페드루 PO REQUIRED② — 클라이언트가 payload.recorded_by="platform"을 실어도
+    서버가 caller_type(여기선 "agent")으로 덮어쓴다. "platform" 표식 위조 불가."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            agent_id = await _seed_evidence_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "metric", "ref": "self-report",
+                "payload": {"kind": "generation_cost", "cost_minor": 500, "currency": "KRW", "recorded_by": "platform"},
+            })
+        assert r.status_code == 201, r.text
+        assert r.json()["payload"]["recorded_by"] == "agent", "클라이언트 recorded_by 위조가 안 막혔다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_evidence_non_generation_cost_payload_still_gets_recorded_by_overwritten():
+    """recorded_by 강제는 generation_cost에 국한되지 않는다 — payload가 있는 모든
+    evidence에 적용(위조 차단 축은 kind 무관)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            agent_id = await _seed_evidence_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "metric", "ref": "self-report",
+                "payload": {"note": "무관한 payload", "recorded_by": "platform"},
+            })
+        assert r.status_code == 201, r.text
+        assert r.json()["payload"]["recorded_by"] == "agent"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── GenerationBudgetRule PUT 3종 검증 ───────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_put_generation_budget_negative_limit_minor_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"generation_budget": {"limit_minor": -1}}},
+            )
+        assert r.status_code == 422, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_put_generation_budget_unsupported_currency_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"generation_budget": {"limit_minor": 1000, "currency": "JPY"}}},
+            )
+        assert r.status_code == 422, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_put_generation_budget_unsupported_period_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"generation_budget": {"limit_minor": 1000, "period": "week"}}},
+            )
+        assert r.status_code == 422, r.text
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3498_generation_budget.py
+++ b/backend/tests/test_3498_generation_budget.py
@@ -1,0 +1,576 @@
+"""story #3498(Phase2·마케팅운영, 페드루 PO 決定 2026-09-05) — 생성 비용 한도(크레딧
+게이트). 블루프린트 v3 §2 「생성 비용 한도」·§PO-3 댄 걸린 자리 4·10.
+
+세팅 헬퍼는 test_3471_org_content_rules_lint.py와 동형(중복 재발명 금지) — org·agent·
+human·connection·content-rules PUT 시딩은 그대로 재사용하고, 이 스토리 전용(evidence
+cost 시딩·estimated_cost_minor submit)만 새로 추가한다."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_3471_org_content_rules_lint import (
+    _client_for,
+    _seed_agent,
+    _seed_connection,
+    _seed_default_role,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _put_generation_budget(session, *, org_id, limit_minor, currency="KRW", period="month"):
+    """content-rules 라우터를 안 거치고 직접(HTTP 검증은 AC1 테스트가 별도로 잰다) —
+    이 파일의 나머지 테스트는 "budget이 이미 설정돼 있다"는 전제에서 시작한다."""
+    from app.services.content_rules import put_org_content_rules
+
+    return await put_org_content_rules(
+        session, org_id=org_id,
+        rules={"generation_budget": {"limit_minor": limit_minor, "currency": currency, "period": period}},
+        updated_by_member_id=uuid.uuid4(),
+    )
+
+
+async def _seed_generation_cost_evidence(
+    session, *, org_id, work_item_id, cost_minor, created_at=None, created_by=None,
+):
+    from app.models.evidence import Evidence
+
+    ev = Evidence(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type="story",
+        type="metric", ref="agent-generation", source="openai", created_by=created_by,
+        payload={"kind": "generation_cost", "cost_minor": cost_minor, "currency": "KRW", "provider": "openai"},
+    )
+    session.add(ev)
+    await session.commit()
+    if created_at is not None:
+        from sqlalchemy import update
+        await session.execute(update(Evidence).where(Evidence.id == ev.id).values(created_at=created_at))
+        await session.commit()
+    return ev
+
+
+async def _create_site_post_draft_submit(
+    client, *, org_id, story_id, estimated_cost_minor=None, slug="post-1",
+):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/site-posts/drafts",
+        json={
+            "work_item_id": str(story_id), "title": "제목", "slug": slug, "lang": "ko",
+            "summary": "요약", "tags": [], "body_md": "본문", "media_manifest": [],
+        },
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    body = {} if estimated_cost_minor is None else {"estimated_cost_minor": estimated_cost_minor}
+    r_submit = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json=body)
+    return draft_id, r_submit
+
+
+async def _create_channel_post_draft_submit(
+    client, *, org_id, story_id, connection_id, estimated_cost_minor=None, text="채널 포스트 본문입니다.",
+):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+        json={"work_item_id": str(story_id), "connection_id": str(connection_id), "text": text},
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    body = {} if estimated_cost_minor is None else {"estimated_cost_minor": estimated_cost_minor}
+    r_submit = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json=body)
+    return draft_id, r_submit
+
+
+async def _approve_gate_directly(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+# ─── AC1: content-rules PUT/GET slot ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_put_generation_budget_reflected_in_get():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r_put = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"generation_budget": {"limit_minor": 100000, "currency": "KRW", "period": "month"}}},
+            )
+            assert r_put.status_code == 200, r_put.text
+            assert r_put.json()["rules"]["generation_budget"] == {
+                "limit_minor": 100000, "currency": "KRW", "period": "month",
+            }
+
+            r_get = await client.get(f"/api/v2/organizations/{org_id}/content-rules")
+        assert r_get.json()["rules"]["generation_budget"]["limit_minor"] == 100000
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_generation_budget_unknown_field_returns_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r_put = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"generation_budget": {"limit_minor": 1000, "unknown_field": "x"}}},
+            )
+        assert r_put.status_code == 422, r_put.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC2: submit-time 거부 ────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_submit_site_post_over_budget_rejected_422_with_four_values():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=1000)
+            await _seed_generation_cost_evidence(s, org_id=org_id, work_item_id=story_id, cost_minor=700)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            _draft_id, r_submit = await _create_site_post_draft_submit(
+                client, org_id=org_id, story_id=story_id, estimated_cost_minor=500,  # remaining=300 < 500
+            )
+        assert r_submit.status_code == 422, r_submit.text
+        error = r_submit.json()["error"]
+        assert error["code"] == "GENERATION_BUDGET_EXCEEDED"
+        assert error["limit_minor"] == 1000
+        assert error["spent_minor"] == 700
+        assert error["estimated_cost_minor"] == 500
+        assert error["remaining_minor"] == 300
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_submit_site_post_within_budget_passes():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=1000)
+            await _seed_generation_cost_evidence(s, org_id=org_id, work_item_id=story_id, cost_minor=300)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            _draft_id, r_submit = await _create_site_post_draft_submit(
+                client, org_id=org_id, story_id=story_id, estimated_cost_minor=700,  # remaining=700 == 700
+            )
+        assert r_submit.status_code == 200, r_submit.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_submit_site_post_no_estimated_cost_skips_check_even_when_over_budget():
+    """AC2 "미설정이면 통과" — 이미 초과 상태여도 estimated_cost_minor를 아예 안
+    실으면 검사 자체를 안 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=100)
+            await _seed_generation_cost_evidence(s, org_id=org_id, work_item_id=story_id, cost_minor=9999)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            _draft_id, r_submit = await _create_site_post_draft_submit(
+                client, org_id=org_id, story_id=story_id, estimated_cost_minor=None,
+            )
+        assert r_submit.status_code == 200, r_submit.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_generation_budget_limit_zero_means_suspended():
+    """PO 確定 "정지 = limit_minor 0" — 지출이 0이어도 0보다 큰 어떤 추정치도 거부."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=0)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            _draft_id, r_submit = await _create_site_post_draft_submit(
+                client, org_id=org_id, story_id=story_id, estimated_cost_minor=1,
+            )
+        assert r_submit.status_code == 422, r_submit.text
+        assert r_submit.json()["error"]["code"] == "GENERATION_BUDGET_EXCEEDED"
+        assert r_submit.json()["error"]["remaining_minor"] == 0
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_submit_channel_post_over_budget_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=100)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            _draft_id, r_submit = await _create_channel_post_draft_submit(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+                estimated_cost_minor=101,
+            )
+        assert r_submit.status_code == 422, r_submit.text
+        assert r_submit.json()["error"]["code"] == "GENERATION_BUDGET_EXCEEDED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC3: 승인 뒤 estimated_cost_minor 변경 → budget_changed 재승인 ───────────────
+
+
+@pytest.mark.anyio
+async def test_budget_only_change_after_approval_reopens_gate_for_reapproval_channel_post():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=100000)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, r_submit = await _create_channel_post_draft_submit(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+                estimated_cost_minor=100,
+            )
+            assert r_submit.status_code == 200, r_submit.text
+            gate_id = uuid.UUID(r_submit.json()["gate_id"])
+            await _approve_gate_directly(s, gate_id)
+
+            # 본문·예약은 그대로, estimated_cost_minor만 변경 — budget_changed 하나만.
+            r_resubmit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit",
+                json={"estimated_cost_minor": 200},
+            )
+            assert r_resubmit.status_code == 200, r_resubmit.text
+            assert r_resubmit.json()["gate_id"] == str(gate_id), "같은 게이트 행을 재사용해야 한다"
+            assert r_resubmit.json()["status"] == "pending"
+
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            # reapproval_required는 "시스템이 조용히 되돌렸다"는 신호(test_3414의
+            # 확립된 계약) — 이건 사람/에이전트가 명시적으로 재상신한 경로라 False로
+            # 복귀하는 게 기존 설계 그대로(submit()의 재상신은 항상 False로 리셋,
+            # content/schedule/media 축과 동형).
+            assert gate.reapproval_required is False
+            assert gate.sealed_estimated_cost_minor == 200, "재봉인이 최신 추정치로 갱신돼야 한다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resubmit_identical_including_budget_is_still_noop_channel_post():
+    """회귀 0 확認 — estimated_cost_minor까지 포함해 아무것도 안 바뀐 재상신은
+    여전히 no-op(short-circuit, budget 축 추가가 기존 관례를 안 깬다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, r_submit = await _create_channel_post_draft_submit(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+                estimated_cost_minor=100,
+            )
+            gate_id = uuid.UUID(r_submit.json()["gate_id"])
+            await _approve_gate_directly(s, gate_id)
+
+            r_resubmit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit",
+                json={"estimated_cost_minor": 100},
+            )
+            assert r_resubmit.status_code == 200, r_resubmit.text
+            assert r_resubmit.json()["status"] == "approved", "아무것도 안 바뀌었으면 approved 그대로여야 한다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC4: 발행 직전 재검사 ────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_publish_rejected_when_spent_increased_after_approval_zero_adapter_calls_site_post(monkeypatch):
+    from app.main import app
+    import app.services.hosted_site_publish as hosted_site_publish
+
+    call_log: list[str] = []
+    _original_publish = hosted_site_publish.publish
+
+    async def _spy_publish(*args, **kwargs):
+        call_log.append("called")
+        return await _original_publish(*args, **kwargs)
+
+    monkeypatch.setattr(hosted_site_publish, "publish", _spy_publish)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=1000)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, r_submit = await _create_site_post_draft_submit(
+                client, org_id=org_id, story_id=story_id, estimated_cost_minor=1000,  # 승인 시점엔 잔량 딱 맞음
+            )
+            assert r_submit.status_code == 200, r_submit.text
+            gate_id = uuid.UUID(r_submit.json()["gate_id"])
+            await _approve_gate_directly(s, gate_id)
+
+            # 승인 뒤 다른 지출이 잔량을 갉아먹었다(예: 다른 draft가 먼저 발행돼 evidence 누적).
+            await _seed_generation_cost_evidence(s, org_id=org_id, work_item_id=story_id, cost_minor=1)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 422, r_pub.text
+        assert r_pub.json()["error"]["code"] == "GENERATION_BUDGET_EXCEEDED"
+        assert call_log == [], "예산 초과인데 hosted_site_publish.publish()가 호출됐다(adapter 호출 0 위반)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC5: evidence 지출 합산 + 기간 경계 ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_evidence_generation_cost_counted_within_period_boundary():
+    from app.services.generation_budget import compute_generation_budget_status
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=10000)
+
+            now = datetime(2026, 9, 15, tzinfo=timezone.utc)
+            month_start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+            # 이번 달 안 — 잡혀야 한다.
+            await _seed_generation_cost_evidence(
+                s, org_id=org_id, work_item_id=story_id, cost_minor=500, created_at=now,
+            )
+            # 이번 달 경계 정확히 그 순간(포함) — 잡혀야 한다.
+            await _seed_generation_cost_evidence(
+                s, org_id=org_id, work_item_id=story_id, cost_minor=300, created_at=month_start,
+            )
+            # 지난 달(달력 경계 밖) — 안 잡혀야 한다.
+            await _seed_generation_cost_evidence(
+                s, org_id=org_id, work_item_id=story_id, cost_minor=9999,
+                created_at=month_start - timedelta(seconds=1),
+            )
+            # type이 metric이 아님 — 안 잡혀야 한다(카테고리 밖).
+            from app.models.evidence import Evidence
+            other = Evidence(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                type="pr", ref="https://example.com/pr/1", payload={"kind": "generation_cost", "cost_minor": 9999},
+            )
+            s.add(other)
+            await s.commit()
+
+            status = await compute_generation_budget_status(s, org_id=org_id, now=now)
+        assert status["spent_minor"] == 800, status
+        assert status["remaining_minor"] == 10000 - 800
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_compute_generation_budget_status_none_when_rule_absent():
+    """«규칙 없음»과 «0 한도»를 가르는 신호 — 규칙 자체가 없으면 None."""
+    from app.services.generation_budget import compute_generation_budget_status
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            status = await compute_generation_budget_status(s, org_id=org_id)
+        assert status is None
+    finally:
+        await engine.dispose()
+
+
+# ─── 조각①(미르코 FE 3500 그라운딩) — GET /generation-budget ────────────────────
+
+
+@pytest.mark.anyio
+async def test_get_generation_budget_endpoint_reflects_limit_and_spent():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _put_generation_budget(s, org_id=org_id, limit_minor=1000)
+            await _seed_generation_cost_evidence(s, org_id=org_id, work_item_id=story_id, cost_minor=300)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/generation-budget")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["limit_minor"] == 1000
+        assert body["currency"] == "KRW"
+        assert body["period"] == "month"
+        assert body["spent_minor"] == 300
+        assert body["remaining_minor"] == 700
+        assert body["period_start"] is not None and body["period_end"] is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_generation_budget_endpoint_all_null_when_rule_absent():
+    """«규칙 없음»(limit_minor 자체가 null)과 «0 한도»(limit_minor=0)를 구분 —
+    규칙 자체가 없으면 전부 null, 지어내지 않는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/generation-budget")
+        assert r.status_code == 200, r.text
+        assert r.json() == {
+            "limit_minor": None, "currency": None, "period": None,
+            "period_start": None, "period_end": None, "spent_minor": None, "remaining_minor": None,
+        }
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1118,6 +1118,11 @@
       "source": "story-3497-publication-id-exposure(조각4, PR#3844 — 로컬 raw pytest 6.19s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3498_generation_budget.py",
+      "sec": 200.0,
+      "source": "story-3498-generation-budget(PR 개설 前 선제 등재 — 로컬 raw pytest 33.06s(14건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 200s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3497_insight_snapshots.py",
       "sec": 85.0,
       "source": "story-3497-insight-snapshots(조각1~3, PR#3844 — 등재 누락분 소급 등록. 로컬 raw pytest 13.82s(12건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 85s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## Summary
- 블루프린트 v3 §2 「생성 비용 한도」·§PO-3 댄 걸린 자리 4·10. Sprintable 결제 원장(lab_credit_minor·billing_ledger)과 무접촉 — 생성 비용은 조직 정책값(`org_content_rules.rules.generation_budget`)으로만 관리.
- Gate.sealed_estimated_cost_minor(migration 0333) 신설 — content/schedule/media와 동형 budget_changed 축. submit(site_post/channel_post)에 estimated_cost_minor 선택 필드.
- fail-closed 서버 거부 2곳(공용 판정 `check_generation_budget_or_raise`) — submit 시 422 GENERATION_BUDGET_EXCEEDED(limit·spent·estimated·remaining) + 발행 직전 재검사(어댑터 호출 0).
- evidence API에 payload 필드 client-writable로 개방(agent가 evidence.payload.kind="generation_cost"·cost_minor로 지출 기록) — 잔량은 저장 안 하고 매번 계산.
- 미르코 FE 3500 그라운딩 후속 — GET /generation-budget 신설.

Base는 develop이 아니라 `feat/3497-insight-snapshots`(#3844, 아직 미착지) — 마이그 0333이 0332 위에 쌓이는 현재 스택 관례 그대로.

## Test plan
- [x] `tests/test_3498_generation_budget.py` 14건 green(PUT/GET 왕복·0한도 정지·submit 거부/통과·미설정 skip·budget_changed 재승인+no-op 회귀·발행 직전 재검사 adapter 0회 spy·기간 경계·GET 엔드포인트 2종)
- [x] AC6 뮤테이션 3건 — 거부 분기 제거→RED, budget_changed 판정 제거→RED, 기간 필터 제거→RED(전부 복원 후 재확인)
- [x] 회귀 스윕 82/82 (test_3471_org_content_rules_lint·test_3414_publication_command·test_3386_site_post_publication·test_0e960006_command_id_exposure·test_3497_channel_post_publication_id_exposure·test_3404_channel_post_gate_already_held·test_e4fc29fa_destination_axis)
- [x] 마이그 0333 round-trip(upgrade/downgrade/재-upgrade) 확인
- [x] `scripts/lint_destructive_schema_weights_registered.py` 239/239 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)