### PR TITLE
[SID:3501] feat: 콘텐츠 규칙 PUT 낙관적 잠금

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4988,7 +4988,15 @@
     "generationBudgetPeriodLabel": "Period",
     "generationBudgetNotSet": "No policy set",
     "generationBudgetSuspendedReadonly": "Suspended",
-    "generationBudgetHint": "Setting the limit to 0 suspends all generation. Leaving it blank means no policy at all (different from unlimited)."
+    "generationBudgetHint": "Setting the limit to 0 suspends all generation. Leaving it blank means no policy at all (different from unlimited).",
+    "brandKitLabel": "Brand kit",
+    "versionConflictFact": "The rules changed after you opened this screen.",
+    "versionConflictFactWithName": "{name} saved changes before you.",
+    "versionConflictPriorChanged": "Changed before yours: {list}",
+    "versionConflictMyChanges": "Your unsaved edits: {list}",
+    "versionConflictRolledBack": "Rolled back: {list} — re-enter them if you still need them.",
+    "versionConflictReloadAction": "Reload",
+    "versionConflictSaveDisabledReason": "You can save again after reloading."
   },
   "insightsBoard": {
     "pageTitle": "Performance board",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4988,7 +4988,15 @@
     "generationBudgetPeriodLabel": "기간",
     "generationBudgetNotSet": "정책 없음",
     "generationBudgetSuspendedReadonly": "정지",
-    "generationBudgetHint": "한도를 0으로 두면 생성이 전부 정지됩니다. 비우면 한도 자체가 없습니다(무제한과는 다릅니다 — 정책이 아예 없다는 뜻입니다)."
+    "generationBudgetHint": "한도를 0으로 두면 생성이 전부 정지됩니다. 비우면 한도 자체가 없습니다(무제한과는 다릅니다 — 정책이 아예 없다는 뜻입니다).",
+    "brandKitLabel": "브랜드 킷",
+    "versionConflictFact": "이 화면을 연 뒤에 규칙이 바뀌었습니다.",
+    "versionConflictFactWithName": "{name}님이 먼저 저장했습니다.",
+    "versionConflictPriorChanged": "먼저 저장된 변경: {list}",
+    "versionConflictMyChanges": "되돌아갈 내 편집: {list}",
+    "versionConflictRolledBack": "방금 되돌린 편집: {list} — 필요하면 다시 넣어 주세요.",
+    "versionConflictReloadAction": "다시 불러오기",
+    "versionConflictSaveDisabledReason": "다시 불러온 뒤에 저장할 수 있습니다."
   },
   "insightsBoard": {
     "pageTitle": "성과 보드",

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -318,6 +318,13 @@ export const EXEMPT_PAIRS = new Set<string>([
   // 개념을 정렬 드롭다운과 표 헤더 두 표면에서 일관되게 쓰는 것 자체가 의도다.
   'insightsBoard.columnD1 <-> insightsBoard.sortD1',
   'insightsBoard.columnD7 <-> insightsBoard.sortD7',
+  // story #3501(doc a0da40c9 §20, 2026-09-05) — contentRules.versionConflictPriorChanged
+  // ("먼저 저장된 변경: {list}", 충돌 배너 한 줄) <-> contentRules.saveAction("저장",
+  // 버튼 라벨). 겹치는 건 "저장"이라는 낱말뿐 — 하나는 "저장하다"는 동사 버튼이고
+  // 하나는 "(남이) 저장한" 과거 수동형 서술이라 화면에서 실제로 헷갈릴 자리가 아니다
+  // (#2352/#2365가 잡으려는 "같은 화면의 두 «수»가 헷갈리는" 병이 아니다 — {list}는
+  // 필드 이름 목록이지 숫자가 아니다).
+  'contentRules.saveAction <-> contentRules.versionConflictPriorChanged',
 ]);
 
 // ⛔⭐오르테가군 지적(2026-07-31) — 이 목록에 «새로» 넣는 것은 PO 승인을 거친다. 이유 없이

--- a/apps/web/src/app/(authenticated)/organization/content-rules/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/content-rules/page.test.tsx
@@ -60,22 +60,29 @@ function stubFetch(opts: {
   version?: number;
   onPut?: (body: unknown) => { status: number; body?: unknown };
   budget?: { limit_minor: number | null; spent_minor: number; remaining_minor: number | null; currency: 'KRW' | 'USD' | null; period: 'month' };
+  // story #3501(doc a0da40c9 §20-4) — 409 재검증 경로가 실제로 별도 GET을 쳐 "새
+  // 서버값"을 얻는지 확認하려면, 그 GET이 «다른» 값을 돌려줘야 한다. 첫 PUT이
+  // 409를 낸 뒤부터 GET이 이 값을 돌려준다(그 전엔 rules/version 그대로).
+  getAfterConflict?: { rules: typeof RULES_V1; version: number };
 }) {
   const rules = opts.rules ?? RULES_V1;
   const version = opts.version ?? 3;
   const budget = opts.budget ?? { limit_minor: null, spent_minor: 0, remaining_minor: null, currency: null, period: 'month' as const };
+  let conflictTriggered = false;
   vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
     if (url.includes('/generation-budget')) {
       return new Response(JSON.stringify({ data: budget }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     }
     if (url.includes('/content-rules') && (!init || init.method === undefined || init.method === 'GET')) {
-      return new Response(JSON.stringify({ data: { org_id: ORG_ID, rules, version } }), {
+      const current = conflictTriggered && opts.getAfterConflict ? opts.getAfterConflict : { rules, version };
+      return new Response(JSON.stringify({ data: { org_id: ORG_ID, rules: current.rules, version: current.version } }), {
         status: 200, headers: { 'Content-Type': 'application/json' },
       });
     }
     if (url.includes('/content-rules') && init?.method === 'PUT') {
       const body = init.body ? JSON.parse(init.body as string) : null;
       const result = opts.onPut?.(body) ?? { status: 200, body: { org_id: ORG_ID, rules: body?.rules ?? rules, version: version + 1 } };
+      if (result.status === 409) conflictTriggered = true;
       const ok = result.status < 400;
       return new Response(JSON.stringify(ok ? { data: result.body } : { data: null, error: result.body }), {
         status: result.status, headers: { 'Content-Type': 'application/json' },
@@ -199,6 +206,152 @@ describe('ContentRulesPage — 저장(story #3472 AC1)', () => {
     await act(async () => { saveBtn.click(); });
     await flush();
     expect(container.querySelector('[role="alert"]')?.textContent).toBe(koMessages.contentRules.errorInvalid);
+  });
+
+  it('⭐저장 요청 body에 expected_version이 로드된 버전 그대로 실린다', async () => {
+    let sentBody: unknown = null;
+    stubFetch({
+      onPut: (body) => { sentBody = body; return { status: 200, body: { org_id: ORG_ID, rules: RULES_V1, version: 4 } }; },
+    });
+    await mount('owner');
+    const saveBtn = container.querySelector('[data-testid="content-rules-save-button"]') as HTMLButtonElement;
+    await act(async () => { saveBtn.click(); });
+    await flush();
+    expect((sentBody as { expected_version?: number } | null)?.expected_version).toBe(3);
+  });
+});
+
+describe('ContentRulesPage — 낙관적 잠금 충돌(story #3501, doc a0da40c9 §20)', () => {
+  const SERVER_CHANGED = {
+    ...RULES_V1, banned_terms: ['서버측_새금칙'], // "먼저 저장된 변경" = banned_terms
+  };
+
+  it('⭐409(이름 있음) — "{이름}이 먼저 저장했습니다"+두 목록+저장 비활성+사유', async () => {
+    stubFetch({
+      onPut: () => ({
+        status: 409,
+        body: { code: 'CONTENT_RULES_VERSION_CONFLICT', current_version: 4, updated_by: { member_id: 'm-1', name: '유나' } },
+      }),
+      getAfterConflict: { rules: SERVER_CHANGED, version: 4 },
+    });
+    await mount('owner');
+
+    // 내 로컬 편집 — tone을 바꾼다("되돌아갈 내 편집" = tone).
+    const toneInput = container.querySelector('#content-rules-tone') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(toneInput, '내가 고친 톤');
+      toneInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const saveBtn = container.querySelector('[data-testid="content-rules-save-button"]') as HTMLButtonElement;
+    await act(async () => { saveBtn.click(); });
+    await flush();
+
+    const banner = container.querySelector('[data-testid="content-rules-version-conflict"]');
+    expect(banner?.textContent).toContain(koMessages.contentRules.versionConflictFactWithName.replace('{name}', '유나'));
+    expect(banner?.textContent).not.toContain(koMessages.contentRules.versionConflictFact);
+    expect(banner?.textContent).toContain(
+      koMessages.contentRules.versionConflictPriorChanged.replace('{list}', koMessages.contentRules.bannedTermsLabel),
+    );
+    expect(banner?.textContent).toContain(
+      koMessages.contentRules.versionConflictMyChanges.replace('{list}', koMessages.contentRules.toneLabel),
+    );
+
+    expect(saveBtn.disabled).toBe(true);
+    expect(container.querySelector('[data-testid="content-rules-save-disabled-reason"]')?.textContent)
+      .toBe(koMessages.contentRules.versionConflictSaveDisabledReason);
+  });
+
+  it('409(이름 없음) — 화면이 모르는 것은 지어내지 않고 일반 사실 문구만', async () => {
+    stubFetch({
+      onPut: () => ({
+        status: 409,
+        body: { code: 'CONTENT_RULES_VERSION_CONFLICT', current_version: 4, updated_by: null },
+      }),
+      getAfterConflict: { rules: SERVER_CHANGED, version: 4 },
+    });
+    await mount('owner');
+    const saveBtn = container.querySelector('[data-testid="content-rules-save-button"]') as HTMLButtonElement;
+    await act(async () => { saveBtn.click(); });
+    await flush();
+    const banner = container.querySelector('[data-testid="content-rules-version-conflict"]');
+    expect(banner?.textContent).toContain(koMessages.contentRules.versionConflictFact);
+  });
+
+  it('⭐"다시 불러오기" — 자동 병합도 조용한 폐기도 아니다: 서버값으로 갈아끼우고 되돌린 필드 이름을 한 줄 남긴다', async () => {
+    stubFetch({
+      onPut: () => ({
+        status: 409,
+        body: { code: 'CONTENT_RULES_VERSION_CONFLICT', current_version: 4, updated_by: null },
+      }),
+      getAfterConflict: { rules: SERVER_CHANGED, version: 4 },
+    });
+    await mount('owner');
+
+    const toneInput = container.querySelector('#content-rules-tone') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(toneInput, '내가 고친 톤');
+      toneInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const saveBtn = container.querySelector('[data-testid="content-rules-save-button"]') as HTMLButtonElement;
+    await act(async () => { saveBtn.click(); });
+    await flush();
+
+    const reloadBtn = container.querySelector('[data-testid="content-rules-reload-button"]') as HTMLButtonElement;
+    await act(async () => { reloadBtn.click(); });
+    await flush();
+
+    // 서버값(SERVER_CHANGED)으로 실제로 갈아끼워졌다 — 내가 고친 톤이 아니라 원래 톤.
+    expect((container.querySelector('#content-rules-tone') as HTMLInputElement).value).toBe(RULES_V1.tone);
+    expect(container.textContent).toContain('서버측_새금칙');
+    expect(container.querySelector('[data-testid="content-rules-version"]')?.textContent)
+      .toBe(koMessages.contentRules.versionLabel.replace('{version}', '4'));
+
+    // 되돌린 필드 이름 한 줄이 남는다 — 값이 아니라 이름만.
+    expect(container.querySelector('[data-testid="content-rules-rolled-back-note"]')?.textContent).toBe(
+      koMessages.contentRules.versionConflictRolledBack.replace('{list}', koMessages.contentRules.toneLabel),
+    );
+
+    // 충돌이 풀려 저장 버튼이 다시 활성화된다.
+    expect((container.querySelector('[data-testid="content-rules-save-button"]') as HTMLButtonElement).disabled).toBe(false);
+    expect(container.querySelector('[data-testid="content-rules-version-conflict"]')).toBeNull();
+  });
+
+  it('겹치는 필드(진짜 충돌)가 각 목록의 맨 앞에 온다', async () => {
+    // 서버가 tone을 바꿨고(먼저 저장된 변경), 나도 tone을 바꿨다(되돌아갈 내 편집) — 겹침.
+    stubFetch({
+      onPut: () => ({
+        status: 409,
+        body: { code: 'CONTENT_RULES_VERSION_CONFLICT', current_version: 4, updated_by: null },
+      }),
+      getAfterConflict: { rules: { ...RULES_V1, tone: '서버가 바꾼 톤', banned_terms: ['서버측_새금칙'] }, version: 4 },
+    });
+    await mount('owner');
+
+    // 내 로컬 편집 — tone(겹침)과 require_utm(안 겹침) 둘 다 바꾼다.
+    const toneInput = container.querySelector('#content-rules-tone') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(toneInput, '내가 고친 톤');
+      toneInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const utmCheckbox = container.querySelector('[data-testid="content-rules-require-utm"]') as HTMLInputElement;
+    await act(async () => { utmCheckbox.click(); });
+
+    const saveBtn = container.querySelector('[data-testid="content-rules-save-button"]') as HTMLButtonElement;
+    await act(async () => { saveBtn.click(); });
+    await flush();
+
+    const banner = container.querySelector('[data-testid="content-rules-version-conflict"]');
+    // §20-4 "겹치는 이름은 앞에 둔다" — tone(겹침)이 require_utm(안 겹침)보다 리스트
+    // 앞에 와야 정확한 문구가 된다(순서가 틀리면 이 exact-match가 깨진다).
+    const expectedMyChanges = [koMessages.contentRules.toneLabel, koMessages.contentRules.requireUtmLabel].join(', ');
+    expect(banner?.textContent).toContain(
+      koMessages.contentRules.versionConflictMyChanges.replace('{list}', expectedMyChanges),
+    );
   });
 });
 

--- a/apps/web/src/app/(authenticated)/organization/content-rules/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/content-rules/page.tsx
@@ -66,7 +66,52 @@ const EMPTY_RULES: ContentRules = {
 // story #3472(BE #3825 "보정 중") — 422 CONTENT_RULES_INVALID의 필드별 shape는 아직
 // 최종이 아니다. 이 화면은 최선으로 `field`가 실려 오면 그 필드 옆에, 없으면 폼
 // 상단 배너로 낸다(둘 다 원문을 안 지운다 — <details> 접기, §3-0 원칙과 동형).
-type ContentRulesErrorBody = { error?: { code?: string; message?: string; field?: string } };
+type ContentRulesErrorBody = {
+  error?: {
+    code?: string; message?: string; field?: string;
+    // story #3501(doc a0da40c9 §20-2) — 409 CONTENT_RULES_VERSION_CONFLICT 전용.
+    current_version?: number;
+    updated_by?: { member_id: string; name: string | null } | null;
+  };
+};
+
+// story #3501(doc a0da40c9 §20) — 필드 «이름»을 사람 라벨로. 이 화면이 편집하지
+// 않는 미지 키(예: 다른 화면이 만든 utm_rules)는 원시 키 그대로 폴백한다.
+const FIELD_LABEL_KEYS: Record<string, string> = {
+  banned_terms: 'bannedTermsLabel',
+  require_utm: 'requireUtmLabel',
+  tone: 'toneLabel',
+  taxonomy: 'taxonomyLabel',
+  channel_priority: 'channelPriorityLabel',
+  brand_kit: 'brandKitLabel',
+  generation_budget: 'generationBudgetSectionTitle',
+};
+
+// story #3501(doc a0da40c9 §20-4) — "화면이 이미 가진 것으로 계산한다": 로드값·
+// 로컬값·새 서버값 세 벌을 두 번 견주면 새 API 없이 두 목록이 나온다.
+function diffFieldNames(a: object, b: object): string[] {
+  const ar = a as Record<string, unknown>;
+  const br = b as Record<string, unknown>;
+  const keys = new Set([...Object.keys(ar), ...Object.keys(br)]);
+  const changed: string[] = [];
+  for (const key of keys) {
+    if (JSON.stringify(ar[key]) !== JSON.stringify(br[key])) changed.push(key);
+  }
+  return changed;
+}
+
+// §20-4 — "두 목록이 겹치는 필드가 «진짜 충돌»이다 — 겹치는 이름은 앞에 둔다."
+function withOverlapFirst(fields: string[], overlap: ReadonlySet<string>): string[] {
+  return [...fields].sort((a, b) => Number(overlap.has(b)) - Number(overlap.has(a)));
+}
+
+interface VersionConflictState {
+  updatedByName: string | null;
+  priorChangedFields: string[];
+  myChangedFields: string[];
+  freshServerRules: ContentRules;
+  freshServerVersion: number;
+}
 
 function TagListEditor({
   items, onChange, readOnly, placeholder, testIdPrefix,
@@ -184,12 +229,20 @@ export default function ContentRulesPage() {
 
   const [rules, setRules] = useState<ContentRules>(EMPTY_RULES);
   const [version, setVersion] = useState<number | null>(null);
+  // story #3501(doc a0da40c9 §20-4) — 로드 시점 스냅샷(내 로컬 편집과 별개). 충돌
+  // 진단 두 목록을 계산하는 기준선 — «로드값」이지 「지금 화면값」이 아니다.
+  const [loadedRules, setLoadedRules] = useState<ContentRules>(EMPTY_RULES);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [saveSuccess, setSaveSuccess] = useState(false);
+  // story #3501(doc a0da40c9 §20) — 409 충돌 상태. null이 아니면 저장 버튼은
+  // 비활성(§20-5, «상태» 축 — 다시 불러오면 풀린다).
+  const [conflict, setConflict] = useState<VersionConflictState | null>(null);
+  // §20-3 "되돌린 뒤에도 그 이름 목록을 한 줄 남긴다" — 다시 불러오기 직후에만 보인다.
+  const [justRolledBackFields, setJustRolledBackFields] = useState<string[] | null>(null);
   // story #3500 — 잔량은 규칙 저장과 별개 왕복(계산값, `rules.generation_budget`은
   // 정책 설정값). 실패해도 규칙 화면 자체를 막지 않는다(§3-2 "모른다≠0").
   const [budget, setBudget] = useState<GenerationBudgetState>({ status: 'loading' });
@@ -203,12 +256,14 @@ export default function ContentRulesPage() {
       if (!res.ok) { setLoadError(true); return; }
       const json = (await res.json().catch(() => null)) as { data?: ContentRulesResponse } | null;
       if (json?.data) {
-        setRules({
+        const merged = {
           ...EMPTY_RULES,
           ...json.data.rules,
           brand_kit: json.data.rules.brand_kit ?? {},
           generation_budget: json.data.rules.generation_budget ?? null,
-        });
+        };
+        setRules(merged);
+        setLoadedRules(merged);
         setVersion(json.data.version);
       }
     } catch {
@@ -245,27 +300,68 @@ export default function ContentRulesPage() {
   }, [orgId]);
 
   const handleSave = useCallback(async () => {
+    if (version === null) return;
     setSaving(true);
     setSaveError(null);
     setFieldErrors({});
     setSaveSuccess(false);
+    setJustRolledBackFields(null);
     try {
       const res = await fetchWithAuth(`/api/organizations/${orgId}/content-rules`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rules }),
+        body: JSON.stringify({ rules, expected_version: version }),
       });
       if (res.ok) {
         const json = (await res.json().catch(() => null)) as { data?: ContentRulesResponse } | null;
         if (json?.data) {
-          setRules({
+          const merged = {
             ...EMPTY_RULES,
             ...json.data.rules,
             brand_kit: json.data.rules.brand_kit ?? {},
             generation_budget: json.data.rules.generation_budget ?? null,
-          });
+          };
+          setRules(merged);
+          setLoadedRules(merged);
           setVersion(json.data.version);
           setSaveSuccess(true);
+          setConflict(null);
+        }
+      } else if (res.status === 409) {
+        // story #3501(doc a0da40c9 §20-2·§20-4) — 409 detail은 current_version+
+        // updated_by만 준다(rules 실물은 없음) — 두 목록을 계산하려면 별도 GET이
+        // 필요하다(§20-4 "화면이 이미 가진 것"은 로드값·로컬값 둘, 새 서버값은
+        // 이 GET으로 얻는다).
+        const body = (await res.json().catch(() => null)) as ContentRulesErrorBody | null;
+        const freshRes = await fetchWithAuth(`/api/organizations/${orgId}/content-rules`);
+        const freshJson = freshRes.ok
+          ? ((await freshRes.json().catch(() => null)) as { data?: ContentRulesResponse } | null)
+          : null;
+        if (freshJson?.data) {
+          const freshServerRules = {
+            ...EMPTY_RULES,
+            ...freshJson.data.rules,
+            brand_kit: freshJson.data.rules.brand_kit ?? {},
+            generation_budget: freshJson.data.rules.generation_budget ?? null,
+          };
+          const priorChangedFields = diffFieldNames(loadedRules, freshServerRules);
+          const myChangedFields = diffFieldNames(loadedRules, rules);
+          const overlap = new Set(priorChangedFields.filter((f) => myChangedFields.includes(f)));
+          setConflict({
+            updatedByName: body?.error?.updated_by?.name ?? null,
+            priorChangedFields: withOverlapFirst(priorChangedFields, overlap),
+            myChangedFields: withOverlapFirst(myChangedFields, overlap),
+            freshServerRules,
+            freshServerVersion: freshJson.data.version,
+          });
+        } else {
+          // 재조회 자체가 실패하면 목록 없이도 최소한 "바뀌었다"는 사실은 전한다
+          // (§20-2 — 화면이 아는 것만 말한다, 지어내지 않는다).
+          setConflict({
+            updatedByName: body?.error?.updated_by?.name ?? null,
+            priorChangedFields: [], myChangedFields: [],
+            freshServerRules: loadedRules, freshServerVersion: body?.error?.current_version ?? version,
+          });
         }
       } else {
         const body = (await res.json().catch(() => null)) as ContentRulesErrorBody | null;
@@ -286,7 +382,23 @@ export default function ContentRulesPage() {
     } finally {
       setSaving(false);
     }
-  }, [orgId, rules, t]);
+  }, [orgId, rules, loadedRules, version, t]);
+
+  // story #3501(doc a0da40c9 §20-3) — "자동 병합은 하지 않는다·말없이 버리지도
+  // 않는다" — 서버 값으로 갈아끼우고, 되돌린 필드 이름을 한 줄 남긴다.
+  const handleReloadAfterConflict = useCallback(() => {
+    if (!conflict) return;
+    setRules(conflict.freshServerRules);
+    setLoadedRules(conflict.freshServerRules);
+    setVersion(conflict.freshServerVersion);
+    setJustRolledBackFields(conflict.myChangedFields);
+    setConflict(null);
+  }, [conflict]);
+
+  const fieldLabel = useCallback(
+    (key: string) => (FIELD_LABEL_KEYS[key] ? t(FIELD_LABEL_KEYS[key]) : key),
+    [t],
+  );
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-6 p-6">
@@ -295,19 +407,13 @@ export default function ContentRulesPage() {
         <p className="text-sm text-muted-foreground">{t('pageDescription')}</p>
       </div>
 
+      {/* doc a0da40c9 §20-1(유나 2026-09-05 정정) — 자리를 "무엇에 대한 말인가"로
+          가른다: 화면이 못 서는 실패(로드 실패)만 맨 위, "내가 누른 것의 답"
+          (저장 성공·실패·충돌)은 저장 버튼 곁으로 내린다(§19-8 422 배너와 같은
+          규율). */}
       {loadError ? (
         <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
           <AlertDescription>{t('loadFailed')}</AlertDescription>
-        </Alert>
-      ) : null}
-      {saveError ? (
-        <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
-          <AlertDescription>{saveError}</AlertDescription>
-        </Alert>
-      ) : null}
-      {saveSuccess && version !== null ? (
-        <Alert variant="success" role="status" aria-live="polite" aria-atomic="true">
-          <AlertDescription>{t('saveSuccess', { version })}</AlertDescription>
         </Alert>
       ) : null}
       {!canEditRules ? (
@@ -556,11 +662,68 @@ export default function ContentRulesPage() {
               한다(어느 SectionCard에도 속하지 않는 페이지 수준). 첫 재배치가 규칙
               카드 안(L456-460 옛 자리)에 남아 있던 게 틀렸다 — 부분 PATCH가 없어
               이 한 버튼이 두 카드(규칙+생성비용한도) 전체를 함께 저장한다는 사실을
-              자리 자체가 말해야 한다. */}
+              자리 자체가 말해야 한다.
+              doc a0da40c9 §20-1 — "내가 누른 것의 답"(성공·실패·충돌)은 이 버튼 곁에. */}
           {canEditRules ? (
-            <Button size="sm" onClick={() => void handleSave()} disabled={saving} data-testid="content-rules-save-button">
-              {saving ? t('savingCta') : t('saveAction')}
-            </Button>
+            <div className="space-y-2">
+              {conflict ? (
+                // §20-2·§20-5 — 충돌 배너는 destructive(§19-8과 같은 톤), 저장 버튼은
+                // «상태» 비활성(다시 불러오면 풀린다 — 3653a18c §2 표대로 안 그림이
+                // 아니라 비활성+사유는 버튼 밖).
+                <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true" data-testid="content-rules-version-conflict">
+                  <AlertDescription>
+                    <span className="block">
+                      {conflict.updatedByName
+                        ? t('versionConflictFactWithName', { name: conflict.updatedByName })
+                        : t('versionConflictFact')}
+                    </span>
+                    {conflict.priorChangedFields.length > 0 ? (
+                      <span className="mt-1 block text-xs">
+                        {t('versionConflictPriorChanged', { list: conflict.priorChangedFields.map(fieldLabel).join(', ') })}
+                      </span>
+                    ) : null}
+                    {conflict.myChangedFields.length > 0 ? (
+                      <span className="mt-1 block text-xs">
+                        {t('versionConflictMyChanges', { list: conflict.myChangedFields.map(fieldLabel).join(', ') })}
+                      </span>
+                    ) : null}
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+              {saveError ? (
+                <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
+                  <AlertDescription>{saveError}</AlertDescription>
+                </Alert>
+              ) : null}
+              {saveSuccess && version !== null ? (
+                <Alert variant="success" role="status" aria-live="polite" aria-atomic="true">
+                  <AlertDescription>{t('saveSuccess', { version })}</AlertDescription>
+                </Alert>
+              ) : null}
+              {justRolledBackFields && justRolledBackFields.length > 0 ? (
+                <p className="text-xs text-muted-foreground" data-testid="content-rules-rolled-back-note">
+                  {t('versionConflictRolledBack', { list: justRolledBackFields.map(fieldLabel).join(', ') })}
+                </p>
+              ) : null}
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  size="sm" onClick={() => void handleSave()} disabled={saving || conflict !== null}
+                  data-testid="content-rules-save-button"
+                >
+                  {saving ? t('savingCta') : t('saveAction')}
+                </Button>
+                {conflict ? (
+                  <Button size="sm" variant="outline" onClick={handleReloadAfterConflict} data-testid="content-rules-reload-button">
+                    {t('versionConflictReloadAction')}
+                  </Button>
+                ) : null}
+                {conflict ? (
+                  <span className="text-xs text-muted-foreground" data-testid="content-rules-save-disabled-reason">
+                    {t('versionConflictSaveDisabledReason')}
+                  </span>
+                ) : null}
+              </div>
+            </div>
           ) : null}
         </>
       )}

--- a/backend/app/routers/content_rules.py
+++ b/backend/app/routers/content_rules.py
@@ -17,9 +17,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.services.content_rules import get_org_content_rules, put_org_content_rules
+from app.services.content_rules import (
+    ContentRulesVersionConflictError, get_org_content_rules, put_org_content_rules,
+)
 from app.services.generation_budget import compute_generation_budget_status
-from app.services.member_resolver import resolve_member
+from app.services.member_resolver import resolve_member, resolve_member_identity
 from app.services.project_auth import assert_target_in_caller_org
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["content-rules"])
@@ -101,6 +103,14 @@ class ContentRulesFields(BaseModel):
 
 class PutContentRulesRequest(BaseModel):
     rules: dict
+    # story #3501(PO 確定, doc a0da40c9 §20) — 낙관적 잠금. 필수 필드라 누락 시
+    # pydantic이 자동 422(별도 처리 불필요, AC1 "누락 422"는 이 자체가 답).
+    expected_version: int
+
+
+class ContentRulesUpdatedBy(BaseModel):
+    member_id: uuid.UUID
+    name: str | None
 
 
 @router.get("/{org_id}/content-rules", response_model=ContentRulesResponse)
@@ -144,9 +154,29 @@ async def put_content_rules_endpoint(
             status_code=422, detail={"code": "CONTENT_RULES_INVALID", "message": str(exc)},
         ) from exc
 
-    row = await put_org_content_rules(
-        db, org_id=org_id, rules=validated.model_dump(), updated_by_member_id=resolved.id,
-    )
+    try:
+        row = await put_org_content_rules(
+            db, org_id=org_id, rules=validated.model_dump(), updated_by_member_id=resolved.id,
+            expected_version=body.expected_version,
+        )
+    except ContentRulesVersionConflictError as exc:
+        # story #3501(doc a0da40c9 §20-2) — "서버가 «누가»를 주면 그때 이름을 쓴다"
+        # PO 決定: updated_by_member_id가 있으면 이름을 해소해 싣고, 없으면(row가
+        # 아직 없던 경우, 또는 orphan 멤버라 해소 실패) updated_by를 아예 안 싣는다
+        # — 화면이 "누가"를 지어내지 않는다(§20-2 규율 그대로).
+        updated_by = None
+        if exc.updated_by_member_id is not None:
+            member = await resolve_member_identity(exc.updated_by_member_id, org_id, db)
+            if member is not None:
+                updated_by = ContentRulesUpdatedBy(member_id=member.id, name=member.name)
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "CONTENT_RULES_VERSION_CONFLICT",
+                "current_version": exc.current_version,
+                "updated_by": updated_by.model_dump(mode="json") if updated_by else None,
+            },
+        ) from exc
     return ContentRulesResponse(org_id=row.org_id, rules=row.rules, version=row.version)
 
 

--- a/backend/app/services/content_rules.py
+++ b/backend/app/services/content_rules.py
@@ -31,6 +31,21 @@ class ContentRuleViolationError(Exception):
         super().__init__(f"콘텐츠 규칙 위반 {len(violations)}건(rules_version={rules_version})")
 
 
+class ContentRulesVersionConflictError(Exception):
+    """story #3501(PO 確定 2026-09-05, doc a0da40c9 §20) — 낙관적 잠금. PUT이 든
+    `expected_version`이 현재 저장된 `version`과 다르면 이 예외 — 라우터가 409
+    `CONTENT_RULES_VERSION_CONFLICT`로 감싼다. `updated_by_member_id`는 현재
+    행(또는 row가 아직 없으면 None)의 값 그대로 실어 보낸다 — 라우터가 이름
+    해소를 담당한다(이 서비스 함수는 이름을 모른다, member_resolver 책임 분리)."""
+
+    def __init__(self, *, current_version: int, updated_by_member_id: uuid.UUID | None):
+        self.current_version = current_version
+        self.updated_by_member_id = updated_by_member_id
+        super().__init__(
+            f"버전 충돌(current_version={current_version}, updated_by={updated_by_member_id})"
+        )
+
+
 async def get_org_content_rules(db: AsyncSession, *, org_id: uuid.UUID) -> OrgContentRule | None:
     return (await db.execute(
         select(OrgContentRule).where(OrgContentRule.org_id == org_id)
@@ -39,18 +54,29 @@ async def get_org_content_rules(db: AsyncSession, *, org_id: uuid.UUID) -> OrgCo
 
 async def put_org_content_rules(
     db: AsyncSession, *, org_id: uuid.UUID, rules: dict, updated_by_member_id: uuid.UUID,
+    expected_version: int,
 ) -> OrgContentRule:
     """upsert — org당 1행(UNIQUE org_id). PUT마다 `version` +1(이력 테이블 없음, 감사는
     이 값+`updated_by_member_id`로 충분 — story #3397 "파생 가능한 값은 별도 저장 안
-    한다" 원칙과 동형)."""
+    한다" 원칙과 동형).
+
+    story #3501 — `expected_version`이 현재 값과 다르면 저장 0(last-write-wins 차단).
+    row가 아직 없는 조직은 GET이 합성으로 돌려주는 `version=0`이 기준이라
+    `expected_version`도 0이어야 한다(그 자체가 "첫 저장" 신호)."""
     existing = await get_org_content_rules(db, org_id=org_id)
     if existing is None:
+        if expected_version != 0:
+            raise ContentRulesVersionConflictError(current_version=0, updated_by_member_id=None)
         row = OrgContentRule(
             id=uuid.uuid4(), org_id=org_id, rules=rules, version=1,
             updated_by_member_id=updated_by_member_id,
         )
         db.add(row)
     else:
+        if existing.version != expected_version:
+            raise ContentRulesVersionConflictError(
+                current_version=existing.version, updated_by_member_id=existing.updated_by_member_id,
+            )
         existing.rules = rules
         existing.version += 1
         existing.updated_by_member_id = updated_by_member_id

--- a/backend/app/services/content_rules.py
+++ b/backend/app/services/content_rules.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.org_content_rule import OrgContentRule
@@ -60,29 +61,49 @@ async def put_org_content_rules(
     이 값+`updated_by_member_id`로 충분 — story #3397 "파생 가능한 값은 별도 저장 안
     한다" 원칙과 동형).
 
-    story #3501 — `expected_version`이 현재 값과 다르면 저장 0(last-write-wins 차단).
-    row가 아직 없는 조직은 GET이 합성으로 돌려주는 `version=0`이 기준이라
-    `expected_version`도 0이어야 한다(그 자체가 "첫 저장" 신호)."""
-    existing = await get_org_content_rules(db, org_id=org_id)
-    if existing is None:
-        if expected_version != 0:
-            raise ContentRulesVersionConflictError(current_version=0, updated_by_member_id=None)
+    story #3501(페드루 PO REQUIRED, PR#3856 리뷰) — 첫 처방은 「읽기→비교→쓰기」 3단계가
+    원자가 아니었다: 두 탭이 같은 version으로 «동시에» 저장하면 둘 다 비교를 통과해
+    last-write-wins가 동시 경로에 그대로 남는다. CAS(compare-and-swap)로 교체한다 —
+    `expected_version`이 있는 조직은 `UPDATE ... WHERE org_id=:org AND version=:expected`
+    한 문장으로 비교+갱신을 한 SQL 왕복에 묶는다(`rowcount==0`이면 그 사이 다른 요청이
+    이미 갱신했다는 뜻 — au_metering.py::record_usage와 동형 rowcount 관례). row가 아직
+    없는 조직(expected_version=0)은 INSERT 자체가 CAS다 — 동시에 두 요청이 처음 만들면
+    `org_id` UNIQUE 제약이 하나만 통과시킨다(assets.py::create_folder의
+    IntegrityError catch와 동형 TOCTOU 방어)."""
+    if expected_version == 0:
         row = OrgContentRule(
             id=uuid.uuid4(), org_id=org_id, rules=rules, version=1,
             updated_by_member_id=updated_by_member_id,
         )
         db.add(row)
-    else:
-        if existing.version != expected_version:
+        try:
+            await db.flush()
+        except IntegrityError:
+            await db.rollback()
+            existing = await get_org_content_rules(db, org_id=org_id)
             raise ContentRulesVersionConflictError(
-                current_version=existing.version, updated_by_member_id=existing.updated_by_member_id,
-            )
-        existing.rules = rules
-        existing.version += 1
-        existing.updated_by_member_id = updated_by_member_id
-        row = existing
+                current_version=existing.version if existing else 0,
+                updated_by_member_id=existing.updated_by_member_id if existing else None,
+            ) from None
+        await db.commit()
+        await db.refresh(row)
+        return row
+
+    result = await db.execute(
+        update(OrgContentRule)
+        .where(OrgContentRule.org_id == org_id, OrgContentRule.version == expected_version)
+        .values(rules=rules, version=OrgContentRule.version + 1, updated_by_member_id=updated_by_member_id)
+    )
+    if result.rowcount == 0:
+        await db.rollback()
+        existing = await get_org_content_rules(db, org_id=org_id)
+        raise ContentRulesVersionConflictError(
+            current_version=existing.version if existing else 0,
+            updated_by_member_id=existing.updated_by_member_id if existing else None,
+        )
     await db.commit()
-    await db.refresh(row)
+    row = await get_org_content_rules(db, org_id=org_id)
+    assert row is not None, "CAS UPDATE가 방금 1행을 갱신했는데 재조회에서 사라질 수 없다"
     return row
 
 

--- a/backend/tests/test_3471_org_content_rules_lint.py
+++ b/backend/tests/test_3471_org_content_rules_lint.py
@@ -200,6 +200,150 @@ async def test_owner_put_content_rules_reflected_in_get_and_version_plus_one():
         await engine.dispose()
 
 
+# ══════════════════════════════════════════════════════════════════════════════
+# story #3501(doc a0da40c9 §20, 페드루 PO REQUIRED — PR#3856 리뷰) — 낙관적 잠금 CAS
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.anyio
+async def test_put_missing_expected_version_returns_422():
+    """AC1 — expected_version 누락은 pydantic이 자동 422(별도 처리 없이 그 자체가 답)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules", json={"rules": {"banned_terms": ["x"]}},
+            )
+        assert r.status_code == 422, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_put_version_mismatch_returns_409_with_current_version_and_updated_by():
+    """AC1 — expected_version 불일치 409, current_version·updated_by(이름 해소) 동봉."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r_put1 = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"banned_terms": ["첫저장"]}, "expected_version": 0},
+            )
+            assert r_put1.status_code == 200, r_put1.text
+            assert r_put1.json()["version"] == 1
+
+            # 이미 version=1인데 expected_version=0(구식)으로 다시 저장 시도 — 409.
+            r_put2 = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"banned_terms": ["충돌시도"]}, "expected_version": 0},
+            )
+        assert r_put2.status_code == 409, r_put2.text
+        error = r_put2.json()["error"]
+        assert error["code"] == "CONTENT_RULES_VERSION_CONFLICT"
+        assert error["current_version"] == 1
+        # updated_by_member_id 컬럼이 이미 있어(첫 PUT이 owner로 채웠다) 이름을 해소해
+        # 싣는다 — §20-2 "서버가 «누가»를 주면 그때 이름을 쓴다".
+        assert error["updated_by"] is not None
+        assert error["updated_by"]["name"] is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_put_matching_version_via_cas_update_path_succeeds():
+    """CAS UPDATE 경로(row가 이미 있음, expected_version>0) 자체를 직접 때린다 —
+    INSERT 경로(expected_version=0)와 별개 분기라 따로 확認할 값어치가 있다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r_put1 = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"banned_terms": ["v1"]}, "expected_version": 0},
+            )
+            assert r_put1.json()["version"] == 1
+
+            r_put2 = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"banned_terms": ["v2"]}, "expected_version": 1},
+            )
+        assert r_put2.status_code == 200, r_put2.text
+        assert r_put2.json()["version"] == 2
+        assert r_put2.json()["rules"]["banned_terms"] == ["v2"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_put_service_layer_cas_two_calls_same_expected_version_only_one_succeeds():
+    """페드루 PO REQUIRED(2026-09-05, PR#3856 리뷰) 핵심 — "읽기→비교→쓰기" 3단계가
+    원자가 아니면 같은 version을 든 두 호출이 «둘 다» 비교를 통과해 last-write-wins가
+    동시 경로에 남는다. 서비스 함수를 같은 expected_version으로 두 번 연달아 불러
+    (순서만 정해지면 참이 되는 성질 — 진짜 스레드 동시성이 없어도 CAS의 정확성은
+    "이미 버전이 옮겨간 뒤의 두 번째 쓰기가 막히는가"로 검증된다) 하나만 성공하고
+    나머지는 ContentRulesVersionConflictError를 받는지 직접 확認한다.
+
+    ⚠️뮤테이션 확認 완료(2026-09-05, 로컬 homebrew postgresql@16 — docker 데몬은 여전히
+    못 띄웠으나 이 realdb 스위트 자체는 실제로 돌렸다) — `put_org_content_rules`의 CAS
+    UPDATE에서 `OrgContentRule.version == expected_version` 절을 지우면(org_id만 남기면)
+    이 테스트가 `DID NOT RAISE`로 RED로 뒤집히는 것을 직접 확認하고 원복했다."""
+    from app.services.content_rules import ContentRulesVersionConflictError, put_org_content_rules
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        async with Session() as s1, Session() as s2:
+            row1 = await put_org_content_rules(
+                s1, org_id=org_id, rules={"banned_terms": ["첫탭"]}, updated_by_member_id=owner_id, expected_version=0,
+            )
+            assert row1.version == 1
+
+            # 두 세션 모두 "지금 서버는 version=1"이라고 믿는 상태(같은 expected_version)
+            # 에서 각자 저장을 시도한다 — 세션1이 먼저 커밋해 실제로 version=2가 된다.
+            row2 = await put_org_content_rules(
+                s1, org_id=org_id, rules={"banned_terms": ["세션1_승리"]}, updated_by_member_id=owner_id, expected_version=1,
+            )
+            assert row2.version == 2
+
+            # 세션2는 아직 자신이 "version=1"이라고 믿은 채(구식) 같은 expected_version=1로
+            # 시도 — CAS WHERE가 실제 저장된 version=2와 안 맞아 rowcount=0 → 409 동형 예외.
+            with pytest.raises(ContentRulesVersionConflictError) as exc_info:
+                await put_org_content_rules(
+                    s2, org_id=org_id, rules={"banned_terms": ["세션2_패배"]}, updated_by_member_id=owner_id, expected_version=1,
+                )
+            assert exc_info.value.current_version == 2
+    finally:
+        # 서비스 함수를 직접 부르는 테스트라 FastAPI app 자체가 없다(app.dependency_overrides
+        # 정리는 HTTP 왕복 테스트 전용 — 이 테스트엔 해당 없음).
+        await engine.dispose()
+
+
 @pytest.mark.anyio
 async def test_put_string_banned_terms_returns_422_not_char_by_char():
     """페드루 PO 리뷰 보정(2026-09-05, PR#3825) — banned_terms에 문자열을 그대로

--- a/backend/tests/test_3471_org_content_rules_lint.py
+++ b/backend/tests/test_3471_org_content_rules_lint.py
@@ -187,7 +187,7 @@ async def test_owner_put_content_rules_reflected_in_get_and_version_plus_one():
 
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"banned_terms": ["테스트금칙"], "require_utm": True}},
+                json={"rules": {"banned_terms": ["테스트금칙"], "require_utm": True}, "expected_version": 0},
             )
             assert r_put.status_code == 200, r_put.text
             assert r_put.json()["version"] == 1
@@ -216,7 +216,8 @@ async def test_put_string_banned_terms_returns_422_not_char_by_char():
         _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
         async with _client_for(app) as client:
             r = await client.put(
-                f"/api/v2/organizations/{org_id}/content-rules", json={"rules": {"banned_terms": "spam"}},
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"banned_terms": "spam"}, "expected_version": 0},
             )
         assert r.status_code == 422, r.text
         assert r.json()["error"]["code"] == "CONTENT_RULES_INVALID"
@@ -241,7 +242,7 @@ async def test_put_unknown_key_returns_422():
         async with _client_for(app) as client:
             r = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"bannned_terms": ["오타"]}},
+                json={"rules": {"bannned_terms": ["오타"]}, "expected_version": 0},
             )
         assert r.status_code == 422, r.text
         assert r.json()["error"]["code"] == "CONTENT_RULES_INVALID"
@@ -265,7 +266,8 @@ async def test_member_put_returns_403_owner_field_untouched():
         _setup_org_scoped_app(app, Session, org_id, user_id=member_id)
         async with _client_for(app) as client:
             r = await client.put(
-                f"/api/v2/organizations/{org_id}/content-rules", json={"rules": {"banned_terms": ["x"]}},
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"banned_terms": ["x"]}, "expected_version": 0},
             )
         assert r.status_code == 403, r.text
         assert r.json()["error"]["code"] == "CONTENT_RULES_ADMIN_ONLY"
@@ -291,7 +293,8 @@ async def test_admin_put_content_rules_succeeds():
         _setup_org_scoped_app(app, Session, org_id, user_id=admin_id)
         async with _client_for(app) as client:
             r = await client.put(
-                f"/api/v2/organizations/{org_id}/content-rules", json={"rules": {"banned_terms": ["금칙어"]}},
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"banned_terms": ["금칙어"]}, "expected_version": 0},
             )
         assert r.status_code == 200, r.text
         assert r.json()["rules"]["banned_terms"] == ["금칙어"]
@@ -316,7 +319,10 @@ async def test_agent_get_sees_declaration_slots_but_put_is_403():
         async with _client_for(app) as client:
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"tone": "친근한", "taxonomy": ["블로그"], "channel_priority": ["threads"]}},
+                json={
+                    "rules": {"tone": "친근한", "taxonomy": ["블로그"], "channel_priority": ["threads"]},
+                    "expected_version": 0,
+                },
             )
             assert r_put.status_code == 200, r_put.text
 
@@ -328,7 +334,8 @@ async def test_agent_get_sees_declaration_slots_but_put_is_403():
             assert r_get.json()["rules"]["taxonomy"] == ["블로그"]
 
             r_put_agent = await client.put(
-                f"/api/v2/organizations/{org_id}/content-rules", json={"rules": {"tone": "x"}},
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"tone": "x"}, "expected_version": 1},
             )
         assert r_put_agent.status_code == 403, r_put_agent.text
     finally:
@@ -352,7 +359,8 @@ async def test_cross_org_rules_isolated():
         _setup_org_scoped_app(app, Session, org_a, user_id=owner_a)
         async with _client_for(app) as client:
             r = await client.put(
-                f"/api/v2/organizations/{org_a}/content-rules", json={"rules": {"banned_terms": ["A전용금칙"]}},
+                f"/api/v2/organizations/{org_a}/content-rules",
+                json={"rules": {"banned_terms": ["A전용금칙"]}, "expected_version": 0},
             )
             assert r.status_code == 200, r.text
 
@@ -385,7 +393,7 @@ async def test_channel_post_draft_create_reports_violation_then_submit_422_then_
         async with _client_for(app) as client:
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"banned_terms": ["테스트금칙"]}},
+                json={"rules": {"banned_terms": ["테스트금칙"]}, "expected_version": 0},
             )
             assert r_put.status_code == 200, r_put.text
 
@@ -451,7 +459,7 @@ async def test_site_post_draft_banned_term_in_title_blocks_submit():
         async with _client_for(app) as client:
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"banned_terms": ["금지어"]}},
+                json={"rules": {"banned_terms": ["금지어"]}, "expected_version": 0},
             )
             assert r_put.status_code == 200, r_put.text
 
@@ -500,7 +508,8 @@ async def test_lint_result_snapshot_preserves_rules_version_after_later_put():
         _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
         async with _client_for(app) as client:
             r_put1 = await client.put(
-                f"/api/v2/organizations/{org_id}/content-rules", json={"rules": {"banned_terms": []}},
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"banned_terms": []}, "expected_version": 0},
             )
             assert r_put1.status_code == 200, r_put1.text
             assert r_put1.json()["version"] == 1
@@ -521,7 +530,7 @@ async def test_lint_result_snapshot_preserves_rules_version_after_later_put():
         async with _client_for(app) as client:
             r_put2 = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"banned_terms": ["새로생긴금칙"]}},
+                json={"rules": {"banned_terms": ["새로생긴금칙"]}, "expected_version": 1},
             )
             assert r_put2.status_code == 200, r_put2.text
             assert r_put2.json()["version"] == 2

--- a/backend/tests/test_3498_generation_budget.py
+++ b/backend/tests/test_3498_generation_budget.py
@@ -66,7 +66,7 @@ async def _put_generation_budget(session, *, org_id, limit_minor, currency="KRW"
     return await put_org_content_rules(
         session, org_id=org_id,
         rules={"generation_budget": {"limit_minor": limit_minor, "currency": currency, "period": period}},
-        updated_by_member_id=uuid.uuid4(),
+        updated_by_member_id=uuid.uuid4(), expected_version=0,
     )
 
 

--- a/backend/tests/test_3498_generation_budget.py
+++ b/backend/tests/test_3498_generation_budget.py
@@ -186,7 +186,10 @@ async def test_put_generation_budget_reflected_in_get():
         async with _client_for(app) as client:
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"generation_budget": {"limit_minor": 100000, "currency": "KRW", "period": "month"}}},
+                json={
+                    "rules": {"generation_budget": {"limit_minor": 100000, "currency": "KRW", "period": "month"}},
+                    "expected_version": 0,
+                },
             )
             assert r_put.status_code == 200, r_put.text
             assert r_put.json()["rules"]["generation_budget"] == {
@@ -214,7 +217,7 @@ async def test_generation_budget_unknown_field_returns_422():
         async with _client_for(app) as client:
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"generation_budget": {"limit_minor": 1000, "unknown_field": "x"}}},
+                json={"rules": {"generation_budget": {"limit_minor": 1000, "unknown_field": "x"}}, "expected_version": 0},
             )
         assert r_put.status_code == 422, r_put.text
     finally:
@@ -791,7 +794,7 @@ async def test_put_generation_budget_negative_limit_minor_rejected_422():
         async with _client_for(app) as client:
             r = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"generation_budget": {"limit_minor": -1}}},
+                json={"rules": {"generation_budget": {"limit_minor": -1}}, "expected_version": 0},
             )
         assert r.status_code == 422, r.text
     finally:
@@ -813,7 +816,7 @@ async def test_put_generation_budget_unsupported_currency_rejected_422():
         async with _client_for(app) as client:
             r = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"generation_budget": {"limit_minor": 1000, "currency": "JPY"}}},
+                json={"rules": {"generation_budget": {"limit_minor": 1000, "currency": "JPY"}}, "expected_version": 0},
             )
         assert r.status_code == 422, r.text
     finally:
@@ -835,7 +838,7 @@ async def test_put_generation_budget_unsupported_period_rejected_422():
         async with _client_for(app) as client:
             r = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"generation_budget": {"limit_minor": 1000, "period": "week"}}},
+                json={"rules": {"generation_budget": {"limit_minor": 1000, "period": "week"}}, "expected_version": 0},
             )
         assert r.status_code == 422, r.text
     finally:

--- a/backend/tests/test_3506_utm_attribution.py
+++ b/backend/tests/test_3506_utm_attribution.py
@@ -185,9 +185,12 @@ async def test_put_utm_rules_reflected_in_get():
         async with _client_for(app) as client:
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"utm_rules": {
-                    "enabled": True, "default_source": "newsletter", "default_medium": "email",
-                }}},
+                json={
+                    "rules": {"utm_rules": {
+                        "enabled": True, "default_source": "newsletter", "default_medium": "email",
+                    }},
+                    "expected_version": 0,
+                },
             )
             assert r_put.status_code == 200, r_put.text
             assert r_put.json()["rules"]["utm_rules"]["enabled"] is True
@@ -217,7 +220,7 @@ async def test_put_utm_rules_unknown_field_returns_422():
         async with _client_for(app) as client:
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"utm_rules": {"enabled": True, "typo_field": "x"}}},
+                json={"rules": {"utm_rules": {"enabled": True, "typo_field": "x"}}, "expected_version": 0},
             )
         assert r_put.status_code == 422, r_put.text
     finally:
@@ -283,7 +286,7 @@ async def test_channel_post_draft_preview_reflects_org_utm_override():
         async with _client_for(app) as client:
             r_put = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"utm_rules": {"enabled": True, "default_source": "newsletter"}}},
+                json={"rules": {"utm_rules": {"enabled": True, "default_source": "newsletter"}}, "expected_version": 0},
             )
             assert r_put.status_code == 200, r_put.text
 

--- a/backend/tests/test_3506_utm_attribution.py
+++ b/backend/tests/test_3506_utm_attribution.py
@@ -64,7 +64,7 @@ async def _put_utm_rules(session, *, org_id, **fields):
     from app.services.content_rules import put_org_content_rules
 
     return await put_org_content_rules(
-        session, org_id=org_id, rules={"utm_rules": fields}, updated_by_member_id=uuid.uuid4(),
+        session, org_id=org_id, rules={"utm_rules": fields}, updated_by_member_id=uuid.uuid4(), expected_version=0,
     )
 
 

--- a/backend/tests/test_3510_member_role_sync.py
+++ b/backend/tests/test_3510_member_role_sync.py
@@ -172,7 +172,7 @@ async def test_shadow_anchor_promotion_gate_passes_after_patch(monkeypatch):
         async with _client_for(app) as client:
             r_gate = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"banned_terms": []}},
+                json={"rules": {"banned_terms": []}, "expected_version": 0},
             )
         assert r_gate.status_code == 200, (
             f"shadow anchor 리졸버가 여전히 옛 role(member)로 판정하면 403: {r_gate.text}"
@@ -206,7 +206,7 @@ async def test_shadow_anchor_demotion_gate_403_after_patch_no_privilege_lingers(
         async with _client_for(app) as client:
             r_gate = await client.put(
                 f"/api/v2/organizations/{org_id}/content-rules",
-                json={"rules": {"banned_terms": []}},
+                json={"rules": {"banned_terms": []}, "expected_version": 0},
             )
         assert r_gate.status_code == 403, (
             f"강등됐는데 옛 anchor role(admin)이 남아 게이트를 통과하면 권한 잔존: {r_gate.text}"


### PR DESCRIPTION
## 요약

`PUT /content-rules`가 응답 `version`을 요청에 안 실어(last-write-wins) 두 편집자가 같은 시각 열어 두면 나중 저장이 앞 저장을 조용히 지웠다. `expected_version` 필수 + 불일치 시 409 `CONTENT_RULES_VERSION_CONFLICT`.

## BE 변경
- `PutContentRulesRequest.expected_version: int` 필수(누락 시 pydantic 422).
- `put_org_content_rules()` — 저장 전 `expected_version` 비교, 불일치면 `ContentRulesVersionConflictError`.
- 라우터가 409로 감싸며 `{current_version, updated_by}` 동봉 — `updated_by`는 기존 `OrgContentRule.updated_by_member_id` 컬럼을 `resolve_member_identity()`로 이름 해소(없으면 null, 지어내지 않음).
- 기존 PUT 테스트 14곳(3파일) — `expected_version` 추가.

## FE 변경 — doc a0da40c9 §20(유나 확定) 그대로
1. 저장 결과(성공/실패/충돌)는 저장 버튼 곁, 로드 실패만 화면 맨 위.
2. 409 문구는 "이 화면을 연 뒤에 규칙이 바뀌었습니다"(화면이 아는 것만 — 주체를 단정하지 않음). 이름이 있으면 그 이름으로.
3. "다시 불러오기" — 자동 병합도 조용한 폐기도 아님: 서버값으로 갈아끼우고 되돌린 필드 **이름**(값 아님)을 한 줄 남김. 로드값·로컬값·새 서버값 세 벌을 비교해 "먼저 저장된 변경"·"되돌아갈 내 편집" 두 목록 계산(겹치는 필드=진짜 충돌이 앞).
4. 충돌 중엔 저장 버튼 비활성 + 사유는 버튼 밖(상태 축).

## ⚠️로컬 검증 한계
로컬에 docker 데몬을 못 띄워 BE 변경(`routers/services/content_rules.py`, 테스트 3파일)을 실 Postgres pytest로 못 돌렸다 — `python -m ast` 구문 검사만 통과했다. CI의 realdb 파이프라인이 최초 실측이니 리뷰 시 감안 부탁.

## 검증
- `npx tsc --noEmit` clean
- `npx eslint <변경 파일> --max-warnings=0` clean
- `npx vitest run`(apps/web) — 642 files / 6094 tests green(신규 렌더 테스트 5건)
- i18n missing 0·phrase-collision 신규 1건 EXEMPT_PAIRS 등재(사유 명시)·한자 0

## 스크린샷
텍스트/상태 게이팅 변경 위주 — 라이브 검증(두 탭 시나리오)은 배포 뒤 QA(AC3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## REQUEST 2 반영(head 813781f65)

**CAS(compare-and-swap)로 교체** — row 있으면 `UPDATE ... WHERE org_id=:org AND version=:expected`(rowcount==0→409, au_metering.py 관례) 한 SQL 문장으로 비교+갱신. row 없으면 INSERT 자체가 CAS(UNIQUE 위반→409, assets.py IntegrityError catch 관례).

**시그니처 변경 전수 호출자 grep**(PO 지시 — 이 push 前에 실행):
```
$ grep -rn 'put_org_content_rules(' backend/ | grep -v 'def put_org_content_rules'
backend/app/routers/content_rules.py:158:        row = await put_org_content_rules(
backend/tests/test_3498_generation_budget.py:66:    return await put_org_content_rules(
backend/tests/test_3506_utm_attribution.py:66:    return await put_org_content_rules(
backend/tests/test_3471_org_content_rules_lint.py:322/329/337: (신규 동시성 테스트 자체)
```
6곳 전부 `expected_version` 확認·수정 완료(HTTP 14곳 + 직접 서비스 호출 2곳 — 이 2곳이 이전 CI 빨강의 원인, 로컬 realdb 재실행으로 직접 잡음).

**로컬 검증(docker 아닌 이미 떠 있던 homebrew postgresql@16, throwaway DB)** — 3파일 52 tests green. 뮤테이션(WHERE version절 제거)도 실제 실행해 동시성 테스트가 DID NOT RAISE로 RED 뒤집히는 것 확認 후 원복.

검증: tsc/eslint clean·FE 645/6121 green(rebase 후)·BE realdb 52 green.