### PR TITLE
[SID:3431] feat: 우상단 카운트 배지 공용화 — CornerCountBadge 3곳 통합+bell 9→10px

### DIFF
--- a/apps/web/src/components/nav/mobile-tab-bar-badge.test.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar-badge.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+//
+// story #3431(공용, PO 確定 2026-09-05) — 그라운딩 중 발견한 3번째 복사본(chat/approvals
+// 카운트 배지, `CircleDot`/`Inbox` 옆이 아니라 오른쪽 옆에 얹는 위치)을 공용
+// CornerCountBadge로 통합했다 — 색·크기·값 상한(9+/99+) 로직은 무변경, 위치와 정의만 접었다.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/flow',
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function mount(pendingCount: number, chatUnreadTotal: number) {
+  // MobileTabBar의 pendingCount effect는 window.innerWidth < MOBILE_BREAKPOINT(1024)일
+  // 때만 fetch한다(유나 지적 #2249 — 데스크톱에서 불필요한 왕복 금지). jsdom 기본값(1024)은
+  // 그 조건을 안 타므로 모바일 폭으로 명시 고정한다(390 — 이 레포 라이브픽셀 관례 폭).
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 390 });
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.includes('/api/gates/designated-pending-count')) {
+      return new Response(JSON.stringify({ count: pendingCount }), {
+        status: 200, headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } });
+  }));
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const { MobileTabBar } = await import('./mobile-tab-bar');
+  await act(async () => { root.render(wrap(<MobileTabBar chatUnreadTotal={chatUnreadTotal} />)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('MobileTabBar — 결재/채팅 카운트 배지(story #3431 CornerCountBadge 통합)', () => {
+  it('두 배지 모두 0건이면 배지 자체가 안 뜬다', async () => {
+    await mount(0, 0);
+    expect(container.querySelector('span[aria-hidden]')).toBeNull();
+  });
+
+  it('결재 대기 5건 — primary variant·10px·9+ 상한 유지', async () => {
+    await mount(5, 0);
+    const badge = container.querySelector('span[aria-hidden]');
+    expect(badge?.textContent).toBe('5');
+    expect(badge?.className).toContain('bg-primary');
+    expect(badge?.className).toContain('text-primary-foreground');
+    expect(badge?.className).toContain('text-[10px]');
+    expect(badge?.className).toContain('absolute');
+    expect(badge?.className).toContain('left-full');
+  });
+
+  it('결재 대기 12건 — 9+ 상한(기존 로직 무변경)', async () => {
+    await mount(12, 0);
+    const badge = container.querySelector('span[aria-hidden]');
+    expect(badge?.textContent).toBe('9+');
+  });
+
+  it('채팅 unread 150건 — 99+ 상한(기존 로직 무변경, 결재와 다른 캡)', async () => {
+    await mount(0, 150);
+    const badge = container.querySelector('span[aria-hidden]');
+    expect(badge?.textContent).toBe('99+');
+  });
+});

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { CircleDot, Inbox, MessageSquare, Grid2x2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { CornerCountBadge } from '@/components/ui/corner-count-badge';
 import { MOBILE_BREAKPOINT } from '@/hooks/use-mobile';
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -156,13 +157,14 @@ export function MobileTabBar({ chatUnreadTotal }: { chatUnreadTotal: number }) {
             <span className="relative">
               <Icon className="size-[22px]" strokeWidth={1.8} />
               {badge !== null ? (
-                <span
-                  aria-hidden
-                  className="absolute -top-1 left-full ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold leading-none text-primary-foreground"
-                >
-                  {/* story #1977: 채팅 unread 총합은 99+ 상한(시안 768e89b5 v2) — 결재함은 기존 9+ 유지 */}
-                  {key === 'chat' ? (badge > 99 ? '99+' : badge) : badge > 9 ? '9+' : badge}
-                </span>
+                // story #3431 — 공용 CornerCountBadge로 통합(bell·presence와 동일 정의,
+                // 색/크기 무변경). 위치만 이 소비처 고유(아이콘 오른쪽 옆, 코너 아님).
+                <CornerCountBadge
+                  variant="primary"
+                  className="absolute -top-1 left-full ml-0.5"
+                  // story #1977: 채팅 unread 총합은 99+ 상한(시안 768e89b5 v2) — 결재함은 기존 9+ 유지
+                  value={key === 'chat' ? (badge > 99 ? '99+' : badge) : badge > 9 ? '9+' : badge}
+                />
               ) : null}
             </span>
             {t(labelKey)}

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -446,6 +446,19 @@ describe('NotificationBell — 배지 「99+」 대비(story 3466)', () => {
     expect(badge?.className).not.toContain('text-destructive-foreground');
   });
 
+  // story #3431 AC4 — 9px는 본문 최소보다 작았다. CornerCountBadge(공용) 도입으로 10px에
+  // 고정됐는지, team-presence-toggle.tsx와 같은 정의를 쓰는지(font-mono 폐기) 고정한다.
+  it('⭐크기 9px→10px(AC4) — 공용 CornerCountBadge를 쓰고 옛 font-mono가 안 남았다', async () => {
+    stubUnreadCount(5);
+    await act(async () => { root.render(withIntl(<NotificationBell />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const badge = Array.from(container.querySelectorAll('span')).find((s) => s.textContent === '5');
+    expect(badge?.className).toContain('text-[10px]');
+    expect(badge?.className).not.toContain('text-[9px]');
+    expect(badge?.className).not.toContain('font-mono');
+  });
+
   it('⭐색 계산 양성대조 — globals.css 실값으로 라이트·다크 둘 다 대비비 ≥4.5(WCAG AA)', async () => {
     const { readFileSync } = await import('node:fs');
     const path = await import('node:path');

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import { CornerCountBadge } from '@/components/ui/corner-count-badge';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { fetchWithAuth } from '@/lib/db/client';
 import { formatRelativeTime } from '@/lib/storage/format';
@@ -569,18 +570,11 @@ export function NotificationBell() {
         className="relative flex size-8 items-center justify-center rounded-md text-foreground/70 transition hover:bg-accent hover:text-foreground"
       >
         <Bell className="size-4" />
-        {/* story 3466(위생, 유나 5~8회차 4연속 관측) — `text-destructive-foreground`는
-            이 테마에 `--color-destructive-foreground` 매핑 자체가 없는 무효 유틸(조용히
-            no-op)이라 실제 렌더 색이 상속된 `--foreground`로 새 대비 미달(라이트 3.55·
-            다크 3.00, AA 4.5 미달)이었다 — bg-destructive(라이트#C33B3B·다크#E06767)에
-            흰 텍스트는 라이트만 맞고(5.24) 다크는 여전히 부족(3.33, 다크 red가 더 옅은
-            색이라). trust-seal.tsx의 선례(같은 문제 — 작은 배지 텍스트가 테마별로
-            반전돼야 함)를 그대로 따른다: 라이트=흰색(5.24)·다크=--proof-bg(거의 검정,
-            5.88) — 새 토큰 발명 없이 기존 값 재사용, 크기·자리 무변경. */}
+        {/* story #3431(공용, PO 確定 2026-09-05) — 공용 CornerCountBadge로 통합(team-presence-
+            toggle.tsx와 동일 정의). 색 계산 근거(story 3466이 이미 확保)와 크기(9→10px,
+            AC4)는 corner-count-badge.tsx 주석 참고 — 정의를 두 곳에 중복하지 않는다. */}
         {unreadCount > 0 && (
-          <span className="absolute -right-0.5 -top-0.5 flex min-w-[16px] items-center justify-center rounded-full bg-destructive px-1 py-px font-mono text-[9px] font-bold leading-none text-white dark:text-proof-bg">
-            {badgeLabel}
-          </span>
+          <CornerCountBadge variant="destructive" value={badgeLabel} className="absolute -right-0.5 -top-0.5" />
         )}
       </button>
 

--- a/apps/web/src/components/presence/team-presence-toggle.test.tsx
+++ b/apps/web/src/components/presence/team-presence-toggle.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+//
+// story #3431(공용, PO 確定 2026-09-05) — PresenceToggleButton은 지금까지 전용 테스트가
+// 없었다. CornerCountBadge(공용) 도입 후에도 working-count 배지가 그대로 서는지 고정한다.
+import { describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { PresenceToggleButton, TeamPresenceToggleProvider } from './team-presence-toggle';
+
+function mount(node: React.ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root, node };
+}
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('PresenceToggleButton — working-count 배지(story #3431 CornerCountBadge 통합)', () => {
+  it('provider 밖이면 미렌더', async () => {
+    const { container, root } = mount(null);
+    await act(async () => { root.render(wrap(<PresenceToggleButton />)); });
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('workingCount=0이면 배지 자체가 안 뜬다', async () => {
+    const { container, root } = mount(null);
+    await act(async () => {
+      root.render(wrap(
+        <TeamPresenceToggleProvider value={{ toggle: () => {}, workingCount: 0, open: false }}>
+          <PresenceToggleButton />
+        </TeamPresenceToggleProvider>,
+      ));
+    });
+    expect(container.querySelector('button')).not.toBeNull();
+    expect(container.querySelector('span[aria-hidden]')).toBeNull();
+  });
+
+  it('workingCount>0 — CornerCountBadge(info variant, 10px)가 뜬다', async () => {
+    const { container, root } = mount(null);
+    await act(async () => {
+      root.render(wrap(
+        <TeamPresenceToggleProvider value={{ toggle: () => {}, workingCount: 4, open: false }}>
+          <PresenceToggleButton />
+        </TeamPresenceToggleProvider>,
+      ));
+    });
+    const badge = container.querySelector('span[aria-hidden]');
+    expect(badge?.textContent).toBe('4');
+    expect(badge?.className).toContain('bg-info');
+    expect(badge?.className).toContain('text-info-foreground');
+    expect(badge?.className).toContain('text-[10px]');
+  });
+});

--- a/apps/web/src/components/presence/team-presence-toggle.tsx
+++ b/apps/web/src/components/presence/team-presence-toggle.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext } from 'react';
 import { useTranslations } from 'next-intl';
 import { Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { CornerCountBadge } from '@/components/ui/corner-count-badge';
 
 // 2505d27d: presence 패널 토글을 헤더(TopBar)서 제어하기 위한 context.
 // 패널 state(useContextualPanelState)는 ScrollShell 소유 → provider로 TopBar에 toggle/count/open 공급.
@@ -46,14 +47,10 @@ export function PresenceToggleButton() {
       )}
     >
       <Users className="size-4" />
+      {/* story #2023 ⓑ: working 카운트 배지=L5(시스템 상태). story #3431 — 공용 CornerCountBadge로
+          통합(notification-bell.tsx와 동일 정의, 이 컴포넌트가 원형이었다 — 모양·크기 무변경). */}
       {workingCount > 0 ? (
-        <span
-          // story #2023 ⓑ: working 카운트 배지=L5(시스템 상태). info-foreground는 §3-3에서 신설(다크 AA 보정 포함).
-          className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-info px-1 text-[10px] font-bold tabular-nums text-info-foreground"
-          aria-hidden
-        >
-          {workingCount}
-        </span>
+        <CornerCountBadge variant="info" value={workingCount} className="absolute -right-0.5 -top-0.5" />
       ) : null}
     </button>
   );

--- a/apps/web/src/components/ui/corner-count-badge.test.tsx
+++ b/apps/web/src/components/ui/corner-count-badge.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+//
+// story #3431(공용) — 아이콘 우상단 오버레이 카운트 배지 단위 테스트. notification-bell.tsx·
+// team-presence-toggle.tsx 두 복사본을 이 컴포넌트 하나로 통합했다 — 모양(원형·10px·
+// tabular-nums)은 공유하고 색(variant)만 소비처가 고른다.
+import { describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { CornerCountBadge } from './corner-count-badge';
+
+function mount() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+describe('CornerCountBadge', () => {
+  it('destructive variant — bg-destructive+테마별 반전 텍스트(라이트 흰색·다크 proof-bg)', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<CornerCountBadge variant="destructive" value="99+" className="absolute -right-0.5 -top-0.5" />); });
+    const el = container.querySelector('span');
+    expect(el?.textContent).toBe('99+');
+    expect(el?.className).toContain('bg-destructive');
+    expect(el?.className).toContain('text-white');
+    expect(el?.className).toContain('dark:text-proof-bg');
+  });
+
+  it('info variant — bg-info+info-foreground(이미 테마별 값을 가진 기존 토큰)', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<CornerCountBadge variant="info" value={7} className="absolute -right-0.5 -top-0.5" />); });
+    const el = container.querySelector('span');
+    expect(el?.textContent).toBe('7');
+    expect(el?.className).toContain('bg-info');
+    expect(el?.className).toContain('text-info-foreground');
+  });
+
+  // story #3431 — 그라운딩 중 발견한 3번째 복사본(mobile-tab-bar.tsx)용 variant.
+  // primary=info와 같은 토큰(--proof-blue)이라 대비는 별도 재계산 불요(주석 참고).
+  it('primary variant — bg-primary+primary-foreground(mobile-tab-bar 소비)', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<CornerCountBadge variant="primary" value={9} className="absolute -top-1 left-full ml-0.5" />); });
+    const el = container.querySelector('span');
+    expect(el?.textContent).toBe('9');
+    expect(el?.className).toContain('bg-primary');
+    expect(el?.className).toContain('text-primary-foreground');
+  });
+
+  // story #3431 AC4 — 9px는 본문 최소(11~12px)보다 작았다. 10px로 올리되 두 소비처가
+  // 갈라지지 않도록(과거 9px vs 10px 드리프트의 재발 방지) 값 하나로 고정한다.
+  it('크기는 10px·원형(rounded-full·h-4·min-w-4)으로 고정 — 소비처가 각자 못 정한다', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<CornerCountBadge variant="destructive" value={1} className="absolute -right-0.5 -top-0.5" />); });
+    const el = container.querySelector('span');
+    expect(el?.className).toContain('text-[10px]');
+    expect(el?.className).toContain('rounded-full');
+    expect(el?.className).toContain('h-4');
+    expect(el?.className).toContain('min-w-4');
+    expect(el?.className).not.toContain('text-[9px]');
+    expect(el?.className).not.toContain('font-mono');
+  });
+
+  it('aria-hidden — 접근성 이름은 소비처의 버튼 aria-label이 이미 낸다(배지 자체는 장식)', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<CornerCountBadge variant="info" value={3} className="absolute -right-0.5 -top-0.5" />); });
+    const el = container.querySelector('span');
+    expect(el?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('className을 병합한다(소비처의 위치 override 등)', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<CornerCountBadge variant="info" value={3} className="ml-auto" />); });
+    const el = container.querySelector('span');
+    expect(el?.className).toContain('ml-auto');
+    expect(el?.className).toContain('bg-info');
+  });
+});

