### PR TITLE
[SID:3538] feat: 이미지 필수 채널 상신 전 선알림 + 422 CHANNEL_IMAGE_REQUIRED 문구 등재

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2518,6 +2518,7 @@
     "channelPostsImageUploading": "Uploading…",
     "channelPostsImageConfirming": "Confirming…",
     "channelPostsImageUploadInProgressReason": "You can't save or submit until the image upload finishes.",
+    "channelPostsImageRequiredReason": "You can't submit without an image — this channel requires an image.",
     "channelPostsImageUnsupportedFormat": "Unsupported format — {contentType} (allowed: {allowed})",
     "channelPostsImageTooLarge": "Only {maxBytes} or less can be attached, but this is {sizeBytes}",
     "channelPostsImageAspectRatioExceeded": "This image is too elongated. The maximum aspect ratio is {maxAspectRatio}, but this is {aspectRatio}",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2518,6 +2518,7 @@
     "channelPostsImageUploading": "업로드 중…",
     "channelPostsImageConfirming": "확인 중…",
     "channelPostsImageUploadInProgressReason": "이미지 업로드가 끝날 때까지 저장·상신을 할 수 없습니다.",
+    "channelPostsImageRequiredReason": "이미지 없이 상신할 수 없습니다 — 이 채널은 이미지가 필요합니다.",
     "channelPostsImageUnsupportedFormat": "지원하지 않는 형식입니다: {contentType}(허용: {allowed})",
     "channelPostsImageTooLarge": "{maxBytes} 이하만 첨부할 수 있는데 {sizeBytes}입니다",
     "channelPostsImageAspectRatioExceeded": "이미지가 너무 길쭉합니다. 비율 한도는 {maxAspectRatio}인데 {aspectRatio}입니다",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -137,6 +137,8 @@ function stubFetch(opts: {
   // 기본값 10 유지, IG 실값(1.91) 테스트만 덮어씀).
   imageAspectMin?: number;
   imageAspectMax?: number;
+  // story #3538(BE #3886) — 기본 false(기존 테스트 전부 회귀 0).
+  imageRequired?: boolean;
   onImageUploadUrl?: (body: unknown) => { status: number; body: unknown };
   onImagePut?: () => { status: number };
   onImageConfirm?: (body: unknown) => { status: number; body: unknown };
@@ -224,6 +226,8 @@ function stubFetch(opts: {
               image_aspect_max: opts.imageAspectMax ?? 10, image_aspect_min: opts.imageAspectMin ?? 0,
               image_width_min: 320, image_width_max: 1440,
               image_color_space: 'sRGB', image_max_count: opts.imageMaxCount ?? 0,
+              // story #3538(BE #3886) — 기본 false(기존 테스트 전부 회귀 0).
+              image_required: opts.imageRequired ?? false,
             }],
             error: null, meta: null,
           }),
@@ -2110,6 +2114,103 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     expect(errorText).not.toContain('1.9인데');
     expect(errorText).not.toContain('가로');
     expect(errorText).not.toContain('세로');
+  });
+});
+
+// story #3538(BE #3886, 유나 §17-16⑤ PO 確定) — 이미지 필수 채널 상신 전 선알림 + 422 문구.
+describe('ChannelPostEditPage — 이미지 필수 채널 선알림(story #3538)', () => {
+  const REASON_TESTID = 'channel-post-image-required-reason';
+
+  it('image_required=true·이미지 0장이면 사유가 뜨고 상신·예약 상신·저장 버튼 상태가 각각 옳다(저장만 활성)', async () => {
+    stubFetch({ imageMaxCount: 1, imageRequired: true });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector(`[data-testid="${REASON_TESTID}"]`)).not.toBeNull();
+    expect((container.querySelector('[data-testid="channel-post-submit-button"]') as HTMLButtonElement).disabled).toBe(true);
+    expect((container.querySelector('[data-testid="channel-post-schedule-submit-button"]') as HTMLButtonElement).disabled).toBe(true);
+    // 페드루 PO 明示(2026-09-06) — 저장은 이미지 필수 축과 무관(본문만 먼저 쓰고
+    // 이미지는 나중에 붙이는 길을 막지 않는다).
+    expect((container.querySelector('[data-testid="channel-post-save-button"]') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('image_required=true여도 이미지가 있으면(같은 마운트에서 첨부 직후) 사유가 즉시 사라지고 상신이 풀린다', async () => {
+    stubFetch({ imageMaxCount: 1, imageRequired: true });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector(`[data-testid="${REASON_TESTID}"]`)).not.toBeNull();
+
+    const input = container.querySelector('[data-testid="channel-post-image-file-input"]') as HTMLInputElement;
+    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    expect(container.querySelector(`[data-testid="${REASON_TESTID}"]`)).toBeNull();
+    expect((container.querySelector('[data-testid="channel-post-submit-button"]') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('image_required=false(Threads 등)이면 이미지 0장이어도 사유가 렌더되지 않는다', async () => {
+    stubFetch({ imageMaxCount: 1, imageRequired: false });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector(`[data-testid="${REASON_TESTID}"]`)).toBeNull();
+    expect((container.querySelector('[data-testid="channel-post-submit-button"]') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('업로드 진행 중엔 「업로드 중」 사유만 뜨고 「이미지 필요」 사유와 동시에 뜨지 않는다', async () => {
+    let releaseUpload: (() => void) | undefined;
+    const imagePutGate = new Promise<void>((resolve) => { releaseUpload = resolve; });
+    stubFetch({ imageMaxCount: 1, imageRequired: true, imagePutGate });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector(`[data-testid="${REASON_TESTID}"]`)).not.toBeNull();
+
+    const input = container.querySelector('[data-testid="channel-post-image-file-input"]') as HTMLInputElement;
+    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 업로드 中(0장 그대로) — 두 조건이 동시에 참일 수 있는 시점이지만 사유는 하나만.
+    expect(container.querySelector('[data-testid="channel-post-image-upload-in-progress-reason"]')).not.toBeNull();
+    expect(container.querySelector(`[data-testid="${REASON_TESTID}"]`)).toBeNull();
+
+    await act(async () => {
+      releaseUpload?.();
+      await Promise.resolve();
+    });
+    await flush();
+
+    // 업로드 완료(이미지 생김) — 둘 다 사라진다.
+    expect(container.querySelector('[data-testid="channel-post-image-upload-in-progress-reason"]')).toBeNull();
+    expect(container.querySelector(`[data-testid="${REASON_TESTID}"]`)).toBeNull();
+  });
+
+  it('422 CHANNEL_IMAGE_REQUIRED — 선알림과 같은 문구가 뜬다(서버 message 그대로 아님)', async () => {
+    stubFetch({
+      onSubmit: () => ({
+        status: 422,
+        body: { detail: { code: 'CHANNEL_IMAGE_REQUIRED', message: '이 채널은 이미지 1장이 필요합니다.' } },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const submitBtn = container.querySelector('[data-testid="channel-post-submit-button"]') as HTMLButtonElement;
+    await act(async () => { submitBtn.click(); });
+    await flush();
+
+    const alertText = container.querySelector('[role="alert"]')?.textContent ?? '';
+    expect(alertText).toContain('이미지 없이 상신할 수 없습니다 — 이 채널은 이미지가 필요합니다.');
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -163,6 +163,10 @@ interface ChannelConnectionInfo {
   image_width_max: number;
   image_color_space: string;
   image_max_count: number;
+  // story #3538(BE #3886, PO 確定 2026-09-06) — image_max_count>0("지원")과 다른
+  // 축: "필수"(이미지 0장이면 상신 자체가 422로 막힘, 예: Instagram). §17-16⑤
+  // 사유 사슬 렌더 조건 재료.
+  image_required: boolean;
 }
 
 // story #3402 ④(AC7) — 한도 잔량은 조회값이고 조회 실패도 상태다. success=false는
@@ -415,6 +419,8 @@ export default function ChannelPostEditPage() {
         // 태그가 이 값을 아예 안 그린다).
         aspectMin: number;
         widthMin: number; widthMax: number; colorSpace: string;
+        // story #3538 — image_required(additive, imageSpec 계열 나머지와 동형 관례).
+        imageRequired: boolean;
       }
     | undefined
   >(undefined);
@@ -549,6 +555,8 @@ export default function ChannelPostEditPage() {
                 // N(페드루 PO, 2026-09-04 13:27Z) — connection 응답에서 이미 읽던 필드가
                 // imageSpec에 안 실려 규격 태그에 한 번도 안 나온 갭.
                 colorSpace: conn.image_color_space,
+                // story #3538 — image_required 그대로(하드코딩 X·채널명 분기 X).
+                imageRequired: conn.image_required,
               });
             }
           }
@@ -670,7 +678,7 @@ export default function ChannelPostEditPage() {
   // AC5 — 상신은 휴먼 전용이 아니다(actor_type 가드 없음) — 이 화면 자체는 휴먼만
   // 접근하므로 버튼 노출 자체엔 영향 없다. AC6 — 초과 상태면 버튼을 비활성화한다.
   const handleSubmitForApproval = async (scheduledAt?: string) => {
-    if (!orgId || !draft || isOverLimit || hasBlockingViolations || imageUploadInProgress) return;
+    if (!orgId || !draft || isOverLimit || hasBlockingViolations || imageUploadInProgress || imageRequiredAndMissing) return;
     const latest = versions[versions.length - 1];
     if (!latest) return;
     if (scheduledAt) setScheduleServerError(null);
@@ -1172,6 +1180,15 @@ export default function ChannelPostEditPage() {
   // 것처럼 보인다). 업로드가 진행 중인 동안은 저장/즉시 상신/예약 상신을 막는다.
   const imageUploadInProgress = imageUploadStatus.phase === 'requesting_url'
     || imageUploadStatus.phase === 'uploading' || imageUploadStatus.phase === 'confirming';
+
+  // story #3538(BE #3886, 유나 §17-16⑤ PO 確定) — 이미지 필수 채널(image_required)인데
+  // 이미지가 없으면(draft.thumbnail_url 없음) 상신·예약 상신이 서버에서 422로 막힌다
+  // (§7 「필수값 빈칸 선알림」). 업로드 진행 中엔 이 사유를 안 보인다(업로드 중엔 실제로
+  // 0장이라 두 조건이 동시에 참일 수 있는데, 그땐 「업로드가 끝나면 된다」가 맞는
+  // 말 — 페드루 PO 明示, 사유 사슬은 한 줄만 뜬다). 저장 버튼은 이 조건과 무관(본문만
+  // 먼저 쓰고 이미지는 나중에 붙이는 길을 막지 않는다 — 상신·발행의 조건이지 저장의
+  // 조건이 아니다).
+  const imageRequiredAndMissing = Boolean(imageSpec?.imageRequired) && !draft?.thumbnail_url && !imageUploadInProgress;
 
   return (
     <div className="mx-auto w-full max-w-2xl space-y-6 p-6">
@@ -1838,7 +1855,7 @@ export default function ChannelPostEditPage() {
         </Button>
         <Button
           onClick={() => void handleSubmitForApproval()}
-          disabled={submitting || isOverLimit || hasBlockingViolations || imageUploadInProgress}
+          disabled={submitting || isOverLimit || hasBlockingViolations || imageUploadInProgress || imageRequiredAndMissing}
           data-testid="channel-post-submit-button"
         >
           {submitting ? t('submitPendingCta') : t('submitCta')}
@@ -1850,7 +1867,7 @@ export default function ChannelPostEditPage() {
         <Button
           variant="outline"
           onClick={() => setScheduleDialogOpen(true)}
-          disabled={submitting || isOverLimit || hasBlockingViolations || blockedByCommandInFlight || imageUploadInProgress}
+          disabled={submitting || isOverLimit || hasBlockingViolations || blockedByCommandInFlight || imageUploadInProgress || imageRequiredAndMissing}
           data-testid="channel-post-schedule-submit-button"
         >
           {t('channelPostsScheduleSubmitCta')}
@@ -1898,6 +1915,15 @@ export default function ChannelPostEditPage() {
       {!isOverLimit && !hasBlockingViolations && imageUploadInProgress ? (
         <p className="text-xs text-muted-foreground" data-testid="channel-post-image-upload-in-progress-reason">
           {t('channelPostsImageUploadInProgressReason')}
+        </p>
+      ) : null}
+      {/* story #3538(유나 §17-16⑤ PO 確定 2026-09-06) — 「업로드 중」 바로 뒤(이미
+          업로드 中일 때 두 조건이 동시에 참일 수 있는데, imageRequiredAndMissing 자체가
+          !imageUploadInProgress를 이미 조건에 넣어 두 줄 동시 노출을 막는다). 개수는
+          말하지 않는다(계약은 image_required: boolean뿐). */}
+      {!isOverLimit && !hasBlockingViolations && imageRequiredAndMissing ? (
+        <p className="text-xs text-muted-foreground" data-testid="channel-post-image-required-reason">
+          {t('channelPostsImageRequiredReason')}
         </p>
       ) : null}
       {!isOverLimit && !hasBlockingViolations && blockedByCommandInFlight ? (

--- a/apps/web/src/components/content/api-error.ts
+++ b/apps/web/src/components/content/api-error.ts
@@ -56,6 +56,10 @@ export type SitePostApiErrorKind =
   | 'image_aspect_ratio_too_narrow'
   | 'image_conversion_failed'
   | 'image_upload_failed'
+  // story #3538(BE #3886, 유나 §17-16⑤) — 이미지 필수 채널(Instagram)에 이미지 없이
+  // 상신 시도. 특별 분기 불요(labelKey만으로 t()가 문장을 조립 — text_too_long류와
+  // 달리 보간값이 없다) — kind는 다른 image_* 항목과 이름 관례만 맞춘다.
+  | 'image_required'
   // story #3500(BE #3498, 아직 미착지 — PO 確定 계약) — 생성 비용 한도(크레딧 게이트)
   // 초과. site_post·channel_post 상신 둘 다 같은 코드·같은 4값 shape를 공유(광고
   // budget_gate와 같은 계약, 블루프린트 §2). labelKey는 비워 두고(text_too_long과
@@ -158,6 +162,9 @@ const KNOWN_ERRORS: Record<string, KnownError> = {
   // "상태를 다시 확認"이 맞는 다음 행동이다(두 번째 요청이 새 게시를 만들지 않는다).
   CHANNEL_PUBLISH_IN_PROGRESS: { labelKey: 'errorChannelPublishInProgress', kind: 'publish_in_progress' },
   CHANNEL_TEXT_TOO_LONG: { labelKey: '', kind: 'text_too_long' }, // maxLength·currentLength로 문구 조립(labelKey는 page.tsx가 보간)
+  // story #3538(BE #3886, 유나 §17-16⑤ PO 確定) — 선알림(사유 사슬)과 같은 i18n 키.
+  // 서버 message를 그대로 뿌리지 않는다(코드→화면 문구 선택, §22-15 규율).
+  CHANNEL_IMAGE_REQUIRED: { labelKey: 'channelPostsImageRequiredReason', kind: 'image_required' },
   // EXTERNAL_PUBLISH_APPROVAL_REQUIRED·SITE_POST_SEAL_MISSING·SITE_POST_REAPPROVAL_REQUIRED
   // 는 위 site 항목을 그대로 재사용한다(같은 external_publish 게이트 개념 공유, doc §9-4).
   // story #3402·PR#3764 — 채널 포스트 전용 GATE_ALREADY_HELD. site와 kind는 같지만


### PR DESCRIPTION
## 배경
3536(BE #3886) — `ChannelConnectionResponse.image_required`가 이미 내려오는데 FE 타입에 없어 못 읽던 갭 + 422 `CHANNEL_IMAGE_REQUIRED`가 `KNOWN_ERRORS`에 없어 서버 원문 message가 그대로(비정본) 뜨던 갭. 블루프린트 §7 「필수값 빈칸 선알림」의 화면 절반.

## 처방(유나 §17-16⑤ PO 確定 정정 반영)
- `ChannelConnectionInfo`·`imageSpec`에 `image_required(boolean)` additive.
- 파생값 `imageRequiredAndMissing = image_required ∧ !draft.thumbnail_url ∧ !imageUploadInProgress`(업로드 中엔 「업로드 중」 사유만 — 두 조건 동시 참 가능하나 사유는 한 줄만).
- 사유 사슬(버튼 밖 「하나만 뜨는」 목록)에 「업로드 중」 바로 뒤 삽입 — `data-testid="channel-post-image-required-reason"`.
- 페드루 PO 정정(2026-09-06) — 저장 버튼은 이 조건과 무관(본문만 먼저 쓰고 이미지는 나중에 붙이는 길을 막지 않음), **상신·예약 상신 disabled 배열 둘 다**에 같은 조건 추가(권한 축 결정을 필드 완결성 축에 잘못 끌어온 최초 「버튼 비활성 X」 문장을 대체) + `handleSubmitForApproval` 자체 가드도 동형 추가(방어적 이중 게이팅, 기존 관례).
- `KNOWN_ERRORS.CHANNEL_IMAGE_REQUIRED` — `labelKey`를 선알림과 **같은** i18n 키로(서버 message 그대로 뿌리지 않음, §22-15 규율).
- i18n ko/en 짝: "이미지 없이 상신할 수 없습니다 — 이 채널은 이미지가 필요합니다." / "You can't submit without an image — this channel requires an image."(개수 안 말함 — 계약은 `image_required: boolean`뿐).

## 테스트
5건 — 사유 유(상신·예약상신 비활성+저장은 활성) · 이미지 첨부 시 같은 마운트에서 즉시 해제 · 불요 채널(`image_required=false`) 렌더 0 · 업로드 中엔 「업로드 중」만(동시 노출 금지 pin) · 422 표시(정본 문구, 서버 원문 아님). 뮤테이션 자가검증 2회(`imageRequiredAndMissing` 강제 false·`KNOWN_ERRORS` 항목 제거, 각각 RED 확인 후 원복). `tsc --noEmit` 0 에러·eslint 0 경고·i18n key-coverage/template-key-coverage 가드·기존 page.test.tsx 155/155(신규 5건 포함) 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)