### PR TITLE
[SID:3511] fix: 회수(unpublish) 뒤 게이트 재상신이 영구 409에 걸리던 결함

### DIFF
--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -641,7 +641,16 @@ async def resolve_gate_holder_draft_id(
     애초에 아직 최초 발행 前이 아닌(=한 번 발행됐다가 지금은 내려간) 경우 — 회수된
     승인이 같은 목적지로의 재상신을 영구히 막는 건 원래 f6d14476의 의도가 아니었다
     (재발행 자체는 새 상신·새 승인이 원칙, 봉인 원칙 유지 — 이 함수는 "막을지"만
-    판정하지 봉인을 우회하지 않는다)."""
+    판정하지 봉인을 우회하지 않는다) · story #3511(카디르 3478-B 재실행 실측,
+    2026-09-05) — 위 라이브니스 체크가 `status == "approved"`에만 걸려 있어, 회수
+    뒤 새 draft가 만들어지면(`_reseal_gate_on_new_version`이 이 함수를 먼저 호출해
+    "approved+not_live→통과"로 자기 자신은 pending 전이를 허락받지만, 그 훅 자체는
+    라이브니스와 무관하게 무조건 pending+reapproval_required=True로 되돌린다) 다음
+    번 이 함수 호출 시점엔 이미 status가 "pending"이라 같은 라이브니스 우회가 다시는
+    안 먹어 영구 409가 됐다 — 이 체크를 pending에도 적용한다(status 조건 자체를
+    없앤다). 방금 상신한 «진짜» pending(한 번도 발행된 적 없음)은 `_gate_publication_
+    is_live`가 발행 기록 0건을 보수적으로 "살아있다"로 취급해(위 함수 자체 docstring)
+    여전히 홀드된다 — 그 무조건 True 반환이 이 확장의 유일한 안전판이다."""
     if existing_gate is None or existing_gate.status not in ("pending", "approved"):
         return None
     holding_raw = (existing_gate.neutral_facts or {}).get("draft_id")
@@ -658,7 +667,7 @@ async def resolve_gate_holder_draft_id(
         return None
     if holding_id == this_draft_id:
         return None
-    if existing_gate.status == "approved" and not await _gate_publication_is_live(session, gate_id=existing_gate.id):
+    if not await _gate_publication_is_live(session, gate_id=existing_gate.id):
         return None
     return holding_id
 

--- a/backend/tests/test_3511_gate_holder_liveness_pending.py
+++ b/backend/tests/test_3511_gate_holder_liveness_pending.py
@@ -1,0 +1,232 @@
+"""story #3511(Phase1·BE·결함·소형, 페드루 PO 確定 2026-09-05) — `resolve_gate_holder_
+draft_id`의 라이브니스 우회가 `status == "approved"`에만 걸려 있어, 회수(unpublish) 뒤
+새 draft/버전이 생기면(`_reseal_gate_on_new_version`이 무조건 pending+reapproval_
+required=True로 되돌림 — 라이브니스 무관) 다음 상신 시점엔 이미 status가 "pending"이라
+같은 우회가 다시는 안 먹어 영구 409(SITE_POST_GATE_ALREADY_HELD·CHANNEL_POST_GATE_
+ALREADY_HELD)가 되던 결함.
+
+fix = `app/services/gate_service.py::resolve_gate_holder_draft_id`의 라이브니스 체크에서
+`status == "approved" and` 조건을 없앤다(1줄) — pending에도 적용.
+
+세팅 헬퍼는 test_3502_insights_board.py/test_e4fc29fa_destination_axis.py와 동형(중복
+재발명 금지). `resolve_gate_holder_draft_id`를 직접 호출해 라이브니스 판정 자체를
+핀 박는다(HTTP round-trip·외부 어댑터 모킹 불요 — 이 함수 자체가 순수하게 DB 행만
+본다).
+
+페드루 PO 확定(2026-09-05, 처방 승인 코멘트) — 세 시나리오 「site_post·channel_post
+동형」:
+① pending+미발행(발행 행 0건) — `_gate_publication_is_live`의 보수 판정("행 0=쥔다")이
+   유일한 안전판. 다른 draft가 여전히 막혀야 한다.
+② approved+live(회수 안 됨) — AC2 회귀, 계속 홀드.
+③ pending+unpublished(3478-B' 경로) — 다른 draft가 통과해야 한다(None 반환).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_3471_org_content_rules_lint import _seed_org, _seed_story, _session_factory
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_gate(session, *, org_id, work_item_id, status, holding_draft_id, reapproval_required=False):
+    from app.models.gate import Gate
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type="story",
+        gate_type="external_publish", status=status,
+        neutral_facts={"draft_id": str(holding_draft_id)},
+        reapproval_required=reapproval_required,
+    )
+    session.add(gate)
+    await session.commit()
+    return gate
+
+
+async def _seed_site_post(session, *, org_id, work_item_id, gate_id, published_at, unpublished_at=None, slug=None):
+    from app.models.site_post import SitePost
+
+    post = SitePost(
+        id=uuid.uuid4(), org_id=org_id, lang="ko", slug=slug or f"post-{uuid.uuid4().hex[:8]}",
+        title="T", summary="요약", tags=[], body_md="본문", published_at=published_at,
+        source_story_id=work_item_id, gate_id=gate_id, unpublished_at=unpublished_at,
+    )
+    session.add(post)
+    await session.commit()
+    return post
+
+
+async def _seed_channel_publication(session, *, org_id, gate_id, status, published_at, channel="threads"):
+    from app.models.channel_publication import ChannelPublication
+
+    pub = ChannelPublication(
+        id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, version_id=uuid.uuid4(),
+        connection_id=uuid.uuid4(), channel=channel, status=status,
+        external_id=f"ext-{uuid.uuid4().hex[:8]}", permalink="https://example.com/post",
+        published_at=published_at,
+    )
+    session.add(pub)
+    await session.commit()
+    return pub
+
+
+# ─── site_post(hosted_site·wordpress/webhook 공용 — SitePost.gate_id 축) ──────
+
+
+@pytest.mark.anyio
+async def test_site_post_pending_never_published_still_holds():
+    """① 방금 상신한 진짜 pending(발행 행 0건) — 다른 draft가 여전히 막혀야 한다.
+    이 assert가 없으면 아래 ③의 fix가 "회수 안 된 pending도 다 뚫는" 반쪽짜리가 된다."""
+    from app.services.gate_service import resolve_gate_holder_draft_id
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_a = uuid.uuid4()
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id, status="pending", holding_draft_id=draft_a)
+
+            holder = await resolve_gate_holder_draft_id(s, gate, this_draft_id=uuid.uuid4())
+        assert holder == draft_a, "발행 행이 아예 없는 pending은 보수적으로 계속 홀드해야 한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_site_post_approved_live_still_holds_regression():
+    """② AC2 회귀 — 승인 뒤 편집(회수 안 됨), 발행이 여전히 live면 계속 홀드."""
+    from app.services.gate_service import resolve_gate_holder_draft_id
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_a = uuid.uuid4()
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id, status="approved", holding_draft_id=draft_a)
+            await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_id, gate_id=gate.id,
+                published_at=datetime.now(timezone.utc), unpublished_at=None,
+            )
+
+            holder = await resolve_gate_holder_draft_id(s, gate, this_draft_id=uuid.uuid4())
+        assert holder == draft_a, "회수 안 된 live 발행은 approved 상태에서 계속 홀드해야 한다(회귀 0)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_site_post_pending_after_unpublish_releases_holder():
+    """③ 3478-B' 경로 — 회수됐는데 훅이 pending+reapproval로 되돌린 상태. 다른 draft가
+    통과해야 한다(#3511 원 증상)."""
+    from app.services.gate_service import resolve_gate_holder_draft_id
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_a = uuid.uuid4()
+            gate = await _seed_gate(
+                s, org_id=org_id, work_item_id=story_id, status="pending",
+                holding_draft_id=draft_a, reapproval_required=True,
+            )
+            await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_id, gate_id=gate.id,
+                published_at=datetime.now(timezone.utc), unpublished_at=datetime.now(timezone.utc),
+            )
+
+            holder = await resolve_gate_holder_draft_id(s, gate, this_draft_id=uuid.uuid4())
+        assert holder is None, "회수(unpublish)된 뒤 pending으로 되돌아간 게이트는 새 draft를 막으면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+# ─── channel_post(threads 등 — ChannelPublication.gate_id 축, site_post와 동형) ──
+
+
+@pytest.mark.anyio
+async def test_channel_post_pending_never_published_still_holds():
+    from app.services.gate_service import resolve_gate_holder_draft_id
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_a = uuid.uuid4()
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id, status="pending", holding_draft_id=draft_a)
+
+            holder = await resolve_gate_holder_draft_id(s, gate, this_draft_id=uuid.uuid4())
+        assert holder == draft_a
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_channel_post_approved_live_still_holds_regression():
+    from app.services.gate_service import resolve_gate_holder_draft_id
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_a = uuid.uuid4()
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id, status="approved", holding_draft_id=draft_a)
+            await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, status="published",
+                published_at=datetime.now(timezone.utc),
+            )
+
+            holder = await resolve_gate_holder_draft_id(s, gate, this_draft_id=uuid.uuid4())
+        assert holder == draft_a
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_channel_post_pending_after_unpublish_releases_holder():
+    from app.services.gate_service import resolve_gate_holder_draft_id
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_a = uuid.uuid4()
+            gate = await _seed_gate(
+                s, org_id=org_id, work_item_id=story_id, status="pending",
+                holding_draft_id=draft_a, reapproval_required=True,
+            )
+            await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, status="unpublished",
+                published_at=datetime.now(timezone.utc),
+            )
+
+            holder = await resolve_gate_holder_draft_id(s, gate, this_draft_id=uuid.uuid4())
+        assert holder is None
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1058,6 +1058,11 @@
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"
     },
     {
+      "file": "tests/test_3511_gate_holder_liveness_pending.py",
+      "sec": 40.0,
+      "source": "story-3511-gate-holder-liveness-pending(PR 개설 前 선제 등재 — 로컬 raw pytest 14.92s(6건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3411_channel_post_text_preview.py",
       "sec": 6.0,
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"


### PR DESCRIPTION
## Summary
- 카디르 3478-B 재실행 실측(2026-09-05) — 발행→회수(unpublish)→같은 work_item·같은 목적지로 새 draft 상신이 영구 409 `SITE_POST_GATE_ALREADY_HELD`.
- 근본 원인: unpublish 자체는 `gate.status`를 안 건드린다(발행 테이블 status만 `unpublished`). 회수 뒤 새 draft/버전이 생기면 `_reseal_gate_on_new_version` 훅이 도는데, 훅 진입 前 `resolve_gate_holder_draft_id`의 "approved+not_live→통과" 체크는 이 시점(gate가 아직 approved)엔 정확히 작동해 진입을 허락하지만, 훅 자체는 라이브니스와 무관하게 무조건 `pending+reapproval_required=True`로 되돌린다 — 이후 실제 `submit()`이 재호출되는 시점엔 `gate.status`가 이미 "pending"이라 같은 라이브니스 우회가 다시는 안 먹어 영구 409가 된다.
- 처방(1줄) — `resolve_gate_holder_draft_id`의 라이브니스 체크에서 `status == "approved" and` 조건을 없앤다. 안전판은 `_gate_publication_is_live`의 기존 "발행 행 0건=쥔다" 보수 판정 그대로 — 한 번도 발행된 적 없는 진짜 pending은 계속 막힌다.

## Test plan
- [x] `tests/test_3511_gate_holder_liveness_pending.py` 6건 green(site_post·channel_post 동형 ×3): ①pending+미발행 0건→계속 홀드 ②approved+live→계속 홀드(AC2 회귀) ③pending+unpublished(3478-B' 경로)→해제
- [x] 뮤테이션 2건 — (a) 보수 판정(행 0건=live) 제거 → ①의 2 테스트 RED(안전판 자체 검증) (b) fix 되돌림(approved-only 복원) → ③의 2 테스트 RED. 둘 다 복원 후 GREEN
- [x] 회귀 21/21(`test_3404_channel_post_gate_already_held.py`·`test_e4fc29fa_destination_axis.py` — `resolve_gate_holder_draft_id` 소비 테스트 전수)
- [x] `scripts/lint_destructive_schema_weights_registered.py` 240/240 통과
- [x] 마이그레이션 없음

라이브 판정(AC3): 배포 뒤 카디르가 3478-B 재실행(B 회수 → B' 상신) 200 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)