### PR TITLE
[SID:3320] feat: Instagram Graph API 커넥터 조각① — OAuth+sandbox 발행 인프라

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -371,6 +371,11 @@ async def authorize_channel_connection(
         url = build_authorize_url(
             redirect_uri=_redirect_uri(org_id, channel), state=state, code_challenge=code_challenge, app_id=app_id,
         )
+    elif channel == "instagram":
+        # story #3320 — Instagram Login은 PKCE 미지원(그라운딩+PO 재확認, instagram_
+        # oauth.py 상단 딱지 참고) — code_challenge를 아예 안 넘긴다.
+        from app.services.instagram_oauth import build_authorize_url as build_instagram_authorize_url
+        url = build_instagram_authorize_url(redirect_uri=_redirect_uri(org_id, channel), state=state, app_id=app_id)
     else:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
     return AuthorizeResponse(url=url, state=state)
@@ -406,7 +411,7 @@ async def channel_connection_callback(
     if adapter is None:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
-    if channel != "threads":
+    if channel not in ("threads", "instagram"):
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
     # authorize 단계와 별도로 다시 조회 — 콜백은 브라우저 왕복(수초~수분) 뒤라 그 사이 owner가
@@ -423,19 +428,45 @@ async def channel_connection_callback(
         )
     app_id, app_secret = app_credentials
 
-    from app.services.threads_oauth import exchange_code_for_short_lived_token, exchange_for_long_lived_token, test_connection
+    # story #3320 — instagram_oauth.InstagramOAuthError는 ThreadsOAuthError와 같은
+    # .code/.message 속성을 갖는 별도 클래스다(진짜 다른 provider — OAuth 예외는
+    # channel_posts.py의 ThreadsPublishError 재사용 판단과 달리 애초에 provider별
+    # 클래스가 따로 있었다, threads_oauth.py 참고). 두 분기가 3콜 순서(단기교환→
+    # 장기교환→시험)는 같지만 함수·예외 타입이 달라 그대로 나열한다(codebase 기존
+    # 관례 — 채널별 명시 분기, 억지 공통 추상화 X).
+    from app.services.instagram_oauth import InstagramOAuthError
 
     async with httpx.AsyncClient(timeout=15) as client:
         try:
-            short_lived_token, external_account_id = await exchange_code_for_short_lived_token(
-                client, code=body.code, redirect_uri=_redirect_uri(org_id, channel),
-                code_verifier=oauth_state.code_verifier, app_id=app_id, app_secret=app_secret,
-            )
-            long_lived_token, expires_in = await exchange_for_long_lived_token(
-                client, short_lived_token=short_lived_token, app_secret=app_secret,
-            )
-            account = await test_connection(client, access_token=long_lived_token)
-        except ThreadsOAuthError as exc:
+            if channel == "threads":
+                from app.services.threads_oauth import (
+                    exchange_code_for_short_lived_token, exchange_for_long_lived_token, test_connection,
+                )
+
+                short_lived_token, external_account_id = await exchange_code_for_short_lived_token(
+                    client, code=body.code, redirect_uri=_redirect_uri(org_id, channel),
+                    code_verifier=oauth_state.code_verifier, app_id=app_id, app_secret=app_secret,
+                )
+                long_lived_token, expires_in = await exchange_for_long_lived_token(
+                    client, short_lived_token=short_lived_token, app_secret=app_secret,
+                )
+                account = await test_connection(client, access_token=long_lived_token)
+            else:
+                from app.services.instagram_oauth import (
+                    exchange_code_for_short_lived_token as ig_exchange_short_lived,
+                    exchange_for_long_lived_token as ig_exchange_long_lived,
+                    test_connection as ig_test_connection,
+                )
+
+                short_lived_token, external_account_id = await ig_exchange_short_lived(
+                    client, code=body.code, redirect_uri=_redirect_uri(org_id, channel),
+                    app_id=app_id, app_secret=app_secret,
+                )
+                long_lived_token, expires_in = await ig_exchange_long_lived(
+                    client, short_lived_token=short_lived_token, app_secret=app_secret,
+                )
+                account = await ig_test_connection(client, access_token=long_lived_token)
+        except (ThreadsOAuthError, InstagramOAuthError) as exc:
             raise HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message}) from exc
         finally:
             del app_secret  # ⛔즉시 소비 후 폐기 — 더 들고 있지 않는다.
