### PR TITLE
[SID:3537] 연결 있는 채널의 «테스트용 연결 만들기» 버튼 부재

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -372,6 +372,49 @@ describe('OrganizationChannelsPage — available-channels 목록 기반 렌더(s
     expect(container.querySelector('[data-testid="channel-connect-sandbox-button"]')).not.toBeNull();
   });
 
+  // story #3537(유나 18회차 발견, PO 確定 2026-09-06) — 배지는 연결 「행」의
+  // credential_kind(상태)로, 버튼은 채널 「항목」의 credential_kind(성질)로만 그려
+  // 연결이 이미 있어도 「…연결 만들기」가 활성으로 남았다. 채널에 연결이 하나라도
+  // 있으면(상태 무관) 버튼 자체가 안 뜬다 — "다시 만들기" 경로는 의도적으로 없다.
+  it('⭐#3537 — 이 채널에 연결이 이미 있으면(channel 일치) 「연결 만들기」 버튼이 안 뜬다', async () => {
+    stubFetch({
+      connections: [{ ...CONNECTION_ACTIVE, id: 'conn-sandbox-1', channel: 'sandbox', credential_kind: 'none' }],
+      availableChannels: AVAILABLE_WITH_SANDBOX,
+    });
+    await mount('owner');
+    expect(container.querySelector('[data-testid="channel-connect-sandbox-button"]')).toBeNull();
+    // 배지는 여전히 뜬다(연결 자체가 사라진 게 아니다 — 버튼만 안 뜨는 것).
+    expect(container.querySelector('[data-testid="channel-connect-sandbox-connection-badge"]')).not.toBeNull();
+  });
+
+  it('⭐#3537 — 연결 상태(만료 등)와 무관하게 그 채널에 행이 하나라도 있으면 버튼이 안 뜬다("다시 만들기" 경로 없음)', async () => {
+    stubFetch({
+      connections: [{ ...CONNECTION_ACTIVE, id: 'conn-sandbox-1', channel: 'sandbox', credential_kind: 'none', status: 'expired' }],
+      availableChannels: AVAILABLE_WITH_SANDBOX,
+    });
+    await mount('owner');
+    expect(container.querySelector('[data-testid="channel-connect-sandbox-button"]')).toBeNull();
+  });
+
+  it('⭐#3537 — 연결이 이미 있으면 member에게도 owner·admin 안내 문구가 안 뜬다(버튼과 조건 일치, 존재하지 않는 액션의 사유는 노이즈)', async () => {
+    stubFetch({
+      connections: [{ ...CONNECTION_ACTIVE, id: 'conn-sandbox-1', channel: 'sandbox', credential_kind: 'none' }],
+      availableChannels: AVAILABLE_WITH_SANDBOX,
+    });
+    await mount('member');
+    expect(container.querySelector('[data-testid="channel-connect-sandbox-button"]')).toBeNull();
+    expect(container.textContent).not.toContain('이 작업은 owner·admin만 할 수 있습니다');
+  });
+
+  it('⭐#3537 — 다른 채널(threads)에만 연결이 있으면 sandbox 「연결 만들기」 버튼은 그대로 뜬다(channel 하드코딩 0, 일치로만 판정)', async () => {
+    stubFetch({
+      connections: [CONNECTION_ACTIVE], // channel: 'threads'
+      availableChannels: AVAILABLE_WITH_SANDBOX,
+    });
+    await mount('owner');
+    expect(container.querySelector('[data-testid="channel-connect-sandbox-button"]')).not.toBeNull();
+  });
+
   it('⭐sandbox 「연결 만들기」를 누르면 BFF POST 성공 뒤 리로드 없이 새 연결 행이 추가된다', async () => {
     stubFetch({ connections: [], availableChannels: AVAILABLE_WITH_SANDBOX });
     await mount('owner');

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -312,8 +312,15 @@ function ChannelSection({
               </a>
             ) : null
           ) : credential_kind === 'none' ? (
+            // story #3537(유나 18회차 발견, PO 確定 2026-09-06) — 배지는 연결 「행」의
+            // credential_kind(상태)로 그리는데, 이 버튼은 채널 「항목」의 credential_kind
+            // (성질)로만 그려 연결이 이미 있어도 「…연결 만들기」가 활성으로 남았다 —
+            // 이름이 "만들기"인데 새로 생기는 게 없으면 라벨이 거짓말이 된다(§17-21).
+            // connections는 이미 이 channel로 필터된 배열(부모 컴포넌트, 위 connections.
+            // length===0/!==1 판정과 같은 변수) — 활성/만료 등 상태 무관하게 행이 하나라도
+            // 있으면 버튼 자체를 안 그린다("다시 만들기" 경로는 의도적으로 두지 않는다).
             // sandbox 생성은 owner|admin(create_sandbox_channel_connection = _require_owner_or_admin).
-            isOwnerOrAdmin ? (
+            isOwnerOrAdmin && connections.length === 0 ? (
               <Button
                 size="sm" onClick={() => void handleCreateSandbox()} disabled={creatingSandbox}
                 data-testid="channel-connect-sandbox-button"
@@ -336,7 +343,10 @@ function ChannelSection({
           {credential_kind === 'oauth' && !isOwnerStrict ? (
             <p className="text-xs text-muted-foreground">{t('channelOwnerOnlyReason')}</p>
           ) : null}
-          {credential_kind === 'none' && !isOwnerOrAdmin ? (
+          {/* story #3537 — 액션 자체가 없는 자리(연결 이미 있음)에 권한 사유 문구를
+              남기면 "안 보이는 버튼을 왜 못 누르나"는 존재하지 않는 질문에 답하는
+              꼴이라 노이즈다 — 버튼과 조건을 맞춘다. */}
+          {credential_kind === 'none' && !isOwnerOrAdmin && connections.length === 0 ? (
             <p className="text-xs text-muted-foreground">{t('channelOwnerOrAdminOnlyReason')}</p>
           ) : null}
           {/* story #3521계 유나 #3877 관찰(PO 確定 2026-09-06) — 이 자리는 권한


### PR DESCRIPTION
## 요약
연결 배지(「Sandbox 테스트용 연결」 등)가 "연결이 있다"고 말하는 바로 그 화면에 「…연결 만들기」 버튼이 계속 활성으로 서 있었다. 원인은 배지=연결 **행**의 `credential_kind`(상태), 버튼=채널 **항목**의 `credential_kind`(성질)로 서로 다른 축을 보고 있었기 때문 — 채널의 "성질"(자격 불요)로 "상태"(미연결)를 열어 둔 자리였다.

## 처방
- 그 채널에 연결이 하나라도 있으면(`connections`가 이미 부모에서 `channel` 일치로 필터된 배열) 버튼 자체를 안 그린다. 연결 상태(active/expired 등) 무관 — "다시 만들기" 경로는 의도적으로 두지 않는다(PO 確定).
- 권한 사유 문구("이 작업은 owner·admin만…")도 같은 조건으로 맞춰 — 존재하지 않는 액션에 대한 사유는 노이즈다(스토리 범위 밖 자체 보강, 사이드이펙트 없음).

## 검증
- 뮤테이션 검증(버튼 조건·문구 조건 각각 무력화 → 구 동작으로 되돌아가는 RED 확인 → 복원).
- 신규 테스트 4개: 연결 있음→버튼 부재(+배지는 그대로), 상태(만료) 무관, 다른 채널엔 영향 없음(channel 하드코딩 0), member에게도 안내 문구 부재.
- 기존 37개 회귀 0.
- `tsc --noEmit` 0 / `eslint --max-warnings=0` 0 / `vitest run` 6331 전부 그린.

## 반응형/스크린샷
- 조건부 렌더 변경뿐(레이아웃 무변경) — 별도 반응형 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)