### PR TITLE
[SID:3506] feat: UTM 귀속 조각②③ — beacon 4필드+집계 + hosted_site clicks

### DIFF
--- a/backend/alembic/versions/0336_org_pageview_utm_daily.py
+++ b/backend/alembic/versions/0336_org_pageview_utm_daily.py
@@ -1,0 +1,57 @@
+"""story #3506(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — UTM 귀속 집계 조각②.
+`org_pageview_utm_daily` 신설 — beacon이 utm_* 4키를 실었을 때만(적어도 하나라도
+있을 때) (org_id, path, day, utm_source, utm_medium, utm_campaign, utm_content) 축으로
+일별 upsert 집계한다(`org_pageview_daily`의 (org_id, path, day) 골격과 동형·PO 決定 (d)).
+
+utm_* 4컬럼은 NOT NULL + 빈 문자열 기본값이다(NULL 아님) — Postgres UNIQUE 제약은
+NULL을 서로 다른 값으로 취급해 (org_id, path, day, NULL, NULL, NULL, NULL) 조합이
+매번 새 행을 만들어버린다(집계가 아니라 매 요청마다 증식). 이 4컬럼은 «측정값»이
+아니라 «그룹핑 키»라 null≠0 원칙(정규화 metric 값 규약)의 적용 대상이 아니다 —
+빈 문자열은 "그 차원이 이번 요청에 없었다"는 그룹 키로만 쓰인다.
+
+페드루 PO 리뷰(2026-09-05, PR#3855) — 최초 버전은 `utm_content` 단독 인덱스를 열었으나
+(A) 決定(조각③, hosted_site clicks=org_id+path 합산·utm_content 값 매칭 없음)으로
+그 접근 패턴 자체가 없어졌다(폐기된 전제 위의 인덱스, raw 저장만·소비자 0) — 제거.
+breakdown 세부조회(story 후속)가 실제로 그 축을 쓰게 되면 그때 연다.
+
+Revision ID: 0336
+Revises: 0335
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0336"
+down_revision = "0335"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_pageview_utm_daily",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("path", sa.Text(), nullable=False),
+        sa.Column("day", sa.Date(), nullable=False),
+        sa.Column("utm_source", sa.Text(), nullable=False, server_default=""),
+        sa.Column("utm_medium", sa.Text(), nullable=False, server_default=""),
+        sa.Column("utm_campaign", sa.Text(), nullable=False, server_default=""),
+        sa.Column("utm_content", sa.Text(), nullable=False, server_default=""),
+        sa.Column("count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint(
+            "org_id", "path", "day", "utm_source", "utm_medium", "utm_campaign", "utm_content",
+            name="uq_org_pageview_utm_daily_grouping",
+        ),
+    )
+    # story #3506(e)/(A) 決定 — clicks 계산(조각③)은 org_id+path로 합산한다(위 UNIQUE
+    # 제약의 선두 두 컬럼이 이미 그 조회를 받친다). utm_content 단독 lookup 경로는
+    # 없어(raw 저장만) 별도 인덱스 불필요(PR#3855 리뷰로 제거).
+
+
+def downgrade() -> None:
+    op.drop_table("org_pageview_utm_daily")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -134,6 +134,7 @@ from app.models.recipe_role_binding import RecipeRoleBinding
 from app.models.recipe_repeat_schedule import RecipeRepeatSchedule
 from app.models.org_metering_key import OrgMeteringKey
 from app.models.org_pageview_daily import OrgPageviewDaily
+from app.models.org_pageview_utm_daily import OrgPageviewUtmDaily
 from app.models.site_post import SitePost
 from app.models.site_post_draft import SitePostDraft
 from app.models.site_post_version import SitePostVersion

--- a/backend/app/models/org_pageview_utm_daily.py
+++ b/backend/app/models/org_pageview_utm_daily.py
@@ -1,0 +1,43 @@
+"""story #3506(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — UTM 귀속 일별 집계.
+`org_pageview_daily`(story #3354)의 (org_id, path, day) 골격에 utm_* 4키를 더한
+그룹핑 축 — beacon이 utm_*을 실었을 때만 이 테이블에 upsert된다(적어도 하나라도
+있을 때만, 순수 pageview와 분리)."""
+from __future__ import annotations
+
+import uuid
+from datetime import date as date_type
+from datetime import datetime
+
+from sqlalchemy import Date, DateTime, Integer, Text, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class OrgPageviewUtmDaily(Base):
+    __tablename__ = "org_pageview_utm_daily"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id", "path", "day", "utm_source", "utm_medium", "utm_campaign", "utm_content",
+            name="uq_org_pageview_utm_daily_grouping",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    day: Mapped[date_type] = mapped_column(Date, nullable=False)
+    # 그룹핑 키(측정값 아님 — null≠0 정규화 규약 적용 대상 아님). "이번 요청에 그 차원이
+    # 없었다"는 빈 문자열로 표시한다(NULL이면 UNIQUE 제약이 매번 새 행으로 취급한다).
+    utm_source: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    utm_medium: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    utm_campaign: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    utm_content: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/public_pageview.py
+++ b/backend/app/routers/public_pageview.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.database import get_db
-from app.services.pageview_counter import record_pageview, resolve_org_by_public_key
+from app.services.pageview_counter import record_pageview, record_pageview_utm, resolve_org_by_public_key
 from app.services.rate_limiter import get_rate_limiter
 
 router = APIRouter(prefix="/api/v2/public", tags=["public-pageview"])
@@ -29,11 +29,33 @@ _BOT_UA_RE = re.compile(r"bot|spider|crawl|slurp|headless", re.IGNORECASE)
 
 _DEDUP_WINDOW_LIMIT = 1  # 레이트리밋 윈도우(rate_limiter.WINDOW_SECS=60s)당 같은 (org,path,ua) 1회만 — AC "1분 내 재요청 억제"
 
+_UTM_MAX_LEN = 256  # UTM 파라미터 값 — referrer(1024)보다 훨씬 짧은 슬러그성 값이라 별도 상한.
+
+
+def _normalize_utm(value: str | None) -> str | None:
+    """story #3506(Phase2·마케팅운영) — utm_* 4필드는 referrer와 달리 «영속»된다(PO
+    決定 (d)) — 소문자+trim 정규화(대소문자만 다른 같은 캠페인이 다른 그룹으로
+    쪼개지지 않게) 후 빈 문자열이면 "차원 없음"(None)으로 접는다. 길이 상한 초과는
+    거부가 아니라 잘라 저장(PO 明示 — beacon 페이지가 못 믿을 querystring을 그대로
+    보낼 수 있어도 요청 자체를 실패시키지 않는다)."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()[:_UTM_MAX_LEN]
+    return normalized or None
+
 
 class PageviewBeaconRequest(BaseModel):
     public_key: str = Field(..., min_length=1, max_length=128)
     path: str = Field(..., min_length=1, max_length=512)
     referrer: str | None = Field(default=None, max_length=1024)