@@ -484,6 +515,44 @@ async def create_sandbox_channel_connection(
     row = await upsert_channel_connection(
         db, org_id=org_id, channel="sandbox", account_id=f"sandbox-{org_id}",
         account_label="Sandbox", credential_kind=adapter.credential_kind,
+        access_token="sandbox-dummy-access-token", refresh_token=None,
+        token_expires_at=None, refresh_mode=adapter.refresh_mode,
+        scopes=adapter.scope.split(","), connected_by=resolved.id,
+    )
+    return _to_response(row)
+
+
+@router.post(
+    "/{org_id}/channel-connections/instagram-sandbox", response_model=ChannelConnectionResponse, status_code=201,
+)
+async def create_instagram_sandbox_channel_connection(
+    org_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelConnectionResponse:
+    """story #3320 조각① — 위 `create_sandbox_channel_connection`(5b27b32f)과 동형
+    (신규 판정 로직 0) — 다만 채널이 "sandbox"가 아니라 "instagram_sandbox"다. 별도
+    라우트인 이유는 URL 자체가 채널을 특정해야(경로에 `{channel}` 변수를 안 쓰는 게
+    기존 관례 — authorize/callback과 달리 이 엔드포인트들은 OAuth가 없어 애초에
+    `{channel}` 파라미터화가 안 돼 있었다) 이 채널 전용 라우트가 자연스럽다."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    resolved = await _require_owner_or_admin(db, auth, org_id)
+
+    adapter = get_channel_adapter("instagram_sandbox")
+    if adapter is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "CHANNEL_SANDBOX_DISABLED",
+                "message": "이 환경에서 샌드박스 채널이 비활성화돼 있습니다(SANDBOX_CHANNEL_ENABLED).",
+            },
+        )
+
+    row = await upsert_channel_connection(
+        db, org_id=org_id, channel="instagram_sandbox", account_id=f"instagram-sandbox-{org_id}",
+        account_label="Instagram Sandbox", credential_kind=adapter.credential_kind,
         access_token="sandbox-dummy-access-token", refresh_token=None,
         token_expires_at=None, refresh_mode=adapter.refresh_mode,
         scopes=adapter.scope.split(","), connected_by=resolved.id,
@@ -717,15 +786,21 @@ async def test_channel_connection(
     if access_token is None:
         return TestConnectionResponse(ok=False, error="연결에 저장된 토큰이 없습니다.")
 
-    if row.channel != "threads":
+    if row.channel not in ("threads", "instagram"):
         return TestConnectionResponse(ok=False, error=f"unsupported channel: {row.channel}")
 
+    # story #3320 — instagram_oauth.InstagramOAuthError는 threads_oauth.ThreadsOAuthError
+    # 와 별도 클래스(진짜 다른 provider)라 둘 다 잡는다.
+    from app.services.instagram_oauth import InstagramOAuthError
+    from app.services.instagram_oauth import test_connection as instagram_test_connection
     from app.services.threads_oauth import test_connection as threads_test_connection
+
+    test_connection_fn = threads_test_connection if row.channel == "threads" else instagram_test_connection
 
     async with httpx.AsyncClient(timeout=10) as client:
         try:
-            account = await threads_test_connection(client, access_token=access_token)
-        except ThreadsOAuthError as exc:
+            account = await test_connection_fn(client, access_token=access_token)
+        except (ThreadsOAuthError, InstagramOAuthError) as exc:
             await apply_refresh_failure(db, connection=row, error_message=exc.message)
             return TestConnectionResponse(ok=False, error=exc.message)
     del access_token  # ⛔즉시 소비 후 폐기 — 더 들고 있지 않는다.

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -55,6 +55,7 @@ from app.services.channel_posts import (
 from app.services.channel_post_images import (
     ChannelImageAnimatedUnsupportedError,
     ChannelImageAspectRatioExceededError,
+    ChannelImageAspectRatioTooNarrowError,
     ChannelImageConversionFailedError,
     ChannelImageObjectNotFoundError,
     ChannelImagePathNotScopedError,
@@ -518,6 +519,14 @@ async def post_channel_post_image_confirm(
             detail={
                 "code": "CHANNEL_IMAGE_ASPECT_RATIO_EXCEEDED", "message": str(exc),
                 "aspect_ratio": exc.aspect_ratio, "max_aspect_ratio": exc.max_aspect_ratio,
+            },
+        ) from exc
+    except ChannelImageAspectRatioTooNarrowError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_IMAGE_ASPECT_RATIO_TOO_NARROW", "message": str(exc),
+                "width_height_ratio": exc.width_height_ratio, "min_width_height_ratio": exc.min_width_height_ratio,
             },
         ) from exc
     except ChannelImageConversionFailedError as exc:

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1238,22 +1238,35 @@ async def refresh_channel_tokens(
         from app.services.channel_connection import (
             apply_refresh_failure, apply_refresh_result, decrypt_for_use, list_connections_due_for_refresh,
         )
-        from app.services.threads_oauth import ThreadsOAuthError, refresh_long_lived_token
+        from app.services.threads_oauth import ThreadsOAuthError, refresh_long_lived_token as refresh_threads_token
+        from app.services.instagram_oauth import (
+            InstagramOAuthError, refresh_long_lived_token as refresh_instagram_token,
+        )
+
+        # story #3320 — Phase1은 threads만 구현했던 skip-guard(`continue`)를 채널→
+        # 갱신함수 명시 dict로 확장(get_publish_client_module의 dispatch dict 근본
+        # 처방과 같은 사상 — "모르는 채널은 조용히 스킵"까지는 fail-closed로서
+        # 안전하지만, instagram은 이제 "아는 채널"이니 여기도 등록해야 실제로
+        # 갱신된다. 등록 안 된 채널은 여전히 스킵되고 다음 refresh tick도 못
+        # 건드리므로 만료 방치 위험 — 새 채널 추가 시 이 dict도 같이 늘릴 것).
+        _REFRESH_FN_BY_CHANNEL = {"threads": refresh_threads_token, "instagram": refresh_instagram_token}
+        _OAUTH_ERROR_TYPES = (ThreadsOAuthError, InstagramOAuthError)
 
         rows = await list_connections_due_for_refresh(session, now=datetime.now(timezone.utc))
         refreshed, failed = 0, 0
         async with _httpx.AsyncClient(timeout=15) as client:
             for row in rows:
-                if row.channel != "threads":
-                    continue  # Phase1 범위: threads만 구현(다른 채널은 후속 스토리)
+                refresh_fn = _REFRESH_FN_BY_CHANNEL.get(row.channel)
+                if refresh_fn is None:
+                    continue  # 미등록 채널(sandbox류 등)은 갱신 대상 아님(토큰 자체가 더미이거나 없음)
                 current_token = decrypt_for_use(row)
                 if current_token is None:
                     await apply_refresh_failure(session, connection=row, error_message="no stored access token")
                     failed += 1
                     continue
                 try:
-                    new_token, expires_in = await refresh_long_lived_token(client, current_token=current_token)
-                except ThreadsOAuthError as exc:
+                    new_token, expires_in = await refresh_fn(client, current_token=current_token)
+                except _OAUTH_ERROR_TYPES as exc:
                     await apply_refresh_failure(session, connection=row, error_message=exc.message)
                     failed += 1
                     continue

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -74,6 +74,12 @@ class ChannelAdapterConfig:
     image_formats: tuple[str, ...] = ()
     image_max_bytes: int = 0
     image_aspect_max: float = 0.0
+    # story #3320(Phase2·마케팅운영) — Threads류(상한만, 0.0 기본값=하한 없음)와 달리
+    # Instagram은 세로 방향에도 하한이 있다(4:5=0.8~1.91:1, 정규화(long/short)로는
+    # 한쪽만 못 잡는다 — width/height 원시 비율로 별도 판정, channel_post_images.py
+    # 검증 함수 참고). 0.0이면 이 하한 검사 자체를 건너뛴다(기존 Threads/hosted_site
+    # 회귀 0 — 새 필드가 없던 것처럼 그대로 동작).
+    image_aspect_min: float = 0.0
     image_width_min: int = 0
     image_width_max: int = 0
     image_color_space: str = ""
@@ -149,6 +155,42 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # 뭉친다). impressions/reach/clicks/spend/conversions는 Threads가 선언 안 함
         # (광고 계정 지표라 유기 게시물 API엔 없음).
         insight_metrics=("views", "engagements"),
+    ),
+    # story #3320(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — M4 두 번째 A(API 자동
+    # 발행) 채널. OAuth 엔드포인트·스코프는 페드루 PO가 2026-09-06 Meta 공식 문서로
+    # 직접 재확認한 값(threads_oauth.py 최초 작성 시의 지식-컷오프 추정과 다름 —
+    # instagram_oauth.py 참고). Facebook Page 연결은 Instagram Login 방식 자체가
+    # 불요(그라운딩+PO 재확認 일치).
+    "instagram": ChannelAdapterConfig(
+        authorize_url="https://www.instagram.com/oauth/authorize",
+        token_url="https://api.instagram.com/oauth/access_token",
+        # manage_comments는 조각③(댓글) 대상이라 지금은 미사용이어도 스코프는 미리
+        # 선언한다(threads_delete·threads_manage_replies 선례와 동형 — 새 연결부터
+        # 적용, 기존 연결은 재인증 전까지 그 능력이 막힌다, 의도).
+        scope="instagram_business_basic,instagram_business_content_publish,instagram_business_manage_comments",
+        refresh_mode="reissue_from_access_token",
+        credential_kind="oauth",
+        display_name="Instagram",
+        max_text_length=2200,  # 캡션 상한(스토리 본문 규격 표 IG 행, 그라운딩 실확認).
+        utm_source="instagram",
+        utm_medium="social",
+        # story #3320 조각① — supports_fetch_replies/reply·insight_metrics는 조각③
+        # 에서 켠다(페드루 PO 明示 — 댓글·인사이트 fetch dispatch가 아직 없어서 지금
+        # 켜면 capability 선언과 실제 구현이 어긋난다). supports_unpublish도 미선언
+        # (instagram_publish.py::delete_media 참고 — 삭제 API 자체가 미확認).
+        # 규격(JPEG·4:5~1.91:1·8MB·피드 이미지 1장) — 스토리 본문 규격 표 IG 행
+        # 그대로(그라운딩 실확認 대상), 캐러셀/릴스는 조각① 스코프 밖. ⚠️width_min/
+        # width_max는 그라운딩이 명시 확認하지 않아 Threads 값(320~1440)을 잠정
+        # 재사용 — IG 최소 권장폭(320px)만 문서상 확실하고 상한은 미확認, 조각②
+        # (실발행 경로) 착수 전 재확認 필요.
+        image_formats=("image/jpeg",),
+        image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91,
+        image_aspect_min=0.8,
+        image_width_min=320,
+        image_width_max=1440,
+        image_color_space="sRGB",
+        image_max_count=1,
     ),
     # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각①) — Sprintable
     # 호스팅 블로그를 blog kind 어댑터 1호로 등재한다. **동작 무변경** — site_posts.py의
@@ -264,6 +306,29 @@ if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
             "impressions", "reach", "views", "engagements", "clicks", "spend", "conversions",
         ),
     )
+    # story #3320 조각① — Instagram 전용 sandbox. 기존 "sandbox"(Threads류 TEXT-
+    # optional)와 같은 값을 재사용하지 않는 이유는 위 instagram_sandbox_publish.py
+    # docstring 참고(이미지 필수라는 성질 차이) — `get_publish_client_module`의
+    # 채널→모듈 dict가 이 구분을 그대로 반영한다.
+    CHANNEL_ADAPTERS["instagram_sandbox"] = ChannelAdapterConfig(
+        authorize_url="",
+        token_url="",
+        scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual",
+        credential_kind="none",
+        display_name="Instagram Sandbox",
+        max_text_length=2200,  # instagram과 동형(캡션 상한).
+        utm_source="instagram_sandbox",
+        utm_medium="test",
+        image_formats=("image/jpeg",),
+        image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91,
+        image_aspect_min=0.8,
+        image_width_min=320,
+        image_width_max=1440,
+        image_color_space="sRGB",
+        image_max_count=1,
+    )
 
 
 def get_channel_adapter(channel: str) -> ChannelAdapterConfig | None:
@@ -289,25 +354,53 @@ class BlogChannelDispatchNotImplementedError(NotImplementedError):
         )
 
 
+class ChannelPublishDispatchNotImplementedError(Exception):
+    """story #3320(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — dispatch fall-
+    through 근본 처방. `get_publish_client_module`이 이전엔 미등록 채널을 조용히
+    `threads_publish`로 떨어뜨렸다(e4fc29fa의 blog 오분기와 같은 사고 클래스 —
+    "모르는 채널=기본값"이 실제로는 "모르는 채널이 Threads API를 잘못 탄다"는 뜻
+    이었다, 이미 한 번 겪음). 이제 아래 dict에 없는 채널은 즉시 이 예외로 fail-
+    closed(뮤테이션 대상 — dict에서 항목을 빼면 그 채널이 곧바로 이 예외를 내야
+    한다)."""
+
+    def __init__(self, *, channel: str):
+        self.channel = channel
+        super().__init__(f"발행 클라이언트 디스패치가 없는 채널입니다: {channel}")
+
+
+# story #3320 — 채널→발행 클라이언트 모듈의 명시 등록표(모듈 경로 문자열, importlib로
+# 지연 import — 순환 import 회피는 기존 로컬 import 관례와 동형). 새 채널을 추가할
+# 때마다 이 한 줄만 늘리면 되고, 안 늘리면 `get_publish_client_module`이 즉시 예외를
+# 낸다(위 사고 클래스의 근본 처방 — "그 외 전부 threads로" 폴백 자체를 없앤다).
+_PUBLISH_CLIENT_MODULE_PATHS: dict[str, str] = {
+    "sandbox": "app.services.sandbox_publish",
+    "instagram_sandbox": "app.services.instagram_sandbox_publish",
+    "threads": "app.services.threads_publish",
+    "instagram": "app.services.instagram_publish",
+}
+
+
 def get_publish_client_module(channel: str):
-    """story 5b27b32f — 발행 클라이언트 모듈 디스패치. `sandbox`만 `threads_publish`
-    대신 `sandbox_publish`로 우회한다(같은 함수 시그니처·같은 `ThreadsPublishError`
-    클래스를 그대로 재사용 — sandbox_publish.py가 신규 예외 타입을 만들지 않으므로
-    channel_posts.py의 기존 except절이 그대로 먹힌다, 신규 판정 로직 0). 실 배포 채널
-    (threads 등)은 전부 threads_publish 그대로 — 이 함수가 sandbox 개입의 유일한
-    지점이다(Threads 어댑터 코드 자체는 무변경).
+    """story 5b27b32f — 발행 클라이언트 모듈 디스패치. `sandbox`/`instagram_sandbox`
+    는 각각 `sandbox_publish`/`instagram_sandbox_publish`로 우회한다(같은 함수
+    시그니처·같은 `ThreadsPublishError` 클래스를 그대로 재사용 — 신규 판정 로직 0).
+    실 배포 채널(threads·instagram)은 각자의 실 클라이언트 모듈.
 
     story e4fc29fa(페드루 PO 리뷰 B2) — kind="blog" 채널(hosted_site 등)은 여기서
-    명시적으로 거부한다. 이 가드가 없으면 마지막 else가 threads_publish로 조용히
-    떨어져(수정 前 결함) 블로그 발행이 Threads API 코드를 잘못 탄다."""
+    명시적으로 거부한다(이 함수 자체가 site_posts.py 도메인과 무관 — blog는 그쪽의
+    자체 어댑터 dispatch를 쓴다).
+
+    story #3320(페드루 PO 確定) — 그 외(위 dict에 없는 채널)는 `ChannelPublishDispatch
+    NotImplementedError`로 fail-closed(위 클래스 docstring 참고 — 예전엔 조용히
+    threads_publish로 떨어지던 자리)."""
     adapter = get_channel_adapter(channel)
     if adapter is not None and adapter.kind == "blog":
         raise BlogChannelDispatchNotImplementedError(channel=channel)
-    if channel == "sandbox":
-        from app.services import sandbox_publish
-        return sandbox_publish
-    from app.services import threads_publish
-    return threads_publish
+    module_path = _PUBLISH_CLIENT_MODULE_PATHS.get(channel)
+    if module_path is None:
+        raise ChannelPublishDispatchNotImplementedError(channel=channel)
+    import importlib
+    return importlib.import_module(module_path)
 
 
 def assert_sandbox_channel_not_registered_in_prod() -> None:

--- a/backend/app/services/channel_app_credentials.py
+++ b/backend/app/services/channel_app_credentials.py
@@ -20,6 +20,13 @@ from app.services.channel_credential_crypto import decrypt_channel_credential, e
 # 때 여기 한 줄만 추가, platform_setting.py에도 그 채널의 컬럼 쌍을 먼저 추가).
 _PLATFORM_SETTINGS_COLUMNS = {
     "threads": ("threads_platform_app_id", "threads_platform_encrypted_app_secret"),
+    # story #3320(Phase2·마케팅운영, 페드루 PO 決定 2026-09-02) — "Threads 온보딩에서
+    # 만드는 Meta 개발자 앱에 Instagram Graph API use case만 추가"가 그라운딩 근거①
+    # 그 자체다: Instagram은 별도 앱이 아니라 **같은** Meta 개발자 앱(app_id/secret
+    # 재사용) — 새 platform_settings 컬럼을 안 만들고 threads 컬럼을 그대로 가리킨다
+    # (신규 컬럼 0·조직 상수 0, 스토리 본문 「결제 게이트 0」과 같은 취지의 「앱 등록
+    # 게이트 0」).
+    "instagram": ("threads_platform_app_id", "threads_platform_encrypted_app_secret"),
 }
 
 

--- a/backend/app/services/channel_post_images.py
+++ b/backend/app/services/channel_post_images.py
@@ -133,6 +133,20 @@ class ChannelImageAspectRatioExceededError(Exception):
         )
 
 
+class ChannelImageAspectRatioTooNarrowError(Exception):
+    """story #3320(Phase2·마케팅운영) — Instagram 4:5(0.8)~1.91:1처럼 «세로가 너무
+    길어도» 거부하는 하한이 있는 채널용(Threads류 상한-only 채널은 image_aspect_min=
+    0.0 기본값이라 이 경로 자체를 안 탄다, 아래 검증 함수 참고 — 회귀 0)."""
+
+    def __init__(self, *, width_height_ratio: float, min_width_height_ratio: float):
+        self.width_height_ratio = width_height_ratio
+        self.min_width_height_ratio = min_width_height_ratio
+        super().__init__(
+            f"세로가 너무 길어(width/height {width_height_ratio:.2f}) 한도 "
+            f"{min_width_height_ratio:.2f}에 못 미칩니다(변환으로 고칠 수 없음)"
+        )
+
+
 class ChannelImageConversionFailedError(Exception):
     """재인코딩해도 어댑터 한도(image_max_bytes) 밑으로 못 낮춘 극히 드문 경우."""
 
@@ -319,11 +333,30 @@ async def confirm_channel_post_image_upload(
 
     probe = ImageOps.exif_transpose(probe)
     width, height = probe.size
-    aspect_ratio = (max(width, height) / min(width, height)) if min(width, height) > 0 else 0.0
-    if aspect_ratio > adapter.image_aspect_max:
-        raise ChannelImageAspectRatioExceededError(
-            aspect_ratio=aspect_ratio, max_aspect_ratio=adapter.image_aspect_max,
-        )
+    if adapter.image_aspect_min > 0 and height > 0:
+        # story #3320 — Instagram류(orientation-aware, 방향별 한도가 다름: 가로
+        # 최대 1.91:1·세로 최대 4:5=0.8). 아래(Threads 등) 정규화(long/short, 항상
+        # ≥1) 검사를 그대로 쓰면 image_aspect_max(1.91)가 방향 구분 없이 양쪽에
+        # 다 적용돼 세로쪽 실제 한도(0.8)보다 훨씬 느슨해진다(정규화 1.91 ==
+        # width/height 1/1.91=0.52까지 통과) — 원시 width/height 비율 하나로
+        # 위(가로 초과)·아래(세로 초과) 두 한도를 각각 직접 비교해야 정확하다.
+        # Threads 등 image_aspect_min=0.0(기본값)인 채널은 이 분기 자체를 안 타
+        # 아래의 기존 정규화 검사 그대로(회귀 0).
+        width_height_ratio = width / height
+        if width_height_ratio > adapter.image_aspect_max:
+            raise ChannelImageAspectRatioExceededError(
+                aspect_ratio=width_height_ratio, max_aspect_ratio=adapter.image_aspect_max,
+            )
+        if width_height_ratio < adapter.image_aspect_min:
+            raise ChannelImageAspectRatioTooNarrowError(
+                width_height_ratio=width_height_ratio, min_width_height_ratio=adapter.image_aspect_min,
+            )
+    else:
+        aspect_ratio = (max(width, height) / min(width, height)) if min(width, height) > 0 else 0.0
+        if aspect_ratio > adapter.image_aspect_max:
+            raise ChannelImageAspectRatioExceededError(
+                aspect_ratio=aspect_ratio, max_aspect_ratio=adapter.image_aspect_max,
+            )
 
     derived_bytes, derived_content_type, derived_width, derived_height, _out_format = _derive_image(
         raw, adapter=adapter,

--- a/backend/app/services/instagram_oauth.py
+++ b/backend/app/services/instagram_oauth.py
@@ -24,9 +24,15 @@ import httpx
 
 _AUTHORIZE_BASE = "https://www.instagram.com/oauth/authorize"
 _TOKEN_URL = "https://api.instagram.com/oauth/access_token"
+# 장기토큰 교환/갱신은 페드루 PO가 2026-09-06 재확認한 그대로 버전 세그먼트가
+# 없는 전용 엔드포인트(일반 Graph API 호출과 다름) — 바꾸지 않는다.
 _EXCHANGE_URL = "https://graph.instagram.com/access_token"
 _REFRESH_URL = "https://graph.instagram.com/refresh_access_token"
-_ME_URL = "https://graph.instagram.com/me"
+# story #3320 — 페드루 PO REQUIRED(2026-09-06, #3872 PASS 철회) — /me는 일반
+# Graph API 호출이라 instagram_publish.py::_GRAPH_BASE와 같은 버전 호스트로
+# 통일(위 두 전용 엔드포인트와는 다른 축).
+_GRAPH_BASE = "https://graph.instagram.com/v25.0"
+_ME_URL = _GRAPH_BASE + "/me"
 
 
 class InstagramOAuthError(Exception):

--- a/backend/app/services/instagram_oauth.py
+++ b/backend/app/services/instagram_oauth.py
@@ -1,0 +1,121 @@
+"""story #3320(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — Instagram Login(Business
+Login for Instagram) 서버 OAuth 교환. `threads_oauth.py`(story #3373)와 동형 구조 —
+app_id/secret은 호출부(`channel_app_credentials.py`의 3단 우선순위)가 해석해 넘긴다.
+
+엔드포인트·스코프·「Facebook Page 연결 불요」는 페드루 PO가 2026-09-06 Meta 공식 문서
+(developers.facebook.com)로 직접 재확認한 값 — threads_oauth.py처럼 지식 컷오프 추정이
+아니다(다만 실 계정 왕복 검증은 아직, App Review 뒤 — sandbox까지가 이 조각 라이브
+범위, 그라운딩 결과 3320 스토리 코멘트 참고).
+
+⚠️미확認 딱지 — PKCE: Meta 문서에 `code_challenge`/`code_challenge_method` 언급이
+없어(페드루 재확認 2026-09-06) 이 구현은 PKCE를 아예 안 보낸다. threads_oauth.py의
+토글 플래그 패턴과 다른 이유 — 그쪽은 문헌이 불확실해 플래그로 즉시 되돌릴 여지를
+남겼지만, 여기는 문헌이 이미 "미언급=미지원"쪽으로 명확해 코드 자체를 단순화했다.
+CSRF·재사용 방지는 `channel_oauth_state.py`의 state 서명이 PKCE 유무와 무관하게
+이미 담당(threads와 동일 축).
+
+흐름: authorize(코드 부여, PKCE 없음) → callback(단기 토큰+IG-scoped user_id, "data"
+배열 응답 — Threads의 평면 응답과 다른 shape, 그라운딩·PO 재확認 둘 다 반영) → 단기→
+장기(60일) 토큰 교환(`ig_exchange_token`) → (만료 임박마다) 장기 토큰 재발급
+(`ig_refresh_token`, refresh_mode="reissue_from_access_token" — threads와 동형)."""
+from __future__ import annotations
+
+import httpx
+
+_AUTHORIZE_BASE = "https://www.instagram.com/oauth/authorize"
+_TOKEN_URL = "https://api.instagram.com/oauth/access_token"
+_EXCHANGE_URL = "https://graph.instagram.com/access_token"
+_REFRESH_URL = "https://graph.instagram.com/refresh_access_token"
+_ME_URL = "https://graph.instagram.com/me"
+
+
+class InstagramOAuthError(Exception):
+    """code→token/장기교환/갱신/me 조회 실패. .code/.message가 그대로 API 에러 응답에
+    매핑(ThreadsOAuthError와 동형 속성 — 라우터가 두 예외를 같은 except 튜플로 묶어
+    처리할 수 있게, 새 에러 매핑 로직 0)."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, app_id: str) -> str:
+    """PKCE 없음(위 미확認 딱지 참고) — `app_id`는 threads_oauth.py와 동형 이유로
+    호출부가 해석해 넘긴다(이 함수는 조직 등록/플랫폼 공용 앱 3단 우선순위를 모른다)."""
+    from urllib.parse import urlencode
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    cfg = CHANNEL_ADAPTERS["instagram"]
+    params = {
+        "client_id": app_id, "redirect_uri": redirect_uri, "scope": cfg.scope,
+        "response_type": "code", "state": state,
+    }
+    return f"{_AUTHORIZE_BASE}?{urlencode(params)}"
+
+
+async def exchange_code_for_short_lived_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, app_id: str, app_secret: str,
+) -> tuple[str, str]:
+    """authorization code → (access_token, ig_scoped_user_id). 단기 토큰. 응답이
+    `{"data": [{"access_token": ..., "user_id": ...}]}` 형태(Instagram Login 특유의
+    data 배열 — threads_oauth.py의 평면 `{"access_token":...,"user_id":...}`와 다름,
+    페드루 재확認 2026-09-06)라 배열이 오면 첫 원소를, 혹시 평면으로 오면 그대로
+    읽는다(양쪽 다 대응 — 문서·실 왕복 사이 사소한 shape 드리프트에 방어적)."""
+    data = {
+        "client_id": app_id, "client_secret": app_secret, "grant_type": "authorization_code",
+        "redirect_uri": redirect_uri, "code": code,
+    }
+    resp = await client.post(_TOKEN_URL, data=data)
+    if resp.status_code != 200:
+        raise InstagramOAuthError("INSTAGRAM_TOKEN_EXCHANGE_FAILED", resp.text[:500])
+    body = resp.json()
+    entries = body.get("data")
+    entry = entries[0] if isinstance(entries, list) and entries else body
+    access_token = entry.get("access_token")
+    user_id = entry.get("user_id")
+    if not access_token or user_id is None:
+        raise InstagramOAuthError("INSTAGRAM_TOKEN_EXCHANGE_MISSING_FIELDS", "access_token/user_id missing")
+    return access_token, str(user_id)
+
+
+async def exchange_for_long_lived_token(
+    client: httpx.AsyncClient, *, short_lived_token: str, app_secret: str,
+) -> tuple[str, int]:
+    """단기 토큰 → (장기 access_token, expires_in초). 장기 토큰은 ~60일."""
+    resp = await client.get(
+        _EXCHANGE_URL,
+        params={"grant_type": "ig_exchange_token", "client_secret": app_secret, "access_token": short_lived_token},
+    )
+    if resp.status_code != 200:
+        raise InstagramOAuthError("INSTAGRAM_LONG_LIVED_EXCHANGE_FAILED", resp.text[:500])
+    body = resp.json()
+    access_token = body.get("access_token")
+    expires_in = body.get("expires_in")
+    if not access_token or not expires_in:
+        raise InstagramOAuthError("INSTAGRAM_LONG_LIVED_EXCHANGE_MISSING_FIELDS", "access_token/expires_in missing")
+    return access_token, int(expires_in)
+
+
+async def refresh_long_lived_token(client: httpx.AsyncClient, *, current_token: str) -> tuple[str, int]:
+    """refresh_mode="reissue_from_access_token" — 현재 유효한 장기 토큰으로 새 장기
+    토큰을 재발급한다(refresh_token 불요, threads와 동형)."""
+    resp = await client.get(_REFRESH_URL, params={"grant_type": "ig_refresh_token", "access_token": current_token})
+    if resp.status_code != 200:
+        raise InstagramOAuthError("INSTAGRAM_REFRESH_FAILED", resp.text[:500])
+    body = resp.json()
+    access_token = body.get("access_token")
+    expires_in = body.get("expires_in")
+    if not access_token or not expires_in:
+        raise InstagramOAuthError("INSTAGRAM_REFRESH_MISSING_FIELDS", "access_token/expires_in missing")
+    return access_token, int(expires_in)
+
+
+async def test_connection(client: httpx.AsyncClient, *, access_token: str) -> dict:
+    """연결 시험 — provider 경량 호출, 토큰은 이 함수 밖으로 절대 안 나간다(threads_
+    oauth.py와 동형 규율)."""
+    resp = await client.get(_ME_URL, params={"fields": "id,username", "access_token": access_token})
+    if resp.status_code != 200:
+        raise InstagramOAuthError("INSTAGRAM_TEST_CONNECTION_FAILED", resp.text[:500])
+    body = resp.json()
+    return {"id": body.get("id"), "username": body.get("username")}

--- a/backend/app/services/instagram_publish.py
+++ b/backend/app/services/instagram_publish.py
@@ -1,0 +1,177 @@
+"""story #3320(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — Instagram Graph API 발행
+클라이언트. `threads_publish.py`(story #f8f7cb0f)와 정확히 같은 함수 시그니처(같은
+파라미터 이름 `threads_user_id`도 그대로 — `channel_posts.py` 오케스트레이션이 어느
+모듈이 골렸는지 몰라도 되게, sandbox_publish.py의 기존 관례와 동형).
+
+**예외는 `threads_publish.py::ThreadsPublishError`를 그대로 재사용한다**(신규 클래스
+0) — `channel_posts.py` 오케스트레이션의 8개 `except ThreadsPublishError` 지점·
+`_classify_threads_error`(코드+status_code만 읽는 순수 함수)가 IG 예외도 그대로
+분류하게 하기 위함이다. sandbox_publish.py가 "sandbox는 진짜 provider가 아니라서"
+재사용한 것과 이유는 다르지만(IG는 진짜 별도 provider) — 결론(신규 판정 로직 0,
+기존 재시도/failure_kind/dead_letter 배선 무변경)은 같다. 새 예외 클래스를 만들면
+그 8곳 전부를 다시 열어 `except (ThreadsPublishError, InstagramPublishError)`로
+넓혀야 하는데, `.code`/`.message`/`.status_code` 3속성만 쓰는 이 클래스를 새로
+쪼갤 실익이 없다(클래스 이름이 "Threads"인 것은 역사적 유산일 뿐 — 이 파일이 두
+번째 진짜 예임).
+
+이 모듈도 순수 API 클라이언트로만 남는다 — 게이트 재검증·멱등·UTM·HTTP status 판단은
+호출부(`channel_posts.py`) 몫(threads_publish.py와 동일 분리).
+
+⚠️미확認 — 컨테이너 생성/상태 폴링/publish/한도조회/permalink 엔드포인트는 IG Graph
+API 지식 컷오프 기준 최선 추정이다(threads_publish.py 최초 작성 시와 동일 상태).
+OAuth·comments 엔드포인트만 페드루 PO가 2026-09-06 Meta 공식 문서로 재확認했다
+(`instagram_oauth.py` 참고) — 이 파일은 아직 그 재확認을 못 받았다. sandbox까지가
+이 조각 라이브 범위(App Review 뒤 실계정 왕복 시점에 재확認 필요)."""
+from __future__ import annotations
+
+import httpx
+
+from app.services.threads_publish import ThreadsPublishError
+
+_MEDIA_CONTAINER_URL_TMPL = "https://graph.facebook.com/v21.0/{ig_user_id}/media"
+_MEDIA_PUBLISH_URL_TMPL = "https://graph.facebook.com/v21.0/{ig_user_id}/media_publish"
+_PUBLISHING_LIMIT_URL_TMPL = "https://graph.facebook.com/v21.0/{ig_user_id}/content_publishing_limit"
+_MEDIA_URL_TMPL = "https://graph.facebook.com/v21.0/{media_id}"
+
+
+async def create_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    image_url: str | None = None,
+) -> str:
+    """미디어 컨테이너 생성 → creation_id. IG는 이미지 필수(피드 이미지 1장, 캐러셀/
+    릴스는 조각① 스코프 밖 — 그라운딩 확認) — `image_url`이 None이면(Threads의
+    TEXT-only 경로와 달리) 호출부가 이미지 없는 초안을 여기까지 보내면 안 된다는
+    뜻이라 즉시 거부한다(사일런트 미디어 없는 컨테이너를 만들지 않는다). `text`는
+    캡션(`caption` 파라미터명 — Threads의 `text`와 다름, IG 실 파라미터명)."""
+    if image_url is None:
+        raise ThreadsPublishError(
+            "INSTAGRAM_IMAGE_REQUIRED", "Instagram 발행은 이미지가 필수입니다(피드 이미지 1장)", status_code=422,
+        )
+    params = {"access_token": access_token, "image_url": image_url}
+    if text:
+        params["caption"] = text
+    resp = await client.post(_MEDIA_CONTAINER_URL_TMPL.format(ig_user_id=threads_user_id), params=params)
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "INSTAGRAM_CREATE_CONTAINER_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    creation_id = body.get("id")
+    if not creation_id:
+        raise ThreadsPublishError(
+            "INSTAGRAM_CREATE_CONTAINER_MISSING_ID", "id missing in response", status_code=resp.status_code,
+        )
+    return str(creation_id)
+
+
+_CONTAINER_STATUS_FINISHED = "FINISHED"
+_CONTAINER_STATUS_IN_PROGRESS = "IN_PROGRESS"
+_CONTAINER_STATUS_ERROR = "ERROR"
+_CONTAINER_STATUS_EXPIRED = "EXPIRED"
+_CONTAINER_STATUS_PUBLISHED = "PUBLISHED"
+
+
+async def get_container_status(
+    client: httpx.AsyncClient, *, access_token: str, creation_id: str,
+) -> tuple[str, str | None]:
+    """(status, error_message) — status ∈ {IN_PROGRESS, FINISHED, PUBLISHED, ERROR,
+    EXPIRED}(threads_publish.py와 같은 값 집합으로 최선 추정 — IG 필드명은 `status_
+    code`(Threads의 `status`와 다름, ⚠️미확認)). `GET /{ig-container-id}?fields=
+    status_code`."""
+    resp = await client.get(
+        _MEDIA_URL_TMPL.format(media_id=creation_id),
+        params={"fields": "status_code", "access_token": access_token},
+    )
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "INSTAGRAM_CONTAINER_STATUS_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    status = body.get("status_code")
+    if not status:
+        raise ThreadsPublishError(
+            "INSTAGRAM_CONTAINER_STATUS_MISSING_FIELD", "status_code missing in response",
+            status_code=resp.status_code,
+        )
+    return str(status), None
+
+
+async def publish_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, creation_id: str,
+) -> str:
+    """컨테이너를 실제로 게시 → media id."""
+    resp = await client.post(
+        _MEDIA_PUBLISH_URL_TMPL.format(ig_user_id=threads_user_id),
+        params={"creation_id": creation_id, "access_token": access_token},
+    )
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "INSTAGRAM_PUBLISH_CONTAINER_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    media_id = body.get("id")
+    if not media_id:
+        raise ThreadsPublishError(
+            "INSTAGRAM_PUBLISH_CONTAINER_MISSING_ID", "id missing in response", status_code=resp.status_code,
+        )
+    return str(media_id)
+
+
+async def get_publishing_limit(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str,
+) -> tuple[int, int, int]:
+    """(quota_usage, quota_total, quota_duration_seconds) — threads_publish.py의
+    `get_publishing_limit`과 동일 파싱 shape으로 최선 추정(`content_publishing_
+    limit` 엔드포인트, 그라운딩③·스토리 본문 명시 — 문서 간 24h 50/100건 불일치라
+    이 실시간 조회가 유일한 신뢰 소스, PO 明示). `GET …/content_publishing_limit`."""
+    resp = await client.get(
+        _PUBLISHING_LIMIT_URL_TMPL.format(ig_user_id=threads_user_id),
+        params={"fields": "quota_usage,config", "access_token": access_token},
+    )
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "INSTAGRAM_PUBLISHING_LIMIT_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    data = body.get("data") or [{}]
+    row = data[0] if data else {}
+    quota_usage = row.get("quota_usage")
+    config = row.get("config") or {}
+    quota_total = config.get("quota_total")
+    quota_duration = config.get("quota_duration")
+    if quota_usage is None or quota_total is None or quota_duration is None:
+        raise ThreadsPublishError(
+            "INSTAGRAM_PUBLISHING_LIMIT_MISSING_FIELDS",
+            "quota_usage/config.quota_total/config.quota_duration missing",
+            status_code=resp.status_code,
+        )
+    return int(quota_usage), int(quota_total), int(quota_duration)
+
+
+async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> None:
+    """story #3320 — Instagram Graph API는 (그라운딩 시점 기준) Threads의 `DELETE
+    /{media-id}`류 공개 삭제 API가 확認되지 않는다 — `ChannelAdapterConfig`의
+    instagram 항목이 `supports_unpublish`를 선언 안 해(기본 False) 이 함수는
+    오케스트레이션에서 호출될 경로 자체가 없다(unpublish 엔드포인트가 그 플래그를
+    먼저 검사). 그래도 실수로 호출되면 조용히 성공한 척하지 않고 명시 예외로
+    막는다(no-fiction — 안 되는 걸 된 것처럼 지어내지 않는다)."""
+    raise ThreadsPublishError(
+        "INSTAGRAM_DELETE_MEDIA_NOT_IMPLEMENTED",
+        "Instagram 미디어 삭제 API는 아직 확認되지 않아 구현하지 않았습니다", status_code=501,
+    )
+
+
+async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> str | None:
+    """`GET /{media-id}?fields=permalink` — threads_publish.py와 동형(값 없으면
+    None, 예외로 승격 안 함)."""
+    resp = await client.get(
+        _MEDIA_URL_TMPL.format(media_id=media_id),
+        params={"fields": "permalink", "access_token": access_token},
+    )
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "INSTAGRAM_GET_PERMALINK_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    permalink = body.get("permalink")
+    return str(permalink) if permalink else None

--- a/backend/app/services/instagram_publish.py
+++ b/backend/app/services/instagram_publish.py
@@ -17,21 +17,33 @@
 이 모듈도 순수 API 클라이언트로만 남는다 — 게이트 재검증·멱등·UTM·HTTP status 판단은
 호출부(`channel_posts.py`) 몫(threads_publish.py와 동일 분리).
 
-⚠️미확認 — 컨테이너 생성/상태 폴링/publish/한도조회/permalink 엔드포인트는 IG Graph
-API 지식 컷오프 기준 최선 추정이다(threads_publish.py 최초 작성 시와 동일 상태).
-OAuth·comments 엔드포인트만 페드루 PO가 2026-09-06 Meta 공식 문서로 재확認했다
-(`instagram_oauth.py` 참고) — 이 파일은 아직 그 재확認을 못 받았다. sandbox까지가
-이 조각 라이브 범위(App Review 뒤 실계정 왕복 시점에 재확認 필요)."""
+⚠️미확認 — 컨테이너 생성/상태 폴링/publish/한도조회/permalink의 파라미터·필드명은
+IG Graph API 지식 컷오프 기준 최선 추정이다(threads_publish.py 최초 작성 시와
+동일 상태). OAuth·comments 엔드포인트만 페드루 PO가 2026-09-06 Meta 공식 문서로
+재확認했다(`instagram_oauth.py` 참고) — 파라미터/필드명은 아직 그 재확認을 못
+받았다. sandbox까지가 이 조각 라이브 범위(App Review 뒤 실계정 왕복 시점에
+재확認 필요).
+
+**호스트 정정(페드루 PO REQUIRED, 2026-09-06, #3872 PASS 철회 뒤 재확認)**: Meta
+공식 문서(developers.facebook.com/docs/instagram-platform/instagram-graph-api/
+get-started · content-publishing, 조회일 2026-09-06, 예시 URL 전부
+`https://graph.instagram.com/v25.0/<IG_ID>/...`) — Instagram Login(Business
+Login for Instagram) 발급 토큰은 **`graph.instagram.com`** 전용이지 Facebook
+Login 경유의 `graph.facebook.com`이 아니다. 최초 작성 시 threads_publish.py의
+`graph.facebook.com` 호스트를 그대로 베꼈던 게 오류(sandbox는 이 URL을 실제로
+안 쳐서 통과했고 실계정 첫 호출에서만 드러나는 클래스) — `instagram_oauth.py`
+의 토큰 교환 엔드포인트들과 같은 호스트로 통일한다."""
 from __future__ import annotations
 
 import httpx
 
 from app.services.threads_publish import ThreadsPublishError
 
-_MEDIA_CONTAINER_URL_TMPL = "https://graph.facebook.com/v21.0/{ig_user_id}/media"
-_MEDIA_PUBLISH_URL_TMPL = "https://graph.facebook.com/v21.0/{ig_user_id}/media_publish"
-_PUBLISHING_LIMIT_URL_TMPL = "https://graph.facebook.com/v21.0/{ig_user_id}/content_publishing_limit"
-_MEDIA_URL_TMPL = "https://graph.facebook.com/v21.0/{media_id}"
+_GRAPH_BASE = "https://graph.instagram.com/v25.0"
+_MEDIA_CONTAINER_URL_TMPL = _GRAPH_BASE + "/{ig_user_id}/media"
+_MEDIA_PUBLISH_URL_TMPL = _GRAPH_BASE + "/{ig_user_id}/media_publish"
+_PUBLISHING_LIMIT_URL_TMPL = _GRAPH_BASE + "/{ig_user_id}/content_publishing_limit"
+_MEDIA_URL_TMPL = _GRAPH_BASE + "/{media_id}"
 
 
 async def create_container(

--- a/backend/app/services/instagram_sandbox_publish.py
+++ b/backend/app/services/instagram_sandbox_publish.py
@@ -1,0 +1,85 @@
+"""story #3320(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — dev 전용 Instagram
+샌드박스 발행 클라이언트. `sandbox_publish.py`(story 5b27b32f)와 정확히 같은 설계
+계약(결정적·상태 없음·`ThreadsPublishError` 재사용, 신규 판정 로직 0) — 다만 이
+채널은 `channel="instagram_sandbox"`로 별도 등록한다(기존 `"sandbox"`는 Threads류
+TEXT-optional 채널을 흉내내는 값이라, 「이미지 필수」인 Instagram의 별도 성질을
+같은 채널 값 안에 욱여넣지 않는다 — `get_publish_client_module`의 채널→모듈 dict가
+이 구분을 그대로 반영).
+
+`channel_adapters.py::get_publish_client_module`이 이 모듈로 디스패치하는 유일한
+지점(sandbox_publish.py와 동형 개입 지점 사상) — 오케스트레이션(channel_posts.py)은
+어느 쪽이 골렸는지 모른다."""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+
+from app.services.threads_publish import ThreadsPublishError
+
+# sandbox_publish.py와 동형 마커 3종(429/provider-error/expired-token) — Instagram
+# 도 인증·한도 실패 시뮬레이션은 같은 어휘를 쓴다(신규 마커 어휘 0). 컨테이너
+# 폴링·comment-2-deleted류는 이 조각(①) 스코프 밖(이미지 필수라 컨테이너 자체는
+# 항상 즉시 FINISHED로 단순화 — Instagram이 Threads IMAGE 컨테이너처럼 비동기
+# 처리 지연을 흉내내야 하는지는 실계정 왕복 뒤 재검토, 그라운딩 미확認 축).
+_MARKER_429 = "[sandbox:429]"
+_MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
+_MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
+
+
+async def create_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    image_url: str | None = None,
+) -> str:
+    """instagram_publish.py와 동형 — 이미지 필수(None이면 즉시 거부, 실 provider와
+    같은 조건을 sandbox도 지킨다 — sandbox가 실제보다 관대하면 「sandbox는 됐는데
+    실계정은 막힘」류 격차가 생긴다)."""
+    if _MARKER_429 in text:
+        raise ThreadsPublishError("SANDBOX_INSTAGRAM_RATE_LIMITED", "sandbox: [sandbox:429] 마커 시뮬레이션", status_code=429)
+    if _MARKER_PROVIDER_ERROR in text:
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_PROVIDER_ERROR", "sandbox: [sandbox:provider-error] 마커 시뮬레이션", status_code=502,
+        )
+    if _MARKER_EXPIRED_TOKEN in text:
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_TOKEN_EXPIRED", "sandbox: [sandbox:expired-token] 마커 시뮬레이션", status_code=401,
+        )
+    if image_url is None:
+        raise ThreadsPublishError(
+            "INSTAGRAM_IMAGE_REQUIRED", "Instagram 발행은 이미지가 필수입니다(피드 이미지 1장)", status_code=422,
+        )
+    return f"sandbox-ig-creation-{uuid.uuid4().hex}"
+
+
+async def get_container_status(
+    client: httpx.AsyncClient, *, access_token: str, creation_id: str,
+) -> tuple[str, str | None]:
+    # 이미지 컨테이너라도 조각①은 즉시 FINISHED로 단순화(위 모듈 docstring 참고).
+    return "FINISHED", None
+
+
+async def publish_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, creation_id: str,
+) -> str:
+    return f"sandbox-ig-media-{uuid.uuid4().hex}"
+
+
+async def get_publishing_limit(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str,
+) -> tuple[int, int, int]:
+    # 항상 넉넉한 잔량 — sandbox_publish.py와 동형(429 시뮬레이션은 create_container
+    # 마커로만 유발, 이 함수는 text를 못 받는다).
+    return 0, 100, 86400
+
+
+async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> str | None:
+    return f"https://sandbox.invalid/instagram/{media_id}"
+
+
+async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> None:
+    # instagram_publish.py와 동형 — 실제로 확認 안 된 능력을 sandbox가 먼저 지어내지
+    # 않는다(no-fiction). supports_unpublish=False라 오케스트레이션이 애초에 안 부름.
+    raise ThreadsPublishError(
+        "INSTAGRAM_DELETE_MEDIA_NOT_IMPLEMENTED",
+        "Instagram 미디어 삭제 API는 아직 확認되지 않아 구현하지 않았습니다", status_code=501,
+    )

--- a/backend/tests/test_3320_instagram_connector.py
+++ b/backend/tests/test_3320_instagram_connector.py
@@ -1,0 +1,634 @@
+"""story #3320(Phase2·마케팅운영, 페드루 PO 確定 2026-09-05) — Instagram Graph API
+커넥터 조각①(연결+sandbox 발행). threads_oauth.py/threads_publish.py/sandbox_
+publish.py와 정확히 같은 계약(신규 판정 로직 0) — 세팅 헬퍼는 test_3373_channel_
+connections.py 재사용(플랫폼 앱 자격 시드가 threads/instagram 공용 컬럼이라
+그대로 맞는다, 그라운딩+PO 決定 반영).
+
+AC 매핑:
+- get_publish_client_module이 명시 dict로 채널을 갈라 미등록 채널은 fail-closed
+  (뮤테이션 대상 — dict에서 instagram을 빼면 threads_publish가 아니라 예외로
+  떨어져야 한다).
+- instagram_oauth.py: PKCE 없음(문서 확認)·"data" 배열 응답 shape 처리.
+- instagram_publish.py/instagram_sandbox_publish.py: 이미지 필수(threads_publish.py
+  의 TEXT-optional과 다른 성질) · ThreadsPublishError 재사용(신규 예외 클래스 0).
+- channel_post_images.py: image_aspect_min(신규 축)이 Threads(0.0=하한 없음)는
+  회귀 0, Instagram(0.8)만 세로 과도 이미지를 거부."""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.test_3373_channel_connections import (
+    _seed_agent, _seed_human, _seed_org, _session_factory, _client_for, _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+    monkeypatch.setattr(config_module.settings, "channel_oauth_state_secret", "test-channel-oauth-state-secret")
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_flag(monkeypatch):
+    """instagram_sandbox 어댑터는 CHANNEL_ADAPTERS의 SANDBOX_CHANNEL_ENABLED
+    조건부 블록 안에 등재된다(기존 sandbox와 동형) — 모듈이 이미 import된 뒤라
+    딕셔너리에 직접 주입(test_3497_insight_snapshots.py의 선례와 동형)."""
+    import app.services.channel_adapters as adapters_mod
+
+    ig_sandbox_cfg = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual", credential_kind="none", display_name="Instagram Sandbox",
+        max_text_length=2200, utm_source="instagram_sandbox", utm_medium="test",
+        image_formats=("image/jpeg",), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91, image_aspect_min=0.8,
+        image_width_min=320, image_width_max=1440, image_color_space="sRGB", image_max_count=1,
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "instagram_sandbox", ig_sandbox_cfg)
+    yield
+
+
+# ─── get_publish_client_module: dict 디스패치·fail-closed ────────────────────
+
+
+def test_get_publish_client_module_dispatches_instagram_and_instagram_sandbox():
+    from app.services.channel_adapters import get_publish_client_module
+    import app.services.instagram_publish as instagram_publish
+    import app.services.instagram_sandbox_publish as instagram_sandbox_publish
+    import app.services.threads_publish as threads_publish
+
+    assert get_publish_client_module("instagram") is instagram_publish
+    assert get_publish_client_module("instagram_sandbox") is instagram_sandbox_publish
+    assert get_publish_client_module("threads") is threads_publish
+
+
+def test_get_publish_client_module_unknown_channel_fail_closed():
+    from app.services.channel_adapters import ChannelPublishDispatchNotImplementedError, get_publish_client_module
+
+    with pytest.raises(ChannelPublishDispatchNotImplementedError):
+        get_publish_client_module("myspace")
+
+
+def test_get_publish_client_module_never_falls_through_to_threads_for_instagram(monkeypatch):
+    """뮤테이션 자가검증 — dict에서 instagram을 빼면(과거 if/elif 폴백 재현) 예전
+    결함처럼 threads_publish로 조용히 떨어지면 안 되고 예외로 fail-closed 되는지."""
+    import app.services.channel_adapters as adapters_mod
+
+    mutated = dict(adapters_mod._PUBLISH_CLIENT_MODULE_PATHS)
+    del mutated["instagram"]
+    monkeypatch.setattr(adapters_mod, "_PUBLISH_CLIENT_MODULE_PATHS", mutated)
+
+    with pytest.raises(adapters_mod.ChannelPublishDispatchNotImplementedError):
+        adapters_mod.get_publish_client_module("instagram")
+
+
+# ─── instagram_oauth.py ───────────────────────────────────────────────────────
+
+
+def test_build_authorize_url_never_sends_pkce_params():
+    from app.services.instagram_oauth import build_authorize_url
+
+    url = build_authorize_url(redirect_uri="https://x/callback", state="s", app_id="app-id")
+    assert "code_challenge" not in url
+    assert "client_id=app-id" in url
+    assert url.startswith("https://www.instagram.com/oauth/authorize?")
+
+
+@pytest.mark.anyio
+async def test_exchange_short_lived_token_handles_data_array_response_shape():
+    from app.services.instagram_oauth import exchange_code_for_short_lived_token
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"data": [{"access_token": "tok", "user_id": "17841400000000"}]}
+
+    class _FakeClient:
+        async def post(self, url, *, data):
+            return _FakeResponse()
+
+    token, user_id = await exchange_code_for_short_lived_token(
+        _FakeClient(), code="c", redirect_uri="https://x/callback", app_id="app-id", app_secret="secret",
+    )
+    assert token == "tok"
+    assert user_id == "17841400000000"
+
+
+@pytest.mark.anyio
+async def test_exchange_short_lived_token_handles_flat_response_shape():
+    from app.services.instagram_oauth import exchange_code_for_short_lived_token
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"access_token": "tok", "user_id": "17841400000000"}
+
+    class _FakeClient:
+        async def post(self, url, *, data):
+            return _FakeResponse()
+
+    token, user_id = await exchange_code_for_short_lived_token(
+        _FakeClient(), code="c", redirect_uri="https://x/callback", app_id="app-id", app_secret="secret",
+    )
+    assert token == "tok"
+    assert user_id == "17841400000000"
+
+
+@pytest.mark.anyio
+async def test_exchange_short_lived_token_failure_raises():
+    from app.services.instagram_oauth import InstagramOAuthError, exchange_code_for_short_lived_token
+
+    class _FakeResponse:
+        status_code = 400
+        text = "bad request"
+
+    class _FakeClient:
+        async def post(self, url, *, data):
+            return _FakeResponse()
+
+    with pytest.raises(InstagramOAuthError):
+        await exchange_code_for_short_lived_token(
+            _FakeClient(), code="c", redirect_uri="https://x/callback", app_id="app-id", app_secret="secret",
+        )
+
+
+@pytest.mark.anyio
+async def test_exchange_for_long_lived_token_uses_ig_exchange_token_grant():
+    from app.services.instagram_oauth import exchange_for_long_lived_token
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"access_token": "long-tok", "expires_in": 5184000}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            captured["params"] = params
+            return _FakeResponse()
+
+    token, expires_in = await exchange_for_long_lived_token(_FakeClient(), short_lived_token="short", app_secret="secret")
+    assert token == "long-tok"
+    assert expires_in == 5184000
+    assert captured["params"]["grant_type"] == "ig_exchange_token"
+
+
+@pytest.mark.anyio
+async def test_refresh_long_lived_token_uses_ig_refresh_token_grant():
+    from app.services.instagram_oauth import refresh_long_lived_token
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"access_token": "refreshed-tok", "expires_in": 5184000}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            captured["params"] = params
+            return _FakeResponse()
+
+    token, expires_in = await refresh_long_lived_token(_FakeClient(), current_token="current")
+    assert token == "refreshed-tok"
+    assert captured["params"]["grant_type"] == "ig_refresh_token"
+
+
+@pytest.mark.anyio
+async def test_instagram_test_connection_returns_id_and_username():
+    from app.services.instagram_oauth import test_connection
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"id": "17841400000000", "username": "sprintable_demo"}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    account = await test_connection(_FakeClient(), access_token="tok")
+    assert account == {"id": "17841400000000", "username": "sprintable_demo"}
+
+
+# ─── instagram_publish.py ─────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_container_requires_image_url():
+    from app.services.instagram_publish import create_container
+    from app.services.threads_publish import ThreadsPublishError
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await create_container(None, access_token="tok", threads_user_id="ig-1", text="캡션", image_url=None)
+    assert exc_info.value.code == "INSTAGRAM_IMAGE_REQUIRED"
+
+
+@pytest.mark.anyio
+async def test_create_container_success_posts_caption_and_image_url():
+    from app.services.instagram_publish import create_container
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"id": "creation-1"}
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            captured["url"], captured["params"] = url, params
+            return _FakeResponse()
+
+    creation_id = await create_container(
+        _FakeClient(), access_token="tok", threads_user_id="ig-1", text="캡션",
+        image_url="https://storage.googleapis.com/bucket/img.jpg",
+    )
+    assert creation_id == "creation-1"
+    assert captured["params"]["caption"] == "캡션"
+    assert captured["params"]["image_url"] == "https://storage.googleapis.com/bucket/img.jpg"
+    assert "ig-1" in captured["url"]
+
+
+@pytest.mark.anyio
+async def test_get_container_status_reads_status_code_field():
+    from app.services.instagram_publish import get_container_status
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"status_code": "FINISHED"}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    status, error_message = await get_container_status(_FakeClient(), access_token="tok", creation_id="c1")
+    assert status == "FINISHED"
+    assert error_message is None
+
+
+@pytest.mark.anyio
+async def test_publish_container_returns_media_id():
+    from app.services.instagram_publish import publish_container
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"id": "media-1"}
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            return _FakeResponse()
+
+    media_id = await publish_container(_FakeClient(), access_token="tok", threads_user_id="ig-1", creation_id="c1")
+    assert media_id == "media-1"
+
+
+@pytest.mark.anyio
+async def test_get_publishing_limit_parses_quota_shape():
+    from app.services.instagram_publish import get_publishing_limit
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"data": [{"quota_usage": 5, "config": {"quota_total": 25, "quota_duration": 86400}}]}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    usage, total, duration = await get_publishing_limit(_FakeClient(), access_token="tok", threads_user_id="ig-1")
+    assert (usage, total, duration) == (5, 25, 86400)
+
+
+@pytest.mark.anyio
+async def test_delete_media_not_implemented():
+    from app.services.instagram_publish import delete_media
+    from app.services.threads_publish import ThreadsPublishError
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await delete_media(None, access_token="tok", media_id="media-1")
+    assert exc_info.value.code == "INSTAGRAM_DELETE_MEDIA_NOT_IMPLEMENTED"
+
+
+@pytest.mark.anyio
+async def test_get_permalink_returns_none_when_absent():
+    from app.services.instagram_publish import get_permalink
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    permalink = await get_permalink(_FakeClient(), access_token="tok", media_id="media-1")
+    assert permalink is None
+
+
+# ─── instagram_sandbox_publish.py ─────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_sandbox_create_container_requires_image_too():
+    """sandbox가 실 provider보다 관대하면 "sandbox는 됐는데 실계정은 막힘" 격차가
+    생긴다 — 이미지 필수는 sandbox도 지킨다."""
+    from app.services.instagram_sandbox_publish import create_container
+    from app.services.threads_publish import ThreadsPublishError
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await create_container(None, access_token="x", threads_user_id="ig-1", text="캡션", image_url=None)
+    assert exc_info.value.code == "INSTAGRAM_IMAGE_REQUIRED"
+
+
+@pytest.mark.anyio
+async def test_sandbox_create_container_success_and_publish_are_deterministic_shape():
+    from app.services.instagram_sandbox_publish import create_container, get_container_status, publish_container
+
+    creation_id = await create_container(
+        None, access_token="x", threads_user_id="ig-1", text="캡션", image_url="https://example.com/img.jpg",
+    )
+    assert creation_id.startswith("sandbox-ig-creation-")
+
+    status, _ = await get_container_status(None, access_token="x", creation_id=creation_id)
+    assert status == "FINISHED"
+
+    media_id = await publish_container(None, access_token="x", threads_user_id="ig-1", creation_id=creation_id)
+    assert media_id.startswith("sandbox-ig-media-")
+
+
+@pytest.mark.anyio
+async def test_sandbox_markers_simulate_failures():
+    from app.services.instagram_sandbox_publish import create_container
+    from app.services.threads_publish import ThreadsPublishError
+
+    with pytest.raises(ThreadsPublishError) as exc_429:
+        await create_container(
+            None, access_token="x", threads_user_id="ig-1", text="[sandbox:429]",
+            image_url="https://example.com/img.jpg",
+        )
+    assert exc_429.value.status_code == 429
+
+    with pytest.raises(ThreadsPublishError) as exc_token:
+        await create_container(
+            None, access_token="x", threads_user_id="ig-1", text="[sandbox:expired-token]",
+            image_url="https://example.com/img.jpg",
+        )
+    assert exc_token.value.status_code == 401
+
+
+# ─── channel_post_images.py: image_aspect_min(신규 축) ───────────────────────
+
+
+def test_channel_adapter_config_image_aspect_min_defaults_to_zero_for_threads():
+    """회귀 0 확인 — 기존 Threads 어댑터는 새 필드를 안 건드려도 기본값(0.0)이라
+    세로 하한 검사 자체를 안 탄다."""
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    assert CHANNEL_ADAPTERS["threads"].image_aspect_min == 0.0
+
+
+def test_channel_adapter_config_instagram_has_aspect_min():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    ig = CHANNEL_ADAPTERS["instagram"]
+    assert ig.image_aspect_min == 0.8
+    assert ig.image_aspect_max == 1.91
+
+
+# ─── _PLATFORM_SETTINGS_COLUMNS: Meta 앱 재사용 ──────────────────────────────
+
+
+def test_instagram_reuses_threads_platform_settings_columns():
+    from app.services.channel_app_credentials import _PLATFORM_SETTINGS_COLUMNS
+
+    assert _PLATFORM_SETTINGS_COLUMNS["instagram"] == _PLATFORM_SETTINGS_COLUMNS["threads"]
+
+
+# ─── API: instagram authorize/callback + instagram-sandbox 연결 생성 ─────────
+
+
+@pytest.mark.anyio
+async def test_api_authorize_instagram_omits_pkce():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            resp = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/instagram/authorize")
+        assert resp.status_code == 200, resp.text
+        assert "code_challenge" not in resp.json()["url"]
+        assert "instagram.com" in resp.json()["url"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_api_authorize_then_callback_creates_instagram_connection():
+    from app.main import app
+    import app.services.instagram_oauth as igo
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r_auth = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/instagram/authorize")
+        assert r_auth.status_code == 200, r_auth.text
+        state = r_auth.json()["state"]
+
+        plaintext_token = "ig_plaintext_super_secret_token_zzz"
+        with patch.object(
+            igo, "exchange_code_for_short_lived_token", AsyncMock(return_value=("short_lived_xyz", "17841400000000")),
+        ), patch.object(
+            igo, "exchange_for_long_lived_token", AsyncMock(return_value=(plaintext_token, 5184000)),
+        ), patch.object(
+            igo, "test_connection", AsyncMock(return_value={"id": "17841400000000", "username": "sprintable_ig_demo"}),
+        ):
+            async with _client_for(app) as client:
+                r_cb = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-connections/instagram/callback",
+                    json={"code": "auth-code-abc", "state": state},
+                )
+        assert r_cb.status_code == 200, r_cb.text
+        payload = r_cb.json()
+        assert payload["channel"] == "instagram"
+        assert payload["account_label"] == "sprintable_ig_demo"
+        assert payload["status"] == "active"
+        assert plaintext_token not in str(payload)
+
+        async with Session() as s:
+            from app.models.channel_connection import ChannelConnection
+            from sqlalchemy import select
+            row = (await s.execute(
+                select(ChannelConnection).where(ChannelConnection.org_id == org_id)
+            )).scalar_one()
+        assert row.encrypted_access_token != plaintext_token
+        assert row.refresh_mode == "reissue_from_access_token"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_api_create_instagram_sandbox_connection():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            resp = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/instagram-sandbox")
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["channel"] == "instagram_sandbox"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── channel_post_images.py: image_aspect_min 실 업로드 흐름(HTTP end-to-end) ──
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage_for_image_upload(monkeypatch, tmp_path):
+    """test_620beefc_channel_post_image.py의 동형 픽스처(중복 재발명 금지) — 이
+    파일의 다른 테스트엔 영향 없다(channel_post_images.py를 안 건드리는 테스트는
+    이 monkeypatch를 그냥 무시). 버킷 이름은 반드시 `_upload_and_confirm`이 쓰는
+    `test_620beefc_channel_post_image.py`의 `_CHANNEL_MEDIA_BUCKET`과 같아야 한다
+    — 다르면 PUT(_put_raw_object가 그 상수로 씀)과 confirm(cpi_module.
+    CHANNEL_MEDIA_BUCKET을 읽음)이 서로 다른 버킷을 봐서 404 CHANNEL_IMAGE_
+    OBJECT_NOT_FOUND가 난다(실제로 한 번 겪은 자리)."""
+    import app.services.channel_post_images as cpi_module
+    from tests.test_620beefc_channel_post_image import _CHANNEL_MEDIA_BUCKET
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage-3320"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+def _tall_png_bytes(width: int, height: int) -> bytes:
+    from PIL import Image
+    import io as _io
+
+    img = Image.new("RGB", (width, height), color=(200, 50, 80))
+    buf = _io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.mark.anyio
+async def test_upload_instagram_image_too_narrow_returns_422_but_threads_unaffected():
+    """image_aspect_min(신규 축) 뮤테이션 자가검증 대조 — 같은 극단 세로 이미지가
+    Instagram(0.8 하한)에서는 거부되고, Threads(0.0=하한 없음)에서는 기존 그대로
+    통과해야 한다(회귀 0의 실제 증거, 흉내가 아니라 같은 이미지로 대조)."""
+    from app.main import app
+    from tests.test_620beefc_channel_post_image import (
+        _create_draft, _seed_connection, _seed_human, _seed_org, _seed_story,
+        _session_factory, _client_for, _setup_org_scoped_app, _upload_and_confirm,
+    )
+
+    # width/height=1:2 → width/height ratio=0.5 < instagram의 image_aspect_min(0.8).
+    # 정규화(long/short)로는 2.0 < 10.0(threads image_aspect_max)이라 threads는 통과.
+    raw = _tall_png_bytes(200, 400)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            ig_connection_id = await _seed_connection(s, org_id, channel="instagram")
+            threads_connection_id = await _seed_connection(s, org_id, channel="threads")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                ig_draft_id = await _create_draft(
+                    client, org_id=org_id, connection_id=ig_connection_id, story_id=story_id,
+                )
+                r_ig = await _upload_and_confirm(client, org_id, ig_draft_id, raw, content_type="image/png")
+            assert r_ig.status_code == 422, r_ig.text
+            error = r_ig.json().get("error") or r_ig.json()
+            assert error["code"] == "CHANNEL_IMAGE_ASPECT_RATIO_TOO_NARROW"
+
+            async with _client_for(app) as client:
+                threads_draft_id = await _create_draft(
+                    client, org_id=org_id, connection_id=threads_connection_id, story_id=story_id,
+                )
+                r_threads = await _upload_and_confirm(
+                    client, org_id, threads_draft_id, raw, content_type="image/png",
+                )
+            assert r_threads.status_code == 201, r_threads.text
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_api_agent_rejected_from_instagram_authorize():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+
+        async with _client_for(app) as client:
+            resp = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/instagram/authorize")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3320_instagram_connector.py
+++ b/backend/tests/test_3320_instagram_connector.py
@@ -243,6 +243,31 @@ async def test_instagram_test_connection_returns_id_and_username():
     assert account == {"id": "17841400000000", "username": "sprintable_demo"}
 
 
+@pytest.mark.anyio
+async def test_instagram_test_connection_uses_graph_instagram_com_host():
+    """페드루 PO REQUIRED(2026-09-06, #3872 PASS 철회) — Instagram Login 토큰은
+    graph.instagram.com 전용, graph.facebook.com이 아니다(Meta 문서 재확認).
+    호스트를 facebook.com으로 되돌리면 이 테스트가 RED — sandbox만으론 이
+    회귀를 못 잡는다(실제로 URL을 안 침)."""
+    from app.services.instagram_oauth import test_connection
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"id": "1", "username": "u"}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            captured["url"] = url
+            return _FakeResponse()
+
+    await test_connection(_FakeClient(), access_token="tok")
+    assert captured["url"].startswith("https://graph.instagram.com/")
+    assert "facebook.com" not in captured["url"]
+
+
 # ─── instagram_publish.py ─────────────────────────────────────────────────────
 
 
@@ -332,6 +357,43 @@ async def test_get_publishing_limit_parses_quota_shape():
 
     usage, total, duration = await get_publishing_limit(_FakeClient(), access_token="tok", threads_user_id="ig-1")
     assert (usage, total, duration) == (5, 25, 86400)
+
+
+@pytest.mark.anyio
+async def test_instagram_publish_client_uses_graph_instagram_com_host_for_all_endpoints():
+    """페드루 PO REQUIRED(2026-09-06, #3872 PASS 철회) — instagram_publish.py의
+    4개 URL 템플릿(container 생성·publish·publishing-limit·permalink) 전부
+    graph.instagram.com이어야 한다(Instagram Login 토큰은 graph.facebook.com을
+    거부). sandbox는 이 URL을 실제로 안 쳐서 이 회귀를 못 잡는 클래스 — 실계정
+    첫 호출에서만 드러난다. 이 테스트가 그 격차를 메운다(호스트를 facebook.com
+    으로 되돌리면 RED)."""
+    from app.services.instagram_publish import create_container, get_permalink, get_publishing_limit, publish_container
+
+    captured_urls: list[str] = []
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"id": "x", "data": [{"quota_usage": 0, "config": {"quota_total": 1, "quota_duration": 1}}], "permalink": None}
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            captured_urls.append(url)
+            return _FakeResponse()
+        async def get(self, url, *, params):
+            captured_urls.append(url)
+            return _FakeResponse()
+
+    client = _FakeClient()
+    await create_container(client, access_token="tok", threads_user_id="ig-1", text="c", image_url="https://x/i.jpg")
+    await publish_container(client, access_token="tok", threads_user_id="ig-1", creation_id="c1")
+    await get_publishing_limit(client, access_token="tok", threads_user_id="ig-1")
+    await get_permalink(client, access_token="tok", media_id="media-1")
+
+    assert len(captured_urls) == 4
+    for url in captured_urls:
+        assert url.startswith("https://graph.instagram.com/"), url
+        assert "facebook.com" not in url, url
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_5b27b32f_sandbox_channel.py
+++ b/backend/tests/test_5b27b32f_sandbox_channel.py
@@ -241,11 +241,15 @@ def test_sandbox_env_flag_gates_registration_via_subprocess():
 
 def test_get_publish_client_module_dispatches_by_channel():
     from app.services import sandbox_publish, threads_publish
-    from app.services.channel_adapters import get_publish_client_module
+    from app.services.channel_adapters import ChannelPublishDispatchNotImplementedError, get_publish_client_module
 
     assert get_publish_client_module("sandbox") is sandbox_publish
     assert get_publish_client_module("threads") is threads_publish
-    assert get_publish_client_module("unknown-channel") is threads_publish  # 기본값(회귀 축)
+    # story #3320(페드루 PO 確定) — 미등록 채널이 threads_publish로 조용히 떨어지던
+    # 옛 기본값(회귀 축)은 근본처방으로 제거됨. 지금은 fail-closed 예외가 정본
+    # (test_3320_instagram_connector.py에 뮤테이션 자가검증 포함 더 자세히 있음).
+    with pytest.raises(ChannelPublishDispatchNotImplementedError):
+        get_publish_client_module("unknown-channel")
 
 
 # ─── AC5 — prod fail-closed ───────────────────────────────────────────────

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1133,6 +1133,11 @@
       "source": "story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3320_instagram_connector.py",
+      "sec": 190.0,
+      "source": "story-3320-instagram-connector-piece1(PR 개설 前 선제 등재 — 로컬 raw pytest 31.46s(28건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 190s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_8b7e52d6_claim_story_signal.py",
       "sec": 92.0,
       "source": "story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## 요약
블루프린트 Phase2·마케팅자동화. threads_oauth.py/threads_publish.py/sandbox_publish.py와 정확히 같은 계약(신규 판정 로직 0)으로 Instagram Login 기반 연결+sandbox 발행 인프라 추가. 조각②(App Review 뒤 실발행 경로)·조각③(인사이트/댓글)은 페드루 PO 明示로 이번 스코프 밖.

## 신규
- `instagram_oauth.py`: threads_oauth 시그니처 동형. authorize/token 엔드포인트가 Threads와 별도 도메인(instagram.com/api.instagram.com/graph.instagram.com), 단기토큰 교환 응답이 `{"data":[{...}]}` 배열 모양일 수 있어 배열/평문 둘 다 처리, PKCE 없음(Meta 문서 확認), FB Page 연결 불요.
- `instagram_publish.py`/`instagram_sandbox_publish.py`: 이미지 필수(Threads의 TEXT-optional과 다른 성질). 신규 예외 클래스 없이 기존 `ThreadsPublishError` 재사용 — `channel_posts.py`의 8개 except절 재오픈 불요(sandbox_publish.py 선례 그대로). 확인된 delete-media 공개 API가 없어 `delete_media()`는 501로 명시 미구현(no-fiction).

## 근본처방(페드루 PO 明示 요구)
`get_publish_client_module`의 옛 if/elif 폴백(미등록 채널 → 조용히 threads_publish로 fall-through, e4fc29fa류 오배선과 동형 위험)을 명시 `_PUBLISH_CLIENT_MODULE_PATHS` dict + `ChannelPublishDispatchNotImplementedError` fail-closed로 교체. `test_5b27b32f_sandbox_channel.py`의 옛 fallback-회귀축 어서션도 새 계약으로 갱신.

## 그 외
- `ChannelAdapterConfig.image_aspect_min`(신규 필드, 기본 0.0=하한 없음=Threads 등 회귀 0): Instagram 실 규격(가로 최대 1.91:1·세로 최대 4:5)은 방향별 한도가 달라 기존 정규화(long/short) 단일 상한 검사로는 세로쪽을 못 잡는다 — orientation-aware 채널(image_aspect_min>0)만 원시 width/height 비율로 상/하한 둘 다 판정하는 별도 분기 추가.
- `channel_app_credentials.py`: Instagram이 Threads와 같은 Meta 개발자 앱을 쓴다는 PO 決定 그대로 platform_settings 컬럼 재사용(신규 컬럼 0).
- `cron.py::refresh_channel_tokens`: 옛 `!= "threads": continue` 스킵 가드가 신규 Instagram 연결의 토큰 자동갱신을 영구 스킵시키던 함정 자가발견·수정(채널→갱신함수 dict화).
- `channel_connections.py`: instagram authorize/callback 분기, 별도 sandbox 채널(`instagram_sandbox`, 기존 sandbox와 별개 — 이미지 필수라 관대함이 다름) 연결 생성 엔드포인트.

## 사람 전담(손 안 댐)
Meta 앱에 Instagram Graph API use case 추가·App Review·뭉클랩 IG 계정+페이지 연결 — 전부 페드루 전담.

## 테스트
`tests/test_3320_instagram_connector.py` 28건 — dict 디스패치+뮤테이션 자가검증(fail-closed 재현)·OAuth 배열/평문 응답·이미지필수·ThreadsPublishError 재사용 확認·image_aspect_min 세로대조(같은 극단이미지로 Instagram 422 vs Threads 201 무회귀 실증)·authorize/callback API 왕복·에이전트 403. 인접회귀(3373·620beefc·5b27b32f·f30da19a) 111 passed 무회귀. migration-free(channel은 Text 컬럼).

🤖 Generated with [Claude Code](https://claude.com/claude-code)