### PR TITLE
[SID:3518] feat: CornerCountBadge 접근성 이름 계약 — 탭바 sr-only+벨 캡 문구 정정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -76,7 +76,7 @@
     "chat": "Chat",
     "more": "More",
     "approvalsPendingSr": "{count, plural, one {# pending approval} other {# pending approvals}}",
-    "approvalsPendingSrCapped": "9+ pending approvals",
+    "approvalsPendingSrCapped": "9 or more pending approvals",
     "chatUnreadSr": "{count} unread",
     "chatUnreadSrCapped": "99 or more unread"
   },
@@ -2848,7 +2848,7 @@
     "emptySystem": "No system notifications",
     "daysAgo": "d ago",
     "bellAriaLabelCount": "{count, plural, one {# notification} other {# notifications}}",
-    "bellAriaLabelCountCapped": "99+ notifications",
+    "bellAriaLabelCountCapped": "99 or more notifications",
     "syncDegradedBanner": "Some older notifications may be missing — check the list below"
   },
   "invite": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -74,7 +74,11 @@
     "now": "Now",
     "approvals": "Approvals",
     "chat": "Chat",
-    "more": "More"
+    "more": "More",
+    "approvalsPendingSr": "{count, plural, one {# pending approval} other {# pending approvals}}",
+    "approvalsPendingSrCapped": "9+ pending approvals",
+    "chatUnreadSr": "{count} unread",
+    "chatUnreadSrCapped": "99 or more unread"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -2843,7 +2847,8 @@
     "emptyStory": "No story notifications",
     "emptySystem": "No system notifications",
     "daysAgo": "d ago",
-    "bellAriaLabelCount": "{count} notifications",
+    "bellAriaLabelCount": "{count, plural, one {# notification} other {# notifications}}",
+    "bellAriaLabelCountCapped": "99+ notifications",
     "syncDegradedBanner": "Some older notifications may be missing — check the list below"
   },
   "invite": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -77,8 +77,8 @@
     "more": "전체",
     "approvalsPendingSr": "대기 {count}건",
     "approvalsPendingSrCapped": "대기 9건 이상",
