### PR TITLE
[SID:3506] feat: UTM 규칙 조각1 — 조직 override + utm_content 4번째 키

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.channel_post_version import ChannelPostVersion
+from app.services.content_rules import get_org_content_rules
 from app.services.channel_posts import (
     ChannelConnectionNotActiveError,
     ChannelImageContainerFailedError,
@@ -377,8 +378,10 @@ async def post_channel_post_draft_version(
             },
         ) from exc
 
+    utm_rule_row = await get_org_content_rules(db, org_id=org_id)
+    utm_rules = (utm_rule_row.rules or {}).get("utm_rules") if utm_rule_row else None
     tagged_link_preview = (
-        build_tagged_link(channel=channel, link_url=body.link_url, draft_id=version.draft_id)
+        build_tagged_link(channel=channel, link_url=body.link_url, draft_id=version.draft_id, utm_rules=utm_rules)
         if body.link_url else None
     )
     return ChannelPostDraftVersionResponse(
@@ -786,13 +789,15 @@ async def list_channel_post_draft_version_history(
         raise HTTPException(status_code=404, detail=f"draft를 찾을 수 없습니다: {draft_id}")
 
     versions = await list_channel_post_draft_versions(db, draft_id=draft_id)
+    utm_rule_row = await get_org_content_rules(db, org_id=org_id)
+    utm_rules = (utm_rule_row.rules or {}).get("utm_rules") if utm_rule_row else None
     return [
         ChannelPostVersionHistoryItem(
             version_id=v.id, version=v.version, draft_id=draft.id, text=v.text, link_url=v.link_url,
             body_sha256=v.body_sha256, author_member_id=v.author_member_id, author_kind=v.author_kind,
             created_at=v.created_at.isoformat(),
             tagged_link_preview=(
-                build_tagged_link(channel=draft.channel, link_url=v.link_url, draft_id=draft.id)
+                build_tagged_link(channel=draft.channel, link_url=v.link_url, draft_id=draft.id, utm_rules=utm_rules)
                 if v.link_url else None
             ),
         )

--- a/backend/app/routers/content_rules.py
+++ b/backend/app/routers/content_rules.py
@@ -61,6 +61,25 @@ class GenerationBudgetRule(BaseModel):
     period: Literal["month"] = "month"
 
 
+class UtmRules(BaseModel):
+    """story #3506(페드루 PO 確定 2026-09-05) — UTM 자동 부착 정책값. source/medium은
+    «어댑터 하드코딩 위에 조직 override»(미설정이면 channel_adapters.py의 어댑터별
+    상수 그대로, app/services/utm.py::attach_utm 호출부가 그 우선순위로 넘긴다).
+
+    `campaign_from`은 지금은 순수 서술용이다 — 실 campaign 해소는 여전히
+    `resolve_utm_campaign()`의 기존 규칙(블로그 경로면 slug·아니면 draft_id) 그대로다
+    (PO 確定 "기존 resolve 규칙 유지" — 이 필드가 그 규칙을 바꾸지 않는다, 값이
+    뭐든 동작 무변경). `content_from="none"`이면 utm_content 자체를 안 붙인다."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    default_source: str | None = None
+    default_medium: str | None = None
+    campaign_from: Literal["campaign_slug", "draft_id"] = "campaign_slug"
+    content_from: Literal["draft_id", "none"] = "draft_id"
+
+
 class ContentRulesFields(BaseModel):
     """페드루 PO 리뷰 보정(2026-09-05, PR#3825) — `rules: dict`가 무형식이라
     `banned_terms`에 문자열 "spam"을 그대로 넣으면 `lint_content()`의
@@ -77,6 +96,7 @@ class ContentRulesFields(BaseModel):
     channel_priority: list[str] = []
     brand_kit: dict | None = None
     generation_budget: GenerationBudgetRule | None = None
+    utm_rules: UtmRules | None = None
 
 
 class PutContentRulesRequest(BaseModel):

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -276,17 +276,32 @@ def compute_channel_post_hash(*, text: str, link_url: str | None) -> str:
     return compute_seal_hash({"text": text, "link_url": link_url})
 
 
-def build_tagged_link(*, channel: str, link_url: str, draft_id: uuid.UUID) -> str | None:
+def build_tagged_link(
+    *, channel: str, link_url: str, draft_id: uuid.UUID, utm_rules: dict | None = None,
+) -> str | None:
     """story #3394(S2c BE 선행) AC5·`publish_channel_post_draft` 공용 — UTM 태그된 최종
     링크 조립. **미리보기(편집·버전이력 응답)와 실제 발행이 반드시 같은 값을 내야 한다** —
     로직을 두 곳에 따로 두면 "미리보기가 거짓말"하는 자리가 생긴다(그래서 publish_channel_
     post_draft도 이 함수로 옮겼다, 신규 로직 아님). 어댑터가 없는 채널이면 None(지어내지
-    않는다 — 발행 자체도 이 경우 별도 가드로 막힌다)."""
+    않는다 — 발행 자체도 이 경우 별도 가드로 막힌다).
+
+    story #3506(페드루 PO 確定 2026-09-05) — `utm_rules`는 org_content_rules.rules.
+    utm_rules 딕셔너리 그대로(호출부가 미리 조회해 넘긴다 — 이 함수 자체는 DB를 안
+    본다, 기존 순수 함수 계약 유지). `enabled`가 아니거나 자체가 없으면(=«규칙
+    없음») source/medium은 어댑터 하드코딩 그대로·utm_content는 안 붙는다(회귀 0,
+    #f8f7cb0f 시절 동작과 완전히 동일). `enabled=true`면 default_source/medium이
+    있는 것만 override하고(둘 다 선택), content_from="draft_id"(기본값)면
+    utm_content=draft_id."""
     adapter = get_channel_adapter(channel)
     if adapter is None:
         return None
     campaign = resolve_utm_campaign(link_url, fallback_draft_id=draft_id)
-    return attach_utm(link_url, source=adapter.utm_source, medium=adapter.utm_medium, campaign=campaign)
+    rules = utm_rules or {}
+    enabled = rules.get("enabled", False)
+    source = (rules.get("default_source") if enabled else None) or adapter.utm_source
+    medium = (rules.get("default_medium") if enabled else None) or adapter.utm_medium
+    content = str(draft_id) if enabled and rules.get("content_from", "draft_id") == "draft_id" else None
+    return attach_utm(link_url, source=source, medium=medium, campaign=campaign, content=content)
 
 
 async def _get_active_connection(
@@ -1186,8 +1201,12 @@ async def publish_channel_post_draft(
     get_publishing_limit = _publish_client.get_publishing_limit
     publish_container = _publish_client.publish_container
 
+    # story #3506 — org의 utm_rules(있으면)를 미리보기(아래 두 라우터 call site)와
+    # 같은 값으로 넘긴다(build_tagged_link 자체는 DB를 안 보는 순수 함수 계약 유지).
+    utm_rule_row = await get_org_content_rules(db, org_id=org_id)
+    utm_rules = (utm_rule_row.rules or {}).get("utm_rules") if utm_rule_row else None
     tagged_link = (
-        build_tagged_link(channel=draft.channel, link_url=latest.link_url, draft_id=draft.id)
+        build_tagged_link(channel=draft.channel, link_url=latest.link_url, draft_id=draft.id, utm_rules=utm_rules)
         if latest.link_url else None
     )
     text_to_post = f"{latest.text}\n\n{tagged_link}" if tagged_link else latest.text

--- a/backend/app/services/content_rules.py
+++ b/backend/app/services/content_rules.py
@@ -85,7 +85,12 @@ def lint_content(rules: dict | None, *, text: str, link_url: str | None) -> list
                 "hint_key": "content_rules.banned_term", "settings_path": _SETTINGS_PATH,
             })
 
-    if rules.get("require_utm") and link_url:
+    # story #3506(페드루 PO 確定 2026-09-05 ⓕ) — utm_rules.enabled=true면 발행 시점에
+    # 서버가 자동 부착을 보장하므로(build_tagged_link), submit 시점에 사람이 손으로
+    # 넣었는지 검사하는 이 축은 «자동 충족»으로 통과시킨다(require_utm 자체는 폐기
+    # 안 함 — 수동 규칙으로 계속 쓸 수 있게 남긴다, PO 明示).
+    utm_rules = rules.get("utm_rules") or {}
+    if rules.get("require_utm") and link_url and not utm_rules.get("enabled"):
         missing = [p for p in _REQUIRED_UTM_PARAMS if f"{p}=" not in link_url]
         if missing:
             violations.append({

--- a/backend/app/services/utm.py
+++ b/backend/app/services/utm.py
@@ -18,15 +18,21 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 _BLOG_PATH_RE = re.compile(r"^/([a-z]{2}(?:-[A-Z]{2})?)/blog/([a-z0-9]+(?:-[a-z0-9]+)*)/?$")
 
 
-def attach_utm(url: str, *, source: str, medium: str, campaign: str) -> str:
+def attach_utm(url: str, *, source: str, medium: str, campaign: str, content: str | None = None) -> str:
     """기존 쿼리 파라미터를 보존하고, `utm_`로 시작하는 키가 이미 하나라도 있으면
     아무것도 건드리지 않고 원본을 그대로 돌려준다(PO 확定 — "자동 부착"은 없을 때만
-    채운다. 사용자가 이미 넣어 둔 UTM을 서버가 덮어쓰지 않는다)."""
+    채운다. 사용자가 이미 넣어 둔 UTM을 서버가 덮어쓰지 않는다).
+
+    story #3506(페드루 PO 確定 2026-09-05) — 네 번째 키 `utm_content` 추가(선택,
+    `content is None`이면 안 붙인다 — `content_from="none"` 정책값이 이 경로로
+    옮겨온다). source/medium/campaign 세 키의 기존 계약(스킵-if-present)은 무변경."""
     parsed = urlsplit(url)
     query = parse_qsl(parsed.query, keep_blank_values=True)
     if any(k.startswith("utm_") for k, _ in query):
         return url
     query += [("utm_source", source), ("utm_medium", medium), ("utm_campaign", campaign)]
+    if content is not None:
+        query.append(("utm_content", content))
     return urlunsplit(parsed._replace(query=urlencode(query)))
 
 

--- a/backend/tests/test_3506_utm_attribution.py
+++ b/backend/tests/test_3506_utm_attribution.py
@@ -1,0 +1,304 @@
+"""story #3506(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — UTM 규칙 + 발행 시 링크
+UTM 자동 부착(조각①: 규칙 슬롯+override+utm_content). 세팅 헬퍼는
+test_3471_org_content_rules_lint.py와 동형(중복 재발명 금지).
+
+그라운딩 확인 — channel_post는 이미 UTM 부착 메커니즘(app/services/utm.py,
+story #f8f7cb0f)이 있다. 이 스토리는 그 위에 ①조직 override(source/medium)
+②utm_content 4번째 키 ③require_utm과의 자동충족 연결을 얹는다 — 새 메커니즘
+발명이 아니다."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_3471_org_content_rules_lint import (
+    _client_for,
+    _seed_agent,
+    _seed_connection,
+    _seed_default_role,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _put_utm_rules(session, *, org_id, **fields):
+    from app.services.content_rules import put_org_content_rules
+
+    return await put_org_content_rules(
+        session, org_id=org_id, rules={"utm_rules": fields}, updated_by_member_id=uuid.uuid4(),
+    )
+
+
+# ─── attach_utm 4번째 키(단위) ────────────────────────────────────────────────
+
+
+def test_attach_utm_content_key_added_when_given():
+    from app.services.utm import attach_utm
+
+    url = attach_utm("https://example.com/x", source="s", medium="m", campaign="c", content="d1")
+    assert "utm_content=d1" in url
+
+
+def test_attach_utm_content_omitted_when_none():
+    from app.services.utm import attach_utm
+
+    url = attach_utm("https://example.com/x", source="s", medium="m", campaign="c", content=None)
+    assert "utm_content" not in url
+
+
+def test_attach_utm_skips_entirely_when_utm_already_present_even_with_content():
+    """기존 계약(스킵-if-present)이 4번째 키 추가로 안 깨졌는지 — utm_* 아무거나
+    하나라도 있으면 content가 와도 원본 그대로."""
+    from app.services.utm import attach_utm
+
+    url = attach_utm("https://example.com/x?utm_source=manual", source="s", medium="m", campaign="c", content="d1")
+    assert url == "https://example.com/x?utm_source=manual"
+
+
+# ─── build_tagged_link — 조직 override ───────────────────────────────────────
+
+
+def test_build_tagged_link_no_utm_rules_uses_adapter_defaults_no_content():
+    """회귀 0 — utm_rules=None(«규칙 없음»)이면 #f8f7cb0f 시절 그대로: 어댑터
+    하드코딩 source/medium·utm_content 없음."""
+    from app.services.channel_posts import build_tagged_link
+
+    draft_id = uuid.uuid4()
+    url = build_tagged_link(channel="threads", link_url="https://example.com/post", draft_id=draft_id, utm_rules=None)
+    assert "utm_source=threads" in url
+    assert "utm_medium=social" in url
+    assert "utm_content" not in url
+
+
+def test_build_tagged_link_disabled_utm_rules_uses_adapter_defaults():
+    from app.services.channel_posts import build_tagged_link
+
+    draft_id = uuid.uuid4()
+    url = build_tagged_link(
+        channel="threads", link_url="https://example.com/post", draft_id=draft_id,
+        utm_rules={"enabled": False, "default_source": "override-src"},
+    )
+    assert "utm_source=threads" in url, "enabled=False면 override를 무시하고 어댑터 값 그대로여야 한다"
+
+
+def test_build_tagged_link_enabled_overrides_source_and_medium():
+    from app.services.channel_posts import build_tagged_link
+
+    draft_id = uuid.uuid4()
+    url = build_tagged_link(
+        channel="threads", link_url="https://example.com/post", draft_id=draft_id,
+        utm_rules={"enabled": True, "default_source": "newsletter", "default_medium": "email"},
+    )
+    assert "utm_source=newsletter" in url
+    assert "utm_medium=email" in url
+
+
+def test_build_tagged_link_enabled_without_override_falls_back_to_adapter():
+    """default_source/medium이 둘 다 미설정이면(enabled=True만) 어댑터 값으로
+    떨어진다 — override는 선택이지 강제가 아니다."""
+    from app.services.channel_posts import build_tagged_link
+
+    draft_id = uuid.uuid4()
+    url = build_tagged_link(
+        channel="threads", link_url="https://example.com/post", draft_id=draft_id,
+        utm_rules={"enabled": True},
+    )
+    assert "utm_source=threads" in url
+    assert "utm_medium=social" in url
+
+
+def test_build_tagged_link_content_from_draft_id_default():
+    from app.services.channel_posts import build_tagged_link
+
+    draft_id = uuid.uuid4()
+    url = build_tagged_link(
+        channel="threads", link_url="https://example.com/post", draft_id=draft_id,
+        utm_rules={"enabled": True},
+    )
+    assert f"utm_content={draft_id}" in url
+
+
+def test_build_tagged_link_content_from_none_omits_utm_content():
+    from app.services.channel_posts import build_tagged_link
+
+    draft_id = uuid.uuid4()
+    url = build_tagged_link(
+        channel="threads", link_url="https://example.com/post", draft_id=draft_id,
+        utm_rules={"enabled": True, "content_from": "none"},
+    )
+    assert "utm_content" not in url
+
+
+# ─── content-rules PUT/GET — utm_rules 슬롯 ──────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_put_utm_rules_reflected_in_get():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r_put = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"utm_rules": {
+                    "enabled": True, "default_source": "newsletter", "default_medium": "email",
+                }}},
+            )
+            assert r_put.status_code == 200, r_put.text
+            assert r_put.json()["rules"]["utm_rules"]["enabled"] is True
+            assert r_put.json()["rules"]["utm_rules"]["default_source"] == "newsletter"
+
+            r_get = await client.get(f"/api/v2/organizations/{org_id}/content-rules")
+        assert r_get.json()["rules"]["utm_rules"]["default_medium"] == "email"
+        # 미설정 필드는 기본값으로 채워진다(모델 default).
+        assert r_get.json()["rules"]["utm_rules"]["campaign_from"] == "campaign_slug"
+        assert r_get.json()["rules"]["utm_rules"]["content_from"] == "draft_id"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_put_utm_rules_unknown_field_returns_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r_put = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"utm_rules": {"enabled": True, "typo_field": "x"}}},
+            )
+        assert r_put.status_code == 422, r_put.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── require_utm ⇄ utm_rules.enabled 자동충족 ────────────────────────────────
+
+
+def test_lint_content_require_utm_violation_when_utm_rules_absent():
+    """회귀 0 — utm_rules 자체가 없으면 require_utm은 기존 그대로 수동 검사."""
+    from app.services.content_rules import lint_content
+
+    violations = lint_content(
+        {"require_utm": True}, text="본문", link_url="https://example.com/no-utm-here",
+    )
+    assert any(v["code"] == "utm_missing" for v in violations)
+
+
+def test_lint_content_require_utm_auto_satisfied_when_utm_rules_enabled():
+    """PO 確定 ⓕ — utm_rules.enabled=true면 자동 부착이 보장되므로 submit 시점
+    수동 검사를 건너뛴다(링크에 아직 utm이 없어도 위반 0건)."""
+    from app.services.content_rules import lint_content
+
+    violations = lint_content(
+        {"require_utm": True, "utm_rules": {"enabled": True}},
+        text="본문", link_url="https://example.com/no-utm-here",
+    )
+    assert not any(v["code"] == "utm_missing" for v in violations)
+
+
+def test_lint_content_require_utm_still_enforced_when_utm_rules_disabled():
+    """utm_rules는 있지만 enabled=False면 자동 부착이 안 보장되므로 여전히 수동
+    검사(회귀 0 — require_utm 자체는 폐기되지 않았다는 PO 明示)."""
+    from app.services.content_rules import lint_content
+
+    violations = lint_content(
+        {"require_utm": True, "utm_rules": {"enabled": False}},
+        text="본문", link_url="https://example.com/no-utm-here",
+    )
+    assert any(v["code"] == "utm_missing" for v in violations)
+
+
+# ─── HTTP 왕복 — 미리보기에 조직 override가 실제로 반영되는지 ───────────────────
+
+
+@pytest.mark.anyio
+async def test_channel_post_draft_preview_reflects_org_utm_override():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r_put = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"utm_rules": {"enabled": True, "default_source": "newsletter"}}},
+            )
+            assert r_put.status_code == 200, r_put.text
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json={
+                    "work_item_id": str(story_id), "connection_id": str(connection_id),
+                    "text": "본문", "link_url": "https://example.com/landing",
+                },
+            )
+        assert r.status_code == 201, r.text
+        preview = r.json()["tagged_link_preview"]
+        assert "utm_source=newsletter" in preview
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1123,6 +1123,11 @@
       "source": "story-3498-generation-budget(PR 개설 前 선제 등재 — 로컬 raw pytest 33.06s(14건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 200s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3506_utm_attribution.py",
+      "sec": 50.0,
+      "source": "story-3506-utm-attribution(조각1, PR 개설 前 선제 등재 — 로컬 raw pytest 7.95s(15건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 50s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3497_insight_snapshots.py",
       "sec": 85.0,
       "source": "story-3497-insight-snapshots(조각1~3, PR#3844 — 등재 누락분 소급 등록. 로컬 raw pytest 13.82s(12건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 85s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## Summary
- 블루프린트 v3 §2 「UTM·GA4·블로그 조회」 MVP. 스택 없음(base=develop 직접, #3849와 무관).
- 그라운딩에서 확인 — channel_post는 이미 UTM 자동 부착 메커니즘이 있음(`app/services/utm.py`, story #f8f7cb0f). 새 메커니즘을 만들지 않고 그 위에 얹는다.
- `org_content_rules.rules.utm_rules{enabled, default_source?, default_medium?, campaign_from, content_from}` 신설(3471 슬롯 확장).
- `attach_utm()`에 4번째 키 `utm_content` 추가, `build_tagged_link()`에 org override 배선(3개 호출부 전부 — 미리보기/발행/이력이 항상 같은 값).
- `require_utm`과의 관계 — `utm_rules.enabled=true`면 submit 시점 수동 검사를 자동 충족으로 통과.
- site_post 본문 링크 태깅은 범위 밖(PO 明示 — hosted_site는 "목적지", UTM은 거기로 향하는 channel_post 링크에만).

조각②(beacon 4필드+집계)·조각③(hosted_site clicks 계산)은 후속 PR.

## Test plan
- [x] `tests/test_3506_utm_attribution.py` 15건 green(attach_utm 단위 3·build_tagged_link override 6·PUT/GET 왕복+422·require_utm 자동충족 3종·HTTP 미리보기 반영)
- [x] 뮤테이션 2건(enabled 게이트·auto-satisfy 게이트 제거) RED→복원→GREEN
- [x] 회귀 스윕 60/60(test_3394·test_3471·test_f8f7cb0f·test_3374)
- [x] `scripts/lint_destructive_schema_weights_registered.py` 240/240 통과
- [x] 마이그레이션 없음(기존 JSONB 슬롯 확장, additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)