### PR TITLE
[SID:3528] feat: 댓글 지속 폴링 — 30분 자기재생성+429 백오프+org 상한 200

### DIFF
--- a/backend/alembic/versions/0341_comment_collection_schedule_next_attempt_at.py
+++ b/backend/alembic/versions/0341_comment_collection_schedule_next_attempt_at.py
@@ -1,0 +1,27 @@
+"""story #3528(BE·Phase2, 페드루 PO 確定 2026-09-06) — 댓글 「지속 폴링」 백오프용
+`channel_post_comment_collection_schedule.next_attempt_at` additive nullable
+컬럼. transient(429/5xx) 실패 시 `next_attempt_at = now + min(2^attempt분, 60분)`
+을 채워 다음 tick이 그 시각 전엔 이 행을 안 집게 한다(publication_command.py의
+`next_attempt_at` 관례와 동형 — 새 백오프 어휘 0). NULL=백오프 없음(대기 없이
+바로 집힘, 기존 행·최초 시도 전부 여기 해당 — 회귀 0).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0341"
+down_revision = "0340"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_post_comment_collection_schedule",
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("channel_post_comment_collection_schedule", "next_attempt_at")

--- a/backend/app/models/channel_post_comment.py
+++ b/backend/app/models/channel_post_comment.py
@@ -91,4 +91,7 @@ class CommentCollectionSchedule(Base):
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default="pending")
     attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #3528(마이그 0341, additive) — transient 백오프. NULL=대기 없음(기존
+    # 행·최초 시도). tick은 `next_attempt_at IS NULL OR <= now`만 집는다.
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -26,6 +26,23 @@ BATCH_SIZE = 50
 _COLLECTION_OFFSETS = (timedelta(hours=1), timedelta(days=1), timedelta(days=7))
 _REFRESH_MIN_INTERVAL = timedelta(minutes=5)
 
+# story #3528(PO 確定 2026-09-06) — 「지속 폴링」. due 3창(위) 뒤에도 "활성" 게시물은
+# 이 주기로 자기재생성한다(due 3창을 대체하지 않음 — additive, 둘이 겹쳐도 upsert라
+# 무해). 값은 채널 무관 서비스 상수(ChannelAdapterConfig가 아니라 여기).
+_CONTINUOUS_POLL_INTERVAL = timedelta(minutes=30)
+# "활성 게시물" = published_at 이후 이 기간 이내 AND (댓글 0건이거나 마지막 댓글
+# external_created_at으로부터 _ACTIVE_LAST_COMMENT_WITHIN 이내). 둘 다 벗어나면
+# due 3창만(재생성 0, 자연 소멸).
+_ACTIVE_PUBLISHED_WITHIN = timedelta(days=14)
+_ACTIVE_LAST_COMMENT_WITHIN = timedelta(days=7)
+# org당 지속 폴링(30분 주기) 대상 상한 — 초과분(published_at 기준 201번째부터)은
+# due 3창만 유지(재생성 0). Threads/IG rate limit 대비 계산(PR 본문): 상한 200 ×
+# (24h/30분=48회) = org당 하루 최대 9,600회 fetch_replies 호출 — Threads 유기
+# 게시물 API의 일반적인 앱 레벨 한도(수만~수십만/일, 앱 사용량 등급별) 대비 여유.
+_ACTIVE_PUBLICATIONS_ORG_CAP = 200
+# transient(429/5xx) 백오프 — next_attempt_at = now + min(2^attempt_count분, 60분).
+_TRANSIENT_BACKOFF_CAP_MINUTES = 60
+
 
 class CommentFetchError(Exception):
     """어댑터 fetch_replies 실패 통로. error_code는 `publication_command.py::
@@ -253,15 +270,88 @@ async def collect_comments_for_publication(
     }
 
 
+async def _is_publication_active(db: AsyncSession, *, publication_id: uuid.UUID, now: datetime) -> bool:
+    """story #3528 PO 確定 — published_at 이후 14일 이내 AND (댓글 0건이거나 마지막
+    댓글 external_created_at으로부터 7일 이내). publication을 못 찾거나 published_at
+    자체가 없으면(발행 전 상태를 이 경로가 볼 리 없지만 방어) 비활성으로 fail-closed."""
+    from app.models.channel_publication import ChannelPublication
+
+    pub = await db.get(ChannelPublication, publication_id)
+    if pub is None or pub.published_at is None:
+        return False
+    if now - pub.published_at > _ACTIVE_PUBLISHED_WITHIN:
+        return False
+    last_comment_at = (await db.execute(
+        select(func.max(ChannelPostComment.external_created_at)).where(
+            ChannelPostComment.publication_id == publication_id, ChannelPostComment.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if last_comment_at is None:
+        return True
+    return now - last_comment_at <= _ACTIVE_LAST_COMMENT_WITHIN
+
+
+async def _within_org_continuous_poll_cap(
+    db: AsyncSession, *, org_id: uuid.UUID, publication_id: uuid.UUID, now: datetime,
+) -> bool:
+    """story #3528 PO 確定 — org당 상한 200, "최신 발행 순"으로 자른다. 이 publication
+    보다 더 최근에 발행됐고(published_at 내림차순) 아직 14일 활성 창 안인 publication
+    개수를 세어 200개 미만이면(=이 publication의 순위가 200 이내) 통과. 정확한
+    "활성"(마지막 댓글 7일 축까지) 순위가 아니라 published_at만으로 근사 — PO 문구
+    "최신 발행 순"과 일치하고, 매 재생성마다 org 전체의 댓글 최신성까지 다시 계산하는
+    비용을 피한다."""
+    from app.models.channel_publication import ChannelPublication
+
+    pub = await db.get(ChannelPublication, publication_id)
+    if pub is None or pub.published_at is None:
+        return False
+    more_recent_count = (await db.execute(
+        select(func.count()).select_from(ChannelPublication).where(
+            ChannelPublication.org_id == org_id,
+            ChannelPublication.published_at.is_not(None),
+            ChannelPublication.published_at > pub.published_at,
+            ChannelPublication.published_at >= now - _ACTIVE_PUBLISHED_WITHIN,
+        )
+    )).scalar_one()
+    return more_recent_count < _ACTIVE_PUBLICATIONS_ORG_CAP
+
+
+async def _schedule_next_continuous_poll_if_active(
+    db: AsyncSession, *, org_id: uuid.UUID, publication_id: uuid.UUID, channel: str,
+    external_id: str | None, now: datetime,
+) -> None:
+    """story #3528 — due 행이 captured/failed로 끝난 뒤(호출부가 그 경우에만 부른다)
+    이 publication이 아직 활성이고 org 상한 안이면 30분 뒤 다음 due 행을 자기재생성
+    한다. 비활성으로 떨어지거나 상한 밖이면 재생성 0(자연 소멸 — due 3창은 이미
+    끝났으니 더는 아무 행도 안 남는다)."""
+    if not await _is_publication_active(db, publication_id=publication_id, now=now):
+        return
+    if not await _within_org_continuous_poll_cap(db, org_id=org_id, publication_id=publication_id, now=now):
+        return
+    stmt = pg_insert(CommentCollectionSchedule).values(
+        id=uuid.uuid4(), org_id=org_id, publication_id=publication_id, channel=channel,
+        external_id=external_id, due_at=now + _CONTINUOUS_POLL_INTERVAL, status="pending",
+    ).on_conflict_do_nothing(constraint="uq_comment_collection_schedule_publication_due_at")
+    await db.execute(stmt)
+
+
 async def process_due_comment_collections(db: AsyncSession, *, now: datetime | None = None) -> dict[str, int]:
     """`insight_snapshots.py::process_due_insight_snapshots`와 동형 SKIP LOCKED 2단계
     커밋(클레임 commit → 개별 처리 commit/rollback 격리)."""
     from app.services.publication_command import classify_failure_kind, FAILURE_KIND_CONNECTION, FAILURE_KIND_TRANSIENT
 
+    from sqlalchemy import or_
+
     now = now or datetime.now(timezone.utc)
     rows = (await db.execute(
         select(CommentCollectionSchedule).where(
             CommentCollectionSchedule.status == "pending", CommentCollectionSchedule.due_at <= now,
+            # story #3528 — transient 백오프 지연 존중(next_attempt_at IS NULL=기존
+            # 행·최초 시도라 그대로 즉시 집힘, 회귀 0).
+            or_(
+                CommentCollectionSchedule.next_attempt_at.is_(None),
+                CommentCollectionSchedule.next_attempt_at <= now,
+            ),
         ).order_by(CommentCollectionSchedule.due_at.asc())
         .limit(BATCH_SIZE)
         .with_for_update(skip_locked=True)
@@ -291,6 +381,10 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
                     await _promote_connection_status(db, publication_id=row.publication_id, channel=row.channel)
                     row.status = "failed"
                     row.error_code = exc.error_code
+                    await _schedule_next_continuous_poll_if_active(
+                        db, org_id=row.org_id, publication_id=row.publication_id, channel=row.channel,
+                        external_id=row.external_id, now=now,
+                    )
                     await db.commit()
                     counts["failed"] += 1
                 elif failure_kind == FAILURE_KIND_TRANSIENT:
@@ -298,15 +392,29 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
                     row.error_code = exc.error_code
                     if row.attempt_count >= 5:
                         row.status = "failed"
+                        await _schedule_next_continuous_poll_if_active(
+                            db, org_id=row.org_id, publication_id=row.publication_id, channel=row.channel,
+                            external_id=row.external_id, now=now,
+                        )
                         await db.commit()
                         counts["failed"] += 1
                     else:
+                        # story #3528 — 지수 백오프(2^attempt_count분, 60분 상한).
+                        # pending_retry는 이 행 자체가 아직 안 끝났으니(재생성 대상
+                        # 아님) 여기선 _schedule_next_continuous_poll_if_active를
+                        # 안 부른다 — 이 행이 나중에 captured/failed로 끝나야 부른다.
                         row.status = "pending"
+                        delay_minutes = min(2 ** row.attempt_count, _TRANSIENT_BACKOFF_CAP_MINUTES)
+                        row.next_attempt_at = now + timedelta(minutes=delay_minutes)
                         await db.commit()
                         counts["pending_retry"] += 1
                 else:
                     row.status = "failed"
                     row.error_code = exc.error_code
+                    await _schedule_next_continuous_poll_if_active(
+                        db, org_id=row.org_id, publication_id=row.publication_id, channel=row.channel,
+                        external_id=row.external_id, now=now,
+                    )
                     await db.commit()
                     counts["failed"] += 1
                 continue
@@ -318,12 +426,20 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
             # upsert 자체는 성공했다 — status는 "captured" 그대로 두고 error_code로만
             # "다 못 봤다"를 남긴다(다음 due 창이 이어서 본다, 실패로 재시도 대상 X).
             row.error_code = None if result["complete"] else "COMMENT_COLLECTION_INCOMPLETE_PAGE"
+            await _schedule_next_continuous_poll_if_active(
+                db, org_id=row.org_id, publication_id=row.publication_id, channel=row.channel,
+                external_id=row.external_id, now=now,
+            )
             await db.commit()
             counts["captured"] += 1
         except Exception:  # noqa: BLE001 — 이 행 하나만 막는다(전체 배치 안 죽음).
             await db.rollback()
             row.status = "failed"
             row.error_code = "COMMENT_COLLECTION_UNCLASSIFIED_ERROR"
+            await _schedule_next_continuous_poll_if_active(
+                db, org_id=row.org_id, publication_id=row.publication_id, channel=row.channel,
+                external_id=row.external_id, now=now,
+            )
             await db.commit()
             counts["failed"] += 1
 

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -299,15 +299,26 @@ async def _within_org_continuous_poll_cap(
     개수를 세어 200개 미만이면(=이 publication의 순위가 200 이내) 통과. 정확한
     "활성"(마지막 댓글 7일 축까지) 순위가 아니라 published_at만으로 근사 — PO 문구
     "최신 발행 순"과 일치하고, 매 재생성마다 org 전체의 댓글 최신성까지 다시 계산하는
-    비용을 피한다."""
+    비용을 피한다.
+
+    페드루 PO 비차단①(2026-09-06, #3882 리뷰) — 순위 카운트를 댓글 수집 자체를
+    지원하는 채널(어댑터 `supports_fetch_replies=True`)로 제한한다. 원래 구현은
+    org의 모든 channel_publications(예: hosted_site처럼 댓글 수집이 아예 없는
+    채널)까지 셌는데, 그런 발행물은 이 폴링 자원을 절대 안 쓰니 순위를 부풀려
+    실제로 폴링 대상인 publication이 상한 밖으로 밀리는 왜곡이 있었다."""
     from app.models.channel_publication import ChannelPublication
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
 
     pub = await db.get(ChannelPublication, publication_id)
     if pub is None or pub.published_at is None:
         return False
+    comment_capable_channels = [
+        channel for channel, adapter in CHANNEL_ADAPTERS.items() if adapter.supports_fetch_replies
+    ]
     more_recent_count = (await db.execute(
         select(func.count()).select_from(ChannelPublication).where(
             ChannelPublication.org_id == org_id,
+            ChannelPublication.channel.in_(comment_capable_channels),
             ChannelPublication.published_at.is_not(None),
             ChannelPublication.published_at > pub.published_at,
             ChannelPublication.published_at >= now - _ACTIVE_PUBLISHED_WITHIN,

--- a/backend/tests/test_3528_comment_continuous_polling.py
+++ b/backend/tests/test_3528_comment_continuous_polling.py
@@ -386,6 +386,53 @@ async def test_backoff_mutation_check_removing_next_attempt_at_lets_immediate_re
 
 
 @pytest.mark.anyio
+async def test_org_cap_rank_ignores_publications_on_comment_incapable_channels(monkeypatch):
+    """페드루 PO 비차단①(2026-09-06, #3882 리뷰) — 상한 순위 카운트는 댓글 수집을
+    지원하는 채널(supports_fetch_replies=True)만 센다. hosted_site(미지원)로 더
+    최근에 발행된 게 상한 수만큼 있어도, 그건 이 폴링 자원을 안 쓰니 대상
+    publication(sandbox)의 순위를 안 밀어야 한다(상한을 1로 낮춰도 통과)."""
+    import app.services.channel_post_comments as comments_module
+    from sqlalchemy import select
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.models.channel_publication import ChannelPublication
+
+    monkeypatch.setattr(comments_module, "_ACTIVE_PUBLICATIONS_ORG_CAP", 1)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            now = datetime.now(timezone.utc)
+
+            for i in range(3):
+                newer_hosted_site_pub = await _seed_channel_publication(
+                    s, org_id=org_id, connection_id=conn.id, channel="hosted_site", external_id=f"newer-hs-{i}",
+                )
+                row = await s.get(ChannelPublication, newer_hosted_site_pub.id)
+                row.published_at = now - timedelta(hours=1)
+                await s.commit()
+
+            target_pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="target",
+            )
+            target_row = await s.get(ChannelPublication, target_pub.id)
+            target_row.published_at = now - timedelta(hours=2)
+            await s.commit()
+
+            await _seed_due_schedule_row(s, org_id=org_id, publication_id=target_pub.id, external_id="target")
+            counts = await comments_module.process_due_comment_collections(s, now=now)
+            assert counts["captured"] == 1, counts
+
+            rows = (await s.execute(
+                select(CommentCollectionSchedule).where(CommentCollectionSchedule.publication_id == target_pub.id)
+            )).scalars().all()
+            assert len(rows) == 2, "hosted_site(댓글 미지원) 발행물은 순위에 안 세야 재생성이 통과함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_org_cap_200_blocks_regeneration_for_older_publications(monkeypatch):
     """AC3 — org당 상한 200. 이 publication보다 최근에 발행된(14일 활성 창 안)
     publication이 200개 이상이면 재생성 0. 상한을 낮춰(2) 테스트 비용을 줄인다."""

--- a/backend/tests/test_3528_comment_continuous_polling.py
+++ b/backend/tests/test_3528_comment_continuous_polling.py
@@ -1,0 +1,482 @@
+"""story #3528(BE·Phase2, 페드루 PO 確定 2026-09-06) — 댓글 「지속 폴링」. due 3창
+(+1h·+1d·+7d, story #3516·#3527) 뒤에도 활성 게시물(published_at 14일 이내 AND
+(댓글 0건이거나 마지막 댓글 7일 이내))은 30분 주기로 자기재생성한다. transient
+(429/5xx) 실패는 `next_attempt_at`(마이그 0341) 백오프로 지연. org당 상한 200
+(초과분은 재생성 0).
+
+세팅 헬퍼는 test_3516_channel_post_comments.py·test_3497_insight_snapshots.py와
+동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+from tests.test_3497_insight_snapshots import _seed_channel_connection, _seed_channel_publication
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    """test_3516_channel_post_comments.py와 동형 — supports_fetch_replies=True로 등재."""
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+        insight_metrics=("impressions", "reach", "views", "engagements", "clicks", "spend", "conversions"),
+        supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+async def _seed_due_schedule_row(session, *, org_id, publication_id, channel="sandbox", external_id="media-1", due_at=None):
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    row = CommentCollectionSchedule(
+        id=uuid.uuid4(), org_id=org_id, publication_id=publication_id, channel=channel,
+        external_id=external_id, due_at=due_at or (datetime.now(timezone.utc) - timedelta(minutes=1)),
+        status="pending",
+    )
+    session.add(row)
+    await session.commit()
+    return row.id
+
+
+# ─── 활성 판정 자체(_is_publication_active) ──────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_is_publication_active_true_when_recently_published_no_comments():
+    from app.services.channel_post_comments import _is_publication_active
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox")
+            now = datetime.now(timezone.utc)
+            assert await _is_publication_active(s, publication_id=pub.id, now=now) is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_is_publication_active_false_after_14_days_published():
+    from app.models.channel_publication import ChannelPublication
+    from app.services.channel_post_comments import _is_publication_active
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox")
+            now = datetime.now(timezone.utc)
+            row = await s.get(ChannelPublication, pub.id)
+            row.published_at = now - timedelta(days=15)
+            await s.commit()
+            assert await _is_publication_active(s, publication_id=pub.id, now=now) is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_is_publication_active_false_when_last_comment_older_than_7_days():
+    from app.models.channel_post_comment import ChannelPostComment
+    from app.services.channel_post_comments import _is_publication_active
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox")
+            now = datetime.now(timezone.utc)
+            s.add(ChannelPostComment(
+                id=uuid.uuid4(), org_id=org_id, publication_id=pub.id, channel="sandbox",
+                external_comment_id="c1", text="옛 댓글", text_sha256="x" * 64,
+                external_created_at=now - timedelta(days=8), captured_at=now - timedelta(days=8),
+            ))
+            await s.commit()
+            assert await _is_publication_active(s, publication_id=pub.id, now=now) is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_is_publication_active_true_when_last_comment_within_7_days():
+    from app.models.channel_post_comment import ChannelPostComment
+    from app.services.channel_post_comments import _is_publication_active
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox")
+            now = datetime.now(timezone.utc)
+            s.add(ChannelPostComment(
+                id=uuid.uuid4(), org_id=org_id, publication_id=pub.id, channel="sandbox",
+                external_comment_id="c1", text="최근 댓글", text_sha256="x" * 64,
+                external_created_at=now - timedelta(days=3), captured_at=now - timedelta(days=3),
+            ))
+            await s.commit()
+            assert await _is_publication_active(s, publication_id=pub.id, now=now) is True
+    finally:
+        await engine.dispose()
+
+
+# ─── 자기재생성(AC1) ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_captured_row_regenerates_next_due_row_30_minutes_later_when_active():
+    from sqlalchemy import select
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.services.channel_post_comments import process_due_comment_collections
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+            await _seed_due_schedule_row(s, org_id=org_id, publication_id=pub.id, external_id="media-1")
+
+            now = datetime.now(timezone.utc)
+            counts = await process_due_comment_collections(s, now=now)
+            assert counts["captured"] == 1, counts
+
+            rows = (await s.execute(
+                select(CommentCollectionSchedule).where(CommentCollectionSchedule.publication_id == pub.id)
+            )).scalars().all()
+            assert len(rows) == 2, "원 행 1개 + 자기재생성 1개가 있어야 함"
+            regenerated = [r for r in rows if r.status == "pending"]
+            assert len(regenerated) == 1
+            assert abs((regenerated[0].due_at - (now + timedelta(minutes=30))).total_seconds()) < 2
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_captured_row_does_not_regenerate_when_publication_inactive():
+    """AC1 — 비활성(발행 14일 초과)이면 재생성 0(자연 소멸)."""
+    from sqlalchemy import select
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.models.channel_publication import ChannelPublication
+    from app.services.channel_post_comments import process_due_comment_collections
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+            now = datetime.now(timezone.utc)
+            row = await s.get(ChannelPublication, pub.id)
+            row.published_at = now - timedelta(days=20)
+            await s.commit()
+            await _seed_due_schedule_row(s, org_id=org_id, publication_id=pub.id, external_id="media-1")
+
+            counts = await process_due_comment_collections(s, now=now)
+            assert counts["captured"] == 1, counts
+
+            rows = (await s.execute(
+                select(CommentCollectionSchedule).where(CommentCollectionSchedule.publication_id == pub.id)
+            )).scalars().all()
+            assert len(rows) == 1, "비활성이면 재생성 행이 없어야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_regeneration_mutation_check_removing_call_stops_continuous_polling(monkeypatch):
+    """뮤테이션 — _schedule_next_continuous_poll_if_active를 no-op으로 바꾸면
+    위 자기재생성 테스트가 RED가 돼야 한다."""
+    import app.services.channel_post_comments as comments_module
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(comments_module, "_schedule_next_continuous_poll_if_active", _noop)
+
+    from sqlalchemy import select
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+            await _seed_due_schedule_row(s, org_id=org_id, publication_id=pub.id, external_id="media-1")
+
+            await comments_module.process_due_comment_collections(s, now=datetime.now(timezone.utc))
+
+            rows = (await s.execute(
+                select(CommentCollectionSchedule).where(CommentCollectionSchedule.publication_id == pub.id)
+            )).scalars().all()
+            assert len(rows) == 1, "뮤테이션 상태에선 재생성이 없어야(원래 있어야 할 게 없어짐=RED 재현)"
+    finally:
+        await engine.dispose()
+
+
+# ─── 백오프(AC2) ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_transient_failure_sets_next_attempt_at_backoff_and_tick_respects_it(monkeypatch):
+    import app.services.sandbox_publish as sandbox_publish
+    from app.services.channel_post_comments import CommentFetchError, process_due_comment_collections
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    async def _rate_limited(client, *, access_token, media_id):
+        raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message="429 시뮬레이션")
+
+    monkeypatch.setattr(sandbox_publish, "fetch_replies", _rate_limited)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+            schedule_id = await _seed_due_schedule_row(s, org_id=org_id, publication_id=pub.id, external_id="media-1")
+
+            now = datetime.now(timezone.utc)
+            counts = await process_due_comment_collections(s, now=now)
+            assert counts["pending_retry"] == 1, counts
+
+            row = await s.get(CommentCollectionSchedule, schedule_id)
+            assert row.status == "pending"
+            assert row.attempt_count == 1
+            expected_delay = timedelta(minutes=2)  # 2**1
+            assert abs((row.next_attempt_at - (now + expected_delay)).total_seconds()) < 2
+
+            # tick이 백오프 전엔 이 행을 안 집는지 — due_at은 이미 지났지만 next_attempt_at
+            # 이 미래라 다시 처리되면 안 된다(attempt_count가 그대로여야 함).
+            counts_again = await process_due_comment_collections(s, now=now + timedelta(minutes=1))
+            assert counts_again["pending_retry"] == 0
+            row_again = await s.get(CommentCollectionSchedule, schedule_id)
+            assert row_again.attempt_count == 1, "백오프 전인데 다시 집혔다"
+
+            # 백오프 시각을 지나면 다시 집힌다.
+            counts_after_backoff = await process_due_comment_collections(s, now=now + expected_delay + timedelta(seconds=1))
+            assert counts_after_backoff["pending_retry"] == 1
+            row_after = await s.get(CommentCollectionSchedule, schedule_id)
+            assert row_after.attempt_count == 2
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_transient_failure_exceeds_5_attempts_marks_failed(monkeypatch):
+    import app.services.sandbox_publish as sandbox_publish
+    from app.services.channel_post_comments import CommentFetchError, process_due_comment_collections
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    async def _rate_limited(client, *, access_token, media_id):
+        raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message="429 시뮬레이션")
+
+    monkeypatch.setattr(sandbox_publish, "fetch_replies", _rate_limited)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+            schedule_id = await _seed_due_schedule_row(s, org_id=org_id, publication_id=pub.id, external_id="media-1")
+
+            now = datetime.now(timezone.utc)
+            for _attempt in range(5):
+                row = await s.get(CommentCollectionSchedule, schedule_id)
+                row.next_attempt_at = None  # 테스트 편의 — 매 시도마다 즉시 재시도되게.
+                await s.commit()
+                await process_due_comment_collections(s, now=now)
+
+            row = await s.get(CommentCollectionSchedule, schedule_id)
+            assert row.status == "failed"
+            assert row.attempt_count == 5
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_backoff_mutation_check_removing_next_attempt_at_lets_immediate_retry(monkeypatch):
+    """뮤테이션 — next_attempt_at 계산을 안 하면 백오프 테스트가 RED가 돼야 한다
+    (다음 tick이 즉시 다시 집어 attempt_count가 곧바로 늘어남)."""
+    import app.services.channel_post_comments as comments_module
+    import app.services.sandbox_publish as sandbox_publish
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    async def _rate_limited(client, *, access_token, media_id):
+        raise comments_module.CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message="429 시뮬레이션")
+
+    monkeypatch.setattr(sandbox_publish, "fetch_replies", _rate_limited)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+            schedule_id = await _seed_due_schedule_row(s, org_id=org_id, publication_id=pub.id, external_id="media-1")
+
+            now = datetime.now(timezone.utc)
+            await comments_module.process_due_comment_collections(s, now=now)
+
+            from app.models.channel_post_comment import CommentCollectionSchedule as CCS
+            row = await s.get(CCS, schedule_id)
+            row.next_attempt_at = None  # 뮤테이션 재현 — 백오프가 없었다고 가정.
+            await s.commit()
+
+            # 백오프가 없었다면 1분 뒤에도 즉시 재시도돼 attempt_count가 늘어야 한다.
+            await comments_module.process_due_comment_collections(s, now=now + timedelta(minutes=1))
+            row_again = await s.get(CCS, schedule_id)
+            assert row_again.attempt_count == 2, "백오프가 무력화되면 즉시 재시도로 attempt_count가 늘어야(뮤테이션 재현)"
+    finally:
+        await engine.dispose()
+
+
+# ─── org 상한(AC3) ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_org_cap_200_blocks_regeneration_for_older_publications(monkeypatch):
+    """AC3 — org당 상한 200. 이 publication보다 최근에 발행된(14일 활성 창 안)
+    publication이 200개 이상이면 재생성 0. 상한을 낮춰(2) 테스트 비용을 줄인다."""
+    import app.services.channel_post_comments as comments_module
+    from sqlalchemy import select
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.models.channel_publication import ChannelPublication
+
+    monkeypatch.setattr(comments_module, "_ACTIVE_PUBLICATIONS_ORG_CAP", 2)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+
+            now = datetime.now(timezone.utc)
+            # 이 publication보다 최근에 발행된 것 2개(상한과 같음) — 대상 publication은
+            # 상한 밖(순위 3번째)이 되어야 한다.
+            for i in range(2):
+                newer_pub = await _seed_channel_publication(
+                    s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id=f"newer-{i}",
+                )
+                row = await s.get(ChannelPublication, newer_pub.id)
+                row.published_at = now - timedelta(hours=1)
+                await s.commit()
+
+            target_pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="target",
+            )
+            target_row = await s.get(ChannelPublication, target_pub.id)
+            target_row.published_at = now - timedelta(hours=2)  # 더 예전 — 순위 밖.
+            await s.commit()
+
+            await _seed_due_schedule_row(s, org_id=org_id, publication_id=target_pub.id, external_id="target")
+
+            counts = await comments_module.process_due_comment_collections(s, now=now)
+            assert counts["captured"] == 1, counts
+
+            rows = (await s.execute(
+                select(CommentCollectionSchedule).where(CommentCollectionSchedule.publication_id == target_pub.id)
+            )).scalars().all()
+            assert len(rows) == 1, "org 상한 밖이면 재생성 0이어야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_cap_mutation_check_removing_check_lets_over_cap_regenerate(monkeypatch):
+    """뮤테이션 — _within_org_continuous_poll_cap을 항상 True로 바꾸면 위 상한
+    테스트가 RED가 돼야 한다."""
+    import app.services.channel_post_comments as comments_module
+
+    async def _always_true(*args, **kwargs):
+        return True
+
+    monkeypatch.setattr(comments_module, "_within_org_continuous_poll_cap", _always_true)
+    monkeypatch.setattr(comments_module, "_ACTIVE_PUBLICATIONS_ORG_CAP", 2)
+
+    from sqlalchemy import select
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.models.channel_publication import ChannelPublication
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            now = datetime.now(timezone.utc)
+
+            for i in range(2):
+                newer_pub = await _seed_channel_publication(
+                    s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id=f"newer-{i}",
+                )
+                row = await s.get(ChannelPublication, newer_pub.id)
+                row.published_at = now - timedelta(hours=1)
+                await s.commit()
+
+            target_pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="target",
+            )
+            target_row = await s.get(ChannelPublication, target_pub.id)
+            target_row.published_at = now - timedelta(hours=2)
+            await s.commit()
+
+            await _seed_due_schedule_row(s, org_id=org_id, publication_id=target_pub.id, external_id="target")
+            await comments_module.process_due_comment_collections(s, now=now)
+
+            rows = (await s.execute(
+                select(CommentCollectionSchedule).where(CommentCollectionSchedule.publication_id == target_pub.id)
+            )).scalars().all()
+            assert len(rows) == 2, "뮤테이션 상태에선 상한 밖인데도 재생성돼야(원래 막혔어야 할 게 통과=RED 재현)"
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -343,6 +343,11 @@
       "source": "story-3516-comment-reply-piece2(PR 개설 前 선제 등재 — 로컬 raw pytest 69.52s(15건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 420s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3528_comment_continuous_polling.py",
+      "sec": 45.0,
+      "source": "story-3528-comment-continuous-polling(PR 개설 前 선제 등재 — 로컬 raw pytest 6.16s(12건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3516_comment_reply_piece2b.py",
       "sec": 240.0,
       "source": "story-3516-comment-reply-piece2b(PR 개설 前 선제 등재 — 로컬 raw pytest 39.98s(10건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 240s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## 요약
3516 due 3창(+1h·+1d·+7d, #3880으로 배선)만으론 「7일 뒤·창 사이 댓글」이 사람이 버튼을 누르기 前엔 안 들어온다. due 행 처리(captured/failed) 뒤 활성 게시물은 30분 주기로 자기재생성해 이어서 수집한다.

**base가 develop 현재(#3880 미착지) 위입니다 — #3880 착지 뒤 rebase 한 번 하겠습니다.**

## 활성 판정(`_is_publication_active`, PO 確定)
`published_at` 이후 14일 이내 AND (댓글 0건이거나 마지막 댓글 `external_created_at`으로부터 7일 이내). 둘 다 벗어나면 재생성 0(자연 소멸 — due 3창은 이미 끝났으니 더는 아무 행도 안 남는다). due 3창을 대체하지 않는다(additive, 겹쳐도 upsert라 무해).

## 백오프(마이그 0341, additive nullable)
transient(429/5xx) 실패 시 `next_attempt_at = now + min(2^attempt_count분, 60분)`. tick 쿼리가 `next_attempt_at IS NULL OR <= now`만 집어 그 전엔 재시도 안 함(기존 행·최초 시도는 NULL이라 회귀 0). 5회 초과 failed 규칙 그대로.

## org 상한(`_within_org_continuous_poll_cap`)
활성 게시물 수 상한 200 — "최신 발행 순"(published_at 내림차순)으로 이 publication보다 최근 발행이 200개 미만이면 통과. Threads/IG rate limit 대비 계산: 상한 200 × (24h/30분=48회) = org당 하루 최대 9,600회 fetch_replies 호출 — Threads 유기 게시물 API의 일반적인 앱 레벨 한도(수만~수십만/일, 앱 사용량 등급별) 대비 여유.

## 테스트
`tests/test_3528_comment_continuous_polling.py` 12건 — 활성 판정 4갈래(발행 14일 초과·댓글 7일 초과·댓글 없음·최근 댓글)·자기재생성(활성 시 30분 뒤 행 생성·비활성 시 재생성 0)·백오프(next_attempt_at 계산+tick이 전엔 안 집음+백오프 지나면 재시도+5회초과 failed)·org 상한(상한 밖이면 재생성 0). 뮤테이션 자가검증 — 실 소스에서 재생성 호출을 직접 지워 포지티브 테스트가 RED로 떨어지는 것 확인 후 원복(추가로 백오프·상한 각각 self-contained 뮤테이션 재현 테스트). 인접회귀(3516 comment_reply·channel_post_comments·3414) 68 passed 무회귀. 마이그 0341 up/down/up 실PG 확인. 컴파일 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)