### PR TITLE
[SID:3519] fix: Promise.all 부수 leg 격리 10곳 + 정적 가드

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.test.tsx
@@ -47,10 +47,24 @@ function wrap(node: React.ReactNode) {
   );
 }
 
-function stubFetch(sprints: unknown[]) {
+function stubFetch(sprints: unknown[], opts: {
+  burndownReject?: boolean;
+  sprintStories?: unknown[];
+  backlogStories?: unknown[];
+} = {}) {
   vi.stubGlobal('fetch', vi.fn(async (url: string) => {
     if (typeof url === 'string' && url.includes('/api/sprints?project_id=')) {
       return { ok: true, json: async () => ({ data: sprints }) };
+    }
+    if (typeof url === 'string' && url.includes('/burndown')) {
+      if (opts.burndownReject) throw new Error('network down');
+      return { ok: false, json: async () => null };
+    }
+    if (typeof url === 'string' && url.includes('/api/stories/backlog')) {
+      return { ok: true, json: async () => ({ data: opts.backlogStories ?? [] }) };
+    }
+    if (typeof url === 'string' && url.includes('/api/stories?')) {
+      return { ok: true, json: async () => ({ data: opts.sprintStories ?? [] }) };
     }
     return { ok: false, json: async () => null };
   }));
@@ -129,6 +143,28 @@ describe('SprintsClient — 스프린트 first-touch 정체성', () => {
     expect(row).not.toBeUndefined();
     await act(async () => { row!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(container.querySelector('button[aria-label="스프린트 삭제"]')).toBeNull();
+  });
+});
+
+// story #3519(§16-7 2부, PO 確定 2026-09-05) — loadSprintDetail의 burndown/sprintStories/
+// backlogStories 3legs 전부 부수인데 catch가 어디에도 없어, 하나가 네트워크단 reject하면
+// Promise.all 전체가 던져 나머지 둘도 조용히 못 채워졌다(에러 표시 0).
+describe('SprintsClient — 스프린트 상세 Promise.all 격리(story #3519)', () => {
+  it('burndown이 네트워크 reject해도 sprintStories·backlogStories는 그대로 채워진다', async () => {
+    stubFetch(
+      [{ id: 's1', title: 'Sprint 1', status: 'planning', start_date: '2026-07-01', end_date: '2026-07-14' }],
+      {
+        burndownReject: true,
+        sprintStories: [{ id: 'st1', title: '스프린트 스토리', story_points: 3 }],
+        backlogStories: [{ id: 'st2', title: '백로그 스토리' }],
+      },
+    );
+    await mount();
+    const row = [...container.querySelectorAll('li')].find((li) => li.textContent?.includes('Sprint 1'));
+    await act(async () => { row!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('스프린트 스토리');
+    expect(container.textContent).toContain('백로그 스토리');
   });
 });
 

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -464,22 +464,27 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
     setActionError(null);
 
     try {
+      // story #3519(§16-7 2부, PO 確定 2026-09-05) — 셋 다 부수(res.ok?채움:그대로 두는
+      // degrade, loadError 없음)인데 catch가 어디에도 없었다 — 셋 중 하나가 네트워크단
+      // reject(HTTP status가 아니라 fetch 자체 실패)면 Promise.all 전체가 던져 나머지도
+      // 조용히 못 채워졌다(setLoading은 finally라 꺼지긴 하나, 원인 표시가 0). leg별로
+      // 격리해 하나가 죽어도 나머지 둘은 그대로 채워진다(doc-status-rail.tsx 정본 패턴).
       const [burndownRes, storiesRes, backlogRes] = await Promise.all([
-        fetchWithAuth(`/api/sprints/${sprint.id}/burndown`),
-        fetchWithAuth(`/api/stories?project_id=${projectId}&sprint_id=${sprint.id}&limit=20`),
-        fetchWithAuth(`/api/stories/backlog?project_id=${projectId}&limit=20`),
+        fetchWithAuth(`/api/sprints/${sprint.id}/burndown`).catch(() => null),
+        fetchWithAuth(`/api/stories?project_id=${projectId}&sprint_id=${sprint.id}&limit=20`).catch(() => null),
+        fetchWithAuth(`/api/stories/backlog?project_id=${projectId}&limit=20`).catch(() => null),
       ]);
-      if (burndownRes.ok) {
+      if (burndownRes?.ok) {
         const json = await burndownRes.json();
         setBurndown(json.data);
       }
-      if (storiesRes.ok) {
+      if (storiesRes?.ok) {
         const json = await storiesRes.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
         setSprintStories(excludeHidden(json.data ?? []));
         setSprintStoriesHasMore(json.meta?.hasMore ?? false);
         setSprintStoriesNextCursor(json.meta?.nextCursor ?? null);
       }
-      if (backlogRes.ok) {
+      if (backlogRes?.ok) {
         const json = await backlogRes.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
         setBacklogStories(excludeHidden(json.data ?? []));
         setBacklogHasMore(json.meta?.hasMore ?? false);

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+//
+// story #3519(§16-7 2부, PO 確定 2026-09-05) — missingRes(부수, "실패해도 본 화면은
+// 막지 않음" 주석)가 sprintsRes/feedbackRes(주)와 같은 미격리 Promise.all 안에 있어,
+// missingRes의 fetch 자체가 네트워크단 reject하면 주 데이터 둘도 같이 못 얻던 결함의
+// 회귀가드. 전체 기능 스위트가 아니라 이 격리 하나만 좁게 검증한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../../messages/ko.json';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({ useDashboardContext: () => useDashboardContextMock() }));
+vi.mock('@/components/nav/top-bar-slot', () => ({ TopBarSlot: () => null }));
+vi.mock('@/components/standup/board-bridge-modal', () => ({ BoardBridgeModal: () => null }));
+vi.mock('@/components/standup/standup-board-card', () => ({ StandupBoardCard: () => null }));
+vi.mock('@/components/standup/standup-feedback-dialog', () => ({ StandupFeedbackDialog: () => null }));
+vi.mock('@/components/standup/standup-history-section', () => ({ StandupHistorySection: () => null }));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">{node}</NextIntlClientProvider>;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [] });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+function stubFetch(opts: { missingReject?: boolean } = {}) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url !== 'string') return { ok: false, json: async () => null };
+    if (url.includes('/api/standup?date=')) return { ok: true, json: async () => ({ data: [] }) };
+    if (url.includes('/api/team-members')) return { ok: true, json: async () => ({ data: [] }) };
+    if (url.includes('/api/sprints?project_id=')) {
+      return { ok: true, json: async () => ({ data: [{ id: 'sp1', title: '진행중 스프린트', status: 'active', start_date: null, end_date: null }] }) };
+    }
+    if (url.includes('/api/standup/feedback')) return { ok: true, json: async () => ({ data: [] }) };
+    if (url.includes('/api/standup/missing')) {
+      if (opts.missingReject) throw new Error('network down');
+      return { ok: true, json: async () => ({ data: { missing: [] } }) };
+    }
+    if (url.includes('/api/stories?project_id=')) {
+      return { ok: true, json: async () => ({ data: [], meta: {} }) };
+    }
+    return { ok: false, json: async () => null };
+  }));
+}
+
+async function mount() {
+  const { default: StandupPage } = await import('./standup-client');
+  await act(async () => { root.render(wrap(<StandupPage projectId="proj-1" />)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('StandupClient — missing 격리(story #3519)', () => {
+  it('missing이 네트워크 reject해도 활성 스프린트(주 데이터)는 그대로 뜬다(loadError 없음)', async () => {
+    stubFetch({ missingReject: true });
+    await mount();
+    expect(container.textContent).toContain('진행중 스프린트');
+    expect(container.textContent).not.toContain(koMessages.standup.loadFailed);
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
@@ -246,10 +246,15 @@ export default function StandupPage({ projectId }: StandupClientProps) {
         let nextStoriesCursor: string | null = null;
 
         if (projectId) {
+          // story #3519(§16-7 2부, PO 確定 2026-09-05) — missingRes는 주석("실패해도 본
+          // 화면은 막지 않음")상 부수인데, sprintsRes/feedbackRes(주)와 같은 미격리
+          // Promise.all 안에 있었다. missingRes의 fetch 자체가 네트워크단 reject(HTTP
+          // status가 아니라)하면 이 Promise.all 전체가 던져 주 데이터 둘도 같이 못
+          // 얻었다 — 주석과 코드가 어긋난 결함. missingRes만 leg 자체를 격리한다.
           const [sprintsRes, feedbackRes, missingRes] = await Promise.all([
             fetchWithAuth(`/api/sprints?project_id=${projectId}&status=active`),
             fetchWithAuth(`/api/standup/feedback?project_id=${projectId}&date=${date}`),
-            fetchWithAuth(`/api/standup/missing?project_id=${projectId}&date=${date}`),
+            fetchWithAuth(`/api/standup/missing?project_id=${projectId}&date=${date}`).catch(() => null),
           ]);
 
           const [sprintsData, fbData] = await Promise.all([
@@ -259,8 +264,8 @@ export default function StandupPage({ projectId }: StandupClientProps) {
           feedbackData = fbData;
 
           // S3: Missing = org 기준(projection get_missing). 실패해도 본 화면은 막지 않음.
-          const missingJson = await missingRes.json().catch(() => null) as { data?: { missing?: { id: string; name: string }[] } } | null;
-          missingList = missingRes.ok ? (missingJson?.data?.missing ?? []) : [];
+          const missingJson = await missingRes?.json().catch(() => null) as { data?: { missing?: { id: string; name: string }[] } } | null;
+          missingList = missingRes?.ok ? (missingJson?.data?.missing ?? []) : [];
 
           sprint = sprintsData.find((item) => item.status === 'active') ?? sprintsData[0] ?? null;
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -163,16 +163,25 @@ function stubFetch(opts: {
   };
   commentsStatus?: number;
   onCommentsRefresh?: () => { status: number; body: unknown; headers?: Record<string, string> };
+  // story #3519(§16-7 2부) — 이미지 confirm 성공 「직후」의 단건 GET 재조회(부수)만
+  // 네트워크단 reject시킨다(격리 회귀가드).
+  rejectDraftRefetchAfterImageConfirm?: boolean;
 }) {
   const versions = opts.versions ?? [VERSION_1];
   const draftDetail: Record<string, unknown> = { ...DRAFT_DETAIL, ...opts.draftDetail };
   if (opts.omitGateStatusKey) delete draftDetail.gate_status;
   let currentDraftDetail = draftDetail;
+  let rejectNextDraftRefetch = false;
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}`) {
+        // story #3519(§16-7 2부) — 이미지 업로드 confirm 성공 뒤 재조회(부수) 격리
+        // 회귀가드용. rejectDraftRefetchAfterImageConfirm이 켜지면 confirm이 성공한
+        // 「다음」 이 URL 호출(=재조회)만 네트워크단 reject한다(최초 페이지 로드
+        // 호출은 그대로 성공).
+        if (rejectNextDraftRefetch) { rejectNextDraftRefetch = false; throw new Error('network down'); }
         return { ok: true, status: 200, json: async () => ({ data: currentDraftDetail, error: null, meta: null }) };
       }
       // story #3402·PR#3767 — GATE_ALREADY_HELD best-effort 상대 초안 단건 조회. 테스트의
@@ -251,6 +260,7 @@ function stubFetch(opts: {
         };
         const ok = result.status < 400;
         if (ok) {
+          if (opts.rejectDraftRefetchAfterImageConfirm) rejectNextDraftRefetch = true;
           // B1 — 실제 백엔드라면 confirm이 반영한 이미지 필드가 그다음 단건 GET에도
           // 그대로 실린다(같은 draft 행). 목(mock)도 그 사실을 반영해야 재조회 검증이
           // 뜻이 있다 — 그 위에 draftAfterImageConfirm(게이트 재오픈 등 이 조각이 별도로
@@ -1725,6 +1735,28 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     await flush();
 
     expect(container.querySelector('[data-testid="channel-post-image-preview"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="channel-post-image-upload-error"]')).toBeNull();
+  });
+
+  // story #3519(§16-7 2부, PO 確定 2026-09-05) — confirm 성공 뒤 재조회(draft/versions
+  // 단건 GET, 부수)가 격리 없이 Promise.all에 있어, 재조회 쪽이 네트워크단 reject하면
+  // 바깥 catch가 "이미지 업로드 실패"로 오문구를 냈다 — 업로드 자체(confirm까지)는 이미
+  // 성공했는데 사용자는 업로드가 실패한 걸로 오인한다.
+  it('⭐#3519 — confirm 성공 뒤 재조회가 네트워크 reject해도 "업로드 실패" 오문구가 안 뜬다', async () => {
+    stubFetch({ imageMaxCount: 1, rejectDraftRefetchAfterImageConfirm: true });
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    const input = container.querySelector('[data-testid="channel-post-image-file-input"]') as HTMLInputElement;
+    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
     expect(container.querySelector('[data-testid="channel-post-image-upload-error"]')).toBeNull();
   });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -757,15 +757,21 @@ export default function ChannelPostEditPage() {
       // gate_status/reapproval_required가 낡아 화면은 "승인됨·발행 가능"으로 남는데
       // 서버는 재승인을 요구한다(눌러야 서버가 거부) — 단건 GET(PR#3788)으로 서버 값을
       // 통째로 교체한다. text/linkUrl은 별도 state라 입력 중이던 내용은 안 건드린다.
+      // story #3519(§16-7 2부, PO 確定 2026-09-05) — 이 재조회 둘은 이미지 업로드 자체가
+      // 끝난 뒤의 부수 새로고침이다(§17 "화면이 판정 X"). 격리가 없어 재조회 쪽이
+      // 네트워크단 reject하면 바깥 catch가 "이미지 업로드 실패"로 오문구를 냈다 — 이미지는
+      // 이미 confirm까지 성공했는데(image 변수가 이미 참조 가능한 시점) 사용자는 업로드
+      // 자체가 실패한 걸로 오인한다. leg별로 격리해 재조회 실패가 업로드 성공 신호를
+      // 삼키지 않게 한다.
       const [draftRes, versionsRes] = await Promise.all([
-        fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}`),
-        fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}/versions`),
+        fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}`).catch(() => null),
+        fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}/versions`).catch(() => null),
       ]);
-      if (draftRes.ok) {
+      if (draftRes?.ok) {
         const draftJson = (await draftRes.json().catch(() => null)) as { data?: ChannelPostDraftDetail } | null;
         if (draftJson?.data) setDraft(draftJson.data);
       }
-      if (versionsRes.ok) {
+      if (versionsRes?.ok) {
         const versionsJson = (await versionsRes.json().catch(() => null)) as { data?: ChannelPostVersion[] } | null;
         if (versionsJson?.data) setVersions(versionsJson.data);
       }

--- a/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// story #3519(§16-7 2부, PO 確定 2026-09-05) — fetchOrgContext의 projectRes/meRes 둘 다
+// 부수(ok?채움:방치)인데 catch가 어디에도 없어, 하나가 네트워크단 reject하면 나머지도
+// 조용히 못 채워지던 결함의 회귀가드. 전체 기능 스위트가 아니라 이 격리 하나만 좁게 검증.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../../messages/ko.json';
+
+// story #3519 harness gotcha — useRouter가 매 렌더 새 객체를 반환하면 fetchAgent의
+// useCallback identity가 매번 바뀌어 로드 useEffect가 무한 재실행된다(fetchAgent가
+// [id, router] 의존). router mock 자체를 안정 참조로 고정해야 한다.
+const { routerReplaceMock, routerMock } = vi.hoisted(() => {
+  const routerReplaceMock = vi.fn();
+  return { routerReplaceMock, routerMock: { replace: routerReplaceMock, push: vi.fn() } };
+});
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'agent-1' }),
+  useRouter: () => routerMock,
+}));
+
+vi.mock('@/components/agents/agent-api-key-manager', () => ({ AgentApiKeyManager: () => null }));
+vi.mock('@/components/agents/agent-connection-settings-section', () => ({ AgentConnectionSettingsSection: () => null }));
+vi.mock('@/components/agents/messaging-policy-section', () => ({ MessagingPolicySection: () => null }));
+vi.mock('@/components/shared/avatar-edit-card', () => ({ AvatarEditCard: () => null }));
+vi.mock('@/components/agents/member-notification-preferences-summary', () => ({ MemberNotificationPreferencesSummary: () => null }));
+// story #3519 — projects prop 확인용. 실제 렌더 대신 개수만 텍스트로 노출한다.
+vi.mock('@/components/settings/agent-project-access-section', () => ({
+  AgentProjectAccessSection: ({ projects }: { projects: { id: string; name: string }[] }) => (
+    <div data-testid="project-access-projects-count">{projects.length}</div>
+  ),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">{node}</NextIntlClientProvider>;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  routerReplaceMock.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+const AGENT = {
+  id: 'agent-1', name: '에이전트1', type: 'agent', role: 'member', project_id: 'proj-1',
+  is_active: true, webhook_url: null, created_by: 'human-1', fakechat_port: null, runtime_type: 'claude-code',
+};
+
+function stubFetch(opts: { meReject?: boolean } = {}) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url !== 'string') return { ok: false, json: async () => null };
+    if (url === '/api/team-members/agent-1') return { ok: true, json: async () => ({ data: AGENT }) };
+    if (url.startsWith('/api/agents/') && url.endsWith('/api-key')) return { ok: true, json: async () => ({ data: [] }) };
+    if (url === '/api/projects') return { ok: true, json: async () => ({ data: [{ id: 'p1', name: '프로젝트 A' }, { id: 'p2', name: '프로젝트 B' }] }) };
+    if (url === '/api/me') {
+      if (opts.meReject) throw new Error('network down');
+      return { ok: true, json: async () => ({ data: { user_id: 'u1', role: 'admin' } }) };
+    }
+    if (url.startsWith('/api/webhooks/config')) return { ok: true, json: async () => ({ data: [] }) };
+    return { ok: false, json: async () => null };
+  }));
+}
+
+async function mount() {
+  const { default: AgentDetailPage } = await import('./page');
+  await act(async () => { root.render(wrap(<AgentDetailPage />)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('AgentDetailPage — fetchOrgContext 격리(story #3519)', () => {
+  it('/api/me가 네트워크 reject해도 /api/projects(주)는 그대로 채워진다', async () => {
+    stubFetch({ meReject: true });
+    await mount();
+    expect(container.querySelector('[data-testid="project-access-projects-count"]')?.textContent).toBe('2');
+  });
+});

--- a/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
@@ -136,15 +136,18 @@ export default function AgentDetailPage() {
   }, [id, router]);
 
   const fetchOrgContext = useCallback(async () => {
+    // story #3519(§16-7 2부, PO 確定 2026-09-05) — 둘 다 부수(ok?채움:방치, 그 외 화면을
+    // 안 막는다)인데 catch가 어디에도 없었다 — 하나가 네트워크단 reject하면 나머지도
+    // 조용히 못 채워졌다. leg별로 격리한다.
     const [projectRes, meRes] = await Promise.all([
-      fetchWithAuth('/api/projects'),
-      fetchWithAuth('/api/me'),
+      fetchWithAuth('/api/projects').catch(() => null),
+      fetchWithAuth('/api/me').catch(() => null),
     ]);
-    if (projectRes.ok) {
+    if (projectRes?.ok) {
       const json = await projectRes.json() as { data: ProjectOption[] };
       setProjects((json.data ?? []).slice().sort((a, b) => a.name.localeCompare(b.name)));
     }
-    if (meRes.ok) {
+    if (meRes?.ok) {
       const json = await meRes.json() as { data?: { user_id?: string | null; role?: string } };
       setCurrentUserId(json.data?.user_id ?? null);
       setOrgRole(json.data?.role ?? 'member');

--- a/apps/web/src/components/agents/agent-management-tab.test.tsx
+++ b/apps/web/src/components/agents/agent-management-tab.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+//
+// story #3519(§16-7 2부, PO 確定 2026-09-05) — meRes/projectsRes 둘 다 부수(ok?채움:방치,
+// meRes는 isAdmin 판정만)인데 격리 없이 같은 try 안에 있어, meRes가 네트워크단 reject하면
+// 바깥 catch가 setLoadError(true)로 승격시켜 에이전트 목록(이 탭의 실제 주 콘텐츠)까지
+// 통째로 못 뜨던 결함의 회귀가드.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { AgentManagementTab } from './agent-management-tab';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">{node}</NextIntlClientProvider>;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function stubFetch(opts: { meReject?: boolean } = {}) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url !== 'string') return { ok: false, json: async () => null };
+    if (url === '/api/me') {
+      if (opts.meReject) throw new Error('network down');
+      return { ok: true, json: async () => ({ data: { role: 'admin' } }) };
+    }
+    if (url === '/api/projects') return { ok: true, json: async () => ({ data: [] }) };
+    if (url.startsWith('/api/team-members?')) {
+      return { ok: true, json: async () => ({ data: [{ id: 'a1', name: '에이전트 하나', role: 'member', is_active: true }] }) };
+    }
+    return { ok: false, json: async () => null };
+  }));
+}
+
+async function mount() {
+  await act(async () => { root.render(wrap(<AgentManagementTab />)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('AgentManagementTab — meRes/projectsRes 격리(story #3519)', () => {
+  it('/api/me가 네트워크 reject해도 에이전트 목록(주 콘텐츠)은 그대로 뜬다(loadError로 승격 안 됨)', async () => {
+    stubFetch({ meReject: true });
+    await mount();
+    expect(container.textContent).toContain('에이전트 하나');
+  });
+});

--- a/apps/web/src/components/agents/agent-management-tab.tsx
+++ b/apps/web/src/components/agents/agent-management-tab.tsx
@@ -112,17 +112,21 @@ export function AgentManagementTab({ onAddAgent }: AgentManagementTabProps) {
       setLoading(true);
       setLoadError(false);
       try {
+        // story #3519(§16-7 2부, PO 確定 2026-09-05) — 둘 다 부수(ok?채움:방치, 예를 들어
+        // meRes는 isAdmin 판정만 바꾼다)인데 격리가 없어, meRes가 네트워크단 reject하면
+        // 이 try/catch 바깥 catch가 setLoadError(true)로 «승격»시켜 에이전트 목록(이
+        // 탭의 실제 주 콘텐츠, refreshAgents가 따로 그린다)까지 통째로 못 뜨게 했다.
         const [meRes, projectsRes] = await Promise.all([
-          fetchWithAuth('/api/me'),
-          fetchWithAuth('/api/projects'),
+          fetchWithAuth('/api/me').catch(() => null),
+          fetchWithAuth('/api/projects').catch(() => null),
         ]);
-        if (meRes.ok) {
+        if (meRes?.ok) {
           const meJson = await meRes.json() as { data?: { role?: string } };
           const role = meJson.data?.role ?? 'member';
           setIsAdmin(role === 'admin' || role === 'owner');
         }
         let projectList: ProjectOption[] = [];
-        if (projectsRes.ok) {
+        if (projectsRes?.ok) {
           const json = await projectsRes.json() as { data?: ProjectOption[] };
           projectList = (json.data ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
         }

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -153,6 +153,25 @@ describe('ApprovalsQueue', () => {
     expect(urls).toContain('/api/gates/inbox?status=held&sort=urgency&assigned_to_me=true');
   });
 
+  // story #3519(§16-7 2부, PO 確定 2026-09-05) — fetchGates 내부에 catch가 어디에도
+  // 없어(then뿐), 하나(held)가 네트워크단 reject하면 fetchGates() 자체가 throw했고
+  // 호출부(useEffect)도 안 잡아 setLoading(false)가 영영 안 불려 무한 스켈레톤(에러
+  // 표시조차 0)이 됐다 — 최악 사례. 이제 leg별 격리+finally 이중 방어로 pending(성공)은
+  // 그대로 뜨고 loading도 반드시 풀린다.
+  it('held가 네트워크 reject해도 pending(성공한 leg)은 뜨고 무한 스켈레톤에 안 걸린다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string }) => {
+      if (init?.method === 'PATCH') return { ok: true, json: async () => ({}) };
+      if (url.includes('status=pending')) {
+        return { ok: true, json: async () => [gate({ id: 'g1', gate_type: 'merge_gate', work_item_summary: { title: '살아남은 항목', slug: null } })] };
+      }
+      if (url.includes('status=held')) throw new Error('network down');
+      return { ok: true, json: async () => [] };
+    }));
+    await mount();
+    expect(container.textContent).not.toContain('게이트 조회 중...');
+    expect(container.textContent).toContain('살아남은 항목');
+  });
+
   it('4유형(게이트·문서결재·머지게이트·보류) 모두 렌더하고 gate_type 배지를 표시한다', async () => {
     mockFetches(
       [

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -44,9 +44,14 @@ import { fetchWithAuth } from '@/lib/db/client';
 // 이 큐 안에서 바로 승인/반려하는 인라인 액션으로 둔다 — Gate 항목은 기존대로 클릭 시
 // `/gates/{id}` 상세로 이동.
 async function fetchGates(): Promise<GateInboxItem[]> {
+  // story #3519(§16-7 2부, PO 確定 2026-09-05) — 두 leg 다 catch가 어디에도 없어(then뿐),
+  // 하나가 네트워크단 reject하면 이 함수 자체가 던졌다. 호출부(useEffect)가 그 reject를
+  // 안 잡아 setLoading(false)가 영영 안 불려 무한 스켈레톤(에러 표시조차 0)이 됐다 — 최악
+  // 사례. leg별로 격리해 하나가 죽어도 나머지는 그대로 보인다(catch(() => [])로 degrade,
+  // 기존 !res.ok 분기와 같은 취급).
   const [pending, held] = await Promise.all([
-    fetchWithAuth('/api/gates/inbox?status=pending&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])),
-    fetchWithAuth('/api/gates/inbox?status=held&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])),
+    fetchWithAuth('/api/gates/inbox?status=pending&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])).catch(() => []),
+    fetchWithAuth('/api/gates/inbox?status=held&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])).catch(() => []),
   ]);
   return [...(pending as GateInboxItem[]), ...(held as GateInboxItem[])];
 }
@@ -199,12 +204,13 @@ export function ApprovalsQueue() {
 
   useEffect(() => {
     let cancelled = false;
-    void fetchGates().then((rows) => {
-      if (!cancelled) {
-        setItems(rows);
-        setLoading(false);
-      }
-    });
+    // story #3519(§16-7 2부, PO 確定 2026-09-05) — "loading은 finally에서 해소"
+    // 하우스룰(feedback-loading-finally). fetchGates 내부를 격리해도 그 함수가
+    // 원리적으로 던질 수 있는 이상 이 호출부도 방어선을 하나 더 둔다 — setLoading(false)
+    // 를 finally로 옮겨 무한 스켈레톤 재발을 원천 차단.
+    void fetchGates()
+      .then((rows) => { if (!cancelled) setItems(rows); })
+      .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
   }, []);
 

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -280,6 +280,25 @@ async function waitForFreshAlert(excludeNode: Element): Promise<Element | null> 
   return null;
 }
 
+// story #3519(§16-7 2부, PO 確定 2026-09-05) — storyResults(보드 몸통, 주)와
+// sprintsRes/epicsRes/membersRes(부수)가 미격리 Promise.all에 있어, 부수 하나가
+// 네트워크단 reject하면 보드 주 데이터까지 조용히 텅 비던 결함의 회귀가드.
+describe('KanbanBoard — Promise.all 부수 격리(story #3519)', () => {
+  it('/api/members가 네트워크 reject해도 스토리(주 데이터)는 그대로 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.startsWith('/api/stories?')) {
+        const status = new URL(url, 'http://localhost').searchParams.get('status');
+        const matched = status === 'backlog' ? [{ id: 's1', title: '살아남은 스토리', status: 'backlog', priority: 'medium', trust_stage: 'queued' }] : [];
+        return { ok: true, json: async () => ({ data: matched, meta: { total: matched.length, nextCursor: null } }) };
+      }
+      if (typeof url === 'string' && url.startsWith('/api/members')) throw new Error('network down');
+      return { ok: false, json: async () => null };
+    }));
+    await mount();
+    expect(container.textContent).toContain('살아남은 스토리');
+  });
+});
+
 describe('KanbanBoard — 스토리 생성 실패 접근성(story #2105 2차)', () => {
   it('생성 실패 시 role="alert" aria-live="assertive"로 배너가 렌더된다', async () => {
     stubFetch([]);

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -392,12 +392,17 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       const memberParams = projectId ? `?project_id=${projectId}` : '';
 
       // CB-S4: status별 5회 독립 호출
+      // story #3519(§16-7 2부, PO 確定 2026-09-05) — storyResults(보드의 실제 몸통, 주)와
+      // sprintsRes/epicsRes/membersRes(부수, ok?채움:방치)가 같은 Promise.all에 미격리로
+      // 묶여 있어, 부수 셋 중 하나가 네트워크단 reject하면 보드 주 데이터까지 조용히 텅
+      // 비었다(finally가 setLoading(false)는 걸어 무한 스켈레톤은 아니지만, 데이터 손실은
+      // 그대로). 부수 셋만 leg별로 격리한다.
       const statuses = COLUMNS.map((c) => c.id);
       const [storyResults, sprintsRes, epicsRes, membersRes] = await Promise.all([
         Promise.all(statuses.map((s) => fetchStoriesByStatus(s))),
-        fetchWithAuth(`/api/sprints${sprintParams}`),
-        fetchWithAuth(`/api/goals?${epicParams.toString()}`),
-        fetchWithAuth(`/api/members${memberParams}`),
+        fetchWithAuth(`/api/sprints${sprintParams}`).catch(() => null),
+        fetchWithAuth(`/api/goals?${epicParams.toString()}`).catch(() => null),
+        fetchWithAuth(`/api/members${memberParams}`).catch(() => null),
       ]);
 
       const allStories: KanbanStory[] = [];
@@ -413,9 +418,9 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       setColumnCursors(newCursors);
 
       const storyIds = allStories.map((s) => s.id);
-      if (sprintsRes.ok) { const json = await sprintsRes.json(); setSprints(json.data); }
-      if (epicsRes.ok) { const json = await epicsRes.json(); setEpics(json.data); setEpicsNextCursor(json.meta?.nextCursor ?? null); }
-      if (membersRes.ok) { const json = await membersRes.json(); setMembers(json.data); }
+      if (sprintsRes?.ok) { const json = await sprintsRes.json(); setSprints(json.data); }
+      if (epicsRes?.ok) { const json = await epicsRes.json(); setEpics(json.data); setEpicsNextCursor(json.meta?.nextCursor ?? null); }
+      if (membersRes?.ok) { const json = await membersRes.json(); setMembers(json.data); }
 
       if (projectId && storyIds.length > 0) {
         try {

--- a/apps/web/src/components/organization/apply-recipe-dialog.test.tsx
+++ b/apps/web/src/components/organization/apply-recipe-dialog.test.tsx
@@ -129,6 +129,49 @@ describe('ApplyRecipeDialog', () => {
     expect(capture.body).toEqual({ project_id: 'proj-1', role_mapping: { step_1: 'agent-1' } });
   });
 
+  // story #3519(§16-7 2부, PO 確定 2026-09-05) — memberRes/bindingsRes 둘 다 부수인데
+  // 격리 없이 같은 Promise.all에 있어, 하나가 네트워크단 reject하면 나머지도 조용히
+  // 빈 값이 됐다("에이전트 없음"처럼 보이지만 실은 네트워크 실패).
+  it('/api/team-members가 네트워크 reject해도 bindings(다른 leg)는 그대로 반영된다', async () => {
+    const capture = { body: null as unknown };
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/projects') return { ok: true, json: async () => ({ data: [{ id: 'proj-1', name: 'Proj One' }] }) };
+      if (url.includes('/api/team-members')) throw new Error('network down');
+      if (url.includes('/api/events/definitions/def-1/bindings')) {
+        return { ok: true, json: async () => ({ bindings: { step_1: 'agent-prebound' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => {
+      root.render(wrap(
+        <ApplyRecipeDialog
+          target={TARGET}
+          open
+          onOpenChange={() => {}}
+          t={((k: string) => k) as never}
+          tc={((k: string) => k) as never}
+          addToast={() => {}}
+        />,
+      ));
+    });
+    await flush();
+
+    const projectSelect = document.body.querySelector('select') as HTMLSelectElement;
+    await act(async () => {
+      projectSelect.value = 'proj-1';
+      projectSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    // bindings leg가 살아서 role_mapping을 미리 채운다(step_1='agent-prebound') — 그
+    // 결과 제출 버튼이 "역할 미지정" 사유로 막히지 않는다. memberRes가 reject해도
+    // agents=[]로 조용히 degrade할 뿐, bindings 값 자체(별개 leg)는 사라지면 안 된다.
+    const submitBtn = [...document.body.querySelectorAll('button')].find((b) => b.textContent === 'eventApplySubmit') as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false);
+    void capture;
+  });
+
   it('apply 응답에 warnings가 있으면 그려진다', async () => {
     const capture = { body: null as unknown };
     stubFetch({ ok: true, bindings_upserted: 1, warnings: ['capability.connector_key 미해소 — org에 매칭되는 커넥터 여러 개'] }, capture);

--- a/apps/web/src/components/organization/apply-recipe-dialog.tsx
+++ b/apps/web/src/components/organization/apply-recipe-dialog.tsx
@@ -60,17 +60,20 @@ export function ApplyRecipeDialog({
     setWarnings([]);
     void (async () => {
       try {
+        // story #3519(§16-7 2부, PO 確定 2026-09-05) — 둘 다 부수(ok?채움:빈값)인데 격리
+        // 없이 같은 Promise.all 안에 있어, 하나가 네트워크단 reject하면 나머지도 조용히
+        // 빈 값이 됐다 — "에이전트 없음"처럼 보이지만 실은 네트워크 실패인 자리.
         const [memberRes, bindingsRes] = await Promise.all([
-          fetchWithAuth(`/api/team-members?project_id=${projectId}&type=agent`),
-          fetchWithAuth(`/api/events/definitions/${target.id}/bindings?project_id=${projectId}`),
+          fetchWithAuth(`/api/team-members?project_id=${projectId}&type=agent`).catch(() => null),
+          fetchWithAuth(`/api/events/definitions/${target.id}/bindings?project_id=${projectId}`).catch(() => null),
         ]);
-        if (memberRes.ok) {
+        if (memberRes?.ok) {
           const json = await memberRes.json() as { data?: AgentOption[] } | AgentOption[];
           setAgents(Array.isArray(json) ? json : (json.data ?? []));
         } else {
           setAgents([]);
         }
-        if (bindingsRes.ok) {
+        if (bindingsRes?.ok) {
           const j = await bindingsRes.json() as { bindings?: Record<string, string> };
           setRoleMapping(j.bindings ?? {});
         } else {

--- a/apps/web/src/components/settings/my-notification-channel-section.test.tsx
+++ b/apps/web/src/components/settings/my-notification-channel-section.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+//
+// story #3519(§16-7 2부, PO 確定 2026-09-05) — projRes만 격리(.catch)돼 있고 meRes는
+// 안 돼 있었다. meRes가 네트워크단 reject하면 Promise.all 전체가 던져(destructuring
+// 자체가 실패) 이미 정상 응답한 projRes의 결과(nameMap)까지 못 반영됐을 뿐 아니라,
+// 호출부가 `void load()`(fire-and-forget, .catch 없음)라 그 예외가 처리되지 않은
+// promise rejection으로 새 나갔다 — 브라우저 전역 unhandledrejection(에러 모니터링
+// 노이즈)로 이어지는 클래스. 한쪽만 격리하면 격리 자체가 무의미해진다는 걸 고정한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { MyNotificationChannelSection } from './my-notification-channel-section';
+
+const { addToastMock } = vi.hoisted(() => ({ addToastMock: vi.fn() }));
+vi.mock('@/components/ui/toast', () => ({ useToast: () => ({ addToast: addToastMock }) }));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">{node}</NextIntlClientProvider>;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('MyNotificationChannelSection — meRes/projRes 격리(story #3519)', () => {
+  it('/api/me가 네트워크 reject해도 처리되지 않은 promise rejection이 새지 않는다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') throw new Error('network down');
+      if (url === '/api/projects') return { ok: true, json: async () => ({ data: [{ id: 'proj-1', name: '프로젝트 A' }] }) };
+      return { ok: false, json: async () => null };
+    }));
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (e: unknown) => { unhandled.push(e); };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await act(async () => {
+        root.render(wrap(<MyNotificationChannelSection projectId="proj-1" projectName="프로젝트 A" />));
+      });
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+      // 마이크로태스크 큐가 완전히 비워질 시간을 한 틱 더 준다(unhandledRejection은
+      // 콜스택이 완전히 비고 난 뒤 다음 틱에 발화한다).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    expect(unhandled).toEqual([]);
+  });
+});

--- a/apps/web/src/components/settings/my-notification-channel-section.tsx
+++ b/apps/web/src/components/settings/my-notification-channel-section.tsx
@@ -90,8 +90,12 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
   useEffect(() => {
     async function load() {
       try {
+        // story #3519(§16-7 2부, PO 確定 2026-09-05) — projRes만 격리돼 있었다(meRes는
+        // 안 됨) — meRes가 네트워크단 reject하면 이 Promise.all 전체가 던져 이미 정상
+        // 응답한 projRes의 결과(nameMap)까지 조용히 못 씌워졌다. meRes도 격리한다(한쪽만
+        // 격리하면 나머지 격리가 무의미해진다).
         const [meRes, projRes] = await Promise.all([
-          fetchWithAuth('/api/me'),
+          fetchWithAuth('/api/me').catch(() => null),
           fetchWithAuth('/api/projects').catch(() => null),
         ]);
         if (projRes?.ok) {
@@ -100,7 +104,7 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
           (pj.data ?? []).forEach((p) => { map[p.id] = p.name; });
           setNameMap(map);
         }
-        if (!meRes.ok) return;
+        if (!meRes?.ok) return;
         const json = await meRes.json() as { data?: { id?: string } };
         const mid = json.data?.id ?? null;
         if (!mid) return;

--- a/apps/web/src/components/settings/workflow-template-gallery-section.test.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.test.tsx
@@ -69,6 +69,23 @@ function stubFetch(overrides: Record<string, unknown> = {}) {
   }));
 }
 
+// story #3519(§16-7 2부, PO 確定 2026-09-05) — defRes(주, 갤러리 몸통)와 memberRes
+// (부수)가 미격리 Promise.all에 있어, memberRes가 네트워크단 reject하면 defRes도
+// 조용히 못 채워져 갤러리가 거짓 "항목 없음"으로 보이던 결함의 회귀가드.
+describe('WorkflowTemplateGallerySection — Promise.all 부수 격리(story #3519)', () => {
+  it('/api/team-members가 네트워크 reject해도 정의 목록(주 데이터)은 그대로 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/events/definitions' && !init) return { ok: true, json: async () => [DEFINITION] };
+      if (url.includes('/api/team-members')) throw new Error('network down');
+      if (url.includes('/api/events/definitions/def-1/bindings')) return { ok: true, json: async () => ({ bindings: {} }) };
+      return { ok: false, json: async () => null };
+    }));
+    await act(async () => { root.render(wrap(<WorkflowTemplateGallerySection projectId="proj-1" />)); });
+    await flush();
+    expect(container.textContent).toContain('테스트 레시피');
+  });
+});
+
 describe('WorkflowTemplateGallerySection — error.message 분기 (story #2501 계승)', () => {
   it('적용 실패 사유가 raw "적용 실패" 폴백 대신 실 서버 메시지로 뜬다(핵심 회귀가드)', async () => {
     stubFetch({

--- a/apps/web/src/components/settings/workflow-template-gallery-section.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.tsx
@@ -61,9 +61,13 @@ export function WorkflowTemplateGallerySection({
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
+      // story #3519(§16-7 2부, PO 確定 2026-09-05) — memberRes(부수, ok?채움:방치)가
+      // defRes(주, 갤러리 몸통)와 미격리로 같은 Promise.all에 있어, memberRes가
+      // 네트워크단 reject하면 defRes도 조용히 못 채워져 갤러리가 거짓 "항목 없음"으로
+      // 보였다. memberRes만 격리한다.
       const [defRes, memberRes] = await Promise.all([
         fetchWithAuth('/api/events/definitions'),
-        fetchWithAuth(`/api/team-members?project_id=${projectId}&type=agent`),
+        fetchWithAuth(`/api/team-members?project_id=${projectId}&type=agent`).catch(() => null),
       ]);
       if (defRes.ok) {
         const data: unknown = await defRes.json();
@@ -81,7 +85,7 @@ export function WorkflowTemplateGallerySection({
         }));
         setAppliedKeys(applied);
       }
-      if (memberRes.ok) {
+      if (memberRes?.ok) {
         const json = await memberRes.json() as { data?: TeamMember[] } | TeamMember[];
         const members = Array.isArray(json) ? json : ((json as { data?: TeamMember[] }).data ?? []);
         setAgents(members);

--- a/apps/web/src/lib/promise-all-isolation.guard.test.ts
+++ b/apps/web/src/lib/promise-all-isolation.guard.test.ts
@@ -1,0 +1,233 @@
+// story #3519(§16-7 2부 "나란히 부르되 같은 급으로 묶지 않는다", PO 確定 2026-09-05) —
+// `Promise.all`에 `fetchWithAuth` 호출을 2개 이상 묶은 자리 전수를 AST(TypeScript
+// 컴파일러 API)로 찾아, 그 자리에 격리 메커니즘(leg별 `.catch`, 전체 체인
+// `.catch`/`.then(ok,err)`, 감싸는 `try{...}catch{...}`, 또는 `Promise.allSettled`
+// 사용)이 «단 하나도» 없는 경우만 RED로 잡는다.
+//
+// ⚠️이 가드가 못 잡는 것(선언) — catch가 «있기는 한데» 부수(secondary) leg를 주
+// (primary)로 잘못 승격시키는 오분류(예: catch가 leg 하나에만 있고 나머지 부수
+// leg는 안 걸린 채로 방치되는 경우, 또는 catch는 있는데 그 catch 자체가 원래
+// «부수»였어야 할 데이터를 «전체 로드 실패»로 승격시켜 버리는 경우)는 이 가드의
+// 기계적 검사(catch 유무)로는 구분이 안 된다 — 표기 존재만 검사하지 «맞다»는
+// 검사 못 한다. 이 스토리 자체가 그 오분류 클래스의 실사례 4곳을 손으로 찾아
+// 고쳤다(standup-client.tsx:249, channel-posts/[draftId]/page.tsx:703,
+// agent-management-tab.tsx:115, my-notification-channel-section.tsx:93 — 전부
+// catch가 «있었지만» 격리 범위가 틀렸던 자리들). 이런 자리의 재발 방지는 이
+// 가드가 아니라 개별 리뷰(§16-7 2부 판정선: !res.ok→setLoadError/return=주,
+// res.ok?채움:degrade=부수)의 몫이다.
+//
+// 양성대조(가드가 실제로 «실패할 수 있다»는 증거) — 이 스토리에서 고친 approvals-
+// queue.tsx:47(수정 前 스냅샷: 두 leg 다 `.then(...)`뿐, catch가 파일 어디에도
+// 없어 이 가드가 실제로 RED였다)를 아래 테스트로 재현해 고정한다. 3514 이전
+// content/[draftId]/page.tsx는 양성대조로 안 쓴다 — 그 버전도 이미 `.catch`가
+// 있어(격리 «범위»가 틀렸을 뿐 catch 자체는 있었다) 이 가드의 검사 대상 밖이다
+// (위 "못 잡는 것" 문단과 동일 사유).
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import * as ts from 'typescript';
+
+const SRC_ROOT = join(__dirname, '../');
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (/\.tsx?$/.test(entry) && !entry.includes('.test.') && !entry.endsWith('.d.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface Site {
+  file: string;
+  line: number;
+  legCount: number;
+  hasAnyCatch: boolean;
+}
+
+/** node 체인(예: `fetchWithAuth(...).then(...).catch(...)`)에서 fetchWithAuth 호출을
+ * 포함하는지, 그리고 그 체인 어딘가에 .catch(...)가 있는지를 판정한다. */
+function analyzeLegExpression(expr: ts.Expression): { isFetchLeg: boolean; hasCatch: boolean } {
+  let isFetchLeg = false;
+  let hasCatch = false;
+  function walk(node: ts.Node) {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      if (ts.isIdentifier(callee) && callee.text === 'fetchWithAuth') isFetchLeg = true;
+      if (ts.isPropertyAccessExpression(callee) && callee.name.text === 'catch') hasCatch = true;
+    }
+    node.forEachChild(walk);
+  }
+  walk(expr);
+  return { isFetchLeg, hasCatch };
+}
+
+/** Promise.all(...) 호출 노드에서 위로 올라가며 (a) 전체 체인에 걸린 .then(...).catch나
+ * .catch가 있는지, (b) try{...}catch{...}로 감싸여 있는지를 판정한다. await 표현식·
+ * 변수 대입 등 중간 노드는 건너뛴다. */
+function hasWholeChainIsolation(promiseAllCall: ts.CallExpression): boolean {
+  let node: ts.Node = promiseAllCall;
+  // 위로 타고 올라가며 .then/.catch 체인 확인 (Promise.all(...).then(...).catch(...) 형태)
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (ts.isPropertyAccessExpression(current) && current.name.text === 'catch') return true;
+    if (ts.isCallExpression(current) || ts.isPropertyAccessExpression(current) || ts.isAwaitExpression(current)) {
+      current = current.parent;
+      continue;
+    }
+    break;
+  }
+  // try { ...await Promise.all(...)... } catch { ... } 형태
+  node = promiseAllCall;
+  while (node.parent) {
+    node = node.parent;
+    if (ts.isTryStatement(node) && node.catchClause) {
+      // node.tryBlock이 promiseAllCall을 실제로 포함하는지(catchBlock 자체 안에서
+      // 시작된 게 아닌지) — SourceFile 위치 비교로 판정.
+      const start = node.tryBlock.getStart();
+      const end = node.tryBlock.getEnd();
+      const target = promiseAllCall.getStart();
+      if (target >= start && target <= end) return true;
+    }
+    if (ts.isSourceFile(node)) break;
+  }
+  return false;
+}
+
+function scanFile(filePath: string, content: string): Site[] {
+  const sourceFile = ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const sites: Site[] = [];
+
+  function resolveArrayElements(arg: ts.Expression): ts.Expression[] | null {
+    if (ts.isArrayLiteralExpression(arg)) return [...arg.elements];
+    if (ts.isIdentifier(arg)) {
+      // 같은 파일 안에서 `const arr = [...]` 형태로 선언된 변수만 추적한다(단일 파일
+      // 스코프 — cross-file 추적은 이 가드 범위 밖).
+      const targetName = arg.text;
+      let found: ts.Expression[] | null = null;
+      function findDecl(n: ts.Node) {
+        if (found) return;
+        if (ts.isVariableDeclaration(n) && ts.isIdentifier(n.name) && n.name.text === targetName && n.initializer && ts.isArrayLiteralExpression(n.initializer)) {
+          found = [...n.initializer.elements];
+        }
+        n.forEachChild(findDecl);
+      }
+      findDecl(sourceFile);
+      return found;
+    }
+    return null;
+  }
+
+  function visit(node: ts.Node) {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      if (
+        ts.isPropertyAccessExpression(callee)
+        && ts.isIdentifier(callee.expression) && callee.expression.text === 'Promise'
+        && callee.name.text === 'all'
+        && node.arguments.length === 1
+      ) {
+        const elements = resolveArrayElements(node.arguments[0]!);
+        if (elements) {
+          let legCount = 0;
+          let anyLegHasCatch = false;
+          for (const el of elements) {
+            const { isFetchLeg, hasCatch } = analyzeLegExpression(el);
+            if (isFetchLeg) {
+              legCount += 1;
+              if (hasCatch) anyLegHasCatch = true;
+            }
+          }
+          if (legCount >= 2) {
+            const hasAnyCatch = anyLegHasCatch || hasWholeChainIsolation(node);
+            const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+            sites.push({ file: filePath, line: line + 1, legCount, hasAnyCatch });
+          }
+        }
+      }
+    }
+    node.forEachChild(visit);
+  }
+  visit(sourceFile);
+  return sites;
+}
+
+function scanAll(): Site[] {
+  const sites: Site[] = [];
+  for (const file of listSourceFiles(SRC_ROOT)) {
+    const content = readFileSync(file, 'utf-8');
+    if (!content.includes('fetchWithAuth')) continue;
+    if (!content.includes('Promise.all')) continue;
+    sites.push(...scanFile(file, content));
+  }
+  return sites;
+}
+
+describe('Promise.all + fetchWithAuth 격리 가드(story #3519)', () => {
+  it('스캔 대상이 비어있지 않다(가드 자체가 죽은 채 항상 통과하는 것 방지)', () => {
+    expect(scanAll().length).toBeGreaterThan(0);
+  });
+
+  it('fetchWithAuth 2legs 이상인 Promise.all 자리 전부에 격리(leg별 catch/전체체인 catch/try-catch)가 최소 하나 있다', () => {
+    const sites = scanAll();
+    const uncaught = sites.filter((s) => !s.hasAnyCatch);
+    const report = uncaught.map((s) => `${s.file.replace(SRC_ROOT, '')}:${s.line} (${s.legCount} legs)`).join('\n');
+    expect(uncaught, `격리 0인 자리:\n${report}`).toEqual([]);
+  });
+
+  // 양성대조 — approvals-queue.tsx의 수정 前 실제 코드(git 이력 그대로, story #3519
+  // 착수 시점 스냅샷)를 이 스캐너에 직접 통과시켜 실제로 RED가 되는지 고정한다.
+  // 이 가드를 미래에 손대다 조용히 무력화되는 걸(항상 그린) 이 테스트가 잡는다.
+  it('양성대조 — approvals-queue.tsx 수정 前 스냅샷(catch 0)은 이 가드가 실제로 잡는다', () => {
+    const beforeFixSnippet = `
+      async function fetchGates(): Promise<GateInboxItem[]> {
+        const [pending, held] = await Promise.all([
+          fetchWithAuth('/api/gates/inbox?status=pending&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])),
+          fetchWithAuth('/api/gates/inbox?status=held&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])),
+        ]);
+        return [...(pending as GateInboxItem[]), ...(held as GateInboxItem[])];
+      }
+    `;
+    const sites = scanFile('positive-control.tsx', beforeFixSnippet);
+    expect(sites.length).toBe(1);
+    expect(sites[0]!.hasAnyCatch).toBe(false);
+  });
+
+  it('음성대조 — 격리된 자리(leg별 catch)는 이 가드가 통과시킨다(오탐 방지)', () => {
+    const isolatedSnippet = `
+      async function load() {
+        const [a, b] = await Promise.all([
+          fetchWithAuth('/api/a').catch(() => null),
+          fetchWithAuth('/api/b').catch(() => null),
+        ]);
+      }
+    `;
+    const sites = scanFile('negative-control.tsx', isolatedSnippet);
+    expect(sites.length).toBe(1);
+    expect(sites[0]!.hasAnyCatch).toBe(true);
+  });
+
+  it('음성대조 — try/catch로 감싼 자리도 이 가드가 통과시킨다(전체체인 격리 인정)', () => {
+    const tryCatchSnippet = `
+      async function load() {
+        try {
+          const [a, b] = await Promise.all([
+            fetchWithAuth('/api/a'),
+            fetchWithAuth('/api/b'),
+          ]);
+        } catch {
+          setLoadError(true);
+        }
+      }
+    `;
+    const sites = scanFile('negative-control-trycatch.tsx', tryCatchSnippet);
+    expect(sites.length).toBe(1);
+    expect(sites[0]!.hasAnyCatch).toBe(true);
+  });
+});


### PR DESCRIPTION
## 요약

§16-7 2부("나란히 부르되 같은 급으로 묶지 않는다") — `Promise.all`에 `fetchWithAuth` 2개 이상을 묶은 자리(전수 37곳, AST 재검산·유나 독립 카운트와 일치) 중 **부수(secondary) leg가 격리 없이 주(primary) leg와 같은 Promise.all에 있어, 부수 하나의 네트워크단 reject(HTTP status가 아니라 fetch 자체 실패)가 전체를 던지던 결함 10곳**을 고치고, 재발 방지용 정적 가드를 추가한다.

판정선(PO 確定): `!res.ok → setLoadError/return` = 주, `res.ok ? 채움 : degrade` = 부수. 부수 leg만 `.catch(() => fallback)`으로 격리한다(주 leg는 그대로 — 여전히 던져서 loadError로 이어져야 하는 자리는 손대지 않았다).

## 결함 10곳 (전부 leg별 `.catch` 격리 + reject 시나리오 테스트 1건씩)

| # | 파일:줄 | 부수 leg | 증상(수정 前) |
|---|---|---|---|
| 1 | `sprints-client.tsx:467` | burndown/sprintStories/backlogStories 3legs | 하나 reject 시 셋 다 조용히 빈 채로 |
| 2 | `standup-client.tsx:249` | missingRes | 주석("실패해도 본 화면은 막지 않음")과 코드가 어긋나 있었음 — reject 시 주 데이터(sprints/feedback)까지 못 뜸 |
| 3 | `channel-posts/[draftId]/page.tsx:703` | 이미지 confirm 성공 뒤 재조회(draft/versions) | 재조회 reject가 "이미지 업로드 실패" 오문구로 둔갑(업로드 자체는 이미 성공) |
| 4 | `workforce/[id]/page.tsx:139` | projectRes/meRes | 하나 reject 시 나머지도 못 채워짐 |
| 5 | `agent-management-tab.tsx:115` | meRes(isAdmin 판정만) | reject가 바깥 catch에서 `setLoadError(true)`로 승격 — 주 콘텐츠(에이전트 목록) 봉쇄 |
| 6 | `approvals-queue.tsx:47` | pending/held | **최악 사례**: catch 0(then뿐) — reject 시 `setLoading(false)` 자체가 안 불려 무한 스켈레톤(에러 표시조차 0). leg별 격리 + 호출부 `setLoading`을 `finally`로 이중 방어 |
| 7 | `kanban-board.tsx:396` | sprints/epics/members | 부수 하나 reject 시 보드 몸통(storyResults, 주)까지 조용히 텅 빔 |
| 8 | `apply-recipe-dialog.tsx:63` | memberRes/bindingsRes | "에이전트 없음"처럼 보이지만 실은 네트워크 실패 |
| 9 | `my-notification-channel-section.tsx:93` | meRes(projRes만 격리돼 있었음) | 한쪽만 격리하면 무의미 — meRes reject 시 이미 성공한 projRes 결과도 못 반영 + 호출부가 `void load()`(catch 없음)라 처리되지 않은 promise rejection이 새 나감 |
| 10 | `workflow-template-gallery-section.tsx:64` | memberRes | reject 시 갤러리가 거짓 "항목 없음" |

## next-maker-screen.tsx:159 (37곳 중 하나, 정상 재확인 — 범위밖 아님)

4legs: `fetchAllGoals`/`fetchAllStoriesByStatus`(opaque helper, 내부에서 `!res.ok → throw`) 2개는 **주**(의도적으로 던져 바깥 `catch { setState({kind:'error'}) }`로 이어짐, PR#3123 401-swallow 수정의 의도적 설계) + `nextUpRes`/`laneRes` 2개는 **부수**(이미 `.then(ok?:fallback).catch(()=>fallback)`로 올바르게 격리). **정상 구성 — 결함 아님.**

## 정적 가드(`src/lib/promise-all-isolation.guard.test.ts`)

TypeScript 컴파일러 API로 `Promise.all`+`fetchWithAuth` 2legs 이상인 자리를 전수 스캔, leg별 `.catch`/전체체인 `.catch`/감싸는 `try-catch` 중 **하나도 없는** 자리만 RED로 잡는다.

- **못 잡는 것(가드 헤더에 명시)**: catch는 있지만 격리 «범위»가 틀린 오분류(이 PR이 고친 #2/#3/#5/#9)는 기계적 검사로 구분 불가 — 개별 리뷰의 몫.
- **양성대조**: `approvals-queue.tsx`(#6) 수정 前 실제 코드 스냅샷을 가드에 직접 통과시켜 RED 확인 + 실 레포 파일 대상 뮤테이션(해당 fix 되돌리기)으로도 RED 재현.
- **음성대조 2건**: leg별 격리·try/catch 격리 둘 다 통과시킴(오탐 방지).
- 3514 이전 `page.tsx`는 양성대조로 안 씀(그 버전도 이미 catch가 있어 — 범위만 틀렸을 뿐 — 이 가드 검사 대상 밖).

## 범위 밖(별건, 이 PR에서 안 고침)

- `loop-detail-client.tsx:81` — artifacts/me 미격리지만 주 데이터(loop)는 이 Promise.all *이전*에 이미 별도 fetch로 커밋돼 있어 화면은 선다(§16-7 기준 충족). 부수품질 연쇄만 있음 — 별건 후보.
- `project-access-section.tsx:53` — "네트워크실패=unauthorized" 오분류는 다른 결함류(이 스토리의 격리 문제와 무관) — 별건.

## 검증

- 10곳 전부 실물 뮤테이션(고친 코드를 되돌려 새 테스트가 RED로 떨어지는 것 확인 후 복원)
- 테스트 인프라가 없던 3곳(standup/workforce/agent-management)은 최소 harness 신규 작성
- `tsc --noEmit`/`eslint --max-warnings=0`(변경 파일) clean
- `vitest run`(전체) 6250/6250 그린
- 정적 가드 자체도 실 레포 파일 대상 뮤테이션으로 RED 재현 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)