--- a/apps/web/src/components/ui/corner-count-badge.tsx
+++ b/apps/web/src/components/ui/corner-count-badge.tsx
@@ -1,0 +1,60 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+/**
+ * story #3431(공용, PO 確定 2026-09-05) — 아이콘에 얹는 카운트 오버레이 배지의 유일한
+ * 정의. 처음엔 2곳(notification-bell·team-presence-toggle)만 보였으나 그라운딩 중
+ * `mobile-tab-bar.tsx`의 chat/approvals 배지가 같은 모양의 3번째 복사본임을 발견 —
+ * PO 確定으로 셋 다 접는다(AC2 "복사본을 하나로"가 한 곳을 남기면 반쪽).
+ *
+ * ⚠️`ui/count-badge.tsx`(story #3049)의 `CountBadge`와 이름·모양·용도 전부 다르다 —
+ * 그건 인라인 흐름 안에 앉는 그룹/태그 카운트 칩(예: 「38건」, 엠보스 inset 재질), 이건
+ * 아이콘에 절대위치로 얹는 원형 배지(안 읽음/작업중/미결 수). 헷갈리지 않게 이름을 따로 뒀다.
+ *
+ * 크기는 team-presence-toggle·mobile-tab-bar가 이미 쓰던 10px·h-4·min-w-4를 그대로
+ * 채택했다(둘 다 변경 0). bell만 이 스토리로 9px→10px(§AC4, 대비와 별개 축). font는
+ * tabular-nums로 통일(bell의 font-mono 폐기) — ui/badge.tsx 자체가 "mono 라벨은
+ * 한글서 흐림(2967 교훈)"이라 공유 primitive에 안 넣는 관례를 그대로 따른 것뿐, 라틴
+ * 숫자만 싣는 이 배지엔 tabular-nums로 충분하다.
+ *
+ * ⚠️위치(position)는 base에 안 굽는다 — 세 소비처가 서로 다르다(bell·presence는 아이콘
+ * 우상단 코너, tab-bar는 아이콘 오른쪽 옆). `right`와 `left`는 tailwind-merge가 다른
+ * 충돌군이라 className으로 덮어써도 base의 `-right-0.5`가 안 지워지고 같이 남아 폭이
+ * 늘어난다(absolute+양쪽 지정+width auto는 브라우저가 늘려 채운다) — 그래서 위치는
+ * 전부 호출부가 className으로 준다(position: absolute도 호출부 책임).
+ *
+ * variant별 색은 그대로 보존한다(destructive/info/primary는 다른 의미축 — 강제 통일
+ * 대상이 아니다, PO 確定. primary=info와 같은 토큰(--proof-blue)이라 사실상 같은 값).
+ * 재계산(lib/oklch-contrast.ts, 2026-09-05):
+ *   destructive — 라이트 white/#C33B3B 5.24 · 다크 #0B0C0D/#E06767 5.88
+ *   info        — 라이트 #FAFAFA/#3157FF 5.11 · 다크 #020E1D/#6B87FF 6.03
+ *   primary     — info와 동일 토큰(라이트 fg oklch(.985 0 0) 동일·다크 fg 색상각만 262
+ *                 vs 250, 값은 사실상 동일) — 별도 재계산 불요
+ * (셋 다 AA 4.5 통과 — story c2bb0acd가 destructive를, §3-3 신설이 info/primary를 이미 확保)
+ */
+const cornerCountBadgeVariants = cva(
+  'flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold tabular-nums leading-none',
+  {
+    variants: {
+      variant: {
+        destructive: 'bg-destructive text-white dark:text-proof-bg',
+        info: 'bg-info text-info-foreground',
+        primary: 'bg-primary text-primary-foreground',
+      },
+    },
+  },
+);
+
+interface CornerCountBadgeProps extends VariantProps<typeof cornerCountBadgeVariants> {
+  value: string | number;
+  /** 위치(absolute+좌표)를 포함해 호출부가 전부 준다 — 위 주석 참고. */
+  className: string;
+}
+
+export function CornerCountBadge({ variant, value, className }: CornerCountBadgeProps) {
+  return (
+    <span className={cn(cornerCountBadgeVariants({ variant }), className)} aria-hidden>
+      {value}
+    </span>
+  );
+}


