### PR TITLE
[SID:3525] fix: publication_id를 «마지막 발행»(published_pub)으로 재정의

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -238,11 +238,29 @@ class ChannelPostDraftListItem(BaseModel):
     # 뒤집는다). true=둘 다 non-null이고 서로 다름(원문이 파생 이후 개정됨) · false=둘 다
     # non-null이고 같음 · None=하나라도 null("모른다" — 레거시 파생분).
     source_changed: bool | None = None
-    # story #3497 조각4(페드루 PO 決定 — 미르코 #3499 그라운딩 갭) — 3497 조회 API
-    # (`/publications/{publication_id}/insights`)의 path 파라미터와 같은 값(latest_pub.id,
-    # "최신 버전"의 publication 행 — publication_status·error_code와 같은 축). 아직 발행
-    # 시도 자체가 없으면 null.
-    publication_id: uuid.UUID | None = None
+    # story #3497 조각4(페드루 PO 決定 — 미르코 #3499 그라운딩 갭)·**story #3525 재정의
+    # (2026-09-06, 페드루 PO 確定, 유나 §22-12)** — 3497 조회 API(`/publications/
+    # {publication_id}/insights`)·3516 댓글 API(`/publications/{publication_id}/
+    # comments`)의 path 파라미터와 같은 값. **«마지막 발행»(published_pub.id) 기준 —
+    # 버전 무관**: `published_at`/`permalink`/`external_id`와 정확히 같은 publication
+    # 행(같은 status='published' 최신 1건)에서 온다. 발행 済 draft에 새 버전이 생겨
+    # 그 버전이 아직 재승인 대기(gate pending)여도 이 필드는 null이 되지 않는다(밖에
+    # 나가 있는 게시물은 새 버전과 무관하게 살아 있다 — 그 실물의 댓글·인사이트가
+    # 상세에서 사라지던 결함의 처방). "지금 버전 자체의 발행 시도 상태"는
+    # `publication_status`/`error_code`(아래, 여전히 latest_pub 축)가 별도로 담당 —
+    # 이 필드와 헷갈리지 말 것. 한 번도 발행된 적 없으면 null.
+    publication_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "«마지막 발행» publication의 id(버전 무관) — published_at/permalink/"
+            "external_id와 같은 publication 행에서 온다. 발행 済 게시물에 새 버전이 "
+            "생겨 재승인 대기(gate pending) 中이어도 null이 되지 않는다: 밖에 나가 "
+            "있는 게시물은 새 버전과 무관하게 살아 있다(story #3525). 댓글·인사이트 "
+            "조회 API(/publications/{publication_id}/comments·insights)의 path "
+            "파라미터가 이 값이다. \"지금 버전 자체\"의 발행 시도 상태는 "
+            "publication_status/error_code가 별도로 담당(다른 축)."
+        ),
+    )
     # story #3514(Phase1·BE+FE·소형, 페드루 PO 確定 2026-09-05) — 단건 조회(lint-on-read)
     # 전용. 목록 응답에선 항상 None(행마다 lint하면 비용 N배, PO 明示 "단건만"). None=
     # "이 응답에선 안 쟀다"·[]="쟀는데 위반 0"(null≠0 원칙 그대로, site_posts.py::
@@ -600,6 +618,10 @@ def _to_draft_list_item(
     if draft.source_site_post_version_id is not None and source_current_site_post_version_id is not None:
         source_changed = draft.source_site_post_version_id != source_current_site_post_version_id
     command_status = latest_command.status if latest_command else None
+    # story #3525 — publication_status/error_code는 의도적으로 latest_pub(현재
+    # 최신 버전의 발행 시도) 축 그대로 둔다 — "지금 버전이 발행 中/실패인지"는
+    # published_pub(마지막으로 실제 나간 것)과는 다른 질문이라 건드리면 컨테이너
+    # 생성 진행 배지(processing_kind, 바로 아래)가 깨진다.
     publication_status = latest_pub.status if latest_pub else None
     # story 620beefc(AC5·§17-15, 페드루 PO 決定) — 판정식은 이 자리 한 곳에서만.
     processing_kind = (
@@ -643,7 +665,10 @@ def _to_draft_list_item(
         image_final_bytes=latest_image.final_bytes if latest_image else None,
         image_was_converted=latest_image.was_converted if latest_image else None,
         processing_kind=processing_kind,
-        publication_id=latest_pub.id if latest_pub else None,
+        # story #3525(재정의) — published_pub 사용(latest_pub 아님). published_at/
+        # permalink/external_id와 정확히 같은 객체라 이 셋과 publication_id가
+        # 절대 어긋날 수 없다(§22-12 계약이 구조적으로 성립).
+        publication_id=published_pub.id if published_pub else None,
         source_content_item_id=draft.source_content_item_id,
         source_title=source_title,
         source_site_post_version_id=draft.source_site_post_version_id,

--- a/backend/tests/test_3525_publication_id_last_published.py
+++ b/backend/tests/test_3525_publication_id_last_published.py
@@ -1,0 +1,130 @@
+"""story #3525(결함·FE/BE, 페드루 PO 確定 2026-09-06, 유나 §22-12) — 발행 済 draft에
+새 버전이 생겨도 조회 뷰의 `publication_id`는 «마지막 발행»(published_pub, 버전
+무관)을 계속 가리켜야 한다. 이전엔 `latest_pub`(현재 최신 버전에 매칭되는 것만)에서
+와 새 버전이 아직 발행 前이면 null이 돼 상세 화면이 밖에 살아 있는 게시물의 댓글·
+인사이트를 감췄다(표본 draft 2220797b, 배포 33).
+
+세팅 헬퍼는 test_3403_channel_post_draft_detail.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.test_3403_channel_post_draft_detail import (
+    _approve_gate_directly, _client_for, _seed_agent, _seed_connection, _seed_default_role,
+    _seed_human, _seed_org, _seed_story, _seed_submit_approve, _session_factory, _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.mark.anyio
+async def test_new_version_after_publish_keeps_publication_id_pointing_at_last_published():
+    """AC1 — v2 생성 뒤 목록·단건 GET 둘 다: publication_id는 v1 발행 그대로(버전
+    무관)·current_version=2·gate_status=pending이 동시에 성립. published_at/
+    permalink/external_id도 함께 살아남는다(같은 published_pub 객체라 구조적으로
+    같이 간다 — 처방의 핵심)."""
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _seed_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-1")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-1")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-1")),
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r_publish = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r_publish.status_code == 200, r_publish.text
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_before = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert r_before.status_code == 200, r_before.text
+            before = r_before.json()
+            assert before["publication_id"] is not None
+            assert before["published_at"] is not None
+            publication_id_after_v1 = before["publication_id"]
+
+            # story #3525 재현 — 같은 work_item+connection에 새 draft 생성 요청을
+            # 다시 보내면(create_channel_post_draft_version의 upsert 분기) 기존
+            # draft에 v2가 추가된다. submit은 호출 안 함(실측 재현 그대로).
+            r_v2 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json={"work_item_id": str(story_id), "connection_id": str(connection_id), "text": "버전 2 본문"},
+            )
+            assert r_v2.status_code == 201, r_v2.text
+            assert r_v2.json()["draft_id"] == draft_id, "같은 draft에 버전만 추가돼야 함(신규 draft 아님)"
+            assert r_v2.json()["version"] == 2
+
+            r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+
+        assert r_detail.status_code == 200, r_detail.text
+        detail = r_detail.json()
+        list_row = next(it for it in r_list.json() if it["draft_id"] == draft_id)
+
+        for label, body in (("detail", detail), ("list", list_row)):
+            assert body["current_version"] == 2, label
+            assert body["gate_status"] == "pending", label
+            assert body["reapproval_required"] is True, label
+            # 처방의 핵심 — publication_id가 v1 발행 그대로(null로 안 떨어짐).
+            assert body["publication_id"] == publication_id_after_v1, label
+            assert body["published_at"] is not None, label
+            assert body["permalink"] == "https://www.threads.net/@demo/post/media-1", label
+            assert body["external_id"] == "media-1", label
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1093,6 +1093,11 @@
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"
     },
     {
+      "file": "tests/test_3525_publication_id_last_published.py",
+      "sec": 45.0,
+      "source": "story-3525-publication-id-last-published(PR 개설 前 선제 등재 — 로컬 raw pytest 6.26s(1건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3404_channel_post_gate_already_held.py",
       "sec": 6.0,
       "source": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held"


### PR DESCRIPTION
## 요약
발행 済 draft에 새 버전이 생기면 조회 뷰의 `publication_id`가 null이 돼 상세 화면이 밖에 살아 있는 게시물의 댓글·인사이트를 통째로 감췄다(표본 draft 2220797b, 배포 33 · 유나 §22-12).

## 근본 원인
`list_channel_post_drafts`(services/channel_posts.py)가 gate_id당 두 개의 다른 dict를 만든다 — `published_pub_by_gate`(status='published' 최신 1건, **버전 무관**) vs `latest_version_pub_by_gate`(**현재 최신 버전에 매칭되는 것만**). `publication_id`는 후자에서, `published_at`/`permalink`/`external_id`는 전자에서 왔다 — 같은 gate인데 완전히 다른 정의의 두 변수. 새 버전이 생기면 `latest_version_pub_by_gate`의 매칭이 실패해 `publication_id`만 null이 되고(`published_at` 등은 버전 무관이라 안 사라짐 — 실측과 정확히 일치).

## 처방
`publication_id=latest_pub.id` → `publication_id=published_pub.id`(routers/channel_posts.py 한 줄). `published_pub`는 이미 `published_at`/`permalink`/`external_id`와 **같은 객체**라 이 넷이 절대 어긋날 수 없다(§22-12 계약이 구조적으로 성립) — 신규 필드 0, FE 조건식(`draft.publication_id`) 무변경. `publication_status`/`error_code`는 의도적으로 `latest_pub` 그대로 유지("지금 버전의 발행 시도 상태"는 별개 축, `processing_kind` 배지가 여기 의존).

## 소비처 확인(grep)
- `unpublish_channel_post`: 이미 자체적으로 `gate_id+status='published' 최신 1건`을 독립 조회(`draft_id`만 받음, `publication_id` 미소비) — 이번 재정의와 이미 같은 정의라 영향 0.
- comments/insights BFF(`channel_post_comments.py`·`insight_snapshots.py`): `publication_id`를 opaque id로만 써(버전 매칭 로직 없음) 어느 값이 와도 그 실제 publication의 댓글·인사이트를 정확히 찾는다 — 이번 재정의가 오히려 의도한 동작(사라졌던 댓글·인사이트가 다시 보임).

## FE 확인
`deriveChannelPostView`(channel-post-status.ts)가 `reapproval_required=true`를 이미 5상태 중 `reapproval_needed`(i18n `contentStatusReapprovalNeeded`)로 그린다 — 새 버전 재승인 대기 배지가 이미 있다. **FE 변경 0.**

## OpenAPI
`publication_id` 필드에 `Field(description=...)` 추가 — 재정의 계약 명시.

## 테스트
`tests/test_3525_publication_id_last_published.py` — 발행 済 draft에 v2 생성 뒤 목록·단건 GET 둘 다 `publication_id`=v1 발행 그대로·`current_version`=2·`gate_status`=pending·`reapproval_required`=true·`published_at`/`permalink`/`external_id` 유지가 동시에 성립(되돌리면 RED, 뮤테이션 자가검증 — 실제로 버그 그대로 재현되는 것 확인 후 원복). 인접회귀(3403·3394·620beefc) 39 passed 무회귀. 컴파일 확인. migration-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)