### PR TITLE
[SID:3514] feat: 초안 로드 시 규칙 재검(lint-on-read) — FE 몫

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2376,6 +2376,7 @@
     "contentRuleGenericBlockedHint": "This value doesn't meet the content rules.",
     "contentRuleSubmitBlockedHint": "Fix {count} rule violation(s) before you can submit.",
     "contentRuleLinkLabel": "Content rules",
+    "contentRuleViolationsLoadFailed": "Couldn't load rule violation info.",
     "channelPostsTextTooLong": "The limit is {max} characters, but this is {current} — shorten it and resubmit.",
     "channelPostsRateLimitedUntil": "You've used today's posting limit — you can post again after {time}.",
     "channelPostsPublishScheduled": "This goes out exactly as it is now, at {time}.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2376,6 +2376,7 @@
     "contentRuleGenericBlockedHint": "이 값은 콘텐츠 규칙에 맞지 않습니다.",
     "contentRuleSubmitBlockedHint": "규칙 위반 {count}건을 고쳐야 상신할 수 있습니다.",
     "contentRuleLinkLabel": "콘텐츠 규칙",
+    "contentRuleViolationsLoadFailed": "위반 정보를 불러오지 못했습니다.",
     "channelPostsTextTooLong": "{max}자 한도인데 {current}자입니다 — 줄여서 재상신해 주세요.",
     "channelPostsRateLimitedUntil": "오늘 한도를 다 썼습니다 — {time} 이후 가능합니다.",
     "channelPostsPublishScheduled": "{time}에 지금 내용 그대로 나갑니다.",

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -121,12 +121,21 @@ function stubFetchWithVersions(
     onPatchCampaign?: (body: unknown) => { status: number; body: unknown };
     // story #3500(BE #3498, 미착지) — 잔량 조회(기본=정책 미설정).
     genBudget?: { limit_minor: number | null; spent_minor: number; remaining_minor: number | null; currency: 'KRW' | 'USD' | null; period: 'month' };
+    // story #3514(lint-on-read, BE 신설) — 단건 GET의 violations[]. 기본값 빈 배열
+    // (대부분 테스트가 이 스토리와 무관 — "위반 없음"이 기본).
+    draftViolations?: unknown[];
   },
 ) {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      // story #3514 — 단건 GET(신설). /versions보다 먼저 걸러야 한다 — 후자가 이
+      // URL을 접두사로 포함한다(정확 일치 비교라 순서 자체는 무해하지만, 나란히
+      // 둬 두 계약이 별개 왕복임을 코드로도 보이게 한다).
+      if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}`) {
+        return { ok: true, status: 200, json: async () => ({ data: { draft_id: DRAFT_ID, violations: opts?.draftViolations ?? [] }, error: null, meta: null }) };
+      }
       if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}/versions`) {
         return { ok: true, status: 200, json: async () => ({ data: versions, error: null, meta: null }) };
       }
@@ -336,6 +345,9 @@ describe('ContentPostEditPage (story #3368 S3)', () => {
     let gateCallCount = 0;
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}`) {
+        return { ok: true, status: 200, json: async () => ({ data: { draft_id: DRAFT_ID, violations: [] }, error: null, meta: null }) };
+      }
       if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}/versions`) {
         return { ok: true, status: 200, json: async () => ({ data: [VERSION_1], error: null, meta: null }) };
       }
@@ -370,6 +382,9 @@ describe('ContentPostEditPage (story #3368 S3)', () => {
     let gateCallCount = 0;
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}`) {
+        return { ok: true, status: 200, json: async () => ({ data: { draft_id: DRAFT_ID, violations: [] }, error: null, meta: null }) };
+      }
       if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}/versions`) {
         return { ok: true, status: 200, json: async () => ({ data: [VERSION_1], error: null, meta: null }) };
       }
@@ -446,6 +461,9 @@ describe('ContentPostEditPage (story #3368 S3)', () => {
       'fetch',
       vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input);
+        if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}`) {
+          return { ok: true, status: 200, json: async () => ({ data: { draft_id: DRAFT_ID, violations: [] }, error: null, meta: null }) };
+        }
         if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}/versions`) {
           return { ok: true, status: 200, json: async () => ({ data: [VERSION_1], error: null, meta: null }) };
         }
