### PR TITLE
[SID:3525] 발행됨 카드 렌더 조건을 draft.publication_id 하나로

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2289,6 +2289,7 @@
     "reapprovalSealedHash": "Approved hash",
     "reapprovalCurrentHash": "Current hash",
     "publishedInfoUrlLabel": "Public URL",
+    "channelPostsPublishedInfoLastPublishedNotice": "The information below is for the last published version.",
     "externalPublicationDestinationLabel": "Destination",
     "externalPublicationStatusLabel": "Status",
     "externalPublicationStatusPublished": "Published",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2289,6 +2289,7 @@
     "reapprovalSealedHash": "승인된 해시",
     "reapprovalCurrentHash": "현재 해시",
     "publishedInfoUrlLabel": "공개 URL",
+    "channelPostsPublishedInfoLastPublishedNotice": "아래 정보는 마지막으로 발행된 버전의 것입니다.",
     "externalPublicationDestinationLabel": "발행 대상",
     "externalPublicationStatusLabel": "상태",
     "externalPublicationStatusPublished": "발행됨",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -301,7 +301,7 @@ function stubFetch(opts: {
       }
       if (url === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}/publish` && init?.method === 'POST') {
         const result = opts.onPublish?.() ?? {
-          status: 200, body: { permalink: 'https://threads.net/@x/1', external_id: 'media-1', published_at: '2026-09-04T00:00:00Z', version_id: 'v1' },
+          status: 200, body: { permalink: 'https://threads.net/@x/1', external_id: 'media-1', published_at: '2026-09-04T00:00:00Z', version_id: 'v1', publication_id: 'pub-1' },
         };
         const ok = result.status < 400;
         return { ok, status: result.status, json: async () => (ok ? { data: result.body, error: null, meta: null } : result.body) };
@@ -694,7 +694,7 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
       draftDetail: {
         gate_status: 'approved', sealed_content_sha256: 'h1', body_sha256: 'h1',
         publication_status: 'published', permalink: 'https://threads.net/@x/1', external_id: 'media-1',
-        published_at: '2026-09-04T00:00:00Z',
+        published_at: '2026-09-04T00:00:00Z', publication_id: 'pub-1',
       },
     });
     await act(async () => {
@@ -1370,6 +1370,7 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
       draftDetail: {
         gate_status: 'approved', sealed_content_sha256: 'h1', body_sha256: 'h1',
         publication_status: 'published', permalink: 'https://old-permalink', published_at: '2026-09-01T00:00:00Z', external_id: 'old-id',
+        publication_id: 'pub-old',
       },
       onPublish: () => ({
         status: 200,
@@ -2498,7 +2499,12 @@ describe('ChannelPostEditPage — 콘텐츠 규칙 위반 표시(story #3472 2�
 });
 
 describe('ChannelPostEditPage — 성과 인사이트 블록(story #3499, BE #3844 조각4 의존)', () => {
-  it('publication_id 없음(BE 미착지 응답) — published 상태여도 인사이트 블록을 안 그린다', async () => {
+  // story #3525(PO 確定 2026-09-06 재대조) — publication_id는 이제 permalink 등과
+  // 구조적으로 같은 객체(published_pub)에서 나와 함께 없거나 함께 있어야 한다
+  // (#3879). 이 시나리오(permalink 있음+publication_id 없음)는 그 계약이 성립하기
+  // 전(BE #3844 조각4 미착지) 상정이었으나, 지금은 publication_id 자체가 발행됨
+  // 카드 전체의 유일한 렌더 조건이라 — 블록 통째로 미렌더가 맞는 동작이다.
+  it('⭐#3525 — publication_id 없으면 발행됨 카드(댓글·인사이트·permalink) 전체가 안 뜬다', async () => {
     stubFetch({
       draftDetail: {
         gate_status: 'approved', sealed_content_sha256: 'h1', body_sha256: 'h1',
@@ -2509,7 +2515,7 @@ describe('ChannelPostEditPage — 성과 인사이트 블록(story #3499, BE #38
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
     await flush();
 
-    expect(container.querySelector('[data-testid="channel-post-published-info"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="channel-post-published-info"]')).toBeNull();
     expect(container.querySelector('[data-testid="content-insight-info"]')).toBeNull();
   });
 
@@ -2536,6 +2542,55 @@ describe('ChannelPostEditPage — 성과 인사이트 블록(story #3499, BE #38
     const values = Array.from(insight!.querySelectorAll('[data-testid="insight-metric-value"]')).map((el) => el.textContent);
     expect(values).toContain('200');
     expect(values).toContain('0');
+  });
+});
+
+// story #3525(PO 確定 재대조 2026-09-06, 유나 §22-12) — 발행됨 카드가 view.status가
+// 아니라 draft.publication_id 하나로 서는지, 그리고 reapproval_required일 때만
+// "마지막 발행 버전" 안내 한 줄이 뜨는지.
+describe('ChannelPostEditPage — 발행됨 카드 렌더 조건(story #3525)', () => {
+  const V2_PENDING_BUT_PUBLISHED = {
+    gate_status: 'pending', reapproval_required: true, sealed_content_sha256: 'h1', body_sha256: 'h2',
+    publication_status: 'published', permalink: 'https://threads.net/@x/1', external_id: 'media-1',
+    published_at: '2026-09-04T00:00:00Z', publication_id: 'cp-1',
+  } as const;
+
+  it('⭐reapproval_required=true+publication_id 있음 — view.status가 published가 아니어도 카드가 뜨고 "마지막 발행 버전" 안내가 함께 보인다', async () => {
+    stubFetch({ draftDetail: V2_PENDING_BUT_PUBLISHED });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="channel-post-published-info"]')).not.toBeNull();
+    expect(container.querySelector('a[href="https://threads.net/@x/1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="channel-post-published-info-last-published-notice"]')).not.toBeNull();
+  });
+
+  it('⭐발행됨(재승인 불요)+publication_id 있음 — 카드는 뜨지만 "마지막 발행 버전" 안내는 없다(같은 버전이라 노이즈)', async () => {
+    stubFetch({
+      draftDetail: {
+        gate_status: 'approved', reapproval_required: false, sealed_content_sha256: 'h1', body_sha256: 'h1',
+        publication_status: 'published', permalink: 'https://threads.net/@x/1', external_id: 'media-1',
+        published_at: '2026-09-04T00:00:00Z', publication_id: 'cp-1',
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="channel-post-published-info"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="channel-post-published-info-last-published-notice"]')).toBeNull();
+  });
+
+  it('⭐publication_id 없음 — reapproval_required와 무관하게 카드 자체가 안 뜬다(회귀)', async () => {
+    stubFetch({
+      draftDetail: {
+        gate_status: 'pending', reapproval_required: true, sealed_content_sha256: 'h1', body_sha256: 'h2',
+        publication_status: null, permalink: null, external_id: null, published_at: null, publication_id: null,
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="channel-post-published-info"]')).toBeNull();
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -864,8 +864,8 @@ export default function ChannelPostEditPage() {
       const res = await fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}/publish`, { method: 'POST' });
       if (res.ok) {
         const json = (await res.json().catch(() => null)) as
-          { data?: { permalink?: string; external_id?: string; published_at?: string; scheduled?: boolean; scheduled_at?: string } } | null;
-        const { permalink, external_id, published_at, scheduled, scheduled_at } = json?.data ?? {};
+          { data?: { permalink?: string; external_id?: string; published_at?: string; scheduled?: boolean; scheduled_at?: string; publication_id?: string | null } } | null;
+        const { permalink, external_id, published_at, scheduled, scheduled_at, publication_id } = json?.data ?? {};
         // story #3414(PR#3769, 아직 리뷰중 — 계약은 그 PR 스키마 기준) — scheduled=true면
         // 이 요청은 command만 만들고 실제 발행은 워커가 나중에 한다. permalink/
         // published_at 셋 다 null인 게 정상이라, 그 null을 "발행됨"으로 그리면 안 된다
@@ -875,7 +875,10 @@ export default function ChannelPostEditPage() {
           setPublishResult({ type: 'scheduled', scheduledAt: scheduled_at });
         } else if (permalink && published_at) {
           setPublishResult({ type: 'success' });
-          setDraft((prev) => prev && { ...prev, permalink, external_id, published_at, publication_status: 'published' });
+          // story #3525(PO 確定 ③) — publication_id도 permalink 등과 같은 병합 대상
+          // (BE #3525가 publish 응답에 이 필드를 추가) — 재로드 없이도 발행됨 카드가
+          // draft.publication_id 조건 하나로 즉시 열린다.
+          setDraft((prev) => prev && { ...prev, permalink, external_id, published_at, publication_status: 'published', publication_id: publication_id ?? prev.publication_id });
         } else {
           setPublishResult({ type: 'error', text: t('publishFailed'), raw: JSON.stringify(json) });
         }
@@ -1298,55 +1301,71 @@ export default function ChannelPostEditPage() {
         ) : null}
       </div>
 
-      {/* story #3402 PR2(T7/T9) — publication_status는 다섯 상태 밖의 신호라
-          deriveChannelPostView가 별도 필드로 얹어 준다(WIP1과 동일 함수, 재사용). T7 —
-          발행됨이면 재진입해도 permalink·published_at·external_id가 그대로 보인다(doc
-          §4-2 "게시 ID로 동일성을 눈에 보이게"). T9 — 부분 성공(container_created)이면
-          "이어서 발행"이 기본 행동임을 미리 안다(발행 버튼 자체의 배선은 이 조각 스코프
-          밖 — 다음 조각). PR1 rebase 반영(2026-09-04) — 위 승인 카드가 이미 계산해 둔
-          `view`를 그대로 재사용한다(같은 함수를 두 번 부르지 않는다 — rebase 전엔 이
-          블록이 자체 IIFE로 따로 계산했으나, PR1의 hasGateContract 가드가 상위로
-          올라오며 중복이 됐다). */}
-      {(() => {
-        if (view.status === 'published' && draft.permalink) {
-          return (
-            <div className="space-y-2 rounded-md border border-border p-4 text-sm" data-testid="channel-post-published-info">
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">{t('publishedInfoUrlLabel')}</span>
-                <a href={draft.permalink} target="_blank" rel="noreferrer" className="underline">{draft.permalink}</a>
-              </div>
-              {draft.published_at ? (
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">{t('publishedInfoAtLabel')}</span>
-                  <span>{formatScheduledAt(draft.published_at, displayTimezone).display}</span>
-                </div>
-              ) : null}
-              {draft.external_id ? (
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground" data-testid="channel-post-external-id-label">{t('channelPostsExternalIdLabel')}</span>
-                  <span data-testid="channel-post-external-id">{draft.external_id}</span>
-                </div>
-              ) : null}
-              {/* story #3499(Phase2·FE) — publication_id 있을 때만(BE #3844 조각4 의존). */}
-              {draft.publication_id ? (
-                <InsightSnapshotBlock snapshots={insightSnapshots} orgTimezone={displayTimezone} locale={locale} />
-              ) : null}
-              {/* story #3517(Phase2·FE, 그라운딩 ① 자리 그대로 — InsightSnapshotBlock 곁,
-                  같은 draft.publication_id 조건) — 댓글 섹션. 조각①-FE 범위(PO 確定
-                  2026-09-05): 세 얼굴·수집 시각·목록·지워진 댓글(§22-9)만 — 행 액션
-                  (작업으로 전환·답변)은 조각②(답변/작업전환 엔드포인트) PR에서. */}
-              {draft.publication_id ? (
-                <CommentsSection
-                  face={commentsFace}
-                  displayTimezone={displayTimezone}
-                  onRefresh={handleCommentsRefresh}
-                  onConvertToTask={setConvertToTaskComment}
-                  onReply={setReplyComment}
-                />
-              ) : null}
+      {/* story #3525(PO 確定 2026-09-06 재대조, 유나 §22-12 「댓글은 «마지막 발행»에
+          붙는다」) — 이 블록은 원래 view.status==='published' 분기 안에 있었다. #3879가
+          draft.publication_id를 «현재 버전의 승인 상태»가 아니라 «마지막 발행
+          publication»(버전 무관)으로 재정의했는데도, 이 블록이 여전히 view.status로
+          한 번 더 게이팅되고 있어(view.status는 «현재 버전»의 파생값 — 새 버전이
+          reapproval_required=true면 'published'가 아니다) 밖에 살아 있는 게시물의
+          댓글·인사이트·permalink가 상세에서 사라지는 사고가 재발했다(유나 18회차
+          실측, draft 2220797b). 렌더 조건을 draft.publication_id 하나로 좁힌다 —
+          #3525 BE(publish 응답에 publication_id 추가)로 동기 발행 즉시반영도 이
+          조건 하나로 선다. 「재승인 필요」는 기존 상태 칩(:1193 부근, view.status
+          기반, contentStatusReapprovalNeeded)이 이미 독립적으로 그린다 — 칩 문구
+          변경 0, 이 블록엔 그 사실을 다시 말하지 않고 아래 안내 한 줄만 얹는다. */}
+      {draft.publication_id ? (
+        <div className="space-y-2 rounded-md border border-border p-4 text-sm" data-testid="channel-post-published-info">
+          {/* story #3525(PO 確定 재대조) — reapproval_required=true(위 칩이 「재승인
+              필요」인 바로 그 경우)일 때만, 아래 정보가 "지금 편집 중인 버전"이
+              아니라 "마지막으로 나간 버전"의 것임을 블록 머리에 한 번 말한다(인사이트·
+              댓글 각각엔 안 넣는다 — 노이즈). 발행됨 상태(재승인 불요)엔 같은 버전
+              이야기라 이 줄 자체가 안 뜬다. */}
+          {draft.reapproval_required === true ? (
+            <p className="text-xs text-muted-foreground" data-testid="channel-post-published-info-last-published-notice">
+              {t('channelPostsPublishedInfoLastPublishedNotice')}
+            </p>
+          ) : null}
+          {draft.permalink ? (
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">{t('publishedInfoUrlLabel')}</span>
+              <a href={draft.permalink} target="_blank" rel="noreferrer" className="underline">{draft.permalink}</a>
             </div>
-          );
-        }
+          ) : null}
+          {draft.published_at ? (
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">{t('publishedInfoAtLabel')}</span>
+              <span>{formatScheduledAt(draft.published_at, displayTimezone).display}</span>
+            </div>
+          ) : null}
+          {draft.external_id ? (
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground" data-testid="channel-post-external-id-label">{t('channelPostsExternalIdLabel')}</span>
+              <span data-testid="channel-post-external-id">{draft.external_id}</span>
+            </div>
+          ) : null}
+          {/* story #3499(Phase2·FE) — publication_id 있을 때만(BE #3844 조각4 의존). */}
+          <InsightSnapshotBlock snapshots={insightSnapshots} orgTimezone={displayTimezone} locale={locale} />
+          {/* story #3517(Phase2·FE, 그라운딩 ① 자리 그대로 — InsightSnapshotBlock 곁,
+              같은 draft.publication_id 조건) — 댓글 섹션. 조각①-FE 범위(PO 確定
+              2026-09-05): 세 얼굴·수집 시각·목록·지워진 댓글(§22-9)만 — 행 액션
+              (작업으로 전환·답변)은 조각②(답변/작업전환 엔드포인트) PR에서. */}
+          <CommentsSection
+            face={commentsFace}
+            displayTimezone={displayTimezone}
+            onRefresh={handleCommentsRefresh}
+            onConvertToTask={setConvertToTaskComment}
+            onReply={setReplyComment}
+          />
+        </div>
+      ) : null}
+
+      {/* story #3402 PR2(T7/T9) — publication_status는 다섯 상태 밖의 신호라
+          deriveChannelPostView가 별도 필드로 얹어 준다(WIP1과 동일 함수, 재사용). T9 —
+          부분 성공(container_created)이면 "이어서 발행"이 기본 행동임을 미리 안다
+          (발행 버튼 자체의 배선은 이 조각 스코프 밖 — 다음 조각). PR1 rebase
+          반영(2026-09-04) — 위 승인 카드가 이미 계산해 둔 `view`를 그대로 재사용한다
+          (같은 함수를 두 번 부르지 않는다). */}
+      {(() => {
         if (view.unpublished) {
           // story #3426(doc §17-10②) — 회수돼도 승인(gate) 자체는 안 풀린다 — 칩은
           // 「승인됨」 그대로이고 이 오버레이가 "회수됨"을 얹는다(partialSuccess/

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -951,6 +951,13 @@ class PublishChannelPostResponse(BaseModel):
     # 지정했다는 뜻과는 다른 축 — 이건 "지금 요청했는데 서버가 자동으로 이어서
     # 처리 중"). true면 permalink/external_id/published_at은 전부 null(아직 없다).
     processing: bool = False
+    # story #3525(PO 確定 2026-09-06) — permalink/external_id/published_at과 같은
+    # 시점에 생기는 값(publish_channel_post_draft가 반환하는 ChannelPublication.id
+    # 그대로). FE handlePublish의 로컬 병합이 이 필드도 draft에 얹어야 §22-12(발행됨
+    # 카드가 draft.publication_id 하나로 즉시 열림)가 재로드 없이 성립한다.
+    # processing=True(컨테이너 비동기 대기)면 아직 최종 published 행이 없어 그 세
+    # 필드처럼 null 그대로.
+    publication_id: uuid.UUID | None = None
 
 
 @router.post(
@@ -1238,7 +1245,7 @@ async def publish_channel_post_draft_endpoint(
     return PublishChannelPostResponse(
         permalink=row.permalink, external_id=row.external_id,
         published_at=row.published_at.isoformat(), version_id=row.version_id,
-        scheduled=False, command_id=command.id,
+        scheduled=False, command_id=command.id, publication_id=row.id,
     )
 
 

--- a/backend/tests/test_3525_publication_id_last_published.py
+++ b/backend/tests/test_3525_publication_id_last_published.py
@@ -88,6 +88,11 @@ async def test_new_version_after_publish_keeps_publication_id_pointing_at_last_p
             async with _client_for(app) as client:
                 r_publish = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
                 assert r_publish.status_code == 200, r_publish.text
+                # story #3525 REQUIRED(PO 確定 ③) — publish 응답 자체가 이미
+                # publication_id를 실어야 FE handlePublish의 로컬 병합(재로드 없이
+                # 발행됨 카드가 즉시 열리는 흐름)이 서버 값 없이도 성립한다.
+                publish_publication_id = r_publish.json()["publication_id"]
+                assert publish_publication_id is not None
 
         _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
         async with _client_for(app) as client:
@@ -97,6 +102,7 @@ async def test_new_version_after_publish_keeps_publication_id_pointing_at_last_p
             assert before["publication_id"] is not None
             assert before["published_at"] is not None
             publication_id_after_v1 = before["publication_id"]
+            assert publish_publication_id == publication_id_after_v1, "publish 응답의 publication_id가 그 뒤 GET과 같은 값이어야 함"
 
             # story #3525 재현 — 같은 work_item+connection에 새 draft 생성 요청을
             # 다시 보내면(create_channel_post_draft_version의 upsert 분기) 기존

--- a/backend/tests/test_620beefc_channel_post_image.py
+++ b/backend/tests/test_620beefc_channel_post_image.py
@@ -733,6 +733,9 @@ async def test_image_publish_creates_container_then_waits_no_immediate_publish_c
             body = r.json()
             assert body["processing"] is True
             assert body["permalink"] is None
+            # story #3525(PO 確定) — publication_id도 permalink 등 셋과 동형(아직
+            # 최종 published 행이 없다 — 지어내지 않는다).
+            assert body["publication_id"] is None
             publish_container_mock.assert_not_called()
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## 요약
#3879가 `draft.publication_id`를 "현재 버전의 승인 상태"가 아니라 "마지막 발행 publication"(버전 무관)으로 재정의했지만, 상세 화면의 발행됨 카드(permalink·published_at·external_id·InsightSnapshotBlock·CommentsSection — 원래 이 다섯이 한 블록)가 여전히 `view.status === 'published'` 분기 안에 있었다. `view.status`는 "현재 버전"의 파생값이라, 새 버전을 상신(`reapproval_required=true`)만 해도 밖에 실제로 살아 있는 게시물의 댓글·인사이트·permalink가 상세에서 통째로 사라지는 사고가 재발했다(유나 18회차 실측, draft `2220797b`, §22-12 위반).

### BE — `PublishChannelPostResponse.publication_id` additive
`permalink`/`external_id`/`published_at`과 같은 시점(동기 발행 성공)에 `publish_channel_post_draft`가 반환하는 `ChannelPublication.id`를 그대로 싣는다. 비동기(`processing=true`, 컨테이너 대기)면 그 셋처럼 `null` 그대로.

### FE
- `handlePublish`의 로컬 병합에 `publication_id`도 얹어 — 재로드 없는 "즉시 반영" UX가 서버 재조회 없이도 성립.
- 발행됨 카드 전체의 렌더 조건을 `draft.publication_id` 하나로(`view.status` 조건 제거).
- `reapproval_required === true`일 때만(기존 "재승인 필요" 칩이 이미 그 사실을 독립적으로 말하므로 칩 문구는 무변경) 카드 머리에 "아래 정보는 마지막으로 발행된 버전의 것입니다" 안내 한 줄 추가.

## 검증
- 기존 4개 회귀 테스트를 새 계약(publication_id는 permalink 등과 구조적으로 함께 있거나 함께 없다 — #3879 이후 이 조합이 불가능해진 낡은 시나리오였던 1건은 "카드 전체 미렌더"로 재작성)에 맞게 갱신.
- 신규 테스트 4개(BE 1: publish 응답 자체에 publication_id 확인, FE 3: reapproval_required+publication_id→카드+안내줄, 발행됨(재승인 불요)→카드만, publication_id 없음→미렌더).
- 전부 뮤테이션 검증(렌더 조건·안내줄 조건 각각 무력화 → 구 동작(view.status 기반)으로 되돌아가는 RED 확인 → 복원).
- BE realdb 37건 그린 / FE `tsc --noEmit` 0 · `eslint --max-warnings=0` 0 · `vitest run` 6330 전부 그린.
- i18n 키 누락 0 · 부분문자열 충돌 신규 0 · 한자 0.

## 반응형/스크린샷
- 기존 카드 레이아웃 안에 안내 문구 한 줄 추가뿐 — 별도 반응형 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)