+    # story #3506(Phase2·마케팅운영, 페드루 PO 決定 (d)) — referrer(버림)와 달리 이
+    # 4필드는 실제 저장 대상이다(org_pageview_utm_daily). Field 자체엔 상한을 안
+    # 두고(트렁케이션 vs 422 거부를 한 곳(_normalize_utm)에서만 결정 — Field
+    # max_length는 초과 시 422라 "잘라 저장" 계약과 어긋난다) 정규화 함수가 자른다.
+    utm_source: str | None = Field(default=None)
+    utm_medium: str | None = Field(default=None)
+    utm_campaign: str | None = Field(default=None)
+    utm_content: str | None = Field(default=None)
 
 
 @router.post("/pageview", status_code=204)
@@ -66,4 +88,18 @@ async def post_pageview(
 
     today = datetime.now(timezone.utc).date()
     await record_pageview(db, org_id=org_id, path=body.path, day=today)
+
+    utm_source = _normalize_utm(body.utm_source)
+    utm_medium = _normalize_utm(body.utm_medium)
+    utm_campaign = _normalize_utm(body.utm_campaign)
+    utm_content = _normalize_utm(body.utm_content)
+    if any((utm_source, utm_medium, utm_campaign, utm_content)):
+        # story #3506(Phase2·마케팅운영) — 적어도 하나라도 있을 때만 별도 집계(순수
+        # pageview와 분리, org_pageview_daily 위 write와 별도 트랜잭션 — 이 write가
+        # 실패해도 이미 커밋된 조회수 집계는 보존된다).
+        await record_pageview_utm(
+            db, org_id=org_id, path=body.path, day=today,
+            utm_source=utm_source, utm_medium=utm_medium,
+            utm_campaign=utm_campaign, utm_content=utm_content,
+        )
     return Response(status_code=204)

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -148,10 +148,12 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # 사실을 정확히 반영할 뿐(신규 동작 아님). 외부 스코프 개념이 없어(credential
         # 자체가 없다) unpublish_required_scope는 비운다.
         supports_unpublish=True,
-        # story #3497 — beacon 집계(org_pageview_daily) 기반 views만. 나머지 6키는
-        # 항상 null(hosted_site는 impressions/reach/engagements/clicks/spend/
-        # conversions 개념 자체가 없다 — 자체 방문자 카운터일 뿐 광고·소셜 API가 아님).
-        insight_metrics=("views",),
+        # story #3497 — beacon 집계(org_pageview_daily) 기반 views. story #3506(e) —
+        # clicks 추가(beacon UTM 집계 org_pageview_utm_daily 기반, "이 글로 온 UTM
+        # 유입 전체"). 나머지 5키는 항상 null(hosted_site는 impressions/reach/
+        # engagements/spend/conversions 개념 자체가 없다 — 자체 방문자 카운터일 뿐
+        # 광고·소셜 API가 아님).
+        insight_metrics=("views", "clicks"),
     ),
     # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각③b) — WordPress
     # self-hosted(Application Password) blog kind 어댑터 2호. WordPress.com OAuth2는

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -149,9 +149,19 @@ async def _fetch_hosted_site(db: AsyncSession, *, org_id: uuid.UUID, publication
     스토리가 세 번째 자리가 될 뻔한 리터럴을 뽑아 재사용)로 구성 — 고객 사이트가
     이 라우트를 실제로 구현했다는 전제 위에 서 있다(강제 보장 없음, 어댑터 선언
     주석·AC에 명시). "미제공"=`org_metering_keys`에 살아있는(revoked_at NULL) 키가