@@ -502,6 +520,9 @@ describe('ContentPostEditPage (story #3368 S3)', () => {
       'fetch',
       vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input);
+        if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}`) {
+          return { ok: true, status: 200, json: async () => ({ data: { draft_id: DRAFT_ID, violations: [] }, error: null, meta: null }) };
+        }
         if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}/versions`) {
           return { ok: true, status: 200, json: async () => ({ data: [VERSION_1], error: null, meta: null }) };
         }
@@ -1438,6 +1459,37 @@ describe('ContentPostEditPage — 콘텐츠 규칙 위반 표시(story #3483, §
     await flush();
     expect(container.querySelector('[data-testid="content-rule-violation-title"]')).toBeNull();
     expect(container.querySelector('[data-testid="content-rule-violation-blocked-reason"]')).toBeNull();
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false);
+  });
+
+  // story #3514(lint-on-read, doc a0da40c9, PO 確定 2026-09-05) — 유나 13회차 ③ 관찰:
+  // 규칙이 바뀐 뒤 기존 초안을 «열기만» 하면(저장·상신 없이) 위반 목록·상신 비활성이
+  // 이미 서야 한다. 위 세 테스트는 전부 저장/상신 응답에서 violations를 갱신하는
+  // 경로만 검증했다 — 이 테스트는 그 축과 별개로 «로드 한 번»만으로 §16-7 픽셀이
+  // 서는지를 잰다(저장·상신 버튼을 누르지 않는다).
+  it('⭐로드만으로(저장·상신 없이) 단건 GET의 violations가 필드 옆 목록·상신 비활성으로 선다', async () => {
+    stubFetchWithVersions([VERSION_1], undefined, undefined, {
+      draftViolations: [
+        { code: 'banned_term', field: 'title', value: '무료체험', hint_key: 'x', settings_path: '/organization/content-rules' },
+      ],
+    });
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+
+    // 저장·상신 버튼을 누르지 않았다 — 그런데도 위반이 이미 보인다.
+    expect(container.querySelector('[data-testid="content-rule-violation-title"]')?.textContent).toContain('무료체험');
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
+    expect(container.querySelector('[data-testid="content-rule-violation-blocked-reason"]')?.textContent)
+      .toBe(koMessages.content.contentRuleSubmitBlockedHint.replace('{count}', '1'));
+  });
+
+  it('단건 GET에 violations가 없으면(계약 없음·BE 미착지) 빈 배열로 안전 폴백한다(지어내지 않는다)', async () => {
+    stubFetchWithVersions([VERSION_1]); // draftViolations 생략 — 기본값 [].
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+    expect(container.querySelector('[data-testid="content-rule-violation-title"]')).toBeNull();
     const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
     expect(submitBtn.disabled).toBe(false);
   });

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -1516,6 +1516,21 @@ describe('ContentPostEditPage — 콘텐츠 규칙 위반 표시(story #3483, §
     expect(container.querySelector('[data-testid="content-rule-violation-load-failed"]')?.textContent)
       .toBe(koMessages.content.contentRuleViolationsLoadFailed);
   });
