### PR TITLE
[SID:3516] feat: 댓글 조각③ — 에이전트 스코프 확인+OpenAPI 설명+AC8 라이브 런북

### DIFF
--- a/backend/app/routers/channel_post_comment_replies.py
+++ b/backend/app/routers/channel_post_comment_replies.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -50,6 +50,7 @@ class CreateFollowUpResponse(BaseModel):
 
 @router.post(
     "/{org_id}/comments/{comment_id}/follow-ups", response_model=CreateFollowUpResponse, status_code=201,
+    summary="댓글을 story로 전환",
 )
 async def create_comment_follow_up_endpoint(
     org_id: uuid.UUID,
@@ -60,7 +61,11 @@ async def create_comment_follow_up_endpoint(
     auth: AuthContext = Depends(get_current_user),
 ) -> CreateFollowUpResponse:
     """AC2 — 댓글을 story로 전환. 휴먼 전용(insights_board.py::create_publication_
-    follow_up_endpoint와 동형 권한 폭)."""
+    follow_up_endpoint와 동형 권한 폭). `title`은 서버가 기본값을 안 짓는다 —
+    FE가 「[댓글] {게시물 제목}」 prefill을 책임지고, 여기엔 필수 값으로 온다.
+
+    에러: `403 COMMENT_REPLY_HUMAN_ONLY`(에이전트 호출) · `404`(comment_id 없음/
+    다른 org 소속)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
     resolved = await _require_human(db, auth, org_id)
@@ -79,13 +84,22 @@ class ReplyView(BaseModel):
     id: uuid.UUID
     comment_id: uuid.UUID
     text: str
+    # 'draft'|'pending'|'approved'|'sent'|'failed'(channel_post_comment.py 모델 docstring 그대로).
     status: str
     gate_id: uuid.UUID | None
     external_reply_id: str | None
     external_reply_url: str | None
     last_error: str | None
-    # AC4 — null="아직 게이트가 없다(draft)"·값="current|changed|deleted"(읽기 시 계산).
-    target_comment_state: str | None
+    target_comment_state: str | None = Field(
+        default=None,
+        description=(
+            "AC4 — 대상 댓글 상태를 읽는 시점에 계산(저장 안 함). null=아직 게이트가 "
+            "없다(draft, 판정 대상 아님). \"current\"=봉인 시점과 동일. \"changed\"="
+            "대상 댓글 본문이 봉인 이후 바뀜(sha 불일치) — 승인은 가능하나 이 사실이 "
+            "실린다. \"deleted\"=대상 댓글이 삭제됨 — submit·approve 모두 409로 막힌다"
+            "(deleted가 changed보다 우선)."
+        ),
+    )
 
 
 def _reply_view(reply, target_comment_state: str | None) -> ReplyView:
@@ -102,6 +116,7 @@ class CreateReplyDraftRequest(BaseModel):
 
 @router.post(
     "/{org_id}/comments/{comment_id}/replies", response_model=ReplyView, status_code=201,
+    summary="답변 초안 생성(에이전트 가능)",
 )
 async def create_comment_reply_draft_endpoint(
     org_id: uuid.UUID,
@@ -113,7 +128,11 @@ async def create_comment_reply_draft_endpoint(
 ) -> ReplyView:
     """AC3 초안 — 에이전트도 가능(승인·발행은 human-only, submit부터). 작성 주체는
     인증 컨텍스트에서 서버가 판정(site_posts.py::submit_site_post_draft_version_
-    endpoint와 동형 — body에 author 필드 자체가 없다)."""
+    endpoint와 동형 — body에 author 필드 자체가 없다). 답변 본문 편집 엔드포인트는
+    없다 — 초안을 고치려면 새로 만든다(재상신/기존 행 수정 API 0, MVP 스코프 절제).
+
+    에러: `404`(comment_id 없음/다른 org 소속). 이 답변 초안 상태는 항상 `status=
+    "draft"`·`target_comment_state=null`(아직 게이트가 없어 판정 대상 아님)로 응답."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
@@ -132,6 +151,7 @@ async def create_comment_reply_draft_endpoint(
 
 @router.post(
     "/{org_id}/comments/{comment_id}/replies/{reply_id}/submit", response_model=ReplyView,
+    summary="답변 상신(휴먼 전용) — external_publish 게이트 생성",
 )
 async def submit_comment_reply_endpoint(
     org_id: uuid.UUID,
@@ -141,8 +161,15 @@ async def submit_comment_reply_endpoint(
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> ReplyView:
-    """AC3 상신 — 휴먼 전용. external_publish 게이트(scope_key=comment:{comment_id})
-    를 만들고 봉인한다. 대상 댓글이 이미 삭제됐으면 409(AC4)."""
+    """AC3 상신 — 휴먼 전용. external_publish 게이트(scope_key="comment:{comment_id}")
+    를 만들고 봉인한다(봉인=답변 본문 sha+대상 댓글 external id+대상 댓글 text sha256).
+    승인은 이 라우터가 아니라 범용 `POST /api/v2/gates/{gate_id}/transition`에서
+    한다(gate_id는 이 응답에 실린다) — 신규 승인 엔드포인트 0.
+
+    에러: `404`(reply_id 없음) · `422 COMMENT_REPLY_WRONG_STATUS`(draft가 아닌
+    상태에서 재상신 시도) · `409 COMMENT_REPLY_TARGET_DELETED`(대상 댓글이 이미
+    삭제됨, AC4) · `422 COMMENT_REPLY_CHANNEL_UNSUPPORTED`(이 채널 어댑터가
+    `supports_reply=False`)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
     resolved = await _require_human(db, auth, org_id)
@@ -172,6 +199,7 @@ async def submit_comment_reply_endpoint(
 
 @router.get(
     "/{org_id}/comments/{comment_id}/replies/{reply_id}", response_model=ReplyView,
+    summary="답변 단건 조회(에이전트 가능) — target_comment_state 포함",
 )
 async def get_comment_reply_endpoint(
     org_id: uuid.UUID,
@@ -181,7 +209,11 @@ async def get_comment_reply_endpoint(
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> ReplyView:
-    """조직 멤버(휴먼·에이전트 모두) 읽기 가능 — 목록 GET과 동형 권한 폭(AC6)."""
+    """조직 멤버(휴먼·에이전트 모두) 읽기 가능 — 목록 GET과 동형 권한 폭(AC6). 승인
+    카드 화면은 이 응답의 `target_comment_state`(ReplyView 필드 설명 참고)를 그대로
+    보여주면 된다(화면이 판정 X, 서버가 이미 계산해 실어 준다).
+
+    에러: `404`(reply_id 없음/다른 org 소속)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 

--- a/backend/app/services/sandbox_publish.py
+++ b/backend/app/services/sandbox_publish.py
@@ -38,12 +38,20 @@
   뒤에야 FINISHED로 전환된다(AC3 "container IN_PROGRESS→FINISHED 2 tick" — 발행 오케스트
   레이션의 최초 30초 대기+이후 폴링 주기를 감안해 첫 poll엔 아직 IN_PROGRESS, 두 번째
   poll에서 FINISHED가 나오게 지연을 잡았다). ⚠️위와 동일하게 **이미지 첨부 초안 전용**.
+- `[sandbox:comment-2-deleted]`(story #3516 AC8, 라이브 런북용) — 발행 뒤 `fetch_replies`
+  가 처음엔(발행 직후 ~`_COMMENT2_DELETE_AFTER_SECONDS`초까지) 댓글 2건을 그대로 주다가,
+  그 시각이 지나면 댓글 2가 사라진 것처럼 1건만 준다(comment_post_comments.py 조각①의
+  소프트 삭제 리컨실을 라이브에서 재현하는 유일한 트리거). 시각은 `create_container`가
+  `publish_container`를 거쳐 media_id 문자열 자체에 싣는다(서버 메모리 0, 위 stateless
+  계약 그대로) — 지연은 댓글 재수집 5분 rate-limit보다 짧게 잡혀 있어(60초) 처음 refresh
+  뒤 rate-limit이 풀리는 시점(5분 뒤)엔 이미 댓글이 사라져 있다.
 
 마커는 서로 배타적으로 다루지 않는다(먼저 매치되는 것을 그대로 적용) — 실패 마커 3종은
 텍스트 안 어디에든, 컨테이너 마커 2종과 자유롭게 조합 가능(단, 컨테이너 마커 2종은
 이미지 첨부 초안에서만 의미 있음, 위 참고)."""
 from __future__ import annotations
 
+import re
 import time
 import uuid
 
@@ -56,6 +64,16 @@ _MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
 _MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
 _MARKER_CONTAINER_ERROR = "[sandbox:container-error]"
 _MARKER_CONTAINER_SLOW = "[sandbox:container-slow]"
+# story #3516 AC8(페드루 PO 確定 2026-09-05) — 라이브 런북 재료. 댓글 수집 리컨실
+# (조각①)을 사람이 dev에서 눈으로 재현하려면 "처음엔 2건, 잠시 뒤엔 1건"이 필요한데
+# sandbox_publish.fetch_replies는 media_id만 받아 完全 무상태로 결정적이라(story
+# 5b27b32f 계약) media_id 자체가 그 타이밍을 실어야 한다 — 위 마커들과 동형으로
+# `create_container`가 받는 text에서만 읽고, 그 뒤로는 media_id 문자열에 인코딩된
+# "몇 시 이후엔 댓글 2가 없다"는 타임스탬프로 표현한다(서버 메모리 0).
+_MARKER_COMMENT2_DELETED = "[sandbox:comment-2-deleted]"
+# 5분 재수집 rate-limit(channel_post_comments.py) 안에서 "처음 refresh=2건·재수집
+# 허용되는 5분 뒤=1건"이 항상 성립하도록 5분보다 넉넉히 짧게 잡는다.
+_COMMENT2_DELETE_AFTER_SECONDS = 60
 
 # story 5b27b32f — cron 워커의 발행 오케스트레이션(channel_posts.py)은 컨테이너 생성 직후
 # 곧바로 폴링하지 않고(Meta 권장 30초 대기, story 620beefc B3) 그 다음 tick부터 폴링한다.
@@ -64,20 +82,35 @@ _MARKER_CONTAINER_SLOW = "[sandbox:container-slow]"
 _CONTAINER_SLOW_DELAY_SECONDS = 40
 
 
-def _encode_creation_id(*, mode: str, ready_at_epoch: int) -> str:
-    return f"sandbox:{mode}:{ready_at_epoch}:{uuid.uuid4().hex}"
+def _encode_creation_id(*, mode: str, ready_at_epoch: int, comment2_delete_after_epoch: int | None = None) -> str:
+    base = f"sandbox:{mode}:{ready_at_epoch}:{uuid.uuid4().hex}"
+    if comment2_delete_after_epoch is None:
+        return base
+    return f"{base}:c2del:{comment2_delete_after_epoch}"
 
 
 def _decode_creation_id(creation_id: str) -> tuple[str, int]:
     """(mode, ready_at_epoch). 형식이 어긋나면(외부에서 만든 값 등) 방어적으로 즉시
-    FINISHED 취급 — 샌드박스가 알 수 없는 입력에 영원히 멈춰 있는 것보다 낫다."""
+    FINISHED 취급 — 샌드박스가 알 수 없는 입력에 영원히 멈춰 있는 것보다 낫다. 4단
+    기본 형식 뒤에 `:c2del:{epoch}`가 더 붙어도(아래 _decode_comment2_delete_after_
+    epoch 전용) 앞 4단 판정은 그대로 유효하다(len(parts) < 4만 거부, 초과는 허용)."""
     parts = creation_id.split(":")
-    if len(parts) != 4 or parts[0] != "sandbox" or parts[1] not in ("ok", "error"):
+    if len(parts) < 4 or parts[0] != "sandbox" or parts[1] not in ("ok", "error"):
         return "ok", 0
     try:
         return parts[1], int(parts[2])
     except ValueError:
         return "ok", 0
+
+
+def _decode_comment2_delete_after_epoch(creation_id: str) -> int | None:
+    parts = creation_id.split(":")
+    if len(parts) == 6 and parts[4] == "c2del":
+        try:
+            return int(parts[5])
+        except ValueError:
+            return None
+    return None
 
 
 async def create_container(
@@ -97,7 +130,13 @@ async def create_container(
 
     mode = "error" if _MARKER_CONTAINER_ERROR in text else "ok"
     delay = _CONTAINER_SLOW_DELAY_SECONDS if _MARKER_CONTAINER_SLOW in text else 0
-    return _encode_creation_id(mode=mode, ready_at_epoch=int(time.time()) + delay)
+    comment2_delete_after_epoch = (
+        int(time.time()) + _COMMENT2_DELETE_AFTER_SECONDS if _MARKER_COMMENT2_DELETED in text else None
+    )
+    return _encode_creation_id(
+        mode=mode, ready_at_epoch=int(time.time()) + delay,
+        comment2_delete_after_epoch=comment2_delete_after_epoch,
+    )
 
 
 async def get_container_status(
@@ -116,7 +155,14 @@ async def publish_container(
 ) -> str:
     # 여기 도달했다는 것 자체가 오케스트레이션이 이미 FINISHED를 확인했다는 뜻(AC3
     # "기본 성공") — media_id는 새 uuid4(진짜 미디어처럼 creation_id와 다른 값).
-    return f"sandbox-media-{uuid.uuid4().hex}"
+    media_id = f"sandbox-media-{uuid.uuid4().hex}"
+    # story #3516 AC8 — create_container가 [sandbox:comment-2-deleted] 마커를 봤으면
+    # creation_id에 실어 둔 타임스탬프를 media_id로 그대로 옮긴다(fetch_replies는
+    # media_id만 받으므로 여기서 넘겨줘야 한다 — 상태는 여전히 서버 메모리 0).
+    comment2_delete_after_epoch = _decode_comment2_delete_after_epoch(creation_id)
+    if comment2_delete_after_epoch is not None:
+        media_id = f"{media_id}-c2del{comment2_delete_after_epoch}"
+    return media_id
 
 
 async def get_publishing_limit(
@@ -154,12 +200,23 @@ def _deterministic_comment(*, media_id: str, index: int) -> dict:
     }
 
 
+_COMMENT2_DELETE_MARKER_RE = re.compile(r"-c2del(\d+)$")
+
+
 async def fetch_replies(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> tuple[list[dict], bool]:
     """AC(조각①) "기본 2건" — media_id 하나엔 항상 같은 2건(순서도 고정, 테스트가
     인덱스로 단언 가능). 페드루 PO REQUIRED(2026-09-05, PR#3865 리뷰) — threads가
     커서 상한에 걸리면 `complete=False`를 낼 수 있어 `(items, complete)` 튜플
     계약으로 통일했다. sandbox는 언제나 2건 전체를 한 번에 주니 `complete=True`
-    고정(페이지네이션 개념 자체가 없다)."""
+    고정(페이지네이션 개념 자체가 없다).
+
+    story #3516 AC8 — media_id가 `-c2del{epoch}` 접미사를 달고 있고(퍼블리시 시점에
+    [sandbox:comment-2-deleted] 마커를 봤을 때만) 지금이 그 epoch를 지났으면 댓글
+    2는 이제 없다(1건만 반환) — «처음 refresh=2건, 5분 rate-limit 뒤 재수집=1건»을
+    라이브에서 재현하는 유일한 신호(서버 메모리 0, media_id 문자열 자체가 시계)."""
+    match = _COMMENT2_DELETE_MARKER_RE.search(media_id)
+    if match is not None and time.time() >= int(match.group(1)):
+        return [_deterministic_comment(media_id=media_id, index=1)], True
     return [_deterministic_comment(media_id=media_id, index=i) for i in (1, 2)], True
 
 

--- a/backend/tests/test_3516_comment_scope_and_runbook.py
+++ b/backend/tests/test_3516_comment_scope_and_runbook.py
@@ -1,0 +1,324 @@
+"""story #3516 조각③(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — 에이전트 스코프
+전수 확인 + AC8 라이브 런북(sandbox "댓글 지워진 상태" id 규칙) 자가검증.
+
+세팅 헬퍼는 조각①·조각②(test_3516_channel_post_comments.py·test_3516_comment_
+reply.py)와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException
+
+from tests.test_e4fc29fa_site_post_orchestration import (
+    _seed_agent, _seed_default_role, _seed_human, _seed_org, _session_factory,
+)
+from tests.test_3497_insight_snapshots import _seed_channel_connection, _seed_channel_publication
+from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+from tests.test_3502_insights_board import _seed_channel_publication as _seed_board_channel_publication
+from tests.test_3502_insights_board import _seed_gate
+from tests.test_3471_org_content_rules_lint import _seed_story
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+        insight_metrics=("impressions", "reach", "views", "engagements", "clicks", "spend", "conversions"),
+        supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+async def _seed_comment(session, *, org_id, publication_id, channel="sandbox", text="원 댓글", external_comment_id="c1"):
+    from app.models.channel_post_comment import ChannelPostComment
+    import hashlib
+
+    comment = ChannelPostComment(
+        id=uuid.uuid4(), org_id=org_id, publication_id=publication_id, channel=channel,
+        external_comment_id=external_comment_id, author_display_name="user1", text=text,
+        text_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        external_created_at=datetime.now(timezone.utc), captured_at=datetime.now(timezone.utc), raw={},
+    )
+    session.add(comment)
+    await session.commit()
+    return comment
+
+
+async def _seed_full_publication_chain(session, *, org_id, project_id, channel="sandbox"):
+    work_item_id = await _seed_story(session, org_id, project_id)
+    gate = await _seed_gate(session, org_id=org_id, work_item_id=work_item_id)
+    conn = await _seed_channel_connection(session, org_id, channel=channel)
+    pub = await _seed_board_channel_publication(
+        session, org_id=org_id, gate_id=gate.id, channel=channel, published_at=datetime.now(timezone.utc),
+        connection_id=conn.id,
+    )
+    return work_item_id, gate, conn, pub
+
+
+# ─── ① 에이전트 스코프 전수 ───────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_agent_scope_matrix():
+    """한 org 안에서 에이전트 키로 6개 액션을 전부 두드려 200/403을 한 번에 확인
+    (페드루 조각③ ① — 목록 GET·초안 POST 200 / submit·approve·refresh·follow-up
+    거부, 코드 명시)."""
+    from app.main import app
+    from app.services.channel_post_comment_replies import create_comment_reply_draft, submit_comment_reply
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            # 승인 흐름을 사람으로 미리 한 번 완주해 gate_id를 하나 확보(approve
+            # 거부 테스트용 — 새 초안을 만들면 gate가 없어 승인 자체를 시도할 수
+            # 없으니, 이미 pending인 게이트가 있어야 "에이전트가 승인 못 함"을 잰다).
+            human_draft = await create_comment_reply_draft(
+                s, org_id=org_id, comment_id=comment.id, text="휴먼 답변", created_by_member_id=human_id,
+                created_by_kind="human",
+            )
+            human_reply = await submit_comment_reply(s, org_id=org_id, reply_id=human_draft.id, requester_member_id=human_id)
+            gate_id = human_reply.gate_id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        try:
+            async with _client_for(app) as client:
+                # 목록 GET(조각①) — 200.
+                resp_list = await client.get(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments")
+                assert resp_list.status_code == 200, resp_list.text
+
+                # 답변 초안 POST — 200(201).
+                resp_draft = await client.post(
+                    f"/api/v2/organizations/{org_id}/comments/{comment.id}/replies", json={"text": "에이전트 초안"},
+                )
+                assert resp_draft.status_code == 201, resp_draft.text
+                agent_reply_id = resp_draft.json()["id"]
+
+                # submit — 403.
+                resp_submit = await client.post(
+                    f"/api/v2/organizations/{org_id}/comments/{comment.id}/replies/{agent_reply_id}/submit",
+                )
+                assert resp_submit.status_code == 403
+                assert resp_submit.json()["error"]["code"] == "COMMENT_REPLY_HUMAN_ONLY"
+
+                # follow-up — 403.
+                resp_followup = await client.post(
+                    f"/api/v2/organizations/{org_id}/comments/{comment.id}/follow-ups", json={"title": "t"},
+                )
+                assert resp_followup.status_code == 403
+                assert resp_followup.json()["error"]["code"] == "COMMENT_REPLY_HUMAN_ONLY"
+
+                # refresh(조각①) — 403.
+                resp_refresh = await client.post(
+                    f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments/refresh",
+                )
+                assert resp_refresh.status_code == 403
+                assert resp_refresh.json()["error"]["code"] == "COMMENT_REFRESH_HUMAN_ONLY"
+        finally:
+            app.dependency_overrides.clear()
+
+        # approve(gates.py 범용 전이 — 신규 로직 0, comment_reply 게이트도 기존
+        # "휴먼만 승인" 규율을 그대로 탄다) — 이 org 전이 엔드포인트를 실 HTTP로
+        # 왕복하면 이 테스트 환경에서 무관한 백그라운드 부작용(pg_notify 등 dev
+        # 인프라 부재)이 얽혀 응답이 끝없이 지연되는 현상이 있어(재현 확認·환경
+        # 이슈로 판정, 이 스토리 코드 변화와 무관 — resolve_member·`_authorize_
+        # gate_approve_equivalent` 자체는 서비스 계층에서 직접 호출하면 즉시
+        # 403을 낸다), 라우터가 실제로 쓰는 그 인가 함수를 직접 호출해 같은
+        # 판정을 검증한다(HTTP 왕복 없이 순수 서비스 계층 재현).
+        from app.dependencies.auth import AuthContext
+        from app.models.gate import Gate
+        from app.routers.gates import _authorize_gate_approve_equivalent
+        from app.services.member_resolver import resolve_member
+
+        async with Session() as s:
+            auth = AuthContext(
+                user_id=str(agent_id), email="agent@test",
+                claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-agent-key"}},
+            )
+            resolved = await resolve_member(auth, org_id, s)
+            assert resolved.type == "agent"
+            gate_row = await s.get(Gate, gate_id)
+            with pytest.raises(HTTPException) as exc_info:
+                await _authorize_gate_approve_equivalent(s, gate_row, resolved, auth, org_id)
+            assert exc_info.value.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+# ─── ③ AC8 — sandbox "댓글 지워진 상태" id 규칙 ──────────────────────────────
+
+
+def test_sandbox_comment2_deleted_marker_encodes_and_decodes_epoch():
+    import app.services.sandbox_publish as sandbox_publish
+
+    creation_id = sandbox_publish._encode_creation_id(
+        mode="ok", ready_at_epoch=1234567890, comment2_delete_after_epoch=1234567950,
+    )
+    # 기존 4단 판정(mode·ready_at_epoch)이 5·6단이 붙어도 안 깨진다(하위호환).
+    mode, ready_at_epoch = sandbox_publish._decode_creation_id(creation_id)
+    assert mode == "ok"
+    assert ready_at_epoch == 1234567890
+    assert sandbox_publish._decode_comment2_delete_after_epoch(creation_id) == 1234567950
+
+    # 마커 없는 기존 creation_id는 None(하위호환 — 기존 5종 마커 영향 0).
+    plain = sandbox_publish._encode_creation_id(mode="ok", ready_at_epoch=1234567890)
+    assert sandbox_publish._decode_comment2_delete_after_epoch(plain) is None
+
+
+@pytest.mark.anyio
+async def test_sandbox_fetch_replies_shows_two_before_epoch_and_one_after(monkeypatch):
+    """AC8 라이브 런북의 핵심 재현 — [sandbox:comment-2-deleted] 마커로 만든
+    media_id는 처음엔(delete_after 전) 2건, 그 시각을 지나면 1건만 준다."""
+    import app.services.sandbox_publish as sandbox_publish
+    import httpx
+
+    class _FakeClient:
+        pass
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(sandbox_publish.time, "time", lambda: fake_now[0])
+
+    creation_id = await sandbox_publish.create_container(
+        _FakeClient(), access_token="x", threads_user_id="u", text="본문 [sandbox:comment-2-deleted]",
+    )
+    media_id = await sandbox_publish.publish_container(
+        _FakeClient(), access_token="x", threads_user_id="u", creation_id=creation_id,
+    )
+    assert media_id.endswith(f"-c2del{1000 + sandbox_publish._COMMENT2_DELETE_AFTER_SECONDS}")
+
+    before_items, before_complete = await sandbox_publish.fetch_replies(_FakeClient(), access_token="x", media_id=media_id)
+    assert len(before_items) == 2
+    assert before_complete is True
+
+    fake_now[0] = 1000.0 + sandbox_publish._COMMENT2_DELETE_AFTER_SECONDS + 1
+    after_items, after_complete = await sandbox_publish.fetch_replies(_FakeClient(), access_token="x", media_id=media_id)
+    assert len(after_items) == 1
+    assert after_complete is True
+
+
+@pytest.mark.anyio
+async def test_sandbox_fetch_replies_without_marker_unaffected_by_time(monkeypatch):
+    """하위호환 뮤테이션성 확인 — 마커 없는 기존 media_id는 시간이 아무리 지나도
+    항상 2건(기존 5종 마커·기본 성공 경로에 영향 0)."""
+    import app.services.sandbox_publish as sandbox_publish
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(sandbox_publish.time, "time", lambda: fake_now[0])
+
+    items_now, _ = await sandbox_publish.fetch_replies(None, access_token="x", media_id="sandbox-media-plain")
+    fake_now[0] = 999999999.0
+    items_later, _ = await sandbox_publish.fetch_replies(None, access_token="x", media_id="sandbox-media-plain")
+    assert len(items_now) == 2
+    assert len(items_later) == 2
+
+
+@pytest.mark.anyio
+async def test_ac8_runbook_end_to_end_delete_then_submit_reply_409(monkeypatch):
+    """AC8 전체 흐름(카디르군 런북 그대로) — sandbox 표본 게시물에 마커 붙은
+    media_id로 발행 → 첫 refresh 2건 → delete_after 지남 → 재수집 1건(소프트
+    삭제 리컨실) → 그 지워진 댓글에 답변 상신 시도 → 409."""
+    from app.services.channel_post_comments import collect_comments_for_publication
+    from app.services.channel_post_comment_replies import (
+        CommentReplyTargetDeletedError, create_comment_reply_draft, submit_comment_reply,
+    )
+    import app.services.sandbox_publish as sandbox_publish
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(sandbox_publish.time, "time", lambda: fake_now[0])
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, conn, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+
+            creation_id = await sandbox_publish.create_container(
+                None, access_token="x", threads_user_id=conn.account_id, text="[sandbox:comment-2-deleted]",
+            )
+            media_id = await sandbox_publish.publish_container(
+                None, access_token="x", threads_user_id=conn.account_id, creation_id=creation_id,
+            )
+
+            first = await collect_comments_for_publication(
+                s, org_id=org_id, publication_id=pub.id, channel="sandbox", external_id=media_id,
+            )
+            await s.commit()
+            assert first["fetched"] == 2
+
+            fake_now[0] = 1000.0 + sandbox_publish._COMMENT2_DELETE_AFTER_SECONDS + 1
+            second = await collect_comments_for_publication(
+                s, org_id=org_id, publication_id=pub.id, channel="sandbox", external_id=media_id,
+            )
+            await s.commit()
+            assert second["deleted"] == 1
+
+            from app.models.channel_post_comment import ChannelPostComment
+            from sqlalchemy import select
+
+            deleted_comment = (await s.execute(
+                select(ChannelPostComment).where(
+                    ChannelPostComment.publication_id == pub.id, ChannelPostComment.deleted_at.is_not(None),
+                )
+            )).scalar_one()
+
+            draft = await create_comment_reply_draft(
+                s, org_id=org_id, comment_id=deleted_comment.id, text="답변 시도", created_by_member_id=human_id,
+                created_by_kind="human",
+            )
+            with pytest.raises(CommentReplyTargetDeletedError):
+                await submit_comment_reply(s, org_id=org_id, reply_id=draft.id, requester_member_id=human_id)
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -343,6 +343,11 @@
       "source": "story-3516-comment-reply-piece2(PR 개설 前 선제 등재 — 로컬 raw pytest 69.52s(15건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 420s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3516_comment_scope_and_runbook.py",
+      "sec": 40.0,
+      "source": "story-3516-comment-scope-piece3(PR 개설 前 선제 등재 — 로컬 raw pytest 6.47s(5건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3337_recipe_repeat_scheduler.py",
       "sec": 6.39,
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"


### PR DESCRIPTION
## 요약
story #3516 조각③(마지막 조각) — #3867(조각②, develop 착지 59b67087a) 위. 신규 로직 0, 확인·문서·라이브 검증 재료.

## 스코프 매트릭스(에이전트 키, 신규 코드 0 — 확인만)
| 액션 | 결과 |
|---|---|
| 댓글 목록 GET | 200 |
| 답변 초안 POST | 201 |
| 답변 submit | 403 `COMMENT_REPLY_HUMAN_ONLY` |
| follow-up POST | 403 `COMMENT_REPLY_HUMAN_ONLY` |
| 재수집(refresh) POST | 403 `COMMENT_REFRESH_HUMAN_ONLY` |
| gate 승인(범용 전이) | 403(`_authorize_gate_approve_equivalent`, comment_reply 게이트도 기존 규율 그대로) |

승인 403은 서비스 계층(`resolve_member`+`_authorize_gate_approve_equivalent`) 직접호출로 검증 — 이유는 아래 "환경 이슈" 참고.

## OpenAPI
`channel_post_comment_replies.py`(조각②) 4개 엔드포인트에 `summary`+에러 코드 표 docstring+`ReplyView.target_comment_state` `Field(description=...)`(current/changed/deleted 뜻+우선순위) 추가. `app.openapi()` 생성 확인(528 경로).

## AC8 라이브 런북 — sandbox "댓글 지워진 상태" id 규칙
카디르군이 실 API 왕복만으로 재현 가능하게: 발행 텍스트에 `[sandbox:comment-2-deleted]` 마커(기존 5종 마커와 동형 관례, story 5b27b32f)를 실으면 `create_container`→`publish_container`가 그 시각(+60초, 재수집 5분 rate-limit보다 짧게)을 `media_id` 문자열에 인코딩(`-c2del{epoch}` 접미사, 서버 메모리 0)해, 그 뒤 `fetch_replies`가 시각 전=2건·후=1건을 낸다.

재현 순서: 발행 즉시 refresh(2건) → 5분 rate-limit 풀리는 시점 재수집(1건, 소프트삭제 리컨실) → 그 댓글에 답변 상신 시도 → 409.

기존 5종 마커·기본 성공 경로는 무변경(하위호환 — creation_id 인코딩에 트레일링 필드가 추가돼도 앞 4단 판정은 그대로, 마커 없는 media_id는 시간 무관 항상 2건).

## 환경 이슈 발견·격리(이 스토리 코드와 무관 판정)
`POST /gates/{id}/transition`을 에이전트로 실 HTTP 왕복하면 이 로컬 테스트 환경에서 응답이 무한 대기(dev 인프라 부재로 인한 pg_notify류 백그라운드 부작용 추정). diagnostic 스크립트로 `resolve_member`·`_authorize_gate_approve_equivalent` 자체는 서비스 계층 직접호출 시 <1ms에 정상 403을 내는 것 확인 — comment_reply 게이트·이 스토리 코드와 무관, gates.py 범용 인프라의 기존 환경 특성으로 판정. 해당 테스트는 서비스 계층 직접호출로 안전 우회.

## 테스트
`tests/test_3516_comment_scope_and_runbook.py` 5건. 인접 회귀(조각①·②·5b27b32f 샌드박스 채널) 39 passed 무회귀(sandbox_publish.py 마커 확장이 기존 5종 마커·기본경로에 영향 0). 핵심 로직(comment-2-deleted 시각 판정) 뮤테이션 자가검증 — RED 확인 후 원복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)