### PR TITLE
[SID:3514] fix: 단건 GET reject(연결 끊김·abort)가 화면 전체를 막던 결함

### DIFF
--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -127,6 +127,10 @@ function stubFetchWithVersions(
     // 유나 Design 변경요청 1(2026-09-05) — 단건 GET 자체가 실패하는 케이스 재현(기본
     // 200). 부수 데이터라 화면은 그대로 서고 violations=[]+안내 한 줄만 뜬다.
     draftStatus?: number;
+    // 유나 실측 후속(§16-7 2부, 2026-09-05) — "응답은 왔는데 실패"(draftStatus)와
+    // "응답이 안 옴"(연결 끊김·abort, fetchWithAuth 자체가 던짐)은 다른 갈래다. 이
+    // 옵션은 후자 — fetch 자체가 reject한다(HTTP 응답 객체 자체가 없다).
+    draftReject?: boolean;
   },
 ) {
   vi.stubGlobal(
@@ -137,6 +141,9 @@ function stubFetchWithVersions(
       // URL을 접두사로 포함한다(정확 일치 비교라 순서 자체는 무해하지만, 나란히
       // 둬 두 계약이 별개 왕복임을 코드로도 보이게 한다).
       if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}`) {
+        if (opts?.draftReject) {
+          throw new Error('network error');
+        }
         if (opts?.draftStatus && opts.draftStatus >= 400) {
           return { ok: false, status: opts.draftStatus, json: async () => ({ detail: 'boom' }) };
         }
@@ -1530,6 +1537,25 @@ describe('ContentPostEditPage — 콘텐츠 규칙 위반 표시(story #3483, §
     await flush();
 
     expect(container.querySelector('[data-testid="content-rule-violation-load-failed"]')).toBeNull();
+  });
+
+  // story #3514(유나 실측 후속, §16-7 2부, 2026-09-05) — 단건 GET이 "응답은 왔는데
+  // 실패"(4xx/5xx)가 아니라 "응답이 안 옴"(연결 끊김·abort, fetch 자체가 reject)이면
+  // Promise.all에 그대로 섞여 있을 때 전체가 거절돼 loadError로 화면 전체가 막혔었다
+  // (§16-7이 "나란히 부르되 같은 급으로 묶지 않는다"고 정한 것의 위반). 단건 GET만
+  // .catch(() => null)로 격리해 이 갈래도 draftStatus와 동일하게 취급되는지 고정.
+  it('⭐단건 GET reject(네트워크 오류) — 본문은 그대로 뜨고 violations=0+안내 한 줄, loadError 아님', async () => {
+    stubFetchWithVersions([VERSION_1], undefined, undefined, { draftReject: true });
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+
+    const titleInput = container.querySelector('#post-title') as HTMLInputElement | null;
+    expect(titleInput?.value).toBe(VERSION_1.title);
+    expect(container.querySelector('[data-testid="content-rule-violation-title"]')).toBeNull();
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false);
+    expect(container.querySelector('[data-testid="content-rule-violation-load-failed"]')?.textContent)
+      .toBe(koMessages.content.contentRuleViolationsLoadFailed);
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -373,8 +373,16 @@ export default function ContentPostEditPage() {
         // (§16-7 "읽기 자리를 주 데이터와 같은 급으로 묶지 않는다") — violations=[]로
         // 진행하고 violationsLoadFailed 한 줄만 띄운다. 변형(channel_post) 화면은 단건
         // GET이 주 데이터라 그대로 loadError 대상.
+        //
+        // ⚠️유나 실측 후속(2026-09-05, §16-7 2부 정정) — "응답은 왔는데 실패"(4xx/5xx,
+        // res.ok===false)와 "응답이 안 옴"(연결 끊김·abort, fetchWithAuth 자체가 던짐)은
+        // 다른 갈래다. 단건 GET을 Promise.all에 그대로 섞으면 후자에서 Promise.all
+        // 전체가 거절돼(§16-7이 지키려던) 부수 데이터 하나가 «나란히 부르되 같은 급으로
+        // 묶지 않는다»는 원칙을 어기고 화면 전체를 막는다 — 단건 GET만 따로
+        // .catch(() => null)로 받아 실패를 이 fetch 자리에 가둔다(/versions는 그대로
+        // Promise.all 안에 남아 실패 시 loadError).
         const [draftRes, versionsRes] = await Promise.all([
-          fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}`),
+          fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}`).catch(() => null),
           fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}/versions`),
         ]);
         if (cancelled) return;
@@ -382,7 +390,7 @@ export default function ContentPostEditPage() {
           setLoadError(true);
           return;
         }
-        if (draftRes.ok) {
+        if (draftRes?.ok) {
           const draftJson = (await draftRes.json().catch(() => null)) as { data?: SitePostDraftDetail } | null;
           setViolations(draftJson?.data?.violations ?? []);
           setViolationsLoadFailed(false);


### PR DESCRIPTION
## 요약
3514 후속(유나 실측, §16-7 2부 정정, 2026-09-05) — "응답은 왔는데 실패"(4xx/5xx)와 "응답이 안 옴"(연결 끊김·abort, fetchWithAuth 자체가 던짐)은 다른 갈래다. 앞 갈래는 #3859에서 이미 고쳤지만, 뒤 갈래는 단건 GET이 `Promise.all`에 그대로 섞여 있어 그 자리에서 reject하면 전체가 거절돼 화면 전체가 막혔다.

## 변경
단건 GET 호출만 `.catch(() => null)`로 격리 — `draftRes?.ok`로 null-safe 판정. `/versions`는 그대로 `Promise.all` 안에 남아 실패 시 loadError(주 데이터라 원래 맞다).

## 검증
신규 렌더테스트 1건(단건 GET reject → 제목 정상+violations=[]+안내문구, loadError 아님) — 뮤테이션(.catch 제거)으로 RED 재현 후 원복 확인. tsc/eslint clean · FE 전체 649/6146 green.

배포 31은 이 PR을 안 기다림(다음 회차).

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>