-    "chatUnreadSr": "읽지 않음 {count}건",
-    "chatUnreadSrCapped": "읽지 않음 99건 이상"
+    "chatUnreadSr": "안읽음 {count}건",
+    "chatUnreadSrCapped": "안읽음 99건 이상"
   },
   "nav": {
     "dashboard": "대시보드",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -74,7 +74,11 @@
     "now": "지금",
     "approvals": "결재",
     "chat": "채팅",
-    "more": "전체"
+    "more": "전체",
+    "approvalsPendingSr": "대기 {count}건",
+    "approvalsPendingSrCapped": "대기 9건 이상",
+    "chatUnreadSr": "읽지 않음 {count}건",
+    "chatUnreadSrCapped": "읽지 않음 99건 이상"
   },
   "nav": {
     "dashboard": "대시보드",
@@ -2844,6 +2848,7 @@
     "emptySystem": "시스템 알림이 없습니다",
     "daysAgo": "일 전",
     "bellAriaLabelCount": "알림 {count}개",
+    "bellAriaLabelCountCapped": "알림 99개 이상",
     "syncDegradedBanner": "일부 지난 알림은 표시되지 않았습니다 — 아래 목록에서 확인할 수 있습니다"
   },
   "invite": {

--- a/apps/web/src/components/nav/mobile-tab-bar-badge.test.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar-badge.test.tsx
@@ -8,6 +8,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/flow',
@@ -18,9 +19,10 @@ vi.mock('next/navigation', () => ({
 let container: HTMLDivElement;
 let root: Root;
 
-function wrap(node: React.ReactNode) {
+function wrap(node: React.ReactNode, locale: 'ko' | 'en' = 'ko') {
+  const messages = locale === 'ko' ? koMessages : enMessages;
   return (
-    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
       {node}
     </NextIntlClientProvider>
   );
@@ -32,7 +34,7 @@ afterEach(async () => {
   vi.unstubAllGlobals();
 });
 
-async function mount(pendingCount: number, chatUnreadTotal: number) {
+async function mount(pendingCount: number, chatUnreadTotal: number, locale: 'ko' | 'en' = 'ko') {
   // MobileTabBar의 pendingCount effect는 window.innerWidth < MOBILE_BREAKPOINT(1024)일
   // 때만 fetch한다(유나 지적 #2249 — 데스크톱에서 불필요한 왕복 금지). jsdom 기본값(1024)은
   // 그 조건을 안 타므로 모바일 폭으로 명시 고정한다(390 — 이 레포 라이브픽셀 관례 폭).
@@ -49,7 +51,7 @@ async function mount(pendingCount: number, chatUnreadTotal: number) {
   document.body.appendChild(container);
   root = createRoot(container);
   const { MobileTabBar } = await import('./mobile-tab-bar');
-  await act(async () => { root.render(wrap(<MobileTabBar chatUnreadTotal={chatUnreadTotal} />)); });
+  await act(async () => { root.render(wrap(<MobileTabBar chatUnreadTotal={chatUnreadTotal} />, locale)); });
   await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 }
 
@@ -80,5 +82,91 @@ describe('MobileTabBar — 결재/채팅 카운트 배지(story #3431 CornerCoun
     await mount(0, 150);
     const badge = container.querySelector('span[aria-hidden]');
     expect(badge?.textContent).toBe('99+');
+  });
+});
+
+// story #3518(유나 사전 스티어, 2026-09-05) — 배지는 aria-hidden이라 그 수를 보조
+// 기술에 전하는 책임은 탭 링크에 있다. aria-label(접근성 이름 통째 교체)은 안 쓴다 —
+// 이 탭은 보이는 텍스트 라벨("채팅"·"결재")이 있어서 aria-label로 갈아치우면 WCAG
+// 2.5.3(Label in Name) 위반이다. 대신 보이는 라벨 뒤에 sr-only 텍스트를 "덧붙인다" —
+// 접근성 이름은 여전히 라벨+children 텍스트 전체(배지의 aria-hidden 텍스트는 accname
+// 계산에서 제외)로 계산된다. jsdom엔 실 accname 알고리즘이 없어 아래 헬퍼로 근사한다
+// (aria-hidden 하위 텍스트를 제외한 텍스트 concat — 이 파일의 마크업 깊이에선 충분).
+function collectVisibleText(el: Element): string {
+  let out = '';
+  for (const node of Array.from(el.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += node.textContent ?? '';
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const child = node as Element;
+      if (child.getAttribute('aria-hidden') === 'true') continue;
+      out += collectVisibleText(child);
+    }
+  }
+  return out;
+}
+
+// 재귀 도중엔(하위 호출마다) 다듬지 않는다 — 각 레벨에서 trim하면 "채팅"+" 읽지…"의
+// 경계 공백이 하위 호출 안에서 먼저 잘려 "채팅읽지…"처럼 붙어버린다(실제 겪은 버그).
+// 정규화는 최종 문자열에서 한 번만.
+function approxAccessibleName(el: Element): string {
+  return collectVisibleText(el).replace(/\s+/g, ' ').trim();
+}
+
+describe('MobileTabBar — 탭 접근성 이름에 카운트 포함(story #3518)', () => {
+  it('배지 0건 — sr-only 텍스트가 안 붙는다(접근성 이름=보이는 라벨 그대로)', async () => {
+    await mount(0, 0);
+    const chatLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/chats')!;
+    expect(approxAccessibleName(chatLink)).toBe('채팅');
+    expect(chatLink.getAttribute('aria-label')).toBeNull(); // 접근성 이름을 통째로 안 갈아치운다(WCAG 2.5.3).
+  });
+
+  it('결재 대기 5건 — 접근성 이름이 «보이는 라벨+수»(라벨을 안 지운다)', async () => {
+    await mount(5, 0);
+    const approvalsLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/inbox?tab=gates')!;
+    expect(approxAccessibleName(approvalsLink)).toBe('결재 대기 5건');
+  });
+
+  it('채팅 unread 3건 — 접근성 이름이 «보이는 라벨+수»', async () => {
+    await mount(0, 3);
+    const chatLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/chats')!;
+    expect(approxAccessibleName(chatLink)).toBe('채팅 읽지 않음 3건');
+  });
+
+  it('결재 대기 12건(시각 9+ 표기) — 접근성 이름엔 "9건 이상"(캡을 말로 반영, 시각 캡과 같은 뜻)', async () => {
+    await mount(12, 0);
+    const approvalsLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/inbox?tab=gates')!;
+    expect(approxAccessibleName(approvalsLink)).toBe('결재 대기 9건 이상');
+    const badge = container.querySelector('span[aria-hidden]');
+    expect(badge?.textContent).toBe('9+'); // 시각 배지는 그대로 '9+'.
+  });
+
+  it('채팅 unread 150건(시각 99+ 표기) — 접근성 이름엔 "99건 이상"', async () => {
+    await mount(0, 150);
+    const chatLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/chats')!;
+    expect(approxAccessibleName(chatLink)).toBe('채팅 읽지 않음 99건 이상');
+    const badge = container.querySelector('span[aria-hidden]');
+    expect(badge?.textContent).toBe('99+');
+  });
+
+  // story #3518(유나 사전 스티어 H, PO 決定) — 결재 sr 문구는 EN에서 "pending approval"
+  // 이라는 셀 수 있는 명사라 ICU plural이 실제로 갈린다(1 vs 그 외). 채팅 "unread"는
+  // 형용사성이라 단수·복수 형태 차이가 없다(그래도 count=1 경계값은 확인).
+  it('[en] 결재 대기 1건 — ICU plural one 갈래("1 pending approval", 단수)', async () => {
+    await mount(1, 0, 'en');
+    const approvalsLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/inbox?tab=gates')!;
+    expect(approxAccessibleName(approvalsLink)).toBe('Approvals 1 pending approval');
+  });
+
+  it('[en] 결재 대기 5건 — ICU plural other 갈래("5 pending approvals", 복수)', async () => {
+    await mount(5, 0, 'en');
+    const approvalsLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/inbox?tab=gates')!;
+    expect(approxAccessibleName(approvalsLink)).toBe('Approvals 5 pending approvals');
+  });
+
+  it('[en] 채팅 unread 1건 — "1 unread"(형태 안 갈림, count=1 경계값 확인)', async () => {
+    await mount(0, 1, 'en');
+    const chatLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/chats')!;
+    expect(approxAccessibleName(chatLink)).toBe('Chat 1 unread');
   });
 });

--- a/apps/web/src/components/nav/mobile-tab-bar-badge.test.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar-badge.test.tsx
@@ -130,7 +130,7 @@ describe('MobileTabBar — 탭 접근성 이름에 카운트 포함(story #3518)
   it('채팅 unread 3건 — 접근성 이름이 «보이는 라벨+수»', async () => {
     await mount(0, 3);
     const chatLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/chats')!;
-    expect(approxAccessibleName(chatLink)).toBe('채팅 읽지 않음 3건');
+    expect(approxAccessibleName(chatLink)).toBe('채팅 안읽음 3건');
   });
 
   it('결재 대기 12건(시각 9+ 표기) — 접근성 이름엔 "9건 이상"(캡을 말로 반영, 시각 캡과 같은 뜻)', async () => {
@@ -144,7 +144,7 @@ describe('MobileTabBar — 탭 접근성 이름에 카운트 포함(story #3518)
   it('채팅 unread 150건(시각 99+ 표기) — 접근성 이름엔 "99건 이상"', async () => {
     await mount(0, 150);
     const chatLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/chats')!;
-    expect(approxAccessibleName(chatLink)).toBe('채팅 읽지 않음 99건 이상');
+    expect(approxAccessibleName(chatLink)).toBe('채팅 안읽음 99건 이상');
     const badge = container.querySelector('span[aria-hidden]');
     expect(badge?.textContent).toBe('99+');
   });

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -144,6 +144,20 @@ export function MobileTabBar({ chatUnreadTotal }: { chatUnreadTotal: number }) {
           : key === 'chat' && chatUnreadTotal > 0
             ? chatUnreadTotal
             : null;
+        // story #3518(유나 사전 스티어, 2026-09-05) — CornerCountBadge는 aria-hidden이라
+        // 그 수를 보조기술에 전하는 책임은 이 링크에 있다(계약은 corner-count-badge.tsx
+        // 주석 참고). ⚠️여기 aria-label을 쓰지 않는다 — 이 탭은 벨/프레즌스와 달리
+        // 보이는 텍스트 라벨("채팅"·"결재")이 이미 있어서, aria-label로 접근성 이름을
+        // 통째로 갈아치우면 그 보이는 라벨이 이름에서 사라진다(WCAG 2.5.3 Label in
+        // Name 위반 — 음성 입력 사용자가 화면에 보이는 말("채팅")로 이 링크를 못
+        // 부른다). 대신 시각 라벨 뒤에 sr-only 텍스트를 덧붙인다 — 보이는 라벨은
+        // 그대로 두고 수만 "더한다". 상한(9+/99+)도 이름에 반영한다(캡 값이 아니라
+        // "그 이상"이라는 사실을 문장으로 — 시각 배지의 캡과 같은 뜻).
+        const srCountText = badge === null
+          ? null
+          : key === 'chat'
+            ? (badge > 99 ? t('chatUnreadSrCapped') : t('chatUnreadSr', { count: badge }))
+            : (badge > 9 ? t('approvalsPendingSrCapped') : t('approvalsPendingSr', { count: badge }));
         return (
           <Link
             key={key}
@@ -168,6 +182,10 @@ export function MobileTabBar({ chatUnreadTotal }: { chatUnreadTotal: number }) {
               ) : null}
             </span>
             {t(labelKey)}
+            {/* story #3518 — 보이는 라벨 뒤에 이어 붙인다(라벨을 갈아치우지 않는다,
+                WCAG 2.5.3). aria-live는 안 붙인다(탭 전환 때마다 안내를 반복하지
+                않는다 — 이 링크에 포커스/진입할 때만 한 번 읽힌다). */}
+            {srCountText ? <span className="sr-only"> {srCountText}</span> : null}
           </Link>
         );
       })}

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -7,6 +7,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
@@ -17,9 +18,10 @@ import type { EventNotification } from './notification-bell';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-function withIntl(node: React.ReactNode) {
+function withIntl(node: React.ReactNode, locale: 'ko' | 'en' = 'ko') {
+  const messages = locale === 'ko' ? koMessages : enMessages;
   return (
-    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
       {node}
     </NextIntlClientProvider>
   );
@@ -457,6 +459,64 @@ describe('NotificationBell — 배지 「99+」 대비(story 3466)', () => {
     expect(badge?.className).toContain('text-[10px]');
     expect(badge?.className).not.toContain('text-[9px]');
     expect(badge?.className).not.toContain('font-mono');
+  });
+
+  // story #3518(유나 사전 스티어 G, 2026-09-05) — 벨 버튼은 아이콘 전용(보이는 텍스트
+  // 라벨이 없다)이라 aria-label로 접근성 이름 전체를 주는 것 자체는 WCAG 2.5.3 문제가
+  // 아니다(mobile-tab-bar와 다른 축 — 그쪽은 보이는 라벨이 있어서 sr-only로 «더하는»
+  // 접근이 필요했다). 여기 결함은 그 값이 badgeLabel('99+' 문자열)이라 100 이상에서
+  // "알림 99+개"처럼 문법이 깨졌던 것 — 원수(unreadCount)+전용 캡 문장으로 고친다.
+  it('⭐unreadCount=3 — aria-label "알림 3개"(원수 그대로, count=1 갈래 포함해 3으로 확인)', async () => {
+    stubUnreadCount(3);
+    await act(async () => { root.render(withIntl(<NotificationBell />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const button = container.querySelector('button[aria-label]');
+    expect(button?.getAttribute('aria-label')).toBe('알림 3개');
+  });
+
+  it('⭐unreadCount=1 — aria-label "알림 1개"(count=1 갈래)', async () => {
+    stubUnreadCount(1);
+    await act(async () => { root.render(withIntl(<NotificationBell />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const button = container.querySelector('button[aria-label]');
+    expect(button?.getAttribute('aria-label')).toBe('알림 1개');
+  });
+
+  it('⭐unreadCount=100(시각 표시 99+) — aria-label "알림 99개 이상"(badgeLabel 문자열이 안 새어든다)', async () => {
+    stubUnreadCount(100);
+    await act(async () => { root.render(withIntl(<NotificationBell />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const button = container.querySelector('button[aria-label]');
+    expect(button?.getAttribute('aria-label')).toBe('알림 99개 이상');
+    expect(button?.getAttribute('aria-label')).not.toContain('99+');
+    const badge = Array.from(container.querySelectorAll('span')).find((s) => s.textContent === '99+');
+    expect(badge).toBeDefined(); // 시각 배지는 그대로 '99+'.
+  });
+
+  // story #3518(유나 사전 스티어 H) — en bellAriaLabelCount는 ICU plural(one/other)
+  // 이라 count=1 갈래가 실제로 갈린다.
+  it('⭐[en] unreadCount=1 — ICU plural one 갈래("1 notification", 단수)', async () => {
+    stubUnreadCount(1);
+    await act(async () => { root.render(withIntl(<NotificationBell />, 'en')); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const button = container.querySelector('button[aria-label]');
+    expect(button?.getAttribute('aria-label')).toBe('1 notification');
+  });
+
+  it('⭐[en] unreadCount=3 — ICU plural other 갈래("3 notifications", 복수)', async () => {
+    stubUnreadCount(3);
+    await act(async () => { root.render(withIntl(<NotificationBell />, 'en')); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const button = container.querySelector('button[aria-label]');
+    expect(button?.getAttribute('aria-label')).toBe('3 notifications');
+  });
+
+  it('⭐[en] unreadCount=100(시각 99+) — "99+ notifications"(고정 문구, badgeLabel 문자열 안 새어듦)', async () => {
+    stubUnreadCount(100);
+    await act(async () => { root.render(withIntl(<NotificationBell />, 'en')); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const button = container.querySelector('button[aria-label]');
+    expect(button?.getAttribute('aria-label')).toBe('99+ notifications');
   });
 
   it('⭐색 계산 양성대조 — globals.css 실값으로 라이트·다크 둘 다 대비비 ≥4.5(WCAG AA)', async () => {

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -511,12 +511,12 @@ describe('NotificationBell — 배지 「99+」 대비(story 3466)', () => {
     expect(button?.getAttribute('aria-label')).toBe('3 notifications');
   });
 
-  it('⭐[en] unreadCount=100(시각 99+) — "99+ notifications"(고정 문구, badgeLabel 문자열 안 새어듦)', async () => {
+  it('⭐[en] unreadCount=100(시각 99+) — "99 or more notifications"(고정 문구, badgeLabel 문자열 안 새어듦)', async () => {
     stubUnreadCount(100);
     await act(async () => { root.render(withIntl(<NotificationBell />, 'en')); });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
     const button = container.querySelector('button[aria-label]');
-    expect(button?.getAttribute('aria-label')).toBe('99+ notifications');
+    expect(button?.getAttribute('aria-label')).toBe('99 or more notifications');
   });
 
   it('⭐색 계산 양성대조 — globals.css 실값으로 라이트·다크 둘 다 대비비 ≥4.5(WCAG AA)', async () => {

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -565,7 +565,15 @@ export function NotificationBell() {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        aria-label={unreadCount > 0 ? t('bellAriaLabelCount', { count: badgeLabel }) : t('panelTitle')}
+        // story #3518(유나 사전 스티어 G, 2026-09-05) — 이름엔 원수(unreadCount)를
+        // 쓴다. 배지 표시(badgeLabel)는 '99+' 문자열이라 그대로 넣으면 "알림 99+개"
+        // 처럼 문법이 어긋난다 — 100 이상은 전용 문장(bellAriaLabelCountCapped)으로
+        // "그 이상"이라는 사실을 말로 낸다(표시 '99+'와 같은 뜻, 다른 표현).
+        aria-label={
+          unreadCount > 0
+            ? (unreadCount > 99 ? t('bellAriaLabelCountCapped') : t('bellAriaLabelCount', { count: unreadCount }))
+            : t('panelTitle')
+        }
         aria-expanded={open}
         className="relative flex size-8 items-center justify-center rounded-md text-foreground/70 transition hover:bg-accent hover:text-foreground"
       >

--- a/apps/web/src/components/ui/corner-count-badge-a11y.guard.test.ts
+++ b/apps/web/src/components/ui/corner-count-badge-a11y.guard.test.ts
@@ -1,0 +1,97 @@
+// story #3518(공용, 유나 #3861 Design 관찰) — CornerCountBadge는 aria-hidden이라 그
+// 수를 보조기술에 전하는 책임은 호출부의 접근성 이름(보통 감싸는 버튼/링크의
+// aria-label)에 있다(계약은 corner-count-badge.tsx 주석 참고). mobile-tab-bar.tsx만
+// 이 계약을 안 지켜 그 수가 스크린리더에 안 갔다(이 스토리의 원인) — 새 소비처가
+// 같은 실수를 하면 이 가드가 잡는다.
+//
+// ⚠️파일 전체에 aria-label이 «어딘가»(예: <nav aria-label=...>) 있는지만 보면 이 스토리의
+// 실제 결함을 못 잡는다 — mobile-tab-bar.tsx는 이 결함이 있던 채로도 이미 nav 랜드마크
+// aria-label을 갖고 있었다(파일 단위 검사로는 통과했을 것). 그래서 이 가드는 각
+// `<CornerCountBadge` 등장 위치의 «가까운 앞뒤 윈도우»에 접근성 이름 배선이 있는지를
+// 잰다 — 완전한 AST 스코프 분석은 아니지만(파서 의존성 추가를 피한다), "파일에 어딘가
+// 존재하는가"보다는 훨씬 좁혀서 «그 배지 자리 근처»를 본다.
+//
+// ⚠️두 배선 방식을 둘 다 인정한다 — ①aria-label(아이콘 전용 소비처, 배지보다 앞서
+// 여는 버튼/링크에 — bell·presence) ②sr-only 텍스트(보이는 라벨이 있는 소비처, WCAG
+// 2.5.3 때문에 aria-label로 못 바꾸고 라벨 뒤에 «더하는» 방식이라 배지보다 뒤에 오는
+// 경우가 많다 — mobile-tab-bar). 그래서 검색창은 배지 앞뒤 «양쪽」 다 본다. 정밀 판정은
+// 소비처별 렌더 테스트(notification-bell.test.tsx §3466·3518, mobile-tab-bar-badge.
+// test.tsx §3518)의 몫 — 이 가드는 "새 소비처가 그 배선 자체를 통째로 빠뜨리는" 가장
+// 흔한 회귀만 잡는다.
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = join(__dirname, '../../');
+// 배지 렌더 지점 앞뒤로 이만큼(문자수) 안에서 접근성 이름 배선을 찾는다 — 이 레포의
+// 세 소비처 모두 그 배선이 배지로부터 최대 수십 줄 안에 있다(관찰값의 3~5배 여유).
+const WINDOW_CHARS = 800;
+const A11Y_WIRING_MARKERS = ['aria-label', 'sr-only'];
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (/\.tsx?$/.test(entry) && !entry.includes('.test.')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const CORNER_COUNT_BADGE_IMPORT = /from ['"]@\/components\/ui\/corner-count-badge['"]/;
+
+function findConsumers(): string[] {
+  return listSourceFiles(SRC_ROOT).filter((f) => CORNER_COUNT_BADGE_IMPORT.test(readFileSync(f, 'utf-8')));
+}
+
+/** 파일 안의 모든 `<CornerCountBadge` 등장 위치 각각에 대해, 그 앞뒤 WINDOW_CHARS
+ * 구간에 접근성 이름 배선(aria-label 또는 sr-only)이 있는지 판정한다. 등장 위치가
+ * 하나도 없으면(import만 하고 실제로는 안 쓰는 죽은 import) 빈 배열. */
+function checkEachUsage(content: string): { index: number; hasNearbyA11yWiring: boolean }[] {
+  const results: { index: number; hasNearbyA11yWiring: boolean }[] = [];
+  const re = /<CornerCountBadge/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const windowStart = Math.max(0, m.index - WINDOW_CHARS);
+    const windowEnd = Math.min(content.length, m.index + WINDOW_CHARS);
+    const window = content.slice(windowStart, windowEnd);
+    results.push({ index: m.index, hasNearbyA11yWiring: A11Y_WIRING_MARKERS.some((marker) => window.includes(marker)) });
+  }
+  return results;
+}
+
+describe('CornerCountBadge 접근성 이름 계약(story #3518) — 소비처 전수', () => {
+  const consumers = findConsumers();
+
+  it('스캔 대상이 비어있지 않다(가드 자체가 죽은 채 항상 통과하는 것 방지)', () => {
+    expect(consumers.length).toBeGreaterThan(0);
+  });
+
+  it('현재 소비처가 정확히 3곳이다(새 소비처가 생기면 이 숫자를 갱신하며 이 가드를 다시 본다)', () => {
+    expect(consumers.map((f) => f.replace(SRC_ROOT, ''))).toEqual(
+      expect.arrayContaining([
+        'components/presence/team-presence-toggle.tsx',
+        'components/nav/notification-bell.tsx',
+        'components/nav/mobile-tab-bar.tsx',
+      ]),
+    );
+    expect(consumers.length).toBe(3);
+  });
+
+  for (const file of findConsumers()) {
+    const relative = file.replace(SRC_ROOT, '');
+    it(`${relative} — <CornerCountBadge 등장 지점마다 그 근처에 접근성 이름 배선(aria-label 또는 sr-only)이 있다`, () => {
+      const content = readFileSync(file, 'utf-8');
+      const usages = checkEachUsage(content);
+      expect(usages.length).toBeGreaterThan(0); // 이 파일이 왜 스캔 대상인지(import만 하고 안 쓰면 죽은 import).
+      for (const usage of usages) {
+        expect(usage.hasNearbyA11yWiring).toBe(true);
+      }
+    });
+  }
+});

--- a/apps/web/src/components/ui/corner-count-badge.tsx
+++ b/apps/web/src/components/ui/corner-count-badge.tsx
@@ -31,6 +31,15 @@ import { cn } from '@/lib/utils';
  *   primary     — info와 동일 토큰(라이트 fg oklch(.985 0 0) 동일·다크 fg 색상각만 262
  *                 vs 250, 값은 사실상 동일) — 별도 재계산 불요
  * (셋 다 AA 4.5 통과 — story c2bb0acd가 destructive를, §3-3 신설이 info/primary를 이미 확保)
+ *
+ * ⚠️접근성 이름 계약(story #3518, 유나 #3861 Design 관찰) — 이 배지는 `aria-hidden`
+ * 이다(스크린리더가 이 <span>을 직접 못 읽는다). 그 수(`value`)를 보조기술에 전하는
+ * 책임은 호출부에 있다 — 가장 가까운 접근성 이름(보통 이 배지를 담은 버튼/링크의
+ * `aria-label`)에 그 수를 넣어야 한다. notification-bell·team-presence-toggle은
+ * 이미 그렇게 한다(`bellAriaLabelCount`·`fabLabelWorking`) — 새 소비처를 추가할
+ * 때 이 자리를 빠뜨리면 그 수는 스크린리더 사용자에게 조용히 사라진다(mobile-
+ * tab-bar가 이 스토리 前까지 그랬다 — content-bff류가 아니라 이 계약 자체가
+ * 문서화 안 돼 있던 것이 원인).
  */
 const cornerCountBadgeVariants = cva(
   'flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold tabular-nums leading-none',


### PR DESCRIPTION
## 요약
story 16548c54(공용·FE·소형, 유나 #3861 Design 관찰) — `CornerCountBadge`가 `aria-hidden`이라 "수는 호출부 접근성 이름이 말한다"가 계약이 됐는데 미문서화. 소비처 3 중 mobile-tab-bar(chat/approvals)만 그 수가 보조기술에 안 갔다.

## 설계(유나 사전 스티어 A~H 전부 반영)
- **탭바는 aria-label이 아니라 sr-only**로 덧붙인다 — 보이는 텍스트 라벨("채팅"·"결재")을 aria-label로 갈아치우면 WCAG 2.5.3(Label in Name) 위반. 벨/프레즌스는 아이콘 전용이라 aria-label이 원래도 안전했다.
- 상한값(9+/99+)도 이름에 반영 — "9건 이상"/"99건 이상"(캡의 사실을 문장으로, 시각 캡과 같은 뜻).
- **벨 자체의 기존 결함도 같은 PR에서 닫음**(PO 決定) — `bellAriaLabelCount`가 `badgeLabel`('99+' 문자열)을 그대로 넣어 100 이상에서 "알림 99+개"처럼 문법이 깨지던 것을 원수(`unreadCount`)+전용 캡 문장(`bellAriaLabelCountCapped`)으로 정정.
- en은 실제로 갈리는 자리만 ICU plural(`notification(s)`·`pending approval(s)` — 셀 수 있는 명사라 갈린다), "unread"는 형태가 안 갈려 plural 불요.
- aria-live 안 붙임(탭 전환마다 반복 안내 방지).

## 검증
tsc/eslint clean · notification-bell.test.tsx 신규 5건(ko count=1/3/100·en ICU plural one/other/capped) · mobile-tab-bar-badge.test.tsx 신규 9건(ko 0/5/3/12/150건·en ICU plural 3건) · 신규 정적 가드(`corner-count-badge-a11y.guard.test.ts`, 소비처 전수 3곳) — 뮤테이션(sr-only 제거→RED) 실제 확인 2회(1회차는 검색창이 배지 "앞"만 봐서 sr-only가 배지 "뒤"에 오는 탭바 패턴을 못 잡던 자기 버그를 발견·수정). i18n 키/충돌 가드 clean · FE 전체 650/6164 green.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>