-    아예 없음(beacon 자체를 도입 안 함) · "0"=키는 있고 집계 행이 0 또는 부재."""
+    아예 없음(beacon 자체를 도입 안 함) · "0"=키는 있고 집계 행이 0 또는 부재.
+
+    story #3506(Phase2·마케팅운영, 페드루 PO 確定 (e), 그라운딩 왕복 2026-09-05 —
+    (A) path 축 확定) — clicks도 같은 path 축으로 `org_pageview_utm_daily`를 합산한다
+    ("이 글로 온 UTM 유입 전체", utm_content 특정값 매칭 아님 — 조각①이 UTM을 «이리로
+    향하는 channel_post 링크»에만 붙이므로 utm_content의 값 공간이 channel_post
+    draft이지 이 hosted_site 글 자신의 식별자가 아니다, (B)안 기각 사유 그대로).
+    views와 동일하게 beacon 미배선이면 null 유지(values에서 뺌) — 배선돼 있으면
+    집계 0건도 정확히 "0". utm_* 분해값은 raw에 그대로 실어(세부 breakdown은 후속
+    스토리 몫, 지금은 손실 없이 보존만)."""
     from app.models.org_metering_key import OrgMeteringKey
     from app.models.org_pageview_daily import OrgPageviewDaily
+    from app.models.org_pageview_utm_daily import OrgPageviewUtmDaily
     from app.models.site_post import SitePost
     from app.services.site_posts import _blog_post_path
 
@@ -172,7 +182,25 @@ async def _fetch_hosted_site(db: AsyncSession, *, org_id: uuid.UUID, publication
         select(OrgPageviewDaily.count).where(OrgPageviewDaily.org_id == org_id, OrgPageviewDaily.path == path)
     )).scalars().all()
     views = sum(total)  # beacon은 있는데 이 path에 아직 집계가 없으면 sum([])==0(정확히 "0").
