### PR TITLE
[SID:3539] publish processing=true를 발행 실패로 그리지 않는다

### DIFF
--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -1252,6 +1252,42 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     expect(container.querySelector('a[href="https://threads.net/@x/1"]')).not.toBeNull();
   });
 
+  // story #3539(PO 確定 2026-09-06) — IG처럼 IMAGE 컨테이너가 비동기인 채널은 즉시
+  // 발행 요청도 응답 시점엔 안 끝나 있을 수 있다(processing:true, permalink 등
+  // 전부 null — 이게 «정상»이다·실패가 아니다). 예전엔 이 응답이 permalink&&
+  // published_at도 scheduled도 아니라서 그냥 else(실패)로 떨어졌다.
+  it('⭐#3539 — publish 응답 processing:true — 「발행 실패」 문구 0·§17-15 awaiting_container 오버레이가 재로드 없이 즉시 선다', async () => {
+    stubFetch({
+      draftDetail: { gate_status: 'approved', sealed_content_sha256: 'h1', body_sha256: 'h1' },
+      onPublish: () => ({ status: 200, body: { version_id: 'v1', scheduled: false, processing: true } }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const btn = container.querySelector('[data-testid="channel-post-publish-button"]') as HTMLButtonElement;
+    await act(async () => { btn.click(); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="channel-post-publish-result"]')).toBeNull();
+    expect(container.textContent).not.toContain(koMessages.content.publishFailed);
+    expect(container.querySelector('[data-testid="channel-post-awaiting-container-notice"]')).not.toBeNull();
+  });
+
+  it('⭐#3539 — processing:true 뒤 발행 버튼이 비활성으로 바뀐다(오버레이 규칙대로·다시 눌러 CHANNEL_PUBLISH_IN_PROGRESS로 꼬이는 것 방지)', async () => {
+    stubFetch({
+      draftDetail: { gate_status: 'approved', sealed_content_sha256: 'h1', body_sha256: 'h1' },
+      onPublish: () => ({ status: 200, body: { version_id: 'v1', scheduled: false, processing: true } }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const btn = container.querySelector('[data-testid="channel-post-publish-button"]') as HTMLButtonElement;
+    await act(async () => { btn.click(); });
+    await flush();
+
+    expect(btn.disabled).toBe(true);
+  });
+
   // story #3402 PR2 ②-c(AC10) — CHANNEL_TEXT_TOO_LONG은 api-error.ts가 humanMessageKey를
   // 일부러 비워 두고 max_length/current_length만 실어 오는 코드다 — page.tsx가 doc §5
   // 표 그대로("500자 한도인데 517자입니다") 값을 실제로 보간해 조립하는지 pin한다.

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -864,8 +864,8 @@ export default function ChannelPostEditPage() {
       const res = await fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}/publish`, { method: 'POST' });
       if (res.ok) {
         const json = (await res.json().catch(() => null)) as
-          { data?: { permalink?: string; external_id?: string; published_at?: string; scheduled?: boolean; scheduled_at?: string; publication_id?: string | null } } | null;
-        const { permalink, external_id, published_at, scheduled, scheduled_at, publication_id } = json?.data ?? {};
+          { data?: { permalink?: string; external_id?: string; published_at?: string; scheduled?: boolean; scheduled_at?: string; publication_id?: string | null; processing?: boolean } } | null;
+        const { permalink, external_id, published_at, scheduled, scheduled_at, publication_id, processing } = json?.data ?? {};
         // story #3414(PR#3769, 아직 리뷰중 — 계약은 그 PR 스키마 기준) — scheduled=true면
         // 이 요청은 command만 만들고 실제 발행은 워커가 나중에 한다. permalink/
         // published_at 셋 다 null인 게 정상이라, 그 null을 "발행됨"으로 그리면 안 된다
@@ -873,6 +873,22 @@ export default function ChannelPostEditPage() {
         // 축). scheduled 분기를 permalink 존재 분기보다 먼저 검사한다.
         if (scheduled) {
           setPublishResult({ type: 'scheduled', scheduledAt: scheduled_at });
+        } else if (processing) {
+          // story #3539(PO 確定 2026-09-06, §17-15와 같은 자리) — IMAGE 컨테이너가
+          // 비동기라 즉시 요청도 이 응답 시점엔 아직 안 끝났을 수 있다(620beefc AC5).
+          // permalink/published_at/publication_id 전부 null인 게 «정상»이지 실패가
+          // 아니다 — 실패 문구 0, draft.processing_kind='awaiting_container'만
+          // 병합해 기존 §17-15 오버레이(:1371 부근, GET 재조회로 서버가 이미 그릴
+          // 줄 아는 바로 그 얼굴)가 재로드 없이 같은 마운트에서 즉시 선다(3525와
+          // 같은 "즉시 반영" 클래스 — 새 문구 0). command_status도 'pending'으로
+          // 같이 병합한다 — BE가 이 응답을 내는 그 분기에서 command.status를 항상
+          // "pending"으로 세팅한다(channel_posts.py 실측, 구조적으로 보장) — 안
+          // 하면 blockedByCommandInFlight가 옛 값을 그대로 들고 있어 오버레이는
+          // "처리 中"이라면서 발행 버튼은 눌리는 이 스토리의 원 사고(사람이 다시
+          // 눌러 CHANNEL_PUBLISH_IN_PROGRESS로 꼬이는 것)가 그대로 재현된다(AC1
+          // "발행 버튼은 오버레이 규칙대로").
+          setPublishResult(null);
+          setDraft((prev) => prev && { ...prev, processing_kind: 'awaiting_container', command_status: 'pending' });
         } else if (permalink && published_at) {
           setPublishResult({ type: 'success' });
           // story #3525(PO 確定 ③) — publication_id도 permalink 등과 같은 병합 대상


### PR DESCRIPTION
## 요약
`handlePublish`의 응답 분기가 `scheduled` / `permalink && published_at`(성공) / `else`(실패) 셋뿐이라, IMAGE 컨테이너가 비동기인 채널(Instagram)의 즉시 발행 응답(`processing: true`, permalink 등 전부 null — 620beefc AC5가 이미 "정상"이라 정의한 상태)이 `else`로 떨어져 "발행 실패"로 그려졌다. 사람이 다시 누르면 `CHANNEL_PUBLISH_IN_PROGRESS`류로 꼬이는 사고까지 이어졌다.

## 처방
- `processing: true` 전용 분기 추가 — 실패 문구 0, `draft.processing_kind='awaiting_container'`를 병합해 기존 §17-15 오버레이(서버 GET 재조회로 이미 그릴 줄 아는 바로 그 얼굴)가 재로드 없이 같은 마운트에서 즉시 선다(#3525와 같은 "즉시 반영" 클래스, 새 문구 0).
- `command_status`도 `'pending'`으로 같이 병합 — BE가 이 응답을 내는 분기에서 항상 그렇게 세팅한다(`channel_posts.py` 실측, 구조적으로 보장). 이게 없으면 오버레이는 "처리 中"이라면서 발행 버튼은 그대로 눌려 이 스토리의 원 사고(다시 눌러 경합)가 재현된다 — AC1 "발행 버튼은 오버레이 규칙대로"를 만족시키는 데 필요.

## 검증
- 뮤테이션 검증(processing 분기 무력화 → 실패 문구 재등장·버튼 재활성 RED 확인 → 복원).
- 신규 테스트 2개(실패 문구 부재+오버레이 렌더 / 버튼 비활성), 기존 153개 회귀 0.
- `tsc --noEmit` 0 / `eslint --max-warnings=0` 0 / `vitest run` 6336 전부 그린.

## 반응형/스크린샷
- 기존 §17-15 오버레이를 그대로 재사용(새 UI 0) — 별도 반응형 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)