### PR TITLE
[SID:3514] feat: 초안 로드 시 규칙 재검(lint-on-read) — BE 절반

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.channel_post_version import ChannelPostVersion
-from app.services.content_rules import get_org_content_rules
+from app.services.content_rules import get_org_content_rules, lint_content
 from app.services.channel_posts import (
     ChannelConnectionNotActiveError,
     ChannelImageContainerFailedError,
@@ -242,6 +242,11 @@ class ChannelPostDraftListItem(BaseModel):
     # "최신 버전"의 publication 행 — publication_status·error_code와 같은 축). 아직 발행
     # 시도 자체가 없으면 null.
     publication_id: uuid.UUID | None = None
+    # story #3514(Phase1·BE+FE·소형, 페드루 PO 確定 2026-09-05) — 단건 조회(lint-on-read)
+    # 전용. 목록 응답에선 항상 None(행마다 lint하면 비용 N배, PO 明示 "단건만"). None=
+    # "이 응답에선 안 쟀다"·[]="쟀는데 위반 0"(null≠0 원칙 그대로, site_posts.py::
+    # SitePostDraftListItem.violations와 동형).
+    violations: list[dict] | None = None
 
 
 class ChannelPostVersionHistoryItem(BaseModel):
@@ -724,7 +729,11 @@ async def get_channel_post_draft_detail_endpoint(
     shape·같은 직렬화 경로(`_to_draft_list_item`) — `list_channel_post_drafts()`를
     draft_id 필터로 그대로 재사용해 조인 축 드리프트가 구조적으로 없다. 권한도 목록과
     동일(휴먼·에이전트 둘 다, `_require_human()` 안 부름). org 스코프 밖이거나 존재하지
-    않으면 404("존재 비노출" 관례, site_posts detail과 동형)."""
+    않으면 404("존재 비노출" 관례, site_posts detail과 동형).
+
+    story #3514(Phase1·BE+FE·소형, 페드루 PO 確定 2026-09-05) — lint-on-read(유나 13회차
+    ③ 관찰). 저장 시점 스냅샷(`draft.lint_result`)이 아니라 **지금** org 규칙으로 최신
+    버전을 다시 lint한다 — 목록 응답엔 안 실음(단건만, 비용 N배 방지)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
@@ -735,7 +744,14 @@ async def get_channel_post_draft_detail_endpoint(
         db, org_id=org_id,
         content_item_ids={rows[0][0].source_content_item_id} if rows[0][0].source_content_item_id else set(),
     )
-    return _to_draft_list_item(rows[0], source_titles)
+    item = _to_draft_list_item(rows[0], source_titles)
+
+    latest_version = rows[0][1]
+    rule_row = await get_org_content_rules(db, org_id=org_id)
+    item.violations = lint_content(
+        rule_row.rules if rule_row else None, text=latest_version.text, link_url=latest_version.link_url,
+    )
+    return item
 
 
 @router.get(

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -19,6 +19,7 @@ from app.services.member_resolver import resolve_member
 from app.routers.insight_snapshots import InsightSnapshotView
 from app.services.generation_budget import GenerationBudgetExceededError
 from app.services.insight_snapshots import get_latest_insight_snapshot
+from app.services.content_rules import get_org_content_rules
 from app.services.site_posts import (
     CampaignNotFoundError,
     ContentRuleViolationError,
@@ -34,6 +35,7 @@ from app.services.site_posts import (
     SitePostReapprovalRequiredError,
     SitePostSealMissingError,
     SitePostVersionNotFoundError,
+    _lint_site_post_fields,
     create_site_post_draft_version,
     get_campaign,
     get_site_post_draft,
@@ -139,6 +141,28 @@ class SitePostDraftListItem(BaseModel):
     sealed_content_sha256: str | None = None
     body_sha256: str
     published_at: str | None = None
+    # story #3514(Phase1·BE+FE·소형, 페드루 PO 確定 2026-09-05) — 단건 조회(lint-on-read)
+    # 전용. channel_posts.py::ChannelPostDraftListItem.violations와 동형 — 목록 응답에선
+    # 항상 None(행마다 lint하면 비용 N배, PO 明示 "단건만"). None="이 응답에선 안 쟀다"·
+    # []="쟀는데 위반 0"(null≠0 원칙 그대로).
+    violations: list[dict] | None = None
+
+
+def _to_site_post_draft_list_item(
+    draft, latest, origin, gate, post, *, violations: list[dict] | None = None,
+) -> SitePostDraftListItem:
+    return SitePostDraftListItem(
+        draft_id=draft.id, work_item_id=draft.work_item_id, slug=draft.slug,
+        lang=latest.lang, title=latest.title, current_version=latest.version,
+        latest_author_kind=latest.author_kind, origin_author_kind=origin.author_kind,
+        updated_at=latest.created_at.isoformat(),
+        body_sha256=latest.body_sha256,
+        gate_status=gate.status if gate else None,
+        reapproval_required=gate.reapproval_required if gate else None,
+        sealed_content_sha256=gate.sealed_content_sha256 if gate else None,
+        published_at=post.published_at.isoformat() if post else None,
+        violations=violations,
+    )
 
 
 class SubmitSitePostDraftRequest(BaseModel):
@@ -407,20 +431,41 @@ async def list_site_post_drafts_endpoint(
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
     rows = await list_site_post_drafts(db, org_id=org_id, limit=limit, offset=offset)
-    return [
-        SitePostDraftListItem(
-            draft_id=draft.id, work_item_id=draft.work_item_id, slug=draft.slug,
-            lang=latest.lang, title=latest.title, current_version=latest.version,
-            latest_author_kind=latest.author_kind, origin_author_kind=origin.author_kind,
-            updated_at=latest.created_at.isoformat(),
-            body_sha256=latest.body_sha256,
-            gate_status=gate.status if gate else None,
-            reapproval_required=gate.reapproval_required if gate else None,
-            sealed_content_sha256=gate.sealed_content_sha256 if gate else None,
-            published_at=post.published_at.isoformat() if post else None,
-        )
-        for draft, latest, origin, gate, post in rows
-    ]
+    return [_to_site_post_draft_list_item(draft, latest, origin, gate, post) for draft, latest, origin, gate, post in rows]
+
+
+@router.get("/{org_id}/site-posts/drafts/{draft_id}", response_model=SitePostDraftListItem)
+async def get_site_post_draft_detail_endpoint(
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> SitePostDraftListItem:
+    """story #3514(Phase1·BE+FE·소형, 페드루 PO 確定 2026-09-05) — 단건 조회 신설(site_post은
+    이제까지 목록·`/versions`·`/publication`뿐, 이 자리가 비어 있었다). 목록 항목과 완전히
+    같은 shape·같은 직렬화 경로(`list_site_post_drafts`를 draft_id 필터로 재사용) —
+    channel_posts.py::get_channel_post_draft_detail_endpoint(story #3403)와 동형. 권한도
+    목록과 동일(휴먼·에이전트 둘 다). org 스코프 밖이거나 존재하지 않으면 404("존재
+    비노출" 관례).
+
+    lint-on-read(이 스토리 본 목적, 유나 13회차 ③ 관찰) — 저장 시점 스냅샷(`draft.
+    lint_result`)이 아니라 **지금** org 규칙으로 최신 버전을 다시 lint한다(규칙이 바뀐
+    뒤 옛 초안을 열어도 위반이 즉시 보이게). `_lint_site_post_fields`(story #3482, 필드별
+    lint) 재사용 — save/submit과 같은 함수, 새 판정 로직 0."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    rows = await list_site_post_drafts(db, org_id=org_id, draft_id=draft_id, limit=1)
+    if not rows:
+        raise HTTPException(status_code=404, detail=f"draft를 찾을 수 없습니다: {draft_id}")
+    draft, latest, origin, gate, post = rows[0]
+
+    rule_row = await get_org_content_rules(db, org_id=org_id)
+    violations = _lint_site_post_fields(
+        rule_row.rules if rule_row else None, title=latest.title, summary=latest.summary, body_md=latest.body_md,
+    )
+    return _to_site_post_draft_list_item(draft, latest, origin, gate, post, violations=violations)
 
 
 @router.get(

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -589,6 +589,7 @@ async def list_site_post_draft_versions(db: AsyncSession, *, draft_id: uuid.UUID
 
 async def list_site_post_drafts(
     db: AsyncSession, *, org_id: uuid.UUID, limit: int = 50, offset: int = 0,
+    draft_id: uuid.UUID | None = None,
 ) -> list[tuple[SitePostDraft, SitePostVersion, SitePostVersion, Gate | None, SitePost | None]]:
     """story #3365 후속(S4 계약 갭, 페드루 PO 확定 2026-09-03) — 조직 스코프 초안 목록. S4
     화면이 열릴 때 draft_id를 미리 알 방법이 없어 만든 자리 — 항목마다 최신 버전(title·lang·
@@ -604,7 +605,12 @@ async def list_site_post_drafts(
     (work_item_id→gate, (org_id,lang,slug)→site_posts)을 페이지 단위로 배치한 것뿐이다.
 
     반환: (draft, latest_version, origin_version, gate, site_post) 튜플 리스트 — gate·
-    site_post는 없으면 None(그 draft가 아직 상신/발행 전이라는 뜻, 지어내지 않는다)."""
+    site_post는 없으면 None(그 draft가 아직 상신/발행 전이라는 뜻, 지어내지 않는다).
+
+    story #3514(Phase1·BE+FE·소형, 페드루 PO 確定 2026-09-05) — `draft_id`를 주면 페이지
+    쿼리에 단건 필터가 추가될 뿐(channel_posts.py::list_channel_post_drafts와 동형) —
+    새 단건 조회 경로(`GET .../site-posts/drafts/{draft_id}`)가 이 함수를 그대로
+    재사용해 목록과 단건이 다른 값을 낼 드리프트 표면을 안 만든다."""
     latest_version_ids = (
         select(
             SitePostVersion.draft_id,
@@ -642,6 +648,8 @@ async def list_site_post_drafts(
         .limit(limit)
         .offset(offset)
     )
+    if draft_id is not None:
+        stmt = stmt.where(SitePostDraft.id == draft_id)
     page_rows = [(row[0], row[1], row[2]) for row in (await db.execute(stmt)).all()]
     if not page_rows:
         return []

--- a/backend/tests/test_3403_channel_post_draft_detail.py
+++ b/backend/tests/test_3403_channel_post_draft_detail.py
@@ -229,7 +229,14 @@ async def test_detail_draft_only_matches_list_item_exactly():
         assert r_detail.status_code == 200, r_detail.text
         list_row = [it for it in r_list.json() if it["draft_id"] == draft_id]
         assert len(list_row) == 1
-        assert r_detail.json() == list_row[0]
+        # story #3514(PO 確定 2026-09-05) — violations는 유일하게 의도적으로 갈리는
+        # 필드다(단건=lint-on-read로 방금 계산·목록=항상 None, 비용 N배 방지). "완전히
+        # 같은 shape"라는 이 파일의 핵심 주장은 그 필드 하나를 빼고 여전히 성립한다.
+        detail_body = {k: v for k, v in r_detail.json().items() if k != "violations"}
+        list_body = {k: v for k, v in list_row[0].items() if k != "violations"}
+        assert detail_body == list_body
+        assert list_row[0]["violations"] is None
+        assert r_detail.json()["violations"] == []
         assert r_detail.json()["gate_status"] is None
         assert r_detail.json()["publication_status"] is None
     finally:
@@ -280,7 +287,14 @@ async def test_detail_published_matches_list_item_exactly():
         assert r_detail.status_code == 200, r_detail.text
         list_row = [it for it in r_list.json() if it["draft_id"] == draft_id]
         assert len(list_row) == 1
-        assert r_detail.json() == list_row[0]
+        # story #3514(PO 確定 2026-09-05) — violations는 유일하게 의도적으로 갈리는
+        # 필드다(단건=lint-on-read로 방금 계산·목록=항상 None, 비용 N배 방지). "완전히
+        # 같은 shape"라는 이 파일의 핵심 주장은 그 필드 하나를 빼고 여전히 성립한다.
+        detail_body = {k: v for k, v in r_detail.json().items() if k != "violations"}
+        list_body = {k: v for k, v in list_row[0].items() if k != "violations"}
+        assert detail_body == list_body
+        assert list_row[0]["violations"] is None
+        assert r_detail.json()["violations"] == []
         body = r_detail.json()
         assert body["publication_status"] == "published"
         assert body["permalink"] == "https://www.threads.net/@demo/post/media-1"
@@ -335,7 +349,14 @@ async def test_detail_partial_success_matches_list_item_exactly():
         assert r_detail.status_code == 200, r_detail.text
         list_row = [it for it in r_list.json() if it["draft_id"] == draft_id]
         assert len(list_row) == 1
-        assert r_detail.json() == list_row[0]
+        # story #3514(PO 確定 2026-09-05) — violations는 유일하게 의도적으로 갈리는
+        # 필드다(단건=lint-on-read로 방금 계산·목록=항상 None, 비용 N배 방지). "완전히
+        # 같은 shape"라는 이 파일의 핵심 주장은 그 필드 하나를 빼고 여전히 성립한다.
+        detail_body = {k: v for k, v in r_detail.json().items() if k != "violations"}
+        list_body = {k: v for k, v in list_row[0].items() if k != "violations"}
+        assert detail_body == list_body
+        assert list_row[0]["violations"] is None
+        assert r_detail.json()["violations"] == []
         assert r_detail.json()["publication_status"] == "container_created"
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_3514_lint_on_read.py
+++ b/backend/tests/test_3514_lint_on_read.py
@@ -1,0 +1,265 @@
+"""story #3514(Phase1·BE+FE·소형, 페드루 PO 確定 2026-09-05) — 초안 로드 시 규칙 재검
+(lint-on-read). 유나 13회차 ③ 관찰 — 규칙이 바뀐 뒤 기존 초안을 «열기만» 하면 위반이
+0으로 보이던 결함(저장/상신 응답에서만 violations가 채워졌다). 원문(site_post)·변형
+(channel_post) 동형.
+
+fix — 두 도메인의 단건 GET이 **지금** org 규칙으로 다시 lint한 `violations[]`를
+싣는다(저장 시점 스냅샷이 아니다). site_post는 이 단건 GET 자체가 이 스토리에서
+신설(이제껏 목록·/versions·/publication뿐이었다). channel_post는 기존 단건 GET(story
+#3403)에 필드만 얹는다. 목록 응답엔 안 실음(행마다 lint하면 비용 N배, PO 明示 "단건만").
+
+세팅 헬퍼는 test_e4fc29fa_site_post_orchestration.py(site_post)·test_3403_channel_
+post_draft_detail.py(channel_post)와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import (
+    _client_for as _sp_client_for,
+    _create_and_submit_site_post_draft,
+    _seed_agent as _seed_sp_agent,
+    _seed_default_role as _seed_sp_default_role,
+    _seed_org as _seed_sp_org,
+    _seed_story as _seed_sp_story,
+    _seed_wordpress_connection,
+    _session_factory as _sp_session_factory,
+    _setup_org_scoped_app as _setup_sp_org_scoped_app,
+)
+from tests.test_3403_channel_post_draft_detail import (
+    _client_for as _cp_client_for,
+    _draft_body,
+    _seed_agent as _seed_cp_agent,
+    _seed_connection as _seed_cp_connection,
+    _seed_org as _seed_cp_org,
+    _seed_story as _seed_cp_story,
+    _session_factory as _cp_session_factory,
+    _setup_org_scoped_app as _setup_cp_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _put_rules(session, *, org_id, rules):
+    from app.services.content_rules import put_org_content_rules
+
+    return await put_org_content_rules(session, org_id=org_id, rules=rules, updated_by_member_id=uuid.uuid4())
+
+
+# ─── site_post ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_site_post_detail_unknown_draft_404():
+    from app.main import app
+
+    engine, Session = await _sp_session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_sp_org(s)
+            agent_id = await _seed_sp_agent(s, org_id, project_id)
+
+        _setup_sp_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _sp_client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{uuid.uuid4()}")
+        assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_site_post_detail_no_rules_violations_empty():
+    from app.main import app
+
+    engine, Session = await _sp_session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_sp_org(s)
+            await _seed_sp_default_role(s, org_id)
+            agent_id = await _seed_sp_agent(s, org_id, project_id)
+            story_id = await _seed_sp_story(s, org_id, project_id)
+            connection_id = await _seed_wordpress_connection(s, org_id, site_url="https://example.com")
+
+        _setup_sp_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _sp_client_for(app) as client:
+            draft_id, _gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+            )
+            r = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}")
+        assert r.status_code == 200, r.text
+        assert r.json()["violations"] == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_site_post_detail_reflects_current_rules_without_resave():
+    """핵심 pin — 초안 생성 «뒤에» 규칙을 추가해도(저장 없이) 다음 GET이 위반을 보인다.
+    규칙 원복 뒤 다시 GET하면 0으로 돌아온다(스냅샷 아니라 매번 재검이라는 증거)."""
+    from app.main import app
+
+    engine, Session = await _sp_session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_sp_org(s)
+            await _seed_sp_default_role(s, org_id)
+            agent_id = await _seed_sp_agent(s, org_id, project_id)
+            story_id = await _seed_sp_story(s, org_id, project_id)
+            connection_id = await _seed_wordpress_connection(s, org_id, site_url="https://example.com")
+
+        _setup_sp_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _sp_client_for(app) as client:
+            draft_id, _gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+            )
+
+            async with Session() as s:
+                await _put_rules(s, org_id=org_id, rules={"banned_terms": ["본문"]})
+
+            r_after_rule = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}")
+            assert r_after_rule.status_code == 200, r_after_rule.text
+            violations = r_after_rule.json()["violations"]
+            assert len(violations) >= 1, "규칙 추가 뒤 재저장 없이 GET했는데 위반이 안 보인다(#3514 원 증상)"
+            assert violations[0]["code"] == "banned_term"
+
+            async with Session() as s:
+                await _put_rules(s, org_id=org_id, rules={"banned_terms": []})
+
+            r_after_revert = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}")
+        assert r_after_revert.json()["violations"] == [], "규칙 원복 뒤에도 옛 위반이 남아있다(스냅샷 캐시 의심)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_site_post_list_does_not_compute_violations():
+    """PO 明示 — 목록 응답은 행마다 lint 안 함(비용 N배 방지), violations=None 그대로."""
+    from app.main import app
+
+    engine, Session = await _sp_session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_sp_org(s)
+            await _seed_sp_default_role(s, org_id)
+            agent_id = await _seed_sp_agent(s, org_id, project_id)
+            story_id = await _seed_sp_story(s, org_id, project_id)
+            connection_id = await _seed_wordpress_connection(s, org_id, site_url="https://example.com")
+
+        _setup_sp_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _sp_client_for(app) as client:
+            await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+            )
+
+            async with Session() as s:
+                await _put_rules(s, org_id=org_id, rules={"banned_terms": ["본문"]})
+
+            r = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts")
+        assert r.status_code == 200, r.text
+        assert all(row.get("violations") is None for row in r.json())
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── channel_post ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_channel_post_detail_reflects_current_rules_without_resave():
+    from app.main import app
+
+    engine, Session = await _cp_session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_cp_org(s)
+            agent_id = await _seed_cp_agent(s, org_id, project_id)
+            story_id = await _seed_cp_story(s, org_id, project_id)
+            connection_id = await _seed_cp_connection(s, org_id)
+
+        _setup_cp_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _cp_client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id, text="채널 포스트 본문입니다."),
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            draft_id = r_draft.json()["draft_id"]
+
+            r_before = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert r_before.json()["violations"] == []
+
+            async with Session() as s2:
+                await _put_rules(s2, org_id=org_id, rules={"banned_terms": ["본문"]})
+
+            r_after = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+        assert r_after.status_code == 200, r_after.text
+        violations = r_after.json()["violations"]
+        assert len(violations) >= 1, "규칙 추가 뒤 재저장 없이 GET했는데 위반이 안 보인다(#3514 원 증상)"
+        assert violations[0]["code"] == "banned_term"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_channel_post_list_does_not_compute_violations():
+    from app.main import app
+
+    engine, Session = await _cp_session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_cp_org(s)
+            agent_id = await _seed_cp_agent(s, org_id, project_id)
+            story_id = await _seed_cp_story(s, org_id, project_id)
+            connection_id = await _seed_cp_connection(s, org_id)
+            await _put_rules(s, org_id=org_id, rules={"banned_terms": ["본문"]})
+
+        _setup_cp_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _cp_client_for(app) as client:
+            await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id, text="채널 포스트 본문입니다."),
+            )
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+        assert r.status_code == 200, r.text
+        assert all(row.get("violations") is None for row in r.json())
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1048,6 +1048,11 @@
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"
     },
     {
+      "file": "tests/test_3514_lint_on_read.py",
+      "sec": 40.0,
+      "source": "story-3514-lint-on-read(PR 개설 前 선제 등재 — 로컬 raw pytest 6.69s(6건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3403_channel_post_draft_detail.py",
       "sec": 8.0,
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"


### PR DESCRIPTION
## Summary
유나 13회차 ③ 관찰 — `content/[draftId]` 화면의 `violations`는 저장/상신 응답에서만 채워진다. 규칙(금칙어 등)이 바뀐 뒤 기존 초안을 "열기만" 하면 위반 0으로 보이고, 상신에서야 422로 막힌다 — 사람이 고칠 것이 있는 줄 모른 채 상신까지 간다.

PO 설계 확定(2026-09-06) — site_post엔 초안 단건 GET이 없었다(목록·`/versions`·`/publication`뿐, channel_post엔 있음 fd5ba66f). 이 PR은 BE 절반만.

- `site_post`: `GET .../site-posts/drafts/{draft_id}` 신설 — 목록 항목(`SitePostDraftListItem`)과 완전히 같은 shape·같은 직렬화 경로(`list_site_post_drafts`를 draft_id 필터로 재사용, channel_post 단건 GET과 동형) + `violations[]`(현재 org 규칙으로 재lint — `_lint_site_post_fields` 재사용, 저장 시점 스냅샷 아님).
- `channel_post`: 기존 단건 GET(#3403)에 `violations[]`만 얹는다.
- 둘 다 목록 응답엔 `violations`를 안 실음(항상 `None` — 행마다 lint하면 비용 N배, PO 明示 "단건만"). null≠0 원칙: `None`="이 응답에선 안 쟀다"·`[]`="쟀는데 위반 0".

FE 절반(미르코, 로드 응답 violations로 상태 초기화)은 공유 브랜치(`feat/3514-lint-on-read`)에서 별도 진행 — 이 BE 브랜치와는 독립.

## Test plan
- [x] 신규 6건 — site_post(404·규칙없음 `[]`·규칙 추가 뒤 재저장 없이 GET하면 위반 보임+원복하면 0·목록은 계산 안 함) + channel_post(동형 2건)
- [x] 뮤테이션 2건 — 각 도메인 lint-on-read를 `[]`로 하드코딩 → 해당 "규칙 반영" 테스트만 RED → 복원 후 GREEN
- [x] 기존 `test_3403_channel_post_draft_detail.py`의 "detail==list item exactly" 3건을 violations 필드 제외 비교로 정정(회귀 아님 — 이번 스토리로 의도된 유일한 차이)
- [x] 회귀 35/35(`test_3403_channel_post_draft_detail.py`·`test_e4fc29fa_site_post_orchestration.py`·`test_3471_org_content_rules_lint.py`)
- [x] `scripts/lint_destructive_schema_weights_registered.py` 244/244 통과
- [x] 마이그레이션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)