-    return {"raw": {"path": path, "beacon_provisioned": True, "daily_rows": len(total)}, "values": {"views": views}}
+
+    utm_rows = (await db.execute(
+        select(
+            OrgPageviewUtmDaily.count, OrgPageviewUtmDaily.utm_source, OrgPageviewUtmDaily.utm_medium,
+            OrgPageviewUtmDaily.utm_campaign, OrgPageviewUtmDaily.utm_content,
+        ).where(OrgPageviewUtmDaily.org_id == org_id, OrgPageviewUtmDaily.path == path)
+    )).all()
+    clicks = sum(r.count for r in utm_rows)
+    utm_breakdown = [
+        {
+            "count": r.count, "utm_source": r.utm_source, "utm_medium": r.utm_medium,
+            "utm_campaign": r.utm_campaign, "utm_content": r.utm_content,
+        }
+        for r in utm_rows
+    ]
+    return {
+        "raw": {"path": path, "beacon_provisioned": True, "daily_rows": len(total), "utm_breakdown": utm_breakdown},
+        "values": {"views": views, "clicks": clicks},
+    }
 
 
 _THREADS_INSIGHTS_URL_TMPL = "https://graph.threads.net/v1.0/{media_id}/insights"

--- a/backend/app/services/pageview_counter.py
+++ b/backend/app/services/pageview_counter.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.org_metering_key import OrgMeteringKey
 from app.models.org_pageview_daily import OrgPageviewDaily
+from app.models.org_pageview_utm_daily import OrgPageviewUtmDaily
 
 _KEY_BYTES = 32  # doc_share.py의 secrets.token_urlsafe(32)와 동일 관례
 
