### PR TITLE
[SID:3529] feat: 댓글 답변 「왜 멈췄고 다음에 뭘 하나」 — 발송 명령 상태 4필드 노출

### DIFF
--- a/backend/app/routers/channel_post_comment_replies.py
+++ b/backend/app/routers/channel_post_comment_replies.py
@@ -134,10 +134,15 @@ class ReplyView(BaseModel):
     reason_code: str | None = Field(
         default=None,
         description=(
-            "voided 사유(실재 값 그대로, 새 이름 짓지 않음) — "
-            "\"GATE_NOT_APPROVED_OR_RESEALED\"(게이트 재검증 실패) 또는 "
-            "\"TARGET_COMMENT_DELETED\"(승인 뒤 워커 도달 前 대상 댓글 삭제 레이스). "
-            "voided 아니면 null."
+            "voided 사유(PublicationCommand.reason_code 그대로, 새 이름 짓지 않음 — "
+            "이 컬럼은 channel_post 발행류(publication_command.py)와 공유라 열거를 "
+            "닫지 않는다). 페드루 PO 대조(2026-09-06) — **현재 관측 값**: "
+            "\"GATE_NOT_APPROVED_OR_RESEALED\"(게이트 재검증 실패) · "
+            "\"TARGET_COMMENT_DELETED\"(승인 뒤 워커 도달 前 대상 댓글 삭제 레이스) · "
+            "\"CONTENT_CHANGED\"(channel_posts.py 재승인 필요 전이 축, 댓글 답변 "
+            "경로가 아니어도 같은 컬럼에 실린다). 이 외에도 미래 값이 더 생길 수 "
+            "있다 — 화면은 아는 값만 문구로 대응하고 모르는 값은 원문 그대로/일반 "
+            "문구로 안전히 처리해야 한다. voided 아니면 null."
         ),
     )
 

--- a/backend/app/routers/channel_post_comment_replies.py
+++ b/backend/app/routers/channel_post_comment_replies.py
@@ -112,14 +112,53 @@ class ReplyView(BaseModel):
             "target_comment_state 판정은 여전히 target_text_sha256(비노출)만 쓴다."
         ),
     )
+    # story #3529(additive, 유나 §22-15 채택) — PublicationCommand 4필드 그대로
+    # (새 이름/새 값 0). command_id가 null이면 넷 다 null.
+    command_status: str | None = Field(
+        default=None,
+        description=(
+            "PublicationCommand.status 그대로 — 다음 할 일이 갈리는 네 값(유나 §22-15): "
+            "\"pending\"(백오프 대기 중, 기다리면 자동 재시도) · \"blocked\"(연결 복구 "
+            "필요, 사람이 재인증해야 함) · \"dead_letter\"(자동 재시도 포기, 사람 판단 "
+            "필요) · \"voided\"(전제가 바뀌어 종결, 재시도 개념 자체가 안 맞음). "
+            "그 외 \"completed\" 등은 성공/진행 중."
+        ),
+    )
+    failure_kind: str | None = Field(
+        default=None,
+        description="유나 design §11-5 세 값(connection|needs_check|transient) — 실패 없었으면 null.",
+    )
+    next_attempt_at: str | None = Field(
+        default=None, description="transient 백오프 다음 시도 시각(ISO) — 없으면 null.",
+    )
+    reason_code: str | None = Field(
+        default=None,
+        description=(
+            "voided 사유(실재 값 그대로, 새 이름 짓지 않음) — "
+            "\"GATE_NOT_APPROVED_OR_RESEALED\"(게이트 재검증 실패) 또는 "
+            "\"TARGET_COMMENT_DELETED\"(승인 뒤 워커 도달 前 대상 댓글 삭제 레이스). "
+            "voided 아니면 null."
+        ),
+    )
 
 
-def _reply_view(reply, target_comment_state: str | None, target_text: str | None = None) -> ReplyView:
+async def _reply_view(
+    db: AsyncSession, reply, target_comment_state: str | None, target_text: str | None = None,
+) -> ReplyView:
+    command = None
+    if reply.command_id is not None:
+        from app.models.publication_command import PublicationCommand
+
+        command = await db.get(PublicationCommand, reply.command_id)
     return ReplyView(
         id=reply.id, comment_id=reply.comment_id, text=reply.text, status=reply.status, gate_id=reply.gate_id,
         command_id=reply.command_id,
         external_reply_id=reply.external_reply_id, external_reply_url=reply.external_reply_url,
         last_error=reply.last_error, target_comment_state=target_comment_state, target_text=target_text,
+        command_status=command.status if command is not None else None,
+        failure_kind=command.failure_kind if command is not None else None,
+        next_attempt_at=command.next_attempt_at.isoformat() if command is not None and command.next_attempt_at else None,
+        reason_code=command.reason_code if command is not None else None,
     )
 
 
@@ -159,7 +198,7 @@ async def create_comment_reply_draft_endpoint(
         )
     except CommentNotFoundError as exc:
         raise HTTPException(status_code=404, detail=f"댓글을 찾을 수 없습니다: {comment_id}") from exc
-    return _reply_view(reply, None)
+    return await _reply_view(db, reply, None)
 
 
 @router.post(
@@ -207,7 +246,7 @@ async def submit_comment_reply_endpoint(
         ) from exc
 
     view = await get_comment_reply_view(db, org_id=org_id, reply_id=reply.id)
-    return _reply_view(view["reply"], view["target_comment_state"], view["target_text"])
+    return await _reply_view(db, view["reply"], view["target_comment_state"], view["target_text"])
 
 
 @router.get(
@@ -234,4 +273,4 @@ async def get_comment_reply_endpoint(
         view = await get_comment_reply_view(db, org_id=org_id, reply_id=reply_id)
     except CommentReplyNotFoundError as exc:
         raise HTTPException(status_code=404, detail=f"답변을 찾을 수 없습니다: {reply_id}") from exc
-    return _reply_view(view["reply"], view["target_comment_state"], view["target_text"])
+    return await _reply_view(db, view["reply"], view["target_comment_state"], view["target_text"])

--- a/backend/app/routers/channel_post_comments.py
+++ b/backend/app/routers/channel_post_comments.py
@@ -67,10 +67,15 @@ class CommentReplySummary(BaseModel):
     reason_code: str | None = Field(
         default=None,
         description=(
-            "voided 사유(실재 값 그대로, 새 이름 짓지 않음) — "
-            "\"GATE_NOT_APPROVED_OR_RESEALED\"(게이트 재검증 실패) 또는 "
-            "\"TARGET_COMMENT_DELETED\"(승인 뒤 워커 도달 前 대상 댓글 삭제 레이스). "
-            "voided 아니면 null."
+            "voided 사유(PublicationCommand.reason_code 그대로, 새 이름 짓지 않음 — "
+            "이 컬럼은 channel_post 발행류(publication_command.py)와 공유라 열거를 "
+            "닫지 않는다). 페드루 PO 대조(2026-09-06) — **현재 관측 값**: "
+            "\"GATE_NOT_APPROVED_OR_RESEALED\"(게이트 재검증 실패) · "
+            "\"TARGET_COMMENT_DELETED\"(승인 뒤 워커 도달 前 대상 댓글 삭제 레이스) · "
+            "\"CONTENT_CHANGED\"(channel_posts.py 재승인 필요 전이 축, 댓글 답변 "
+            "경로가 아니어도 같은 컬럼에 실린다). 이 외에도 미래 값이 더 생길 수 "
+            "있다 — 화면은 아는 값만 문구로 대응하고 모르는 값은 원문 그대로/일반 "
+            "문구로 안전히 처리해야 한다. voided 아니면 null."
         ),
     )
 

--- a/backend/app/routers/channel_post_comments.py
+++ b/backend/app/routers/channel_post_comments.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -45,6 +45,51 @@ class CommentReplySummary(BaseModel):
     status: str
     external_reply_url: str | None
     command_id: uuid.UUID | None
+    # story #3529(additive, 유나 §22-15 채택) — PublicationCommand 4필드 그대로
+    # (새 이름/새 값 0). command_id가 null이면 넷 다 null.
+    command_status: str | None = Field(
+        default=None,
+        description=(
+            "PublicationCommand.status 그대로 — 다음 할 일이 갈리는 네 값(유나 §22-15): "
+            "\"pending\"(백오프 대기 중, 기다리면 자동 재시도) · \"blocked\"(연결 복구 "
+            "필요, 사람이 재인증해야 함) · \"dead_letter\"(자동 재시도 포기, 사람 판단 "
+            "필요) · \"voided\"(전제가 바뀌어 종결, 재시도 개념 자체가 안 맞음). "
+            "그 외 \"completed\" 등은 성공/진행 중."
+        ),
+    )
+    failure_kind: str | None = Field(
+        default=None,
+        description="유나 design §11-5 세 값(connection|needs_check|transient) — 실패 없었으면 null.",
+    )
+    next_attempt_at: str | None = Field(
+        default=None, description="transient 백오프 다음 시도 시각(ISO) — 없으면 null.",
+    )
+    reason_code: str | None = Field(
+        default=None,
+        description=(
+            "voided 사유(실재 값 그대로, 새 이름 짓지 않음) — "
+            "\"GATE_NOT_APPROVED_OR_RESEALED\"(게이트 재검증 실패) 또는 "
+            "\"TARGET_COMMENT_DELETED\"(승인 뒤 워커 도달 前 대상 댓글 삭제 레이스). "
+            "voided 아니면 null."
+        ),
+    )
+
+
+def _comment_reply_summary(reply, command_by_id: dict) -> CommentReplySummary:
+    """story #3529 — command_id가 있으면 배치 조회된 PublicationCommand에서 4필드를
+    그대로 옮긴다(command 행 자체가 없으면(레이스·오탐) 4필드 전부 null — fail-closed,
+    지어내지 않는다)."""
+    command = command_by_id.get(reply.command_id) if reply.command_id is not None else None
+    return CommentReplySummary(
+        id=reply.id, status=reply.status, external_reply_url=reply.external_reply_url,
+        command_id=reply.command_id,
+        command_status=command.status if command is not None else None,
+        failure_kind=command.failure_kind if command is not None else None,
+        next_attempt_at=(
+            command.next_attempt_at.isoformat() if command is not None and command.next_attempt_at else None
+        ),
+        reason_code=command.reason_code if command is not None else None,
+    )
 
 
 class CommentItem(BaseModel):
@@ -105,6 +150,7 @@ async def list_publication_comments_endpoint(
         raise HTTPException(status_code=404, detail=f"발행 기록을 찾을 수 없습니다: {publication_id}") from exc
 
     reply_by_comment_id = result["reply_by_comment_id"]
+    command_by_id = result["command_by_id"]
     return CommentListResponse(
         last_collected_at=result["last_collected_at"].isoformat() if result["last_collected_at"] else None,
         comments=[
@@ -113,11 +159,7 @@ async def list_publication_comments_endpoint(
                 text=c.text, external_created_at=c.external_created_at.isoformat() if c.external_created_at else None,
                 captured_at=c.captured_at.isoformat(), deleted_at=c.deleted_at.isoformat() if c.deleted_at else None,
                 reply=(
-                    CommentReplySummary(
-                        id=reply_by_comment_id[c.id].id, status=reply_by_comment_id[c.id].status,
-                        external_reply_url=reply_by_comment_id[c.id].external_reply_url,
-                        command_id=reply_by_comment_id[c.id].command_id,
-                    )
+                    _comment_reply_summary(reply_by_comment_id[c.id], command_by_id)
                     if c.id in reply_by_comment_id else None
                 ),
             )

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -472,6 +472,13 @@ async def list_comments_for_publication(
         db, comment_ids=[c.id for c in rows],
     )
 
+    # story #3529(additive, 유나 §22-15 채택) — 댓글 목록 reply{} 요약에 발송 명령
+    # 상태 4필드(command_status·failure_kind·next_attempt_at·reason_code)를 얹기
+    # 위한 배치 조회(N+1 X) — PublicationCommand 그대로, 새 컬럼/새 이름 0.
+    command_by_id = await _commands_by_ids(
+        db, command_ids=[r.command_id for r in latest_reply_by_comment_id.values() if r.command_id is not None],
+    )
+
     # 조각②-b 추가(유나 16회차) — comments_last_collected_at과 같은 계산 자리
     # (바로 위 `last_captured_at`, refresh_comments_now의 rate-limit 판정과는
     # 별개 축 — "지금 화면에 보여줄 마지막 수집 시각"을 그대로 재사용). null=지금
@@ -487,7 +494,21 @@ async def list_comments_for_publication(
         "active_count": active_count, "deleted_count": deleted_count,
         "reply_by_comment_id": latest_reply_by_comment_id,
         "comments_next_allowed_at": comments_next_allowed_at,
+        "command_by_id": command_by_id,
     }
+
+
+async def _commands_by_ids(db: AsyncSession, *, command_ids: list[uuid.UUID]) -> dict[uuid.UUID, "PublicationCommand"]:  # noqa: F821
+    """story #3529 — publication_command_id 배치 조회(N+1 X). command_ids 없으면
+    빈 dict(호출부가 `.get(command_id)` → None="이 답변엔 명령이 없다")."""
+    if not command_ids:
+        return {}
+    from app.models.publication_command import PublicationCommand
+
+    rows = (await db.execute(
+        select(PublicationCommand).where(PublicationCommand.id.in_(command_ids))
+    )).scalars().all()
+    return {row.id: row for row in rows}
 
 
 async def _latest_reply_by_comment_ids(

--- a/backend/tests/test_3529_comment_reply_command_status.py
+++ b/backend/tests/test_3529_comment_reply_command_status.py
@@ -1,0 +1,341 @@
+"""story #3529(additive, 유나 §22-15 채택 · 페드루 PO 確定 2026-09-06) — 댓글 답변
+「왜 멈췄고 다음에 뭘 하나」. 서버가 이미 §11-5 세 값(connection/needs_check/
+transient)으로 접어 command 상태(pending+next_attempt_at/blocked/dead_letter/
+voided)로 보내는 축을 ReplyView·댓글 목록 reply{} 요약에 그대로 노출한다(새 컬럼
+0·새 이름 0 — PublicationCommand.status·failure_kind·next_attempt_at·reason_code
+그대로). 디디 그라운딩(2026-09-06 04:11 KST)이 확인한 실재 이름만 쓴다.
+
+세팅 헬퍼는 test_3516_comment_reply.py(조각②)와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import (
+    _seed_default_role, _seed_human, _seed_org, _session_factory,
+)
+from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+from tests.test_3516_comment_reply import _seed_comment, _seed_full_publication_chain, _submit_and_approve_reply
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    """test_3516_comment_reply.py와 동형 — supports_reply/fetch_replies=True로 등재."""
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+        insight_metrics=("impressions", "reach", "views", "engagements", "clicks", "spend", "conversions"),
+        supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+async def _get_reply_and_list_summary(client, org_id, comment_id, reply_id, publication_id):
+    r_reply = await client.get(f"/api/v2/organizations/{org_id}/comments/{comment_id}/replies/{reply_id}")
+    assert r_reply.status_code == 200, r_reply.text
+    r_list = await client.get(f"/api/v2/organizations/{org_id}/publications/{publication_id}/comments")
+    assert r_list.status_code == 200, r_list.text
+    list_reply_summary = next(c["reply"] for c in r_list.json()["comments"] if c["id"] == str(comment_id))
+    return r_reply.json(), list_reply_summary
+
+
+def _assert_four_fields(payload, *, command_status, failure_kind, next_attempt_at_is_none, reason_code):
+    assert payload["command_status"] == command_status, payload
+    assert payload["failure_kind"] == failure_kind, payload
+    assert (payload["next_attempt_at"] is None) == next_attempt_at_is_none, payload
+    assert payload["reason_code"] == reason_code, payload
+
+
+@pytest.mark.anyio
+async def test_before_submit_all_four_fields_null():
+    """command_id가 null(초안 상태)이면 4필드 전부 null."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                r_draft = await client.post(
+                    f"/api/v2/organizations/{org_id}/comments/{comment.id}/replies", json={"text": "답변 초안"},
+                )
+                assert r_draft.status_code == 201, r_draft.text
+                assert r_draft.json()["command_id"] is None
+                _assert_four_fields(
+                    r_draft.json(), command_status=None, failure_kind=None,
+                    next_attempt_at_is_none=True, reason_code=None,
+                )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_transient_failure_exposes_pending_backoff(monkeypatch):
+    """CHANNEL_RATE_LIMITED(429) → failure_kind=transient·command는 pending으로
+    남고(MAX_RETRIES=5 미도달) next_attempt_at이 채워진다. reason_code는 voided
+    전용이라 null 유지."""
+    from app.main import app
+    from app.services.threads_publish import ThreadsPublishError
+    import app.services.sandbox_publish as sandbox_publish
+    from app.services.publication_command import process_due_publication_commands
+
+    async def _fake_reply(client, *, access_token, threads_user_id, reply_to_id, text):
+        raise ThreadsPublishError("rate_limited", "요청이 너무 잦습니다", status_code=429)
+
+    monkeypatch.setattr(sandbox_publish, "reply", _fake_reply)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id, external_comment_id="ext-transient")
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+            await process_due_publication_commands(s)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                reply_payload, list_payload = await _get_reply_and_list_summary(
+                    client, org_id, comment.id, reply.id, pub.id,
+                )
+                for payload in (reply_payload, list_payload):
+                    _assert_four_fields(
+                        payload, command_status="pending", failure_kind="transient",
+                        next_attempt_at_is_none=False, reason_code=None,
+                    )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_connection_failure_exposes_blocked_status(monkeypatch):
+    """CHANNEL_TOKEN_EXPIRED(401) → failure_kind=connection·command는 blocked로
+    멈춘다(재시도 큐 X, 연결 복구 대기)."""
+    from app.main import app
+    from app.services.threads_publish import ThreadsPublishError
+    import app.services.sandbox_publish as sandbox_publish
+    from app.services.publication_command import process_due_publication_commands
+
+    async def _fake_reply(client, *, access_token, threads_user_id, reply_to_id, text):
+        raise ThreadsPublishError("token_expired", "토큰이 만료되었습니다", status_code=401)
+
+    monkeypatch.setattr(sandbox_publish, "reply", _fake_reply)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id, external_comment_id="ext-blocked")
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+            await process_due_publication_commands(s)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                reply_payload, list_payload = await _get_reply_and_list_summary(
+                    client, org_id, comment.id, reply.id, pub.id,
+                )
+                for payload in (reply_payload, list_payload):
+                    _assert_four_fields(
+                        payload, command_status="blocked", failure_kind="connection",
+                        next_attempt_at_is_none=True, reason_code=None,
+                    )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comment_not_found_exposes_dead_letter_status():
+    """대상 댓글 행 자체가 사라지면(COMMENT_NOT_FOUND) needs_check로 분류돼 즉시
+    dead_letter(재시도해도 다시 실패할 뿐이라 백오프 큐에 안 넣는다).
+
+    HTTP 왕복이 아니라 command 행을 직접 대조한다 — 이 시나리오(댓글 행 하드
+    삭제)에선 GET reply 자체가 `get_comment_reply_view`의 `_get_owned_comment`가
+    `CommentNotFoundError`를 던져(그 라우터는 `CommentReplyNotFoundError`만
+    catch) 500이 나는 별개의 기존 갭이라(#3529 스코프 밖 — 이 스토리는 서버가 이미
+    아는 상태를 노출만 하는 것이지 읽기 경로 자체를 고치는 게 아니다), 여기서는
+    command 행이 곧 «검증 대상 진실»이므로 그걸 직접 본다."""
+    from app.models.channel_post_comment import ChannelPostComment
+    from app.models.publication_command import PublicationCommand
+    from app.services.publication_command import process_due_publication_commands
+    from sqlalchemy import delete, select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id, external_comment_id="ext-notfound")
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+
+            # 승인 뒤·워커 도달 前 레이스를 극단으로 — 댓글 행 자체가 사라짐(하드
+            # 삭제, FK 없음 관례 — 소프트 삭제(TARGET_COMMENT_DELETED)와는 다른 경로).
+            await s.execute(delete(ChannelPostComment).where(ChannelPostComment.id == comment.id))
+            await s.commit()
+
+            await process_due_publication_commands(s)
+
+            command = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == reply.gate_id)
+            )).scalar_one()
+            assert command.status == "dead_letter"
+            assert command.failure_kind == "needs_check"
+            assert command.next_attempt_at is None
+            assert command.reason_code is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_target_comment_deleted_exposes_voided_with_reason_code():
+    """AC4 — 승인 뒤·워커 도달 前 대상 댓글이 소프트 삭제되면 voided+reason_code=
+    TARGET_COMMENT_DELETED(재시도 대상 아님). voided 경로는 apply_command_failure를
+    안 거치므로 failure_kind는 null로 남는다."""
+    from app.main import app
+    from app.models.channel_post_comment import ChannelPostComment
+    from app.services.publication_command import process_due_publication_commands
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id, external_comment_id="ext-voided1")
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+
+            comment_row = (await s.execute(
+                select(ChannelPostComment).where(ChannelPostComment.id == comment.id)
+            )).scalar_one()
+            comment_row.deleted_at = datetime.now(timezone.utc)
+            await s.commit()
+
+            await process_due_publication_commands(s)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                reply_payload, list_payload = await _get_reply_and_list_summary(
+                    client, org_id, comment.id, reply.id, pub.id,
+                )
+                for payload in (reply_payload, list_payload):
+                    _assert_four_fields(
+                        payload, command_status="voided", failure_kind=None,
+                        next_attempt_at_is_none=True, reason_code="TARGET_COMMENT_DELETED",
+                    )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_reseal_mismatch_exposes_voided_with_reason_code():
+    """승인 뒤·워커 도달 前 답변 본문이 바뀌어(재상신 개념 없음이라 직접 대입으로
+    레이스 재현) 봉인 sha와 어긋나면 voided+reason_code=GATE_NOT_APPROVED_OR_
+    RESEALED(TARGET_COMMENT_DELETED와는 다른 voided 사유)."""
+    from app.main import app
+    from app.models.channel_post_comment import ChannelPostCommentReply
+    from app.services.publication_command import process_due_publication_commands
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id, external_comment_id="ext-voided2")
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+
+            reply_row = (await s.execute(
+                select(ChannelPostCommentReply).where(ChannelPostCommentReply.id == reply.id)
+            )).scalar_one()
+            reply_row.text = "봉인 이후 바뀐 본문(레이스 재현)"
+            await s.commit()
+
+            await process_due_publication_commands(s)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                reply_payload, list_payload = await _get_reply_and_list_summary(
+                    client, org_id, comment.id, reply.id, pub.id,
+                )
+                for payload in (reply_payload, list_payload):
+                    _assert_four_fields(
+                        payload, command_status="voided", failure_kind=None,
+                        next_attempt_at_is_none=True, reason_code="GATE_NOT_APPROVED_OR_RESEALED",
+                    )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1123,6 +1123,11 @@
       "source": "story-3527-comment-collection-cron-wiring(PR 개설 前 선제 등재 — 로컬 raw pytest 7.14s(2건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3529_comment_reply_command_status.py",
+      "sec": 35.0,
+      "source": "story-3529-comment-reply-command-status(PR 개설 前 선제 등재 — 로컬 raw pytest 5.18s(6건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 35s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_3415_channel_post_command_exposure.py",
       "sec": 19.0,
       "source": "story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)"


### PR DESCRIPTION
## 배경
3517 §22-14 「실패 얼굴엔 액션·위로 문구 0 — 사유 코드가 없어 다음 발을 모른다」 BE 후속. 디디 그라운딩(2026-09-06 04:11 KST·코드 X)이 확인: 워커 내부 error_code(7갈래)는 classify_failure_kind로 §11-5 세 값(connection/needs_check/transient)에 접혀 command 상태로만 남고, 지역변수 자체는 저장 안 됨.

## PO 決定(유나 §22-15 채택, 2026-09-06 04:50 KST) — 최초 案(last_error_code 신규 컬럼) 폐기
서버는 이미 command를 pending+next_attempt_at(기다리면 됨)/blocked(연결 고쳐야)/dead_letter(사람 판단)/voided(전제 바뀜) 넷으로 분류해서 보낸다 — 사람이 「다음에 할 일」을 가르는 축은 이 넷. 7코드를 실으면 FE가 다시 7→4로 접어 정책이 두 벌이 된다(§11-5 「화면이 error_code로 조립하면 BE 정책이 화면에 산다」).

**신규 컬럼 0·마이그 0** — `PublicationCommand.status`/`failure_kind`/`next_attempt_at`/`reason_code`를 읽기 시점에 그대로 옮긴다(새 이름 짓지 않음):
- `ReplyView`(단건, `channel_post_comment_replies.py`) — `reply.command_id`로 단건 조회
- 댓글 목록 `reply{}` 요약(`channel_post_comments.py`) — 배치 조회(N+1 X, #3876 배치 조인 관례 재사용)
- `command_id`가 null이면 넷 다 null. `last_error` 원문은 여전히 비노출.

## 테스트
`test_3529_comment_reply_command_status.py` 6건 — 제출 前(4필드 null) · transient(CHANNEL_RATE_LIMITED 429 → pending+next_attempt_at) · connection(CHANNEL_TOKEN_EXPIRED 401 → blocked) · needs_check(대상 댓글 행 하드삭제 → COMMENT_NOT_FOUND → dead_letter 즉시 확정) · voided 2종(TARGET_COMMENT_DELETED · GATE_NOT_APPROVED_OR_RESEALED — voided 경로는 apply_command_failure를 안 거쳐 failure_kind는 null로 남음, 코드로 확인). 뮤테이션 자가검증 2회(ReplyView 경로·목록 요약 경로 각각 실 소스에서 command 조회를 무력화해 RED 확인 후 원복). 인접회귀(3516 댓글류 44건·3414) 72 passed 무회귀.

## 스코프 밖 발견(기록만, 이 PR에서 안 고침)
댓글 행이 하드 삭제되면 GET reply 자체가 `_get_owned_comment`의 `CommentNotFoundError`를 그 라우터가 못 잡아 500 — 이 스토리는 서버가 이미 아는 상태를 노출만 하는 것이지 읽기 경로 자체를 고치는 게 아니라 그대로 둠(needs_check/dead_letter 테스트는 command 행을 DB에서 직접 대조해 우회).

🤖 Generated with [Claude Code](https://claude.com/claude-code)