+
+  // story #3514(PO REQUIRED, 2026-09-05) — 저장 응답이 violations를 권위 값으로
+  // 채운 뒤에는 "불러오지 못했습니다" 줄이 그 곁에 남아 모순되면 안 된다.
+  it('⭐단건 GET 500 뒤에도 저장에 성공하면 안내 줄이 사라진다(권위 값이 덮어씀)', async () => {
+    stubFetchWithVersions([VERSION_1], () => ({ status: 201, body: { violations: [] } }), undefined, { draftStatus: 500 });
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+    expect(container.querySelector('[data-testid="content-rule-violation-load-failed"]')).not.toBeNull();
+
+    const saveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.editSaveCta) as HTMLButtonElement;
+    await act(async () => { saveBtn.click(); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="content-rule-violation-load-failed"]')).toBeNull();
+  });
 });
 
 // story #3479(BE #3476/#3828 실물 계약, 페드루 PO 確定 2026-09-05) — 원문 상세

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -124,6 +124,9 @@ function stubFetchWithVersions(
     // story #3514(lint-on-read, BE 신설) — 단건 GET의 violations[]. 기본값 빈 배열
     // (대부분 테스트가 이 스토리와 무관 — "위반 없음"이 기본).
     draftViolations?: unknown[];
+    // 유나 Design 변경요청 1(2026-09-05) — 단건 GET 자체가 실패하는 케이스 재현(기본
+    // 200). 부수 데이터라 화면은 그대로 서고 violations=[]+안내 한 줄만 뜬다.
+    draftStatus?: number;
   },
 ) {
   vi.stubGlobal(
@@ -134,6 +137,9 @@ function stubFetchWithVersions(
       // URL을 접두사로 포함한다(정확 일치 비교라 순서 자체는 무해하지만, 나란히
       // 둬 두 계약이 별개 왕복임을 코드로도 보이게 한다).
       if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}`) {
+        if (opts?.draftStatus && opts.draftStatus >= 400) {
+          return { ok: false, status: opts.draftStatus, json: async () => ({ detail: 'boom' }) };
+        }
         return { ok: true, status: 200, json: async () => ({ data: { draft_id: DRAFT_ID, violations: opts?.draftViolations ?? [] }, error: null, meta: null }) };
       }
       if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}/versions`) {
@@ -1492,6 +1498,23 @@ describe('ContentPostEditPage — 콘텐츠 규칙 위반 표시(story #3483, §
     expect(container.querySelector('[data-testid="content-rule-violation-title"]')).toBeNull();
     const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
     expect(submitBtn.disabled).toBe(false);
+  });
+
+  // story #3514(유나 Design 변경요청 1, 2026-09-05) — 단건 GET은 이 화면에서 부수
+  // 데이터(주 데이터는 /versions)라 그 실패가 초안 열기 자체를 막으면 안 된다.
+  it('⭐단건 GET 500 — 본문(제목·요약 등)은 그대로 뜨고 violations=0+안내 한 줄만 뜬다(loadError 아님)', async () => {
+    stubFetchWithVersions([VERSION_1], undefined, undefined, { draftStatus: 500 });
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+
+    // 화면이 안 막혔다 — /versions의 제목이 정상적으로 폼에 실렸다.
+    const titleInput = container.querySelector('#post-title') as HTMLInputElement | null;
+    expect(titleInput?.value).toBe(VERSION_1.title);
+    expect(container.querySelector('[data-testid="content-rule-violation-title"]')).toBeNull();
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false); // violations=[]라 상신 자체는 안 막힌다.
+    expect(container.querySelector('[data-testid="content-rule-violation-load-failed"]')?.textContent)
+      .toBe(koMessages.content.contentRuleViolationsLoadFailed);
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -51,6 +51,16 @@ import { GenerationBudgetExceededBanner } from '@/components/content/generation-
  * `/gates/{id}` 딥링크(§6-1 재사용 목록, 게이트 상세)한다.
  */
 
+// story #3514(BE 신설, PO 確定 2026-09-05) — 단건 GET(site_post는 이 스토리 前엔 이
+// 엔드포인트 자체가 없었다, channel-posts/drafts/[draftId] #3445와 같은 갭). 목록
+// 항목(SitePostDraftListItem) shape에 lint-on-read `violations[]`를 얹은 응답 —
+// 이 화면이 지금 당장 쓰는 건 violations뿐이라(제목·본문 등은 여전히 /versions의
+// 최신 항목에서 온다) 그 필드만 타입에 싣는다(ChannelPostDraftDetail처럼 optional).
+interface SitePostDraftDetail {
+  draft_id: string;
+  violations?: ContentRuleViolation[];
+}
+
 interface SitePostVersion {
   version_id: string;
   version: number;
@@ -347,21 +357,32 @@ export default function ContentPostEditPage() {
       setLoading(true);
       setLoadError(false);
       try {
-        const res = await fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}/versions`);
+        // story #3514(doc a0da40c9, PO 確定 2026-09-05) — lint-on-read: 단건 GET을
+        // /versions와 병렬로 부른다(channel-posts/[draftId]/page.tsx :340-341과 동형
+        // 패턴 — site_post는 이 스토리 前까지 단건 GET 자체가 없어 /versions 하나만
+        // 불렀다). 단건 GET의 violations[]로 "저장 없이" 위반 목록·상신 비활성이
+        // 선다(§16-7을 읽기까지 넓힘).
+        const [draftRes, versionsRes] = await Promise.all([
+          fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}`),
+          fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}/versions`),
+        ]);
         if (cancelled) return;
-        if (res.ok) {
-          const json = (await res.json().catch(() => null)) as { data?: SitePostVersion[] } | null;
-          const list = json?.data ?? [];
-          setVersions(list);
-          const latest = list[list.length - 1];
-          if (latest) {
-            setTitle(latest.title);
-            setSummary(latest.summary);
-            setTagsText(latest.tags.join(', '));
-            setBodyMd(latest.body_md);
-          }
-        } else {
+        if (!draftRes.ok || !versionsRes.ok) {
           setLoadError(true);
+          return;
+        }
+        const draftJson = (await draftRes.json().catch(() => null)) as { data?: SitePostDraftDetail } | null;
+        setViolations(draftJson?.data?.violations ?? []);
+
+        const json = (await versionsRes.json().catch(() => null)) as { data?: SitePostVersion[] } | null;
+        const list = json?.data ?? [];
+        setVersions(list);
+        const latest = list[list.length - 1];
+        if (latest) {
+          setTitle(latest.title);
+          setSummary(latest.summary);
+          setTagsText(latest.tags.join(', '));
+          setBodyMd(latest.body_md);
         }
       } catch {
         if (!cancelled) setLoadError(true);

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -228,6 +228,11 @@ export default function ContentPostEditPage() {
   // story #3483(BE 3482, §16-7) — 저장/상신 응답이 채우는 하나의 목록. 상신 422는
   // 새 배너를 안 만들고 이 state를 서버 응답으로 갱신한다(channel-posts 상세와 동형).
   const [violations, setViolations] = useState<ContentRuleViolation[]>([]);
+  // story #3514(유나 Design 변경요청 1, 2026-09-05) — 단건 GET(violations 부수 호출)
+  // 실패가 초안 열기 자체를 막으면 안 된다(주 데이터는 여전히 /versions). 실패해도
+  // violations=[]로 진행하고 이 한 줄로만 "모른다"를 알린다(§16-7 "읽기 자리를 주
+  // 데이터와 같은 급으로 묶지 않는다").
+  const [violationsLoadFailed, setViolationsLoadFailed] = useState(false);
   // "편집 중에도 같은 강도" — severity가 없어 위반이 있으면 전부 차단(channel-posts
   // 상세와 동형).
   const hasBlockingViolations = violations.length > 0;
@@ -362,17 +367,29 @@ export default function ContentPostEditPage() {
         // 패턴 — site_post는 이 스토리 前까지 단건 GET 자체가 없어 /versions 하나만
         // 불렀다). 단건 GET의 violations[]로 "저장 없이" 위반 목록·상신 비활성이
         // 선다(§16-7을 읽기까지 넓힘).
+        //
+        // ⚠️유나 Design 변경요청 1(2026-09-05) — 단건 GET은 이 화면에선 부수 데이터다
+        // (주 데이터는 여전히 /versions). 단건 GET만 실패해도 화면 전체를 막지 않는다
+        // (§16-7 "읽기 자리를 주 데이터와 같은 급으로 묶지 않는다") — violations=[]로
+        // 진행하고 violationsLoadFailed 한 줄만 띄운다. 변형(channel_post) 화면은 단건
+        // GET이 주 데이터라 그대로 loadError 대상.
         const [draftRes, versionsRes] = await Promise.all([
           fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}`),
           fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}/versions`),
         ]);
         if (cancelled) return;
-        if (!draftRes.ok || !versionsRes.ok) {
+        if (!versionsRes.ok) {
           setLoadError(true);
           return;
         }
-        const draftJson = (await draftRes.json().catch(() => null)) as { data?: SitePostDraftDetail } | null;
-        setViolations(draftJson?.data?.violations ?? []);
+        if (draftRes.ok) {
+          const draftJson = (await draftRes.json().catch(() => null)) as { data?: SitePostDraftDetail } | null;
+          setViolations(draftJson?.data?.violations ?? []);
+          setViolationsLoadFailed(false);
+        } else {
+          setViolations([]);
+          setViolationsLoadFailed(true);
+        }
 
         const json = (await versionsRes.json().catch(() => null)) as { data?: SitePostVersion[] } | null;
         const list = json?.data ?? [];
@@ -1512,6 +1529,15 @@ export default function ContentPostEditPage() {
               걸렸나)와 자리가 다르다 — 여기는 개수만 세고 가리킨다. */}
           {hasBlockingViolations ? (
             <ContentRuleSubmitBlockedReason count={violations.length} testId="content-rule-violation-blocked-reason" t={t} />
+          ) : null}
+          {/* story #3514(유나 Design 변경요청 1, 2026-09-05) — 단건 GET(violations 부수
+              데이터) 실패는 화면을 안 막되, "모른다"는 사실은 숨기지 않는다(지어내지
+              않는다 — 위반 0으로 조용히 넘어가면 실제로 위반이 있는데 못 본 것과
+              구별이 안 된다). */}
+          {violationsLoadFailed ? (
+            <p className="text-xs text-muted-foreground" data-testid="content-rule-violation-load-failed">
+              {t('contentRuleViolationsLoadFailed')}
+            </p>
           ) : null}
           {/* §6-2-1 — 비활성 발행 버튼 라벨 자체는 WCAG 면제 대상이지만, "눌리지 않는
               이유"를 옆에 두는 이 문구는 실제 정보라 4.5:1 판정 대상이다(text-muted-

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -745,6 +745,9 @@ export default function ContentPostEditPage() {
         // 배열 — 화면은 아무것도 지어내지 않는다.
         const saveJson = (await res.json().catch(() => null)) as { data?: { violations?: ContentRuleViolation[] } } | null;
         setViolations(saveJson?.data?.violations ?? []);
+        // story #3514(PO REQUIRED, 2026-09-05) — 저장 응답이 권위 값을 방금 채웠으니
+        // 로드-실패 안내 줄이 그 옆에 남아 모순되면 안 된다.
+        setViolationsLoadFailed(false);
         // 새 버전이 생겼다 — 이력을 다시 읽어 새 버전 번호·"미상신" 상태를 반영한다(AC2).
         const versionsRes = await fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}/versions`);
         if (versionsRes.ok) {
@@ -816,6 +819,9 @@ export default function ContentPostEditPage() {
         const ruleViolationBody = body as { error?: { code?: string; violations?: ContentRuleViolation[] } } | null;
         if (ruleViolationBody?.error?.code === 'CONTENT_RULE_VIOLATION') {
           setViolations(ruleViolationBody.error.violations ?? []);
+          // story #3514(PO REQUIRED, 2026-09-05) — 상신 422도 권위 값이다(위 저장
+          // 응답과 동형 이유).
+          setViolationsLoadFailed(false);
           return;
         }
         const info = parseSitePostApiError(body);

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -93,6 +93,9 @@ const DRAFT_DETAIL = {
   source_current_site_post_version_id: null as string | null,
   // story #3453 AC3 후속(BE 판정 이관) — null=모른다(기본값).
   source_changed: null as boolean | null,
+  // story #3514(lint-on-read, PO 確定 2026-09-05) — 단건 GET의 규칙 위반 목록.
+  // 기본값 빈 배열(대부분 테스트가 이 스토리와 무관 — "위반 없음"이 기본).
+  violations: [] as { code: string; field: string; value: string; hint_key: string; settings_path: string }[],
 };
 const VERSION_1 = {
   version_id: 'v1', version: 1, draft_id: DRAFT_ID, text: '초안 본문입니다', link_url: null,
@@ -2375,6 +2378,25 @@ describe('ChannelPostEditPage — 콘텐츠 규칙 위반 표시(story #3472 2�
     expect(container.querySelector('[data-testid="channel-post-rule-violation-text"]')).toBeNull();
     expect(container.querySelector('[data-testid="channel-post-rule-violation-blocked-reason"]')).toBeNull();
     expect((container.querySelector('[data-testid="channel-post-submit-button"]') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  // story #3514(lint-on-read, doc a0da40c9, PO 確定 2026-09-05) — 유나 13회차 ③ 관찰:
+  // 규칙이 바뀐 뒤 기존 초안을 «열기만» 하면(저장·상신 없이) 위반 목록·상신 비활성이
+  // 이미 서야 한다. 이 화면은 로드 시 이미 단건 GET을 부르므로(#3402) 그 응답의
+  // violations를 그대로 초기값으로 쓰면 되는 자리 — save/submit 흐름과 별개로 검증.
+  it('⭐로드만으로(저장·상신 없이) 단건 GET의 violations가 필드 옆 목록·상신 비활성으로 선다', async () => {
+    stubFetch({
+      draftDetail: {
+        violations: [{ code: 'banned_term', field: 'text', value: '무료 보장', hint_key: 'x', settings_path: '/organization/content-rules' }],
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="channel-post-rule-violation-text"]')?.textContent).toContain('무료 보장');
+    const submitBtn = container.querySelector('[data-testid="channel-post-submit-button"]') as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
+    expect(container.querySelector('[data-testid="channel-post-rule-violation-blocked-reason"]')).not.toBeNull();
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -112,6 +112,10 @@ interface ChannelPostDraftDetail {
   // 한 곳에서 낸다(FE가 직접 비교하지 않는다 — id 비교식은 서버 전용, 이 필드만 본다).
   // true=원문이 파생 이후 개정됨 · false=안 바뀜 · null=모른다(레거시 파생분).
   source_changed?: boolean | null;
+  // story #3514(BE 신설, PO 確定 2026-09-05) — lint-on-read. 단건 GET(이미 이 화면이
+  // 로드 시 부르는 자리)에 규칙 위반 목록을 얹는다 — 저장/상신 응답과 같은 shape,
+  // 계약 없으면(BE 미착지) undefined → 화면은 아무것도 지어내지 않는다.
+  violations?: ContentRuleViolation[];
 }
 
 interface ChannelPostVersion {
@@ -350,6 +354,11 @@ export default function ChannelPostEditPage() {
         const d = draftJson?.data;
         const list = versionsJson?.data ?? [];
         setDraft(d ?? null);
+        // story #3514(doc a0da40c9, PO 確定 2026-09-05) — lint-on-read. 저장/상신
+        // 응답에서만 갱신되던 위반 목록을 로드 시점에도 채운다 — "저장 없이" 위반
+        // 목록·상신 비활성이 선다(§16-7을 읽기까지 넓힘). 계약 없으면(BE 미착지)
+        // undefined → 빈 배열(지어내지 않는다).
+        setViolations(d?.violations ?? []);
         setVersions(list);
         const latest = list[list.length - 1];
         if (latest) {

--- a/apps/web/src/app/api/organizations/[id]/site-posts/drafts/[draftId]/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/site-posts/drafts/[draftId]/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { GET } from './route';
+
+describe('/api/organizations/[id]/site-posts/drafts/[draftId] (story #3514 — 신설, channel-posts 동형 형제와 동일 패턴)', () => {
+  it('GET — FastAPI 단건 GET 엔드포인트로 draftId를 그대로 위임', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ draft_id: 'd1', slug: 'my-post', current_version: 1, violations: [] }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const request = new Request('http://test');
+    const resp = await GET(request, { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request, '/api/v2/organizations/[id]/site-posts/drafts/[draftId]', { id: 'org-1', draftId: 'd1' },
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({
+      data: { draft_id: 'd1', slug: 'my-post', current_version: 1, violations: [] }, error: null, meta: null,
+    });
+  });
+
+  it('GET — 존재하지 않는 draftId의 404를 그대로 통과시킨다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'draft를 찾을 수 없습니다: d-missing' }), { status: 404, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const resp = await GET(new Request('http://test'), { params: Promise.resolve({ id: 'org-1', draftId: 'd-missing' }) });
+    expect(resp.status).toBe(404);
+  });
+
+  it('GET — 무자격 요청에 대한 BE의 401도 그대로 통과시킨다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(new Response(null, { status: 401 }));
+    const resp = await GET(new Request('http://test'), { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+    expect(resp.status).toBe(401);
+  });
+
+  it('GET — 다른 org의 draft 접근 403도 그대로 통과시킨다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const resp = await GET(new Request('http://test'), { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+    expect(resp.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/site-posts/drafts/[draftId]/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/site-posts/drafts/[draftId]/route.ts
@@ -1,0 +1,19 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; draftId: string }> };
+
+// story #3514(BE 신설, PO 確定 2026-09-05) — site_post는 원래 단건 GET 자체가 없었다
+// (형제 폴더 campaign·publication·publish·submit·unpublish·variants·versions 7개는
+// 있었지만 이 자리만 비어 있었다 — channel-posts/drafts/[draftId]/route.ts(#3445)의
+// "상세 page.tsx가 부르는 단건 GET이 애초에 없었다"와 같은 클래스 갭). BE가 목록
+// 항목(SitePostDraftListItem) shape에 `violations[]`(lint-on-read)를 얹은 단건
+// `GET .../site-posts/drafts/{draft_id}`를 새로 낸다 — 이 라우트는 그대로 위임.
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id, draftId } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request, '/api/v2/organizations/[id]/site-posts/drafts/[draftId]', { id, draftId },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}


### PR DESCRIPTION
## ⚠️머지 순서 — BE(디디, 3514 site_post 단건 GET) 착지 뒤 머지
site_post 단건 GET(`GET .../site-posts/drafts/{draft_id}`)이 아직 BE에 없다(이 스토리로 신설). 이 PR은 그 계약을 fixture로 가정하고 FE만 먼저 짠 것 — **BE 착지 前까지 site_post 화면의 라이브 로드는 이 BFF에서 404**(계약 자체가 없으므로). channel_post 쪽은 기존 단건 GET을 그대로 쓰므로 BE의 `violations[]` 필드 추가만 기다리면 된다(둘 다 BE 착지 확인 후 머지).

**BFF 경로 확認**: `apps/web/src/app/api/organizations/[id]/site-posts/drafts/[draftId]/route.ts`가 위임하는 FastAPI 경로 문자열은 `/api/v2/organizations/[id]/site-posts/drafts/[draftId]` — channel_post 형제(`.../channel-posts/drafts/[draftId]/route.ts`, #3445)와 동일한 `proxyToFastapiWithParams` 템플릿 관례이고, 실제로 `GET /api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}`로 매핑된다. 디디 BE 라우트(`GET …/site-posts/drafts/{draft_id}`)와 글자까지 같다.

## 요약
story 0edc263b(유나 13회차 ③ 관찰, PO 確定 2026-09-05) — 규칙이 바뀐 뒤 기존 초안을 «열기만» 해도(저장 없이) 위반 목록·상신 비활성이 서게 한다.

## 그라운딩에서 발견한 비대칭
channel_post는 이미 단건 GET(#3403)이 있어 계약 붙일 자리가 있었지만, site_post는 단건 GET 자체가 없었다(#3445 "단건 GET이 애초에 없었다"와 같은 클래스 갭) — PO 確定으로 이 스토리에서 site_post 단건 GET을 신설한다.

## FE 변경
- site_post(`content/[draftId]/page.tsx`): 로드를 «단건 GET+/versions 병렬»로 전환(channel_post 동형 패턴). violations state를 단건 GET 응답으로 초기화.
- channel_post(`content/channel-posts/[draftId]/page.tsx`): 이미 로드 시 부르던 단건 GET 응답에서 violations[]를 읽어 초기화(왕복 신설 없음).
- site_post 단건 GET BFF 신설 + route.test.ts 4케이스. content-bff-route-coverage 가드가 자동으로 새 라우트를 감지(등록 불요, 실측 확認).
- 저장/상신 응답 갱신 경로는 그대로 — lint-on-read는 그 위에 «로드 시점» 갱신을 더하는 것뿐.

## 검증
tsc/eslint clean · 신규 렌더테스트 4건(로드만으로 위반 표시 2건 + 계약없음 안전 폴백 1건 + 기존 스텁 보강) · FE 전체 646/6124 green · i18n 키/충돌 가드 clean.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

## 추가 push(head 44ddb487a) — 유나 Design 변경요청 1 반영

단건 GET(violations)은 site_post에서 부수 데이터다(주 데이터는 /versions) — 그 실패가 화면 로드 자체를 막지 않게 고쳤다. 단건 GET만 실패하면 violations=[]로 진행 + `contentRuleViolationsLoadFailed` 한 줄만 뜬다(loadError 아님). 변형(channel_post)은 단건 GET이 주 데이터라 그대로 loadError 대상 — 의도된 비대칭.

신규 렌더테스트 1건(단건 GET 500 → 제목 정상 표시+violations=[]+안내문구, loadError 아님을 직접 확인).

**실제 BE 계약 대조 완료**(#3858 병합 済) — `SitePostDraftListItem.violations: list[dict]|None`, 필드 shape `{code,field,value,hint_key,settings_path}` 전부 그라운딩 당시 fixture 가정과 일치, FE 타입 변경 불요. 이제 fixture가 아니라 실계약 기준.

검증: tsc/eslint clean·i18n 가드 clean·FE 646/6130 green.