@@ -74,6 +75,28 @@ async def record_pageview(db: AsyncSession, *, org_id: uuid.UUID, path: str, day
     stmt = stmt.on_conflict_do_update(
         constraint="uq_org_pageview_daily_org_path_day",
         set_={"count": OrgPageviewDaily.count + 1, "updated_at": datetime.now(timezone.utc)},
+    )
+    await db.execute(stmt)
+    await db.commit()
+
+
+async def record_pageview_utm(
+    db: AsyncSession, *, org_id: uuid.UUID, path: str, day: date_type,
+    utm_source: str | None, utm_medium: str | None, utm_campaign: str | None, utm_content: str | None,
+) -> None:
+    """story #3506(Phase2·마케팅운영, 페드루 PO 決定 (d)) — beacon이 utm_* 중 적어도
+    하나라도 실었을 때만 호출된다(호출부 책임 — 순수 pageview와 분리, 이 함수 자체는
+    무조건 upsert). 4컬럼은 NOT NULL이라 None은 빈 문자열로 치환(모델 docstring
+    참고 — 그룹핑 키, null≠0 정규화 규약 적용 대상 아님)."""
+    stmt = pg_insert(OrgPageviewUtmDaily).values(
+        id=uuid.uuid4(), org_id=org_id, path=path, day=day,
+        utm_source=utm_source or "", utm_medium=utm_medium or "",
+        utm_campaign=utm_campaign or "", utm_content=utm_content or "",
+        count=1,
+    )
+    stmt = stmt.on_conflict_do_update(
+        constraint="uq_org_pageview_utm_daily_grouping",
+        set_={"count": OrgPageviewUtmDaily.count + 1, "updated_at": datetime.now(timezone.utc)},
     )
     await db.execute(stmt)
     await db.commit()

--- a/backend/tests/test_3497_insight_snapshots.py
+++ b/backend/tests/test_3497_insight_snapshots.py
@@ -268,6 +268,91 @@ async def test_hosted_site_views_reflects_real_pageview_count():
         await engine.dispose()
 
 
+# ─── hosted_site: clicks(story #3506·PO 決定 (e), views와 동형 path 축) ────────
+
+
+@pytest.mark.anyio
+async def test_hosted_site_clicks_null_when_no_metering_key_provisioned():
+    """views와 동형 — beacon 자체가 없으면 clicks도 미제공(null), 0으로 지어내지 않는다.
+    어댑터 실 선언(views, clicks) 그대로 _normalize에 넣는다(story #3506이 insight_
+    metrics를 확장한 실물을 직접 검증)."""
+    from app.services.insight_snapshots import _fetch_hosted_site, _normalize
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            post = await _seed_site_post(s, org_id=org_id, work_item_id=uuid.uuid4())
+
+            result = await _fetch_hosted_site(s, org_id=org_id, publication_id=post.id)
+            normalized = _normalize(declared_metrics=("views", "clicks"), values=result["values"])
+            assert normalized["clicks"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hosted_site_clicks_zero_when_metering_key_exists_but_no_utm_pageviews():
+    from app.models.org_metering_key import OrgMeteringKey
+    from app.services.insight_snapshots import _fetch_hosted_site, _normalize
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            post = await _seed_site_post(s, org_id=org_id, work_item_id=uuid.uuid4())
+            s.add(OrgMeteringKey(id=uuid.uuid4(), org_id=org_id, public_key="pub-key-clicks-0"))
+            await s.commit()
+
+            result = await _fetch_hosted_site(s, org_id=org_id, publication_id=post.id)
+            normalized = _normalize(declared_metrics=("views", "clicks"), values=result["values"])
+            assert normalized["clicks"] == 0, "beacon은 있고 UTM 집계 0인데 null로 나왔다(0≠미제공 축 붕괴)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hosted_site_clicks_sums_utm_daily_by_path_ignoring_dimension_values():
+    """PO 決定(A) — utm_content 특정값 매칭이 아니라 path 축으로 utm 4필드 중 하나라도
+    있던 방문 전부를 합산한다(서로 다른 campaign 2행도 같이 더해진다)."""
+    from app.models.org_metering_key import OrgMeteringKey
+    from app.models.org_pageview_utm_daily import OrgPageviewUtmDaily
+    from app.services.insight_snapshots import _fetch_hosted_site
+    from app.services.site_posts import _blog_post_path
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            post = await _seed_site_post(s, org_id=org_id, work_item_id=uuid.uuid4(), lang="ko", slug="utm-clicks")
+            path = _blog_post_path(lang="ko", slug="utm-clicks")
+            s.add(OrgMeteringKey(id=uuid.uuid4(), org_id=org_id, public_key="pub-key-clicks-sum"))
+            s.add(OrgPageviewUtmDaily(
+                id=uuid.uuid4(), org_id=org_id, path=path, day=datetime.now(timezone.utc).date(),
+                utm_source="twitter", utm_medium="social", utm_campaign="spring", utm_content="draft-1",
+                count=5,
+            ))
+            s.add(OrgPageviewUtmDaily(
+                id=uuid.uuid4(), org_id=org_id, path=path, day=datetime.now(timezone.utc).date(),
+                utm_source="newsletter", utm_medium="email", utm_campaign="summer", utm_content="draft-2",
+                count=3,
+            ))
+            # 다른 path의 utm 집계는 이 글의 clicks에 안 섞인다.
+            s.add(OrgPageviewUtmDaily(
+                id=uuid.uuid4(), org_id=org_id, path="/ko/blog/other-post", day=datetime.now(timezone.utc).date(),
+                utm_source="twitter", utm_medium="social", utm_campaign="spring", utm_content="draft-3",
+                count=100,
+            ))
+            await s.commit()
+
+            result = await _fetch_hosted_site(s, org_id=org_id, publication_id=post.id)
+            assert result["values"]["clicks"] == 8, "path 밖 행이 섞였거나 자기 path 행 일부를 놓쳤다"
+            assert len(result["raw"]["utm_breakdown"]) == 2
+            assert {b["utm_campaign"] for b in result["raw"]["utm_breakdown"]} == {"spring", "summer"}
+    finally:
+        await engine.dispose()
+
+
 # ─── wordpress/webhook: unsupported 즉시(어댑터 미선언) ───────────────────────
 
 

--- a/backend/tests/test_3506_utm_beacon_aggregate.py
+++ b/backend/tests/test_3506_utm_beacon_aggregate.py
@@ -1,0 +1,235 @@
+"""story #3506(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — UTM 귀속 조각②(beacon
+4필드 기록 + `org_pageview_utm_daily` 일별 집계). 세팅 헬퍼는 test_3354_pageview_
+counter.py와 동형(중복 재발명 금지) — beacon 인프라(org_metering_keys·rate limiter)는
+그대로 재사용, 이 스토리 전용(utm_* 4필드+신규 집계 테이블)만 새로 추가한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_3354_pageview_counter import (
+    _client_for,
+    _seed_org,
+    _session_factory,
+    _setup_public_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _get_utm_rows(session, org_id, path):
+    from sqlalchemy import select
+    from app.models.org_pageview_utm_daily import OrgPageviewUtmDaily
+
+    rows = (await session.execute(
+        select(OrgPageviewUtmDaily).where(OrgPageviewUtmDaily.org_id == org_id, OrgPageviewUtmDaily.path == path)
+    )).scalars().all()
+    return rows
+
+
+@pytest.mark.anyio
+async def test_beacon_with_utm_records_aggregate_row():
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            r = await public_client.post(
+                "/api/v2/public/pageview",
+                json={
+                    "public_key": public_key, "path": "/ko/blog/utm-post",
+                    "utm_source": "Newsletter", "utm_medium": "Email",
+                    "utm_campaign": "Launch", "utm_content": "draft-abc",
+                },
+                headers={"user-agent": "Mozilla/5.0 test-utm-A"},
+            )
+        assert r.status_code == 204
+
+        async with Session() as s:
+            rows = await _get_utm_rows(s, org_id, "/ko/blog/utm-post")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.count == 1
+        # 소문자+trim 정규화(대소문자만 다른 같은 캠페인이 다른 그룹으로 안 쪼개지게).
+        assert row.utm_source == "newsletter"
+        assert row.utm_medium == "email"
+        assert row.utm_campaign == "launch"
+        assert row.utm_content == "draft-abc"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_beacon_without_utm_does_not_write_utm_table():
+    """PO 決定(d) — utm_* 4개가 전부 없으면(순수 pageview) 이 테이블엔 아예 안 쓴다
+    (org_pageview_daily만 늘어난다, 회귀 0)."""
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            r = await public_client.post(
+                "/api/v2/public/pageview",
+                json={"public_key": public_key, "path": "/ko/blog/plain-post"},
+                headers={"user-agent": "Mozilla/5.0 test-utm-B"},
+            )
+        assert r.status_code == 204
+
+        async with Session() as s:
+            rows = await _get_utm_rows(s, org_id, "/ko/blog/plain-post")
+        assert rows == [], "utm_* 없는 순수 pageview가 UTM 집계 테이블에 행을 만들었다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_beacon_utm_upsert_increments_same_grouping():
+    """같은 (org, path, day, 4키) 조합으로 2번 beacon → count=2(다른 UA로 dedup 우회)."""
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        body = {
+            "public_key": public_key, "path": "/ko/blog/utm-repeat",
+            "utm_source": "twitter", "utm_medium": "social",
+            "utm_campaign": "launch", "utm_content": "draft-xyz",
+        }
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            r1 = await public_client.post(
+                "/api/v2/public/pageview", json=body, headers={"user-agent": "Mozilla/5.0 test-utm-C1"},
+            )
+            r2 = await public_client.post(
+                "/api/v2/public/pageview", json=body, headers={"user-agent": "Mozilla/5.0 test-utm-C2"},
+            )
+        assert r1.status_code == 204 and r2.status_code == 204
+
+        async with Session() as s:
+            rows = await _get_utm_rows(s, org_id, "/ko/blog/utm-repeat")
+        assert len(rows) == 1, "같은 그룹핑 키인데 행이 갈라졌다(UNIQUE 제약/upsert 결함)"
+        assert rows[0].count == 2
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_beacon_utm_different_campaign_same_path_separate_rows():
+    """같은 path·다른 campaign은 별도 행(그룹핑 축이 utm_campaign도 포함한다는 확인)."""
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            await public_client.post(
+                "/api/v2/public/pageview",
+                json={
+                    "public_key": public_key, "path": "/ko/blog/multi-campaign",
+                    "utm_source": "twitter", "utm_medium": "social", "utm_campaign": "spring",
+                },
+                headers={"user-agent": "Mozilla/5.0 test-utm-D1"},
+            )
+            await public_client.post(
+                "/api/v2/public/pageview",
+                json={
+                    "public_key": public_key, "path": "/ko/blog/multi-campaign",
+                    "utm_source": "twitter", "utm_medium": "social", "utm_campaign": "summer",
+                },
+                headers={"user-agent": "Mozilla/5.0 test-utm-D2"},
+            )
+
+        async with Session() as s:
+            rows = await _get_utm_rows(s, org_id, "/ko/blog/multi-campaign")
+        campaigns = sorted(r.utm_campaign for r in rows)
+        assert campaigns == ["spring", "summer"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_beacon_utm_partial_fields_missing_ones_are_empty_string_not_null():
+    """utm_content만 없으면(source/medium/campaign만) 그 컬럼은 빈 문자열(NOT NULL) —
+    NULL이면 UNIQUE 제약이 매번 새 행을 만든다(마이그 docstring이 경고하는 그 함정)."""
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            await public_client.post(
+                "/api/v2/public/pageview",
+                json={
+                    "public_key": public_key, "path": "/ko/blog/partial-utm",
+                    "utm_source": "twitter", "utm_medium": "social", "utm_campaign": "x",
+                },
+                headers={"user-agent": "Mozilla/5.0 test-utm-E"},
+            )
+
+        async with Session() as s:
+            rows = await _get_utm_rows(s, org_id, "/ko/blog/partial-utm")
+        assert len(rows) == 1
+        assert rows[0].utm_content == ""
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+def test_normalize_utm_lowercases_trims_and_caps_length():
+    from app.routers.public_pageview import _normalize_utm, _UTM_MAX_LEN
+
+    assert _normalize_utm(None) is None
+    assert _normalize_utm("  ") is None
+    assert _normalize_utm("  Newsletter  ") == "newsletter"
+    long_value = "x" * (_UTM_MAX_LEN + 50)
+    result = _normalize_utm(long_value)
+    assert result is not None and len(result) == _UTM_MAX_LEN

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -173,6 +173,11 @@
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"
     },
     {
+      "file": "tests/test_3506_utm_beacon_aggregate.py",
+      "sec": 70.0,
+      "source": "story-3506-utm-beacon-aggregate(조각2, PR 개설 前 선제 등재 — 로컬 raw pytest 10.96s(6건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 70s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_2038_hypothesis_outcome_result_enforce.py",
       "sec": 8.05,
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"
@@ -1144,8 +1149,8 @@
     },
     {
       "file": "tests/test_3497_insight_snapshots.py",
-      "sec": 85.0,
-      "source": "story-3497-insight-snapshots(조각1~3, PR#3844 — 등재 누락분 소급 등록. 로컬 raw pytest 13.82s(12건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 85s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 130.0,
+      "source": "story-3497-insight-snapshots(조각1~3+3506 clicks 3건 추가, PR#3844 — 등재 누락분 소급 등록. 로컬 raw pytest 21.77s(15건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 130s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
       "file": "tests/test_e4fc29fa_hosted_site_publish_adapter.py",


### PR DESCRIPTION
## ⚠️ 스택 임시(#3849·#3852 착지 뒤 develop retarget)
base=`fix/3510-member-role-sync`(PR#3852, 0335 위) — 0336↓0335 마이그 체인이라 그 실물 위에서 CI를 돌리려고 임시 스택. #3849→#3852 순서로 develop에 착지하면 retarget.

## Summary
조각①(utm_rules+override, PR#3851)은 이미 develop 머지 済. 이 PR은 그 위에 얹는 나머지 두 조각.

**조각②(beacon+집계)**:
- `PageviewBeaconRequest`에 utm_source/medium/campaign/content 4필드 추가 — referrer(버림)와 달리 실제 영속. 소문자+trim 정규화, 빈 문자열이면 None으로 접음, 길이 상한(256) 초과는 잘라 저장(거부 아님).
- 신규 `org_pageview_utm_daily` — utm_* 4개가 전부 없으면(순수 pageview) 아예 안 쓴다. 4컬럼 NOT NULL+빈문자열 기본값(그룹핑 키라 null≠0 규약 대상 아님 — NULL이면 UNIQUE 제약이 매번 새 행을 만든다).

**조각③(hosted_site clicks)** — 그라운딩 왕복(2026-09-05, PO 確定 (A)):
- hosted_site 글 자신의 clicks = `org_pageview_utm_daily`를 path 축으로 합산(views와 동일 축, "이 글로 온 UTM 유입 전체"). utm_content 특정값 매칭(B안)은 기각 — 조각①이 UTM을 "이리로 향하는 channel_post 링크"에만 붙여 utm_content의 값 공간이 channel_post draft이지 hosted_site 자신의 식별자가 아니기 때문.
- 어댑터 insight_metrics에 "clicks" 추가(views와 동일 beacon-미배선=null 규약). utm_* 분해값은 raw.utm_breakdown에 보존.

## Test plan
- [x] 신규 8건(beacon 6+hosted_site clicks 3, 일부 회귀 겹침) green
- [x] 뮤테이션 3건 — utm-존재 게이트 제거→RED / ON CONFLICT 제거→RED(무결성 위반) / path 필터 제거→RED(cross-path 누수) — 전부 복원 후 GREEN
- [x] 회귀 55/55(test_3497·test_3506_beacon·test_3354·test_3510·test_3502)
- [x] 마이그 0336↓0335 체인 + up/down 왕복
- [x] `scripts/lint_destructive_schema_weights_registered.py` 243/243 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)