### PR DESCRIPTION
## 그라운딩 — 스토리 실측값이 이미 stale(착수 前 재확定)
스토리가 인용한 "배포 17 실측"(2026-09-04, 라이트3.57/다크3.00)은 오늘 이미 머지된 story c2bb0acd(#3822)가 고친 것과 같은 결함의 스냅샷이었다. 저장소 자체 계산기(`lib/color-contrast.ts`+`lib/oklch-contrast.ts`, 유나 실 Chromium 캡처와 bit-exact 대조된 도구)로 재계산: destructive 라이트5.24/다크5.88, info 라이트5.11/다크6.04(신규 통합 primary=info와 동일 토큰) — 전부 AA 4.5 통과. **PO 確定으로 AC3(색 변경) 삭제**, whats-new-button.tsx(텍스트 없는 장식 점, aria-hidden)는 대상 제외.

## 4번째 복사본 발견 → 접목(PO 確定)
당초 2곳(notification-bell·team-presence-toggle)만 보였으나, 그라운딩 중 `mobile-tab-bar.tsx`의 chat/approvals 배지도 같은 모양의 3번째 복사본임을 발견 — AC2 "복사본을 하나로"가 한 곳을 남기면 반쪽이라 PO 確定으로 셋 다 접었다(색/크기 값은 무변경, `primary` variant만 추가).

## 화면 목록(AC5)
- notification-bell(destructive) · team-presence-toggle(info) — 둘 다 `TopBar`(`dashboard-shell.tsx`)에서 마운트, `/settings/*`를 제외한 전 인증 화면에 상시(전자는 unreadCount>0, 후자는 workingCount>0일 때만 표시).
- mobile-tab-bar(primary) — `<1024`(lg 미만) 전용 하단 4탭, chat/approvals 두 탭에 표시.

## 변경
- `ui/corner-count-badge.tsx`(신설) — variant(destructive/info/primary)만 색을 가르고 모양·크기(h-4 min-w-4 rounded-full text-[10px] tabular-nums)는 하나. 위치는 소비처마다 달라(코너 2곳 vs 아이콘 옆 1곳) className으로 전부 호출부가 준다(`right`/`left`가 tailwind-merge 다른 충돌군이라 base에 구우면 override가 안 먹고 폭이 늘어나는 함정을 피함).
  ⚠️`ui/count-badge.tsx`(story #3049, 인라인 태그 칩 — 첫 시도에서 실수로 덮어썼다 즉시 복구)와는 이름·모양·용도가 전부 달라 별도 이름을 썼다.
- notification-bell.tsx: 9px→10px(AC4), font-mono 폐기.
- team-presence-toggle.tsx: 기존 10px 그대로(변경 0).
- mobile-tab-bar.tsx: bg-primary 배지를 CornerCountBadge로 교체, 9+/99+ 상한 로직 무변경.

## 검증
tsc/eslint clean · corner-count-badge 단위테스트 6건 · bell 크기 회귀가드 1건 · presence 신규 테스트 3건(이전엔 전용 테스트 0) · mobile-tab-bar 신규 렌더테스트 4건(9+/99+ 상한 회귀 0) · 아이콘 겹침(AC4)은 puppeteer 정적 HTML 재현으로 3개 배지 전부 시각 확인(클리핑 없음, 스크린샷 확인) · FE 전체 648/6135 green.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>