### PR TITLE
[SID:3514] fix: develop CI 핫픽스 — put_org_content_rules expected_version 누락

### DIFF
--- a/backend/tests/test_3514_lint_on_read.py
+++ b/backend/tests/test_3514_lint_on_read.py
@@ -74,9 +74,19 @@ def _configure_secrets(monkeypatch):
 
 
 async def _put_rules(session, *, org_id, rules):
-    from app.services.content_rules import put_org_content_rules
+    # story #3501(PR#3856, CAS 낙관적 잠금) — expected_version이 필수 인자가 됐다(#3514
+    # 브랜치가 #3856 착지 前에 갈라져 나와 몰랐던 자리, develop CI 핫픽스). 이 헬퍼가
+    # PUT 엔드포인트와 동형으로 "지금 서버 버전"을 먼저 읽어 넘긴다 — 한 테스트 안에서
+    # 같은 org에 두 번 PUT하는 경우(규칙 추가→원복)가 있어 0 하드코딩은 두 번째 호출을
+    # 깬다.
+    from app.services.content_rules import get_org_content_rules, put_org_content_rules
 
-    return await put_org_content_rules(session, org_id=org_id, rules=rules, updated_by_member_id=uuid.uuid4())
+    existing = await get_org_content_rules(session, org_id=org_id)
+    expected_version = existing.version if existing else 0
+    return await put_org_content_rules(
+        session, org_id=org_id, rules=rules, updated_by_member_id=uuid.uuid4(),
+        expected_version=expected_version,
+    )
 
 
 # ─── site_post ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
#3856(3501 CAS 낙관적 잠금)이 develop에 착지하며 `put_org_content_rules()`의 `expected_version`을 필수 키워드 인자로 바꿨는데, #3858(3514 BE) 브랜치가 그 착지 前에 갈라져 나와 이 헬퍼가 옛 시그니처 그대로였다(병렬 PR 낡은 시그니처 — develop shard 4 RED, run 33967493648).

`_put_rules` 헬퍼를 PUT 엔드포인트와 동형으로 고쳤다 — 호출 前 `get_org_content_rules()`로 "지금 서버 버전"을 읽어 넘긴다(0 하드코딩 금지 — 이 파일의 한 테스트가 같은 org에 두 번 PUT한다, 규칙 추가→원복. 0 하드코딩이면 두 번째 호출이 버전 충돌로 깨진다).

## develop 전수 grep 결과 (PO 요청)
`put_org_content_rules(` 호출자 전부(6곳) `expected_version=` 보유 확인 — 이 파일이 유일한 갭이었다:
- `app/routers/content_rules.py` — 済
- `tests/test_3471_org_content_rules_lint.py`(3곳) — 済
- `tests/test_3498_generation_budget.py` — 済
- `tests/test_3506_utm_attribution.py` — 済
- `tests/test_3514_lint_on_read.py` — 이 PR로 済

## Test plan
- [x] 회귀 58/58(`test_3514_lint_on_read.py`·`test_3471_org_content_rules_lint.py`·`test_3498_generation_budget.py`·`test_3506_utm_attribution.py` 전 계열)
- [x] 마이그레이션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)