### PR TITLE
[SID:3320] feat: Instagram 커넥터 조각③ — 인사이트+댓글 fetch/reply

### DIFF
--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -174,10 +174,10 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         max_text_length=2200,  # 캡션 상한(스토리 본문 규격 표 IG 행, 그라운딩 실확認).
         utm_source="instagram",
         utm_medium="social",
-        # story #3320 조각① — supports_fetch_replies/reply·insight_metrics는 조각③
-        # 에서 켠다(페드루 PO 明示 — 댓글·인사이트 fetch dispatch가 아직 없어서 지금
-        # 켜면 capability 선언과 실제 구현이 어긋난다). supports_unpublish도 미선언
-        # (instagram_publish.py::delete_media 참고 — 삭제 API 자체가 미확認).
+        # story #3320 조각③ — supports_fetch_replies/reply를 켠다(페드루 PO 明示,
+        # `instagram_publish.py::fetch_replies`/`reply`+`channel_post_comments.py`
+        # dispatch가 이제 있다). supports_unpublish는 여전히 미선언(instagram_
+        # publish.py::delete_media 참고 — 삭제 API 자체가 미확認, 조각①과 무변경).
         # 규격(JPEG·4:5~1.91:1·8MB·피드 이미지 1장) — 스토리 본문 규격 표 IG 행
         # 그대로(그라운딩 실확認 대상), 캐러셀/릴스는 조각① 스코프 밖. ⚠️width_min/
         # width_max는 그라운딩이 명시 확認하지 않아 Threads 값(320~1440)을 잠정
@@ -191,6 +191,14 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         image_width_max=1440,
         image_color_space="sRGB",
         image_max_count=1,
+        supports_fetch_replies=True,
+        supports_reply=True,
+        reply_required_scope="instagram_business_manage_comments",
+        # story #3320 조각③ — 페드루 PO 決定⑤=(b): likes+comments+saved(+shares)를
+        # engagements로 합산(insight_snapshots.py::_fetch_instagram 참고). impressions/
+        # reach는 §2(d) 7키 이름 그대로 개별 유지. clicks/spend/conversions는 IG
+        # 유기 미디어 API가 안 줌(Threads와 동일 사유).
+        insight_metrics=("impressions", "reach", "engagements"),
     ),
     # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각①) — Sprintable
     # 호스팅 블로그를 blog kind 어댑터 1호로 등재한다. **동작 무변경** — site_posts.py의
@@ -313,13 +321,18 @@ if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
     CHANNEL_ADAPTERS["instagram_sandbox"] = ChannelAdapterConfig(
         authorize_url="",
         token_url="",
-        scope="sandbox_publish,sandbox_delete",
+        scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
         refresh_mode="manual",
         credential_kind="none",
         display_name="Instagram Sandbox",
         max_text_length=2200,  # instagram과 동형(캡션 상한).
         utm_source="instagram_sandbox",
         utm_medium="test",
+        # story #3320 조각③ — "sandbox"(위)와 동형으로 켠다(instagram_sandbox_publish.py
+        # ::fetch_replies/reply가 이제 있다).
+        supports_fetch_replies=True,
+        supports_reply=True,
+        reply_required_scope="sandbox_manage_replies",
         image_formats=("image/jpeg",),
         image_max_bytes=8 * 1024 * 1024,
         image_aspect_max=1.91,
@@ -328,6 +341,7 @@ if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
         image_width_max=1440,
         image_color_space="sRGB",
         image_max_count=1,
+        insight_metrics=("impressions", "reach", "engagements"),
     )
 
 

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -195,10 +195,12 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         supports_reply=True,
         reply_required_scope="instagram_business_manage_comments",
         # story #3320 조각③ — 페드루 PO 決定⑤=(b): likes+comments+saved(+shares)를
-        # engagements로 합산(insight_snapshots.py::_fetch_instagram 참고). impressions/
-        # reach는 §2(d) 7키 이름 그대로 개별 유지. clicks/spend/conversions는 IG
-        # 유기 미디어 API가 안 줌(Threads와 동일 사유).
-        insight_metrics=("impressions", "reach", "engagements"),
+        # engagements로 합산(insight_snapshots.py::_fetch_instagram 참고). reach는
+        # §2(d) 7키 이름 그대로 개별 유지. clicks/spend/conversions는 IG 유기 미디어
+        # API가 안 줌(Threads와 동일 사유). 페드루 PO REQUIRED(2026-09-06, #3874
+        # 리뷰) — impressions는 2024-07-02 이후 미디어에 폐기돼 선언 안 함(항상
+        # None), 대신 views를 threads와 같은 이름으로 선언.
+        insight_metrics=("views", "reach", "engagements"),
     ),
     # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각①) — Sprintable
     # 호스팅 블로그를 blog kind 어댑터 1호로 등재한다. **동작 무변경** — site_posts.py의
@@ -341,7 +343,9 @@ if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
         image_width_max=1440,
         image_color_space="sRGB",
         image_max_count=1,
-        insight_metrics=("impressions", "reach", "engagements"),
+        # 페드루 PO REQUIRED(2026-09-06, #3874 리뷰) — 위 instagram과 동형 정정
+        # (impressions 폐기, views로 대체).
+        insight_metrics=("views", "reach", "engagements"),
     )
 
 

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -126,6 +126,52 @@ async def _fetch_replies_raw(
                 raise CommentFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
             raise
 
+    if channel == "instagram":
+        from app.models.channel_connection import ChannelConnection
+        from app.models.channel_publication import ChannelPublication
+        from app.services.channel_connection import decrypt_for_use
+        from app.services.instagram_publish import fetch_replies as instagram_fetch_replies
+
+        pub = (await db.execute(
+            select(ChannelPublication).where(ChannelPublication.id == publication_id)
+        )).scalar_one_or_none()
+        if pub is None or pub.external_id is None:
+            raise CommentFetchError(
+                error_code="CHANNEL_CONNECTION_NOT_ACTIVE",
+                message=f"channel_publication을 찾을 수 없습니다: {publication_id}",
+            )
+        connection = await db.get(ChannelConnection, pub.connection_id)
+        if connection is None or connection.status != "active":
+            raise CommentFetchError(
+                error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"연결이 활성 상태가 아닙니다: {pub.connection_id}",
+            )
+        access_token = decrypt_for_use(connection)
+        if access_token is None:
+            raise CommentFetchError(error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message="연결에 자격이 없습니다")
+
+        import httpx
+        try:
+            async with httpx.AsyncClient() as client:
+                return await instagram_fetch_replies(client, access_token=access_token, media_id=pub.external_id)
+        except Exception as exc:  # noqa: BLE001 — ThreadsPublishError는 상태코드로 분류(instagram도 재사용)
+            from app.services.threads_publish import ThreadsPublishError
+            if isinstance(exc, ThreadsPublishError):
+                if exc.status_code in (401, 403):
+                    raise CommentFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message=str(exc)) from exc
+                if exc.status_code == 429:
+                    raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message=str(exc)) from exc
+                raise CommentFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
+            raise
+
+    if channel == "instagram_sandbox":
+        from app.services import instagram_sandbox_publish
+
+        if external_id is None:
+            raise CommentFetchError(error_code="COMMENT_EXTERNAL_ID_MISSING", message="external_id가 없습니다")
+        import httpx
+        async with httpx.AsyncClient() as client:
+            return await instagram_sandbox_publish.fetch_replies(client, access_token="sandbox", media_id=external_id)
+
     raise CommentFetchError(
         error_code="COMMENT_CHANNEL_NOT_IMPLEMENTED", message=f"fetch_replies dispatch가 없습니다: {channel}",
     )

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -18,6 +18,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.insight_snapshot import InsightSnapshot
+from app.services.instagram_publish import _GRAPH_BASE as _INSTAGRAM_GRAPH_BASE
 
 logger = logging.getLogger(__name__)
 
@@ -247,7 +248,11 @@ async def _fetch_threads(client: "httpx.AsyncClient", *, access_token: str, medi
     return {"raw": body, "values": values}
 
 
-_INSTAGRAM_INSIGHTS_URL_TMPL = "https://graph.facebook.com/v21.0/{media_id}/insights"
+# story #3320 — 페드루 PO REQUIRED(2026-09-06, #3872 PASS 철회, #3874 리뷰
+# "자체 상수 X, _GRAPH_BASE 참조") — 새 호스트 상수를 여기 또 만들지 않고
+# instagram_publish.py의 것을 그대로 import해 쓴다(호스트를 되돌리는 실수가
+# 한 곳만 고치면 되게 — instagram_publish.py::_GRAPH_BASE docstring 참고).
+_INSTAGRAM_INSIGHTS_URL_TMPL = _INSTAGRAM_GRAPH_BASE + "/{media_id}/insights"
 # story #3320 조각③ — 페드루 PO 決定⑤=(b): likes+comments+saved(+shares, 있으면)를
 # threads_publish.py의 engagements 합산과 같은 모양으로 뭉친다(같은 낱말=같은
 # 정의). impressions/reach는 §2(d) 7키에 그대로 이름이 있어 개별 유지. IG 이미지

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -247,6 +247,75 @@ async def _fetch_threads(client: "httpx.AsyncClient", *, access_token: str, medi
     return {"raw": body, "values": values}
 
 
+_INSTAGRAM_INSIGHTS_URL_TMPL = "https://graph.facebook.com/v21.0/{media_id}/insights"
+# story #3320 조각③ — 페드루 PO 決定⑤=(b): likes+comments+saved(+shares, 있으면)를
+# threads_publish.py의 engagements 합산과 같은 모양으로 뭉친다(같은 낱말=같은
+# 정의). impressions/reach는 §2(d) 7키에 그대로 이름이 있어 개별 유지. IG 이미지
+# 미디어 insights의 정확한 지표 이름 집합은 ⚠️미확認(그라운딩⑤ 원문 그대로 —
+# Threads insights처럼 페드루가 developers.facebook.com으로 재확認한 축이 아니다,
+# 라이브 왕복 전 재검증 필요) — 최선 추정으로 이 5개를 요청한다.
+_INSTAGRAM_INSIGHTS_METRICS = "impressions,reach,likes,comments,saved,shares"
+_INSTAGRAM_ENGAGEMENT_METRICS = ("likes", "comments", "saved", "shares")
+
+
+async def _fetch_instagram(client: "httpx.AsyncClient", *, access_token: str, media_id: str) -> dict[str, Any]:  # noqa: F821
+    """_fetch_threads와 동형 에러분류(같은 error_code 문자열 재사용, 새 매핑표 0)."""
+    import httpx
+
+    resp = await client.get(
+        _INSTAGRAM_INSIGHTS_URL_TMPL.format(media_id=media_id),
+        params={"metric": _INSTAGRAM_INSIGHTS_METRICS, "access_token": access_token},
+    )
+    if resp.status_code == 401:
+        raise InsightFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message="Instagram 액세스 토큰이 만료되었습니다")
+    if resp.status_code == 429:
+        raise InsightFetchError(error_code="CHANNEL_RATE_LIMITED", message="Instagram 인사이트 API 한도 초과")
+    if resp.status_code >= 500:
+        raise InsightFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=f"Instagram 서버 오류: {resp.status_code}")
+    if resp.status_code >= 400:
+        raise InsightFetchError(error_code="CHANNEL_PUBLISH_AUTH_REJECTED", message=f"Instagram 인사이트 요청 거부: {resp.status_code}")
+
+    body = resp.json()
+    values: dict[str, int] = {}
+    for item in body.get("data", []):
+        name = item.get("name")
+        total = 0
+        for v in item.get("values", []) or []:
+            total += int(v.get("value", 0) or 0)
+        if name in ("impressions", "reach"):
+            values[name] = values.get(name, 0) + total
+        elif name in _INSTAGRAM_ENGAGEMENT_METRICS:
+            values["engagements"] = values.get("engagements", 0) + total
+    return {"raw": body, "values": values}
+
+
+async def _fetch_instagram_via_connection(db: AsyncSession, snapshot: InsightSnapshot) -> dict[str, Any]:
+    from app.models.channel_connection import ChannelConnection
+    from app.models.channel_publication import ChannelPublication
+    from app.services.channel_connection import decrypt_for_use
+
+    pub = (await db.execute(
+        select(ChannelPublication).where(ChannelPublication.id == snapshot.publication_id)
+    )).scalar_one_or_none()
+    if pub is None or pub.external_id is None:
+        raise InsightFetchError(
+            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
+        )
+    connection = await db.get(ChannelConnection, pub.connection_id)
+    if connection is None or connection.status != "active":
+        raise InsightFetchError(
+            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"연결이 활성 상태가 아닙니다: {pub.connection_id}",
+        )
+    access_token = decrypt_for_use(connection)
+    if access_token is None:
+        raise InsightFetchError(error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message="연결에 자격이 없습니다")
+
+    import httpx
+
+    async with httpx.AsyncClient() as client:
+        return await _fetch_instagram(client, access_token=access_token, media_id=pub.external_id)
+
+
 async def _fetch_for_snapshot(db: AsyncSession, snapshot: InsightSnapshot) -> dict[str, Any]:
     """channel별 dispatch. 호출 前 `insight_metrics`가 빈 튜플이 아님을 이미 확인했다는
     전제(호출자 `process_due_insight_snapshots`가 그 판정을 한다 — 여기선 순수 dispatch
@@ -257,6 +326,8 @@ async def _fetch_for_snapshot(db: AsyncSession, snapshot: InsightSnapshot) -> di
         return await _fetch_hosted_site(db, org_id=snapshot.org_id, publication_id=snapshot.publication_id)
     if snapshot.channel == "threads":
         return await _fetch_threads_via_connection(db, snapshot)
+    if snapshot.channel == "instagram":
+        return await _fetch_instagram_via_connection(db, snapshot)
     raise InsightFetchError(
         error_code="INSIGHT_CHANNEL_NOT_IMPLEMENTED",
         message=f"insight_metrics는 선언됐지만 fetch dispatch가 없습니다: {snapshot.channel}",

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -255,11 +255,17 @@ async def _fetch_threads(client: "httpx.AsyncClient", *, access_token: str, medi
 _INSTAGRAM_INSIGHTS_URL_TMPL = _INSTAGRAM_GRAPH_BASE + "/{media_id}/insights"
 # story #3320 조각③ — 페드루 PO 決定⑤=(b): likes+comments+saved(+shares, 있으면)를
 # threads_publish.py의 engagements 합산과 같은 모양으로 뭉친다(같은 낱말=같은
-# 정의). impressions/reach는 §2(d) 7키에 그대로 이름이 있어 개별 유지. IG 이미지
-# 미디어 insights의 정확한 지표 이름 집합은 ⚠️미확認(그라운딩⑤ 원문 그대로 —
-# Threads insights처럼 페드루가 developers.facebook.com으로 재확認한 축이 아니다,
-# 라이브 왕복 전 재검증 필요) — 최선 추정으로 이 5개를 요청한다.
-_INSTAGRAM_INSIGHTS_METRICS = "impressions,reach,likes,comments,saved,shares"
+# 정의). reach는 §2(d) 7키에 그대로 이름이 있어 개별 유지.
+#
+# 페드루 PO REQUIRED(2026-09-06, #3874 리뷰, Meta 문서 재확認) — **impressions는
+# 2024-07-02 이후 생성된 미디어에 폐기**됐다(우리 발행물 전부 이 이후) — 요청
+# metric에 넣으면 실계정 첫 호출이 400(#3872의 graph.facebook.com 호스트 오류와
+# 같은 클래스: sandbox는 이 파라미터를 실제로 안 쳐서 통과하고 실계정에서만
+# 드러남). impressions는 이제 요청도 안 하고 항상 None(선언 안 함, insight_
+# snapshots.py의 null≠0 원칙 그대로 — "쟀는데 0"이 아니라 "이 채널이 이 지표를
+# 안 준다"). 대신 `views`를 요청해 §2(d) 7키의 `views`에 그대로 싣는다(threads의
+# views와 같은 이름, 별도 합산 없음).
+_INSTAGRAM_INSIGHTS_METRICS = "views,reach,likes,comments,saved,shares"
 _INSTAGRAM_ENGAGEMENT_METRICS = ("likes", "comments", "saved", "shares")
 
 
@@ -287,7 +293,7 @@ async def _fetch_instagram(client: "httpx.AsyncClient", *, access_token: str, me
         total = 0
         for v in item.get("values", []) or []:
             total += int(v.get("value", 0) or 0)
-        if name in ("impressions", "reach"):
+        if name in ("views", "reach"):
             values[name] = values.get(name, 0) + total
         elif name in _INSTAGRAM_ENGAGEMENT_METRICS:
             values["engagements"] = values.get("engagements", 0) + total

--- a/backend/app/services/instagram_publish.py
+++ b/backend/app/services/instagram_publish.py
@@ -44,6 +44,8 @@ _MEDIA_CONTAINER_URL_TMPL = _GRAPH_BASE + "/{ig_user_id}/media"
 _MEDIA_PUBLISH_URL_TMPL = _GRAPH_BASE + "/{ig_user_id}/media_publish"
 _PUBLISHING_LIMIT_URL_TMPL = _GRAPH_BASE + "/{ig_user_id}/content_publishing_limit"
 _MEDIA_URL_TMPL = _GRAPH_BASE + "/{media_id}"
+_COMMENTS_URL_TMPL = _GRAPH_BASE + "/{media_id}/comments"
+_COMMENT_REPLIES_URL_TMPL = _GRAPH_BASE + "/{comment_id}/replies"
 
 
 async def create_container(
@@ -187,3 +189,79 @@ async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_i
     body = resp.json()
     permalink = body.get("permalink")
     return str(permalink) if permalink else None
+
+
+# ─── story #3320 조각③ — 댓글 수집+답변 ───────────────────────────────────────
+# 페드루 PO가 2026-09-06 Meta 공식 문서로 재확認한 엔드포인트(instagram_oauth.py
+# 헤더와 동일 신뢰도 — 이 파일 상단 발행 엔드포인트류의 "⚠️미확認"과 다름):
+# `GET /{ig-media-id}/comments`·`GET|POST /{ig-comment-id}/replies`, 필드
+# `id,text,timestamp,from{id,username}`, 스코프 instagram_business_basic+
+# instagram_business_manage_comments.
+
+_COMMENTS_FIELDS = "id,text,timestamp,from{id,username}"
+_REPLIES_MAX_PAGES = 10  # threads_publish.py::fetch_replies와 동일 상한·동일 사유
+
+
+async def fetch_replies(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> tuple[list[dict], bool]:
+    """이 media의 댓글 목록 + 완전 수집 여부(threads_publish.py::fetch_replies와
+    동형 커서 상한 방어 — PR#3865 리뷰에서 나온 "첫 페이지만 보고 리컨실하면
+    뒷페이지가 오삭제되는" 결함 클래스를 여기서도 똑같이 막는다).
+
+    `channel_post_comments.py::collect_comments_for_publication`은 각 항목의
+    `raw.get("username")`을 top-level에서 읽는다(sandbox/threads raw 모양과
+    동일 계약) — IG는 실제로 `from.username`에 있어(threads의 top-level
+    `username`과 다른 응답 모양) 여기서 `username`/`from_id`를 top-level로
+    끌어올려 얹는다(원본 `from` 필드도 raw에 그대로 보존, 유실 없음)."""
+    items: list[dict] = []
+    after_cursor: str | None = None
+    for _ in range(_REPLIES_MAX_PAGES):
+        params = {"fields": _COMMENTS_FIELDS, "access_token": access_token}
+        if after_cursor:
+            params["after"] = after_cursor
+        resp = await client.get(_COMMENTS_URL_TMPL.format(media_id=media_id), params=params)
+        if resp.status_code != 200:
+            raise ThreadsPublishError(
+                "INSTAGRAM_FETCH_REPLIES_FAILED", resp.text[:500], status_code=resp.status_code,
+            )
+        body = resp.json()
+        for raw in body.get("data") or []:
+            frm = raw.get("from") or {}
+            item = dict(raw)
+            item["username"] = frm.get("username")
+            item["from_id"] = frm.get("id")
+            items.append(item)
+        after_cursor = ((body.get("paging") or {}).get("cursors") or {}).get("after")
+        if not after_cursor:
+            return items, True
+    return items, False
+
+
+async def reply(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, reply_to_id: str, text: str,
+) -> tuple[str, str | None]:
+    """댓글에 답변 — `POST /{ig-comment-id}/replies`(전용 엔드포인트, Threads의
+    "미확認 2-step 추정"과 달리 Meta 문서로 확認됨). `reply_to_id`=대상 댓글의
+    external_comment_id. `threads_user_id`는 이 호출엔 안 쓴다(대상이 댓글
+    id라 유저/미디어 id가 URL에 안 들어감) — 시그니처는 dispatch 통일을 위해
+    그대로 유지(sandbox_publish.py·threads_publish.py와 동일 관례).
+
+    ⚠️미확認 1건: POST 파라미터명이 `message`라는 것은 Meta의 Comment→Replies
+    edge 표준 관례를 따른 최선 추정 — 페드루가 재확認한 건 엔드포인트 URL/메서드·
+    GET 응답 필드까지고 이 POST 파라미터명 자체는 아니다(라이브 왕복 전 재확認
+    필요). 응답엔 permalink 개념이 없어(댓글은 media가 아님) 두 번째 반환값은
+    항상 None."""
+    resp = await client.post(
+        _COMMENT_REPLIES_URL_TMPL.format(comment_id=reply_to_id),
+        params={"message": text, "access_token": access_token},
+    )
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "INSTAGRAM_REPLY_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    external_reply_id = body.get("id")
+    if not external_reply_id:
+        raise ThreadsPublishError(
+            "INSTAGRAM_REPLY_MISSING_ID", "id missing in response", status_code=resp.status_code,
+        )
+    return str(external_reply_id), None

--- a/backend/app/services/instagram_publish.py
+++ b/backend/app/services/instagram_publish.py
@@ -245,11 +245,11 @@ async def reply(
     id라 유저/미디어 id가 URL에 안 들어감) — 시그니처는 dispatch 통일을 위해
     그대로 유지(sandbox_publish.py·threads_publish.py와 동일 관례).
 
-    ⚠️미확認 1건: POST 파라미터명이 `message`라는 것은 Meta의 Comment→Replies
-    edge 표준 관례를 따른 최선 추정 — 페드루가 재확認한 건 엔드포인트 URL/메서드·
-    GET 응답 필드까지고 이 POST 파라미터명 자체는 아니다(라이브 왕복 전 재확認
-    필요). 응답엔 permalink 개념이 없어(댓글은 media가 아님) 두 번째 반환값은
-    항상 None."""
+    페드루 PO가 2026-09-06 Meta comment-moderation 문서로 POST 파라미터명
+    (`message`)·응답 필드(`{id}`)·요구 스코프(`instagram_business_manage_
+    comments`)까지 재확認했다 — 이 함수는 이제 미확認 딱지 0(OAuth·GET 댓글
+    엔드포인트와 같은 신뢰도). 응답엔 permalink 개념이 없어(댓글은 media가
+    아님) 두 번째 반환값은 항상 None."""
     resp = await client.post(
         _COMMENT_REPLIES_URL_TMPL.format(comment_id=reply_to_id),
         params={"message": text, "access_token": access_token},

--- a/backend/app/services/instagram_sandbox_publish.py
+++ b/backend/app/services/instagram_sandbox_publish.py
@@ -83,3 +83,33 @@ async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id
         "INSTAGRAM_DELETE_MEDIA_NOT_IMPLEMENTED",
         "Instagram 미디어 삭제 API는 아직 확認되지 않아 구현하지 않았습니다", status_code=501,
     )
+
+
+# ─── story #3320 조각③ — 댓글 수집+답변(sandbox_publish.py와 동형 계약) ────────
+
+
+def _deterministic_comment(*, media_id: str, index: int) -> dict:
+    seed = int(uuid.uuid5(uuid.NAMESPACE_URL, f"{media_id}:{index}").hex[:8], 16)
+    return {
+        "id": f"sandbox-ig-comment-{media_id}-{index}",
+        "text": f"샌드박스 IG 댓글 {index}(seed={seed % 1000})",
+        "username": f"sandbox_ig_user_{index}",
+        "timestamp": "2026-09-05T00:00:00+00:00",
+    }
+
+
+async def fetch_replies(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> tuple[list[dict], bool]:
+    """sandbox_publish.py::fetch_replies와 동형 — media_id 하나엔 항상 같은 2건
+    (순서 고정), complete=True 고정(페이지네이션 개념 없음). AC8류
+    comment-2-deleted 시각 시뮬레이션은 이 조각(③) 스코프 밖(원 스토리 §3516
+    AC8이 이미 threads/기존 sandbox에서 검증한 마커라 여기서 중복 재발명 안 함)."""
+    return [_deterministic_comment(media_id=media_id, index=i) for i in (1, 2)], True
+
+
+async def reply(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, reply_to_id: str, text: str,
+) -> tuple[str, str | None]:
+    """instagram_publish.py::reply와 동형 계약 — 댓글 답변엔 permalink 개념이
+    없어 두 번째 반환값은 항상 None(실 클라이언트와 동일하게, sandbox가 실제보다
+    관대한 값을 지어내지 않는다)."""
+    return f"sandbox-ig-reply-{uuid.uuid4().hex}", None

--- a/backend/tests/test_3320_instagram_piece3.py
+++ b/backend/tests/test_3320_instagram_piece3.py
@@ -68,7 +68,7 @@ def _enable_instagram_sandbox_adapter(monkeypatch):
         image_aspect_max=1.91, image_aspect_min=0.8,
         image_width_min=320, image_width_max=1440, image_color_space="sRGB", image_max_count=1,
         supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
-        insight_metrics=("impressions", "reach", "engagements"),
+        insight_metrics=("views", "reach", "engagements"),
     )
     monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "instagram_sandbox", ig_sandbox_cfg)
     yield
@@ -99,7 +99,7 @@ def test_instagram_adapter_declares_fetch_replies_reply_and_insight_metrics():
     assert ig.supports_fetch_replies is True
     assert ig.supports_reply is True
     assert ig.reply_required_scope == "instagram_business_manage_comments"
-    assert ig.insight_metrics == ("impressions", "reach", "engagements")
+    assert ig.insight_metrics == ("views", "reach", "engagements")
 
 
 # ─── instagram_publish.py::fetch_replies ─────────────────────────────────────
@@ -417,7 +417,7 @@ async def test_instagram_insights_200_maps_likes_comments_saved_shares_to_engage
             await s.commit()
 
             _patch_transport(monkeypatch, lambda request: httpx.Response(200, json={"data": [
-                {"name": "impressions", "values": [{"value": 500}]},
+                {"name": "views", "values": [{"value": 500}]},
                 {"name": "reach", "values": [{"value": 300}]},
                 {"name": "likes", "values": [{"value": 10}]},
                 {"name": "comments", "values": [{"value": 2}]},
@@ -430,12 +430,29 @@ async def test_instagram_insights_200_maps_likes_comments_saved_shares_to_engage
             snap = (await s.execute(
                 select(InsightSnapshot).where(InsightSnapshot.publication_id == pub.id)
             )).scalars().first()
-            assert snap.normalized["impressions"] == 500
+            assert snap.normalized["views"] == 500
             assert snap.normalized["reach"] == 300
             assert snap.normalized["engagements"] == 17  # 10+2+1+4
-            assert snap.normalized["views"] is None  # instagram이 선언 안 한 축.
+            # 페드루 PO REQUIRED(2026-09-06, #3874 리뷰) — impressions는 2024-07-02
+            # 이후 미디어에 폐기돼 선언 자체를 안 한다(insight_metrics에 없음) —
+            # "쟀는데 0"이 아니라 "이 채널이 이 지표를 안 준다"(null≠0 원칙).
+            assert snap.normalized["impressions"] is None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_instagram_insights_metric_param_excludes_impressions_includes_views():
+    """페드루 PO REQUIRED(2026-09-06, #3874 리뷰) — impressions가 2024-07-02
+    이후 미디어에 폐기돼 요청 파라미터에 들어가면 실계정 첫 호출이 400난다
+    (#3872의 graph.facebook.com 호스트 오류와 같은 클래스: sandbox는 이
+    파라미터를 실제로 안 쳐서 통과하고 실계정에서만 드러남). 되돌리면(mutation)
+    이 테스트가 RED."""
+    from app.services.insight_snapshots import _INSTAGRAM_INSIGHTS_METRICS
+
+    requested = _INSTAGRAM_INSIGHTS_METRICS.split(",")
+    assert "impressions" not in requested
+    assert "views" in requested
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_3320_instagram_piece3.py
+++ b/backend/tests/test_3320_instagram_piece3.py
@@ -1,0 +1,425 @@
+"""story #3320(Phase2·마케팅운영, 페드루 PO 決定 2026-09-06) — Instagram Graph API
+커넥터 조각③(인사이트+댓글). 조각①(연결+sandbox 발행)이 이미 만든 dict 기반
+dispatch(`get_publish_client_module`)에 그대로 얹는다 — 신규 dispatch 로직은
+`insight_snapshots.py::_fetch_for_snapshot`/`channel_post_comments.py::
+_fetch_replies_raw`의 instagram/instagram_sandbox 분기 2곳뿐, 그 외 오케스트
+레이션(`channel_posts.py`·`publication_command.py::reply` 호출부)은 무변경.
+
+세팅 헬퍼는 test_3497_insight_snapshots.py·test_3516_channel_post_comments.py와
+동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+from tests.test_3497_insight_snapshots import _seed_channel_connection, _seed_channel_publication
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_instagram_sandbox_adapter(monkeypatch):
+    """instagram_sandbox는 SANDBOX_CHANNEL_ENABLED env가 모듈 import 시점에 없으면
+    CHANNEL_ADAPTERS에 아예 없다 — test_3320_instagram_connector.py의 dict 직접
+    주입 선례와 동형(중복 재발명 금지), 조각③ capability(supports_fetch_replies/
+    reply=True) 포함."""
+    import app.services.channel_adapters as adapters_mod
+
+    ig_sandbox_cfg = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
+        refresh_mode="manual", credential_kind="none", display_name="Instagram Sandbox",
+        max_text_length=2200, utm_source="instagram_sandbox", utm_medium="test",
+        image_formats=("image/jpeg",), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91, image_aspect_min=0.8,
+        image_width_min=320, image_width_max=1440, image_color_space="sRGB", image_max_count=1,
+        supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
+        insight_metrics=("impressions", "reach", "engagements"),
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "instagram_sandbox", ig_sandbox_cfg)
+    yield
+
+
+def _patch_transport(monkeypatch, handler) -> None:
+    """test_3497_insight_snapshots.py::_patch_threads_transport와 동형."""
+    import httpx
+
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    class _PatchedAsyncClient(real_async_client):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _PatchedAsyncClient)
+
+
+# ─── ChannelAdapterConfig: 조각③에서 켠 capability 선언 ──────────────────────
+
+
+def test_instagram_adapter_declares_fetch_replies_reply_and_insight_metrics():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    ig = CHANNEL_ADAPTERS["instagram"]
+    assert ig.supports_fetch_replies is True
+    assert ig.supports_reply is True
+    assert ig.reply_required_scope == "instagram_business_manage_comments"
+    assert ig.insight_metrics == ("impressions", "reach", "engagements")
+
+
+# ─── instagram_publish.py::fetch_replies ─────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_instagram_fetch_replies_normalizes_from_username_to_top_level():
+    """channel_post_comments.py::collect_comments_for_publication이 raw.get("username")
+    을 top-level에서 읽는다(sandbox/threads raw 모양과 동일 계약) — IG 실 응답은
+    `from.username`에 있어 fetch_replies가 이걸 끌어올려야 한다."""
+    from app.services.instagram_publish import fetch_replies
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {
+                "data": [
+                    {"id": "c1", "text": "댓글1", "timestamp": "2026-09-06T00:00:00+0000",
+                     "from": {"id": "u1", "username": "sprintable_demo"}},
+                ],
+                "paging": {},
+            }
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    items, complete = await fetch_replies(_FakeClient(), access_token="tok", media_id="media-1")
+    assert complete is True
+    assert items[0]["username"] == "sprintable_demo"
+    assert items[0]["from_id"] == "u1"
+    assert items[0]["from"] == {"id": "u1", "username": "sprintable_demo"}  # 원본 보존.
+
+
+@pytest.mark.anyio
+async def test_instagram_fetch_replies_follows_cursor_until_exhausted():
+    from app.services.instagram_publish import fetch_replies
+
+    pages = [
+        {"data": [{"id": "c1", "from": {"username": "u1"}}], "paging": {"cursors": {"after": "cursor2"}}},
+        {"data": [{"id": "c2", "from": {"username": "u2"}}], "paging": {}},
+    ]
+    call_count = {"n": 0}
+
+    class _FakeResponse:
+        def __init__(self, body):
+            self.status_code = 200
+            self._body = body
+        def json(self):
+            return self._body
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            resp = _FakeResponse(pages[call_count["n"]])
+            call_count["n"] += 1
+            return resp
+
+    items, complete = await fetch_replies(_FakeClient(), access_token="tok", media_id="media-1")
+    assert [i["id"] for i in items] == ["c1", "c2"]
+    assert complete is True
+    assert call_count["n"] == 2
+
+
+@pytest.mark.anyio
+async def test_instagram_fetch_replies_failure_raises_threads_publish_error():
+    from app.services.instagram_publish import fetch_replies
+    from app.services.threads_publish import ThreadsPublishError
+
+    class _FakeResponse:
+        status_code = 400
+        text = "bad request"
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await fetch_replies(_FakeClient(), access_token="tok", media_id="media-1")
+    assert exc_info.value.code == "INSTAGRAM_FETCH_REPLIES_FAILED"
+
+
+# ─── instagram_publish.py::reply ──────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_instagram_reply_posts_to_comment_replies_endpoint():
+    from app.services.instagram_publish import reply
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"id": "reply-1"}
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            captured["url"], captured["params"] = url, params
+            return _FakeResponse()
+
+    external_reply_id, permalink = await reply(
+        _FakeClient(), access_token="tok", threads_user_id="ig-1", reply_to_id="c1", text="답변합니다",
+    )
+    assert external_reply_id == "reply-1"
+    assert permalink is None  # IG 댓글엔 permalink 개념이 없음.
+    assert captured["url"].endswith("/c1/replies")
+    assert captured["params"]["message"] == "답변합니다"
+
+
+@pytest.mark.anyio
+async def test_instagram_reply_failure_raises():
+    from app.services.instagram_publish import reply
+    from app.services.threads_publish import ThreadsPublishError
+
+    class _FakeResponse:
+        status_code = 403
+        text = "forbidden"
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            return _FakeResponse()
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await reply(_FakeClient(), access_token="tok", threads_user_id="ig-1", reply_to_id="c1", text="x")
+    assert exc_info.value.code == "INSTAGRAM_REPLY_FAILED"
+
+
+# ─── instagram_sandbox_publish.py: 결정적 댓글+답변 ──────────────────────────
+
+
+@pytest.mark.anyio
+async def test_instagram_sandbox_fetch_replies_deterministic_two_comments():
+    from app.services.instagram_sandbox_publish import fetch_replies
+
+    items, complete = await fetch_replies(None, access_token="x", media_id="media-1")
+    assert complete is True
+    assert [i["id"] for i in items] == [
+        "sandbox-ig-comment-media-1-1", "sandbox-ig-comment-media-1-2",
+    ]
+
+    items2, _ = await fetch_replies(None, access_token="x", media_id="media-1")
+    assert items == items2, "결정적이어야 함(같은 media_id는 매번 같은 값)"
+
+
+@pytest.mark.anyio
+async def test_instagram_sandbox_reply_returns_id_without_permalink():
+    from app.services.instagram_sandbox_publish import reply
+
+    external_reply_id, permalink = await reply(
+        None, access_token="x", threads_user_id="ig-1", reply_to_id="c1", text="답변",
+    )
+    assert external_reply_id.startswith("sandbox-ig-reply-")
+    assert permalink is None
+
+
+# ─── channel_post_comments.py::_fetch_replies_raw dispatch(instagram/instagram_sandbox) ─
+
+
+@pytest.mark.anyio
+async def test_collect_comments_for_publication_dispatches_instagram(monkeypatch):
+    from app.models.channel_post_comment import ChannelPostComment
+    from app.services.channel_post_comments import collect_comments_for_publication
+    import app.services.instagram_publish as instagram_publish
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="instagram", external_id="ig-media-1",
+            )
+
+            async def _fake_fetch(client, *, access_token, media_id):
+                return [{"id": "c1", "text": "댓글", "username": "u1", "timestamp": datetime.now(timezone.utc).isoformat()}], True
+
+            monkeypatch.setattr(instagram_publish, "fetch_replies", _fake_fetch)
+            await collect_comments_for_publication(
+                s, org_id=org_id, publication_id=pub.id, channel="instagram", external_id="ig-media-1",
+            )
+            await s.commit()
+
+            rows = (await s.execute(
+                select(ChannelPostComment).where(ChannelPostComment.publication_id == pub.id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].external_comment_id == "c1"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_collect_comments_for_publication_dispatches_instagram_sandbox():
+    from app.models.channel_post_comment import ChannelPostComment
+    from app.services.channel_post_comments import collect_comments_for_publication
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+
+            await collect_comments_for_publication(
+                s, org_id=org_id, publication_id=uuid.uuid4(), channel="instagram_sandbox",
+                external_id="ig-sandbox-media-1",
+            )
+            await s.commit()
+
+            rows = (await s.execute(select(ChannelPostComment))).scalars().all()
+            assert len(rows) == 2, "sandbox는 결정적 2건을 upsert해야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_collect_comments_instagram_token_expired_maps_to_channel_token_expired(monkeypatch):
+    from app.services.channel_post_comments import CommentFetchError, collect_comments_for_publication
+    import app.services.instagram_publish as instagram_publish
+    from app.services.threads_publish import ThreadsPublishError
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="instagram", external_id="ig-media-1",
+            )
+
+            async def _fake_fetch_401(client, *, access_token, media_id):
+                raise ThreadsPublishError("INSTAGRAM_FETCH_REPLIES_FAILED", "expired", status_code=401)
+
+            monkeypatch.setattr(instagram_publish, "fetch_replies", _fake_fetch_401)
+            with pytest.raises(CommentFetchError) as exc_info:
+                await collect_comments_for_publication(
+                    s, org_id=org_id, publication_id=pub.id, channel="instagram", external_id="ig-media-1",
+                )
+            assert exc_info.value.error_code == "CHANNEL_TOKEN_EXPIRED"
+    finally:
+        await engine.dispose()
+
+
+# ─── insight_snapshots.py::_fetch_instagram(MockTransport) ───────────────────
+
+
+@pytest.mark.anyio
+async def test_instagram_insights_200_maps_likes_comments_saved_shares_to_engagements(monkeypatch):
+    import httpx
+
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="instagram")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="instagram", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            _patch_transport(monkeypatch, lambda request: httpx.Response(200, json={"data": [
+                {"name": "impressions", "values": [{"value": 500}]},
+                {"name": "reach", "values": [{"value": 300}]},
+                {"name": "likes", "values": [{"value": 10}]},
+                {"name": "comments", "values": [{"value": 2}]},
+                {"name": "saved", "values": [{"value": 1}]},
+                {"name": "shares", "values": [{"value": 4}]},
+            ]}))
+            counts = await process_due_insight_snapshots(s)
+
+            assert counts["captured"] == 2, counts
+            snap = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == pub.id)
+            )).scalars().first()
+            assert snap.normalized["impressions"] == 500
+            assert snap.normalized["reach"] == 300
+            assert snap.normalized["engagements"] == 17  # 10+2+1+4
+            assert snap.normalized["views"] is None  # instagram이 선언 안 한 축.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_instagram_insights_401_promotes_connection(monkeypatch):
+    import httpx
+
+    from app.models.channel_connection import ChannelConnection
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="instagram")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="instagram", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            _patch_transport(monkeypatch, lambda request: httpx.Response(401, json={"error": {"message": "expired"}}))
+            counts = await process_due_insight_snapshots(s)
+            assert counts["failed"] == 2, counts
+
+            refreshed = await s.get(ChannelConnection, connection.id)
+            assert refreshed.status == "expired"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3320_instagram_piece3.py
+++ b/backend/tests/test_3320_instagram_piece3.py
@@ -164,6 +164,53 @@ async def test_instagram_fetch_replies_follows_cursor_until_exhausted():
 
 
 @pytest.mark.anyio
+async def test_instagram_fetch_replies_uses_graph_instagram_com_host():
+    """페드루 PO REQUIRED(2026-09-06, #3872 PASS 철회) — comments 엔드포인트도
+    graph.instagram.com이어야 한다(instagram_publish.py::_GRAPH_BASE와 동일
+    호스트로 통일). 호스트를 facebook.com으로 되돌리면 RED."""
+    from app.services.instagram_publish import fetch_replies
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"data": [], "paging": {}}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            captured["url"] = url
+            return _FakeResponse()
+
+    await fetch_replies(_FakeClient(), access_token="tok", media_id="media-1")
+    assert captured["url"].startswith("https://graph.instagram.com/")
+    assert "facebook.com" not in captured["url"]
+
+
+@pytest.mark.anyio
+async def test_instagram_reply_uses_graph_instagram_com_host():
+    """페드루 PO REQUIRED(2026-09-06, #3872 PASS 철회) — comment replies
+    엔드포인트도 graph.instagram.com이어야 한다."""
+    from app.services.instagram_publish import reply
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"id": "reply-1"}
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            captured["url"] = url
+            return _FakeResponse()
+
+    await reply(_FakeClient(), access_token="tok", threads_user_id="ig-1", reply_to_id="c1", text="x")
+    assert captured["url"].startswith("https://graph.instagram.com/")
+    assert "facebook.com" not in captured["url"]
+
+
+@pytest.mark.anyio
 async def test_instagram_fetch_replies_failure_raises_threads_publish_error():
     from app.services.instagram_publish import fetch_replies
     from app.services.threads_publish import ThreadsPublishError
@@ -387,6 +434,45 @@ async def test_instagram_insights_200_maps_likes_comments_saved_shares_to_engage
             assert snap.normalized["reach"] == 300
             assert snap.normalized["engagements"] == 17  # 10+2+1+4
             assert snap.normalized["views"] is None  # instagram이 선언 안 한 축.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_instagram_insights_uses_graph_instagram_com_host(monkeypatch):
+    """페드루 PO REQUIRED(2026-09-06, #3872 PASS 철회) — insights 엔드포인트도
+    graph.instagram.com이어야 한다. 호스트를 facebook.com으로 되돌리면 RED
+    (real HTTP 왕복 없이 MockTransport의 request.url로 실제 나간 호스트를 본다)."""
+    import httpx
+
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="instagram")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="instagram", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            captured = {}
+
+            def _handler(request):
+                captured["url"] = str(request.url)
+                return httpx.Response(200, json={"data": []})
+
+            _patch_transport(monkeypatch, _handler)
+            await process_due_insight_snapshots(s)
+
+            assert captured["url"].startswith("https://graph.instagram.com/"), captured["url"]
+            assert "facebook.com" not in captured["url"]
     finally:
         await engine.dispose()
 

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1143,6 +1143,11 @@
       "source": "story-3320-instagram-connector-piece1(PR 개설 前 선제 등재 — 로컬 raw pytest 31.46s(28건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 190s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3320_instagram_piece3.py",
+      "sec": 90.0,
+      "source": "story-3320-instagram-connector-piece3(PR 개설 前 선제 등재 — 로컬 raw pytest 14.96s(13건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 90s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_8b7e52d6_claim_story_signal.py",
       "sec": 92.0,
       "source": "story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## 요약
조각①(#3872, 아직 develop 미착지)이 만든 dict 기반 dispatch(`get_publish_client_module`)에 그대로 얹는다 — 신규 dispatch 분기는 `insight_snapshots.py::_fetch_for_snapshot`/`channel_post_comments.py::_fetch_replies_raw` 2곳뿐, `channel_posts.py` 오케스트레이션·`publication_command.py::reply` 호출부는 무변경(get_publish_client_module이 이미 instagram/instagram_sandbox를 알아 자동으로 얹힘). **base가 #3872(조각①) 브랜치입니다 — 조각①이 develop에 착지하면 이 PR도 base를 develop으로 재조준하겠습니다.**

## instagram_publish.py
- `fetch_replies`: `GET /{ig-media-id}/comments`(페드루 PO가 2026-09-06 Meta 문서로 재확認한 엔드포인트). threads_publish.py와 동일 커서 상한(10페이지) 방어(PR#3865 리뷰의 "첫 페이지만 보고 리컨실하면 뒷페이지 오삭제" 결함 클래스 재발 방지). IG 응답은 `from.username`/`from.id`에 있어(sandbox/threads의 top-level `username`과 다른 모양) top-level로 끌어올려 `channel_post_comments.py`가 무변경으로 소비하게 정규화(원본 `from`도 보존).
- `reply`: `POST /{ig-comment-id}/replies`(전용 엔드포인트, Threads의 미확認 2-step 추정과 달리 확認됨) — POST 파라미터명(`message`)은 미확認 딱지. 댓글 답변엔 permalink 개념이 없어 반환값 항상 None.

## insight_snapshots.py
- `_fetch_instagram`: 페드루 PO 決定⑤=(b) — likes+comments+saved(+shares)를 engagements로 합산(threads_publish.py의 engagements 정의와 같은 모양). impressions/reach는 §2(d) 7키 이름 그대로 개별 유지. 에러분류(401/429/5xx)는 _fetch_threads와 같은 error_code 문자열 재사용(새 매핑표 0).

## instagram_sandbox_publish.py
sandbox_publish.py와 동형 결정적 fetch_replies(media_id당 항상 같은 2건)·reply(permalink 없음).

## ChannelAdapterConfig
instagram/instagram_sandbox 둘 다 `supports_fetch_replies`/`supports_reply` 켬(조각①에선 미선언 — dispatch가 없어서 capability만 먼저 켜면 선언과 구현이 어긋난다는 이유였음, 이제 구현이 있어 켠다). `insight_metrics=("impressions", "reach", "engagements")`.

## 테스트
`tests/test_3320_instagram_piece3.py` 13건 — fetch_replies 정규화·커서 페이지네이션·에러분류·reply 엔드포인트/파라미터·sandbox 결정적값·collect_comments_for_publication dispatch(instagram/instagram_sandbox 둘 다)·insight MockTransport(200 합산+401 connection 승격). 인접회귀(3320 조각①·3497·3516 댓글류) 91+13 passed(`test_agent_scope_matrix` 1건은 이 세션과 무관한 기존 환경 이슈로 deselect, 별도 기록 있음).

조각②(App Review 뒤 실발행 경로)는 여전히 스코프 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)