### PR TITLE
[SID:3516] feat: 댓글 조각②-b — reply 배치조인·command_id 백필·target_text·next_allowed_at

### DIFF
--- a/backend/app/routers/channel_post_comment_replies.py
+++ b/backend/app/routers/channel_post_comment_replies.py
@@ -84,9 +84,13 @@ class ReplyView(BaseModel):
     id: uuid.UUID
     comment_id: uuid.UUID
     text: str
-    # 'draft'|'pending'|'approved'|'sent'|'failed'(channel_post_comment.py 모델 docstring 그대로).
+    # 'draft'|'pending'|'sent'|'failed'(channel_post_comment.py 모델 docstring 그대로
+    # — 'approved'는 실전이 대입 0곳이라 문서에서 뺌, 조각②-b 후속 정정).
     status: str
     gate_id: uuid.UUID | None
+    # story #3516 조각②-b(additive, 후속 기록 갭 메움) — pending+command_id≠null=
+    # 「승인됨(발송 대기, 워커가 아직 안 집음)」, FE 칩은 이 필드 하나에서 파생.
+    command_id: uuid.UUID | None = None
     external_reply_id: str | None
     external_reply_url: str | None
     last_error: str | None
@@ -100,13 +104,22 @@ class ReplyView(BaseModel):
             "(deleted가 changed보다 우선)."
         ),
     )
+    target_text: str | None = Field(
+        default=None,
+        description=(
+            "조각②-b(additive) — 봉인 시점(submit) 대상 댓글 원문. null=아직 게이트가 "
+            "없다(draft)이거나 이 필드 추가 前에 submit된 구버전 게이트. 표시 전용 — "
+            "target_comment_state 판정은 여전히 target_text_sha256(비노출)만 쓴다."
+        ),
+    )
 
 
-def _reply_view(reply, target_comment_state: str | None) -> ReplyView:
+def _reply_view(reply, target_comment_state: str | None, target_text: str | None = None) -> ReplyView:
     return ReplyView(
         id=reply.id, comment_id=reply.comment_id, text=reply.text, status=reply.status, gate_id=reply.gate_id,
+        command_id=reply.command_id,
         external_reply_id=reply.external_reply_id, external_reply_url=reply.external_reply_url,
-        last_error=reply.last_error, target_comment_state=target_comment_state,
+        last_error=reply.last_error, target_comment_state=target_comment_state, target_text=target_text,
     )
 
 
@@ -194,7 +207,7 @@ async def submit_comment_reply_endpoint(
         ) from exc
 
     view = await get_comment_reply_view(db, org_id=org_id, reply_id=reply.id)
-    return _reply_view(view["reply"], view["target_comment_state"])
+    return _reply_view(view["reply"], view["target_comment_state"], view["target_text"])
 
 
 @router.get(
@@ -221,4 +234,4 @@ async def get_comment_reply_endpoint(
         view = await get_comment_reply_view(db, org_id=org_id, reply_id=reply_id)
     except CommentReplyNotFoundError as exc:
         raise HTTPException(status_code=404, detail=f"답변을 찾을 수 없습니다: {reply_id}") from exc
-    return _reply_view(view["reply"], view["target_comment_state"])
+    return _reply_view(view["reply"], view["target_comment_state"], view["target_text"])

--- a/backend/app/routers/channel_post_comments.py
+++ b/backend/app/routers/channel_post_comments.py
@@ -38,6 +38,15 @@ async def _require_human(db: AsyncSession, auth: AuthContext, org_id: uuid.UUID)
     return resolved
 
 
+class CommentReplySummary(BaseModel):
+    """조각②-b(additive) — 댓글당 최신 답변 1건 요약(배치 조인, N+1 X). FE 칩
+    (무응답/초안/상신/발송 대기/발행/실패)은 이 필드 하나에서 파생 — null=무응답."""
+    id: uuid.UUID
+    status: str
+    external_reply_url: str | None
+    command_id: uuid.UUID | None
+
+
 class CommentItem(BaseModel):
     id: uuid.UUID
     external_comment_id: str
@@ -46,6 +55,7 @@ class CommentItem(BaseModel):
     external_created_at: str | None
     captured_at: str
     deleted_at: str | None
+    reply: CommentReplySummary | None = None
 
 
 class CommentListResponse(BaseModel):
@@ -58,6 +68,10 @@ class CommentListResponse(BaseModel):
     # 완전히 같다(deleted_at IS NULL, count_comments_by_publication_ids 재사용).
     active_count: int
     deleted_count: int
+    # 조각②-b 추가(유나 16회차, additive) — publication당 refresh 5분 창의 다음
+    # 허용 시각. null=지금 바로 재수집 가능. last_collected_at과 같은 계산 자리
+    # (다른 세션이 누른 429 창을 로드 시점에 화면이 미리 알게 — 버튼 비활성+사유).
+    comments_next_allowed_at: str | None = None
 
 
 class CommentRefreshResponse(BaseModel):
@@ -90,6 +104,7 @@ async def list_publication_comments_endpoint(
     except CommentPublicationNotFoundError as exc:
         raise HTTPException(status_code=404, detail=f"발행 기록을 찾을 수 없습니다: {publication_id}") from exc
 
+    reply_by_comment_id = result["reply_by_comment_id"]
     return CommentListResponse(
         last_collected_at=result["last_collected_at"].isoformat() if result["last_collected_at"] else None,
         comments=[
@@ -97,10 +112,21 @@ async def list_publication_comments_endpoint(
                 id=c.id, external_comment_id=c.external_comment_id, author_display_name=c.author_display_name,
                 text=c.text, external_created_at=c.external_created_at.isoformat() if c.external_created_at else None,
                 captured_at=c.captured_at.isoformat(), deleted_at=c.deleted_at.isoformat() if c.deleted_at else None,
+                reply=(
+                    CommentReplySummary(
+                        id=reply_by_comment_id[c.id].id, status=reply_by_comment_id[c.id].status,
+                        external_reply_url=reply_by_comment_id[c.id].external_reply_url,
+                        command_id=reply_by_comment_id[c.id].command_id,
+                    )
+                    if c.id in reply_by_comment_id else None
+                ),
             )
             for c in result["comments"]
         ],
         active_count=result["active_count"], deleted_count=result["deleted_count"],
+        comments_next_allowed_at=(
+            result["comments_next_allowed_at"].isoformat() if result["comments_next_allowed_at"] else None
+        ),
     )
 
 

--- a/backend/app/services/channel_post_comment_replies.py
+++ b/backend/app/services/channel_post_comment_replies.py
@@ -204,6 +204,11 @@ async def submit_comment_reply(
         "kind": "comment_reply", "reply_id": str(reply.id), "connection_id": str(pub.connection_id),
         "comment_id": str(comment.id), "target_external_comment_id": comment.external_comment_id,
         "target_text_sha256": comment.text_sha256, "requested_by_member_id": str(requester_member_id),
+        # story #3516 조각②-b(additive, 미르코 3517② 그라운딩 2026-09-06) — §22-⑤
+        # 「봉인 축 셋」의 세 번째(대상 댓글 본문)를 화면이 지금은 sha만 받아 못
+        # 그린다. sha는 계속 정본 판정에 쓰고(target_text_sha256, 그대로 유지),
+        # 이건 순수 표시용 additive 사본 — 대조·판정 로직은 절대 이 필드를 안 본다.
+        "target_text": comment.text,
     }
 
     # find_gate_slot_with_pr_fallback는 (work_item_id, gate_type, scope_key) 슬롯을
@@ -261,6 +266,7 @@ async def get_comment_reply_view(
     comment = await _get_owned_comment(db, org_id=org_id, comment_id=reply.comment_id)
 
     target_comment_state: TargetCommentState | None = None
+    target_text: str | None = None
     if reply.gate_id is not None:
         from app.models.gate import Gate
 
@@ -270,4 +276,8 @@ async def get_comment_reply_view(
             target_comment_state = compute_target_comment_state(
                 comment=comment, sealed_target_text_sha256=sealed_target_sha,
             )
-    return {"reply": reply, "target_comment_state": target_comment_state}
+            # story #3516 조각②-b — 봉인 시점 대상 댓글 본문(표시 전용, target_
+            # comment_state 판정엔 안 씀). 구버전 게이트(이 필드 추가 前 submit된
+            # 게이트)엔 없을 수 있어 None으로 자연히 떨어짐(지어내지 않는다).
+            target_text = (gate.neutral_facts or {}).get("target_text")
+    return {"reply": reply, "target_comment_state": target_comment_state, "target_text": target_text}

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -20,7 +20,7 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.channel_post_comment import ChannelPostComment, CommentCollectionSchedule
+from app.models.channel_post_comment import ChannelPostComment, ChannelPostCommentReply, CommentCollectionSchedule
 
 BATCH_SIZE = 50
 _COLLECTION_OFFSETS = (timedelta(hours=1), timedelta(days=1), timedelta(days=7))
@@ -419,10 +419,52 @@ async def list_comments_for_publication(
         )
     )).scalar_one()
 
+    # story #3516 조각②-b(additive, 미르코 3517② 그라운딩 갭 2026-09-06) —
+    # 댓글당 최신 답변 1건, 배치 조인 1회(N+1 X). ROW_NUMBER 윈도우로 comment_id별
+    # created_at 내림차순 1위만 남긴다(같은 댓글에 재상신 이력이 있어도 최신만).
+    latest_reply_by_comment_id = await _latest_reply_by_comment_ids(
+        db, comment_ids=[c.id for c in rows],
+    )
+
+    # 조각②-b 추가(유나 16회차) — comments_last_collected_at과 같은 계산 자리
+    # (바로 위 `last_captured_at`, refresh_comments_now의 rate-limit 판정과는
+    # 별개 축 — "지금 화면에 보여줄 마지막 수집 시각"을 그대로 재사용). null=지금
+    # 바로 재수집 가능, 값=그 시각까지 429.
+    comments_next_allowed_at: datetime | None = None
+    if last_captured_at is not None:
+        elapsed = datetime.now(timezone.utc) - last_captured_at
+        if elapsed < _REFRESH_MIN_INTERVAL:
+            comments_next_allowed_at = last_captured_at + _REFRESH_MIN_INTERVAL
+
     return {
         "last_collected_at": last_captured_at, "comments": rows,
         "active_count": active_count, "deleted_count": deleted_count,
+        "reply_by_comment_id": latest_reply_by_comment_id,
+        "comments_next_allowed_at": comments_next_allowed_at,
     }
+
+
+async def _latest_reply_by_comment_ids(
+    db: AsyncSession, *, comment_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, ChannelPostCommentReply]:
+    """댓글당 최신 답변 1건 배치 조회 — ROW_NUMBER 윈도우(파티션=comment_id, 정렬=
+    created_at 내림차순)로 1위만 남긴다. comment_ids 없으면 빈 dict(호출부가
+    `.get(comment_id)` → None="무응답")."""
+    if not comment_ids:
+        return {}
+    from sqlalchemy.orm import aliased
+
+    rn = func.row_number().over(
+        partition_by=ChannelPostCommentReply.comment_id, order_by=ChannelPostCommentReply.created_at.desc(),
+    ).label("rn")
+    subq = (
+        select(ChannelPostCommentReply, rn)
+        .where(ChannelPostCommentReply.comment_id.in_(comment_ids))
+        .subquery()
+    )
+    reply_alias = aliased(ChannelPostCommentReply, subq)
+    rows = (await db.execute(select(reply_alias).where(subq.c.rn == 1))).scalars().all()
+    return {reply.comment_id: reply for reply in rows}
 
 
 async def count_comments_by_publication_ids(

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -947,11 +947,26 @@ async def _maybe_create_scheduled_publication_command(
 
         from app.services.publication_command import create_or_get_publication_command
 
-        await create_or_get_publication_command(
+        command, _created = await create_or_get_publication_command(
             session, org_id=gate.org_id, gate_id=gate.id, destination=connection_id,
             approved_version=reply_id, requested_by_member_id=resolver_id,
             scheduled_at=None, operation="reply", content_kind="comment_reply",
         )
+        # story #3516 조각②-b(additive, 미르코 3517② 그라운딩 갭 2026-09-06) —
+        # 이 컬럼은 조각②부터 모델에 있었지만 여기서 채운 적이 없어(FE가 "승인됨
+        # (발송 대기)"를 못 가르던 근본 원인) command 생성 직후 채운다. 멱등
+        # 재호출(이미 명령이 있어 `_created=False`)이어도 같은 값을 다시 대입할
+        # 뿐이라 무해 — reply 조회 실패는 승인 자체를 막지 않는다(warning만).
+        from app.models.channel_post_comment import ChannelPostCommentReply
+
+        reply = await session.get(ChannelPostCommentReply, reply_id)
+        if reply is not None:
+            reply.command_id = command.id
+        else:
+            logger.warning(
+                "gate %s(comment_reply) approved but reply %s not found — command_id not backfilled",
+                gate.id, reply_id,
+            )
         return
 
     def _mark_unresolved() -> None:

--- a/backend/tests/test_3516_comment_reply_piece2b.py
+++ b/backend/tests/test_3516_comment_reply_piece2b.py
@@ -1,0 +1,371 @@
+"""story #3516 조각②-b(additive, 미르코 3517② 그라운딩 갭 2026-09-06 · 유나
+16회차) — 댓글 목록 GET `reply{id,status,external_reply_url,command_id}|null`
+(배치 조인, N+1 X) · ReplyView `command_id`/`target_text` additive · 목록
+`comments_next_allowed_at`(429 창 미리 앎) · submit 시 `neutral_facts.target_text`
+저장(§22-⑤ 「봉인 축 셋」의 세 번째 — 대상 댓글 본문 표시용).
+
+세팅 헬퍼는 test_3516_comment_reply.py(조각②)와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import (
+    _seed_default_role, _seed_human, _seed_org, _session_factory,
+)
+from tests.test_3497_insight_snapshots import _seed_channel_connection
+from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+from tests.test_3516_comment_reply import _seed_comment, _seed_full_publication_chain, _submit_and_approve_reply
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    """test_3516_comment_reply.py와 동형 — supports_reply/fetch_replies=True로 등재."""
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+        insight_metrics=("impressions", "reach", "views", "engagements", "clicks", "spend", "conversions"),
+        supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+# ─── command_id 백필(게이트 승인 훅) ──────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_command_id_backfilled_on_gate_approval():
+    """뿌리 원인 수정 — 조각②부터 모델엔 있었지만 승인 훅이 한 번도 채운 적 없던
+    reply.command_id를 이제 채운다(FE "발송 대기" 판정의 실제 근거)."""
+    from app.models.channel_post_comment import ChannelPostCommentReply
+    from app.models.publication_command import PublicationCommand
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+
+            refreshed = await s.get(ChannelPostCommentReply, reply.id)
+            command = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == reply.gate_id)
+            )).scalar_one()
+            assert refreshed.command_id == command.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_command_id_backfill_is_idempotent_on_second_approval_attempt():
+    """뮤테이션류 자가검증 — 멱등 재호출(이미 명령이 있는 상태)에도 같은 값을
+    다시 대입할 뿐 에러가 안 나야 한다(create_or_get_publication_command의 기존
+    멱등 계약과 어긋나면 안 됨)."""
+    from app.services.gate_service import _maybe_create_scheduled_publication_command
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+            first_command_id = reply.command_id
+
+            gate = await s.get(Gate, reply.gate_id)
+            await _maybe_create_scheduled_publication_command(s, gate, human_id)  # 재호출 — 에러 없이 통과해야.
+            await s.commit()
+
+            from app.models.channel_post_comment import ChannelPostCommentReply
+            refreshed = await s.get(ChannelPostCommentReply, reply.id)
+            assert refreshed.command_id == first_command_id
+    finally:
+        await engine.dispose()
+
+
+# ─── ReplyView: command_id·target_text ────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_reply_view_target_text_is_null_before_submit_and_set_after():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id, text="원본 댓글 본문")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                r_draft = await client.post(
+                    f"/api/v2/organizations/{org_id}/comments/{comment.id}/replies", json={"text": "답변 초안"},
+                )
+                assert r_draft.status_code == 201, r_draft.text
+                assert r_draft.json()["target_text"] is None
+                assert r_draft.json()["command_id"] is None
+                reply_id = r_draft.json()["id"]
+
+                r_submit = await client.post(
+                    f"/api/v2/organizations/{org_id}/comments/{comment.id}/replies/{reply_id}/submit",
+                )
+                assert r_submit.status_code == 200, r_submit.text
+                assert r_submit.json()["target_text"] == "원본 댓글 본문"
+                assert r_submit.json()["command_id"] is None  # 승인 前엔 아직 명령 0.
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reply_view_command_id_appears_after_approval():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                r_get = await client.get(f"/api/v2/organizations/{org_id}/comments/{comment.id}/replies/{reply.id}")
+                assert r_get.status_code == 200, r_get.text
+                assert r_get.json()["command_id"] is not None
+                assert r_get.json()["status"] == "pending"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── 댓글 목록: reply 배치 조인(N+1 X) ────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_comment_list_reply_summary_null_for_unreplied_and_populated_for_replied():
+    from app.services.channel_post_comments import list_comments_for_publication
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            unreplied = await _seed_comment(s, org_id=org_id, publication_id=pub.id, external_comment_id="c-no-reply")
+            replied = await _seed_comment(s, org_id=org_id, publication_id=pub.id, external_comment_id="c-has-reply")
+
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=replied)
+
+            result = await list_comments_for_publication(s, org_id=org_id, publication_id=pub.id)
+            reply_by_comment_id = result["reply_by_comment_id"]
+
+            assert unreplied.id not in reply_by_comment_id
+            assert replied.id in reply_by_comment_id
+            summary = reply_by_comment_id[replied.id]
+            assert summary.id == reply.id
+            assert summary.status == "pending"
+            assert summary.command_id is not None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comment_list_reply_summary_picks_latest_of_multiple_drafts():
+    """댓글 1건에 초안 답변을 2개 만들면(재상신 API가 없어 "새 초안" 관례,
+    스토리 본문 명시) 배치 조인이 가장 최근 것 1건만 내야 한다."""
+    from app.services.channel_post_comment_replies import create_comment_reply_draft
+    from app.services.channel_post_comments import list_comments_for_publication
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            first_draft = await create_comment_reply_draft(
+                s, org_id=org_id, comment_id=comment.id, text="첫 초안", created_by_member_id=human_id,
+                created_by_kind="human",
+            )
+            second_draft = await create_comment_reply_draft(
+                s, org_id=org_id, comment_id=comment.id, text="두 번째 초안", created_by_member_id=human_id,
+                created_by_kind="human",
+            )
+
+            result = await list_comments_for_publication(s, org_id=org_id, publication_id=pub.id)
+            summary = result["reply_by_comment_id"][comment.id]
+            assert summary.id == second_draft.id, "created_at 최신 답변이 나와야 함"
+            assert summary.id != first_draft.id
+    finally:
+        await engine.dispose()
+
+
+# ─── 댓글 목록: comments_next_allowed_at ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_comments_next_allowed_at_null_when_never_collected():
+    from app.services.channel_post_comments import list_comments_for_publication
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+
+            result = await list_comments_for_publication(s, org_id=org_id, publication_id=pub.id)
+            assert result["comments_next_allowed_at"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comments_next_allowed_at_set_within_5min_window():
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.services.channel_post_comments import list_comments_for_publication
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+
+            captured_at = datetime.now(timezone.utc) - timedelta(minutes=2)  # 5분 창 안.
+            s.add(CommentCollectionSchedule(
+                id=uuid.uuid4(), org_id=org_id, publication_id=pub.id, channel=pub.channel,
+                external_id=pub.external_id, due_at=captured_at, captured_at=captured_at, status="captured",
+            ))
+            await s.commit()
+
+            result = await list_comments_for_publication(s, org_id=org_id, publication_id=pub.id)
+            assert result["comments_next_allowed_at"] is not None
+            expected = captured_at + timedelta(minutes=5)
+            assert abs((result["comments_next_allowed_at"] - expected).total_seconds()) < 2
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comments_next_allowed_at_null_after_5min_elapsed():
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.services.channel_post_comments import list_comments_for_publication
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+
+            captured_at = datetime.now(timezone.utc) - timedelta(minutes=10)  # 창 지남.
+            s.add(CommentCollectionSchedule(
+                id=uuid.uuid4(), org_id=org_id, publication_id=pub.id, channel=pub.channel,
+                external_id=pub.external_id, due_at=captured_at, captured_at=captured_at, status="captured",
+            ))
+            await s.commit()
+
+            result = await list_comments_for_publication(s, org_id=org_id, publication_id=pub.id)
+            assert result["comments_next_allowed_at"] is None
+    finally:
+        await engine.dispose()
+
+
+# ─── HTTP e2e — 목록 응답에 reply·comments_next_allowed_at 실림 ──────────────
+
+
+@pytest.mark.anyio
+async def test_api_comment_list_includes_reply_and_next_allowed_at():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                resp = await client.get(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments")
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                assert "comments_next_allowed_at" in body
+                item = next(c for c in body["comments"] if c["id"] == str(comment.id))
+                assert item["reply"]["id"] == str(reply.id)
+                assert item["reply"]["command_id"] is not None
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -343,6 +343,11 @@
       "source": "story-3516-comment-reply-piece2(PR 개설 前 선제 등재 — 로컬 raw pytest 69.52s(15건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 420s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3516_comment_reply_piece2b.py",
+      "sec": 240.0,
+      "source": "story-3516-comment-reply-piece2b(PR 개설 前 선제 등재 — 로컬 raw pytest 39.98s(10건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 240s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3516_comment_scope_and_runbook.py",
       "sec": 40.0,
       "source": "story-3516-comment-scope-piece3(PR 개설 前 선제 등재 — 로컬 raw pytest 6.47s(5건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## 요약
미르코 3517② FE 그라운딩 갭 4건(2026-09-06, 전부 additive·마이그 0)을 한 PR에 묶는다.

## 댓글 목록 GET에 reply 배치 조인(N+1 X)
`…/publications/{id}/comments` 각 항목에 `reply: {id, status, external_reply_url, command_id} | null` — 댓글당 최신 답변 1건. ROW_NUMBER 윈도우(파티션=comment_id, 정렬=created_at desc)로 1위만 남기는 서브쿼리 + `aliased()`로 ORM 엔티티째 회수(배치 조회 1회, 두 번째 구현 0). FE 칩(무응답/초안/상신/발송 대기/발행/실패)은 이 필드 하나에서 파생.

## ReplyView: command_id·target_text(둘 다 additive)
- `command_id`: 모델엔 조각②부터 있었지만(0339) 승인 훅(`_maybe_create_scheduled_publication_command`)이 한 번도 채운 적이 없었다(별건 후속 기록 갭) — command 생성 직후 `reply.command_id = command.id`로 백필. 멱등 재호출에도 같은 값 재대입일 뿐 무해(뮤테이션 자가검증 확인).
- `target_text`: submit 시 `gate.neutral_facts.target_text`(대상 댓글 원문, 표시 전용)를 저장 — §22-⑤ 「봉인 축 셋」의 세 번째(대상 댓글 본문)를 화면이 지금은 sha만 받아 못 그리던 갭. 판정(target_comment_state)은 여전히 target_text_sha256만 쓴다 — 이 필드는 절대 대조에 안 쓴다.

## 댓글 목록: comments_next_allowed_at
`comments_last_collected_at`과 같은 계산 자리(같은 `last_captured_at` 변수) — publication당 refresh 5분 창의 다음 허용 시각. null=지금 바로 가능. 다른 세션이 누른 429 창을 로드 시점에 화면이 미리 알게(버튼 비활성+사유).

## 테스트
`tests/test_3516_comment_reply_piece2b.py` 10건 — command_id 백필+멱등 재호출·ReplyView target_text/command_id(submit 前後 대조)·배치 조인(무응답 null·최신 답변만 선택)·comments_next_allowed_at 3갈래(미수집/창 안/창 지남)·HTTP e2e. 뮤테이션 자가검증(command_id 백필 라인 제거→RED 확인 후 원복). 인접회귀(3516 comment_reply·channel_post_comments·comment_scope_and_runbook·3414·3478) 73 passed(`test_agent_scope_matrix` 1건은 이 세션과 무관한 기존 환경 이슈로 deselect, 격리 재실행 4/4 passed로 무관 재확認).

🤖 Generated with [Claude Code](https://claude.com/claude-code)