### PR TITLE
[SID:3536] fix: 이미지 필수 채널 상신 시 422 사전체크 + 영구조건 실패 needs_check 분류

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -138,6 +138,11 @@ class ChannelConnectionResponse(BaseModel):
     image_width_max: int = 0
     image_color_space: str = ""
     image_max_count: int = 0
+    # story #3536(AC1, PO 確定 2026-09-06) — image_max_count>0("지원")과는 다른 축:
+    # "필수"(이미지 0장이면 발행 자체가 provider에서 거부됨, 예: Instagram). FE가
+    # 「올리기 전에」 안내를 만들 수 있게 노출(max_text_length·image_max_count와 동형
+    # 관례 — 상수 하드코딩 X).
+    image_required: bool = False
     # story #3492 — 붙여넣기(pasted_secret) 재방문 표시(§2 규격 3, app_id_suffix와
     # 동형). oauth 채널은 항상 null(secret_hint 자체를 안 씀).
     secret_hint: str | None = None
@@ -173,6 +178,7 @@ def _to_response(row) -> ChannelConnectionResponse:
         image_width_max=adapter.image_width_max if adapter is not None else 0,
         image_color_space=adapter.image_color_space if adapter is not None else "",
         image_max_count=adapter.image_max_count if adapter is not None else 0,
+        image_required=adapter.image_required if adapter is not None else False,
         secret_hint=row.secret_hint,
     )
 

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -17,6 +17,7 @@ from app.services.content_rules import get_org_content_rules, lint_content
 from app.services.channel_posts import (
     ChannelConnectionNotActiveError,
     ChannelImageContainerFailedError,
+    ChannelImageRequiredError,
     ChannelPostApproverRoleMissingError,
     ChannelPostDraftNotFoundError,
     ChannelPostGateAlreadyHeldError,
@@ -926,6 +927,13 @@ async def submit_channel_post_draft_endpoint(
                 "code": "CONTENT_RULE_VIOLATION", "rules_version": exc.rules_version,
                 "violations": exc.violations,
             },
+        ) from exc
+    except ChannelImageRequiredError as exc:
+        # story #3536(PO 確定 2026-09-06) — 필드 완결성 422(CHANNEL_TEXT_TOO_LONG류와
+        # 동형). 승인 게이트 낭비를 상신 단계에서 미리 막는다.
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "CHANNEL_IMAGE_REQUIRED", "message": str(exc)},
         ) from exc
 
     return SubmitChannelPostDraftResponse(

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -101,6 +101,12 @@ class ChannelAdapterConfig:
     # 明示 — 읽기는 기존 연결 스코프로 충분하다는 전제, 조각①은 sandbox까지가 라이브
     # 범위라 실제 부족 여부는 Threads 실계정 왕복 시점에 재확認).
     reply_required_scope: str | None = None
+    # story #3536(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — image_max_count>0
+    # (이미지를 지원함)과는 다른 축: "지원"이 아니라 "필수"(이미지 0장이면 발행 자체가
+    # provider에서 거부됨, 예: Instagram 피드 게시물). 기본 False=기존 채널(Threads
+    # 등, TEXT-only 허용) 회귀 0. True면 submit(상신) 단계에서 이미지 0장을 즉시 422로
+    # 막는다 — 승인 게이트를 낭비하고 발행 시점에야 죽는 것을 방지.
+    image_required: bool = False
 
 
 CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
@@ -201,6 +207,10 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # 리뷰) — impressions는 2024-07-02 이후 미디어에 폐기돼 선언 안 함(항상
         # None), 대신 views를 threads와 같은 이름으로 선언.
         insight_metrics=("views", "reach", "engagements"),
+        # story #3536(PO 確定 2026-09-06) — IG 피드 발행은 이미지 1장이 구조적으로
+        # 필수(캡션만으론 컨테이너 생성 자체가 provider에서 거부됨, instagram_
+        # publish.py::create_media_container의 image_url=None 즉시 거부와 동형 사실).
+        image_required=True,
     ),
     # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각①) — Sprintable
     # 호스팅 블로그를 blog kind 어댑터 1호로 등재한다. **동작 무변경** — site_posts.py의
@@ -346,6 +356,8 @@ if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
         # 페드루 PO REQUIRED(2026-09-06, #3874 리뷰) — 위 instagram과 동형 정정
         # (impressions 폐기, views로 대체).
         insight_metrics=("views", "reach", "engagements"),
+        # story #3536(PO 確定 2026-09-06) — 위 "instagram"과 동형(이미지 필수).
+        image_required=True,
     )
 
 

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -94,6 +94,16 @@ class ChannelTextTooLongError(ValueError):
         super().__init__(f"본문이 한도를 넘었습니다(한도 {max_length}자, 현재 {current_length}자)")
 
 
+class ChannelImageRequiredError(ValueError):
+    """story #3536(PO 確定 2026-09-06) — 어댑터가 image_required=True(예: Instagram)인데
+    상신하려는 버전에 이미지가 없음. 상신(submit) 시점에 막아 승인 게이트를 낭비하지
+    않는다(발행 시점에야 provider에서 422/실패로 아는 것을 사전 차단, ChannelTextTooLong
+    Error와 동형 관례 — 입력 형태 오류는 422)."""
+
+    def __init__(self) -> None:
+        super().__init__("이 채널은 이미지 1장이 필요합니다.")
+
+
 class ChannelTokenExpiredError(Exception):
     """story #f8f7cb0f — provider가 401/403(인증 실패)로 응답 — 토큰이 만료/철회됐다는
     뜻. `apply_refresh_failure`와 동형으로 connection.status를 expired로 내려 재인증을
@@ -911,6 +921,14 @@ async def submit_channel_post_draft(
     if target is None:
         raise ChannelPostVersionNotFoundError(version_id)
     origin_author_member_id = versions[0].author_member_id
+
+    # story #3536(PO 確定 2026-09-06) — 이미지 필수 채널(image_required=True)인데
+    # 이 버전에 이미지가 없으면 게이트 생성 前 즉시 422(§ChannelImageRequiredError
+    # docstring). ChannelTextTooLongError와 나란한 필드 완결성 검사 — content_rules
+    # lint보다 먼저 두는 이유는 같다(반쪽 봉인 없이 사전 거부).
+    adapter = get_channel_adapter(draft.channel)
+    if adapter is not None and adapter.image_required and not target.image_sha256:
+        raise ChannelImageRequiredError()
 
     # story #3471(페드루 PO 確定 2026-09-05) — submit(상신) 시점에 재검사·위반 1건
     # 이상이면 422(금지 AC=서버 거부). create/update의 lint_result 스냅샷을 다시

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -67,6 +67,15 @@ _CONNECTION_BLOCKED_CODES = frozenset({
 # needs_check(사람 재시도, AC5)로 바로 보낸다.
 _NEEDS_CHECK_CODES = frozenset({"CHANNEL_PUBLISH_IN_PROGRESS", "CHANNEL_IMAGE_CONTAINER_FAILED"})
 _TRANSIENT_CODES = frozenset({"CHANNEL_PUBLISH_PROVIDER_ERROR", "CHANNEL_RATE_LIMITED"})
+# story #3536(PO 確定 2026-09-06) — ChannelPublishProviderError.provider_code가 이
+# 집합에 있으면(어댑터가 구조적으로 실어 준 코드, 문자열 매칭 아님 — instagram_
+# publish.py::create_media_container가 ThreadsPublishError("INSTAGRAM_IMAGE_
+# REQUIRED", ...)로 던진 값이 _classify_threads_error→ChannelPublishProviderError.
+# provider_code에 그대로 실린다) 「영구 조건」이라 재시도해도 다시 같은 결과 —
+# 일반 provider 오류(_TRANSIENT_CODES)와 달리 classify_failure_kind가 needs_check로
+# 보내도록 이 코드 자체를 error_code로 승격한다(아래 except 분기). 매핑표에 없는
+# 코드는 이미 needs_check가 기본값이라 이 집합에 새 이름을 추가하는 것만으로 충분.
+_PERMANENT_PROVIDER_CONDITION_CODES = frozenset({"INSTAGRAM_IMAGE_REQUIRED"})
 
 
 # story #3474(페드루 PO 確定 2026-09-05) — 게이트가 approved가 아니거나(missing)
@@ -365,7 +374,14 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
         error_code, last_error = "CHANNEL_RATE_LIMITED", str(exc)
         retry_after_seconds = max(0, int((exc.reset_at - now).total_seconds()))
     except ChannelPublishProviderError as exc:
-        error_code, last_error = "CHANNEL_PUBLISH_PROVIDER_ERROR", str(exc)
+        # story #3536 — 어댑터가 넘긴 provider_code가 「영구 조건」이면(예: 이미지
+        # 필수 채널에 이미지 없이 도달) 그 코드 자체를 error_code로 써서 classify_
+        # failure_kind가 needs_check(재시도 0·dead_letter)로 보내게 한다. 그 외
+        # 일반 provider 오류는 기존처럼 CHANNEL_PUBLISH_PROVIDER_ERROR(transient).
+        if exc.provider_code in _PERMANENT_PROVIDER_CONDITION_CODES:
+            error_code, last_error = exc.provider_code, str(exc)
+        else:
+            error_code, last_error = "CHANNEL_PUBLISH_PROVIDER_ERROR", str(exc)
     except ChannelPublishInProgressError as exc:
         error_code, last_error = "CHANNEL_PUBLISH_IN_PROGRESS", str(exc)
     except Exception as exc:  # noqa: BLE001 — 미분류 실패도 이 command 하나만 막는다.

--- a/backend/tests/test_3536_channel_image_required.py
+++ b/backend/tests/test_3536_channel_image_required.py
@@ -1,0 +1,280 @@
+"""story #3536(BE·결함, 페드루 PO 確定 2026-09-06) — 이미지 필수 채널(Instagram)에
+이미지 없는 초안이 상신·승인까지 통과하고 발행에서야 죽는 것을 상신 단계에서 막는다
+(422 `CHANNEL_IMAGE_REQUIRED`) + 그 실패가 어댑터 「영구 조건」 코드로 오면
+`classify_failure_kind`가 needs_check(재시도 0·dead_letter)로 보내게 한다(기존
+transient «기다리면 됨» 오분류 정정).
+
+세팅 헬퍼는 test_620beefc_channel_post_image.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_620beefc_channel_post_image import (
+    _approve_gate_directly, _client_for, _create_draft, _png_bytes, _seed_connection,
+    _seed_default_role, _seed_human, _seed_org, _seed_story, _session_factory,
+    _setup_org_scoped_app, _upload_and_confirm,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage_for_image_upload(monkeypatch, tmp_path):
+    """test_620beefc_channel_post_image.py와 동형(중복 재발명 금지) — 버킷 이름은
+    반드시 그 파일의 `_CHANNEL_MEDIA_BUCKET`과 같아야 한다(다르면 PUT과 confirm이
+    서로 다른 버킷을 봐서 404가 난다, test_3320_instagram_connector.py와 동일 관례)."""
+    import app.services.channel_post_images as cpi_module
+    from tests.test_620beefc_channel_post_image import _CHANNEL_MEDIA_BUCKET
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage-3536"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+async def _submit(client, org_id, draft_id, *, scheduled_at: datetime | None = None):
+    body = {}
+    if scheduled_at is not None:
+        body["scheduled_at"] = scheduled_at.isoformat()
+    return await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json=body,
+    )
+
+
+@pytest.mark.anyio
+async def test_submit_instagram_draft_without_image_returns_422():
+    """AC2 — 이미지 없는 IG 초안은 상신 자체가 막힌다(게이트 생성 前, 승인 게이트
+    낭비 방지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+                r_submit = await _submit(client, org_id, draft_id)
+                assert r_submit.status_code == 422, r_submit.text
+                error = r_submit.json().get("error") or r_submit.json()
+                assert error["code"] == "CHANNEL_IMAGE_REQUIRED"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_submit_instagram_draft_with_image_succeeds():
+    """이미지가 있으면 정상 통과(회귀 0)."""
+    from app.main import app
+
+    raw = _png_bytes(800, 800)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+                r_upload = await _upload_and_confirm(client, org_id, draft_id, raw, content_type="image/png")
+                assert r_upload.status_code == 201, r_upload.text
+
+                r_submit = await _submit(client, org_id, draft_id)
+                assert r_submit.status_code == 200, r_submit.text
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_submit_threads_draft_without_image_succeeds_unaffected():
+    """회귀 — image_required=False(Threads 등)는 이미지 없어도 그대로 통과."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="threads")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+                r_submit = await _submit(client, org_id, draft_id)
+                assert r_submit.status_code == 200, r_submit.text
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_channel_connection_response_exposes_image_required():
+    """AC1 — GET channel-connections 응답에 image_required가 그대로 실린다(instagram
+    True·threads False)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            ig_connection_id = await _seed_connection(s, org_id, channel="instagram")
+            threads_connection_id = await _seed_connection(s, org_id, channel="threads")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+                assert r.status_code == 200, r.text
+                by_id = {row["id"]: row for row in r.json()}
+                assert by_id[str(ig_connection_id)]["image_required"] is True
+                assert by_id[str(threads_connection_id)]["image_required"] is False
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def _fake_create_container_raises_image_required(client, *, access_token, threads_user_id, text, image_url=None):
+    from app.services.threads_publish import ThreadsPublishError
+
+    raise ThreadsPublishError(
+        "INSTAGRAM_IMAGE_REQUIRED", "Instagram 발행은 이미지가 필수입니다(피드 이미지 1장)", status_code=422,
+    )
+
+
+async def _fake_get_publishing_limit(client, *, access_token, threads_user_id):
+    return (0, 100, 24 * 60 * 60)
+
+
+async def _seed_scheduled_instagram_command(session, client, *, org_id, connection_id, story_id, human_id):
+    """이미지 있는 IG 초안으로 상신(#3536 사전체크 통과)+승인 뒤, 발행 시점 provider가
+    그래도(레이스·서버·클라이언트 판정 불일치 등 방어선 시나리오) INSTAGRAM_IMAGE_
+    REQUIRED로 거부하는 상황을 워커까지 직접 재현하기 위해 scheduled command를
+    수동으로 심는다(test_3414_publication_command.py::test_cron_deterministic_
+    failure...와 동형 기법)."""
+    from app.models.publication_command import PublicationCommand
+
+    raw = _png_bytes(800, 800)
+    draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+    r_upload = await _upload_and_confirm(client, org_id, draft_id, raw, content_type="image/png")
+    assert r_upload.status_code == 201, r_upload.text
+    r_submit = await _submit(client, org_id, draft_id, scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1))
+    assert r_submit.status_code == 200, r_submit.text
+    gate_id = uuid.UUID(r_submit.json()["gate_id"])
+    version_id = uuid.UUID(r_submit.json()["version_id"])
+    await _approve_gate_directly(session, gate_id)
+
+    now = datetime.now(timezone.utc)
+    cmd = PublicationCommand(
+        id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+        approved_version=version_id, operation="publish",
+        scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=human_id,
+    )
+    session.add(cmd)
+    await session.commit()
+    return cmd.id
+
+
+@pytest.mark.anyio
+async def test_instagram_permanent_provider_failure_classified_as_needs_check_dead_letter(monkeypatch):
+    """AC3 — 어댑터가 INSTAGRAM_IMAGE_REQUIRED(영구 조건)로 실패하면 needs_check로
+    분류돼 즉시 dead_letter(재시도 0·next_attempt_at null). 뮤테이션 자가검증 —
+    _PERMANENT_PROVIDER_CONDITION_CODES에서 이 코드를 지우면(실 소스 대입) 같은
+    실패가 CHANNEL_PUBLISH_PROVIDER_ERROR(transient)로 떨어져 pending+next_attempt_at
+    이 채워지는 것으로 되돌아간다."""
+    import app.services.instagram_publish as instagram_publish_module
+    from app.models.publication_command import PublicationCommand
+    from app.services.publication_command import process_due_publication_commands
+    from sqlalchemy import select
+
+    monkeypatch.setattr(instagram_publish_module, "create_container", _fake_create_container_raises_image_required)
+    monkeypatch.setattr(instagram_publish_module, "get_publishing_limit", _fake_get_publishing_limit)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client, Session() as s:
+                cmd_id = await _seed_scheduled_instagram_command(
+                    s, client, org_id=org_id, connection_id=connection_id, story_id=story_id, human_id=human_id,
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            cmd_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd_row.status == "dead_letter", cmd_row.status
+            assert cmd_row.failure_kind == "needs_check", cmd_row.failure_kind
+            assert cmd_row.next_attempt_at is None
+            assert cmd_row.attempt_count == 1
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1158,6 +1158,11 @@
       "source": "story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3536_channel_image_required.py",
+      "sec": 30.0,
+      "source": "story-3536-channel-image-required(PR 개설 前 선제 등재 — 로컬 raw pytest 4.38s(5건) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 30s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
       "file": "tests/test_5b27b32f_sandbox_channel.py",
       "sec": 115.0,
       "source": "story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## 배경(배포 34 실측, 표본 ec02b1d6)
instagram_sandbox 연결에 이미지 없는 초안 → 상신 200(게이트 pending) → 승인 200 → publish 502 `CHANNEL_PUBLISH_PROVIDER_ERROR`(내부 `INSTAGRAM_IMAGE_REQUIRED`)·`command_status=pending`·`next_attempt_at=+2분`.

**결함 ①(사전체크 0)**: 「이미지 필수인데 없음」류 필드 완결성 검사가 상신 단계에 없어 승인 게이트가 낭비되고 사람은 발행을 눌러야 안다.
**결함 ②(오분류)**: 어댑터의 영구 조건(이미지 없음) 실패가 `classify_failure_kind`에서 provider error 계열(transient)로 접혀 백오프 재시도된다 — 사람에게 「기다리면 됨」(§22-15 pending+next_attempt_at)으로 보이지만 실제는 「다시 해도 같음」(needs_check→dead_letter).

## 처방
1. `ChannelAdapterConfig.image_required: bool = False` additive — instagram·instagram_sandbox=True. `ChannelConnectionResponse`에도 노출.
2. `submit_channel_post_draft`에서 `image_required∧이미지 0` → 422 `CHANNEL_IMAGE_REQUIRED`(게이트 생성 前, `ChannelTextTooLongError`와 동형).
3. `classify_failure_kind`(publication_command.py) — `ChannelPublishProviderError.provider_code`가 영구 조건 코드(`INSTAGRAM_IMAGE_REQUIRED`)면 그 코드 자체를 error_code로 승격해 needs_check로 보낸다(문자열 매칭이 아니라 어댑터가 구조적으로 넘긴 `provider_code` 필드 — `classify_failure_kind` 함수 자체는 무변경, 매핑표 밖 코드는 이미 needs_check가 기본값).

## 테스트
`test_3536_channel_image_required.py` 5건 — IG 이미지 없는 상신 422 · 있으면 통과 · Threads(불요) 회귀 · GET channel-connections `image_required` 노출(true/false) · 워커 레벨(mock adapter가 INSTAGRAM_IMAGE_REQUIRED로 실패 → dead_letter·failure_kind=needs_check·next_attempt_at null). 뮤테이션 자가검증 2회(submit 가드 제거·영구조건 코드셋 비움, 각각 실 소스에서 RED 확인 후 원복). 인접회귀(620beefc·3320 조각①③·3414) 95 passed 무회귀.

## 라이브
배포 뒤 표본 ec02b1d6 재상신 → 422 문장(사람 손 0으로 「기다리면 됨」 얼굴 소멸).

🤖 Generated with [Claude Code](https://claude.com/claude-code)