### PR TITLE
[SID:3545] 채널 미디어 버킷 CORS에 x-goog-if-generation-match 추가

### DIFF
--- a/backend/tests/gcs_cors_ssot_helpers.py
+++ b/backend/tests/gcs_cors_ssot_helpers.py
@@ -1,0 +1,25 @@
+"""story #3545 — GCS CORS json 파일이 서명 create-only PUT에 필요한 요청 헤더를
+전부 허용하는지 재는 공용 헬퍼. `infra/gcs-attachments-cors.json`과
+`infra/gcs-channel-media-cors.json` 둘 다 같은 실패 클래스(#3242 → #3545 재발)를
+겪었다 — 필요 헤더 값을 각 테스트 파일에 따로 하드코딩하면 세 번째 버킷이 또
+같은 구멍을 낸다. `GcsStorageProvider.required_write_headers()`가 유일한 정본이라
+여기서 한 번만 읽어 두 파일 모두에 강제한다.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.services.storage.gcs import GcsStorageProvider
+
+
+def assert_cors_file_allows_required_write_headers(cors_file: Path) -> None:
+    """create-only PUT(서명 업로드)에 GCS가 실제로 요구하는 헤더 전부가 이 CORS
+    json의 responseHeader 목록에 있는지 pin한다. GCS의 responseHeader는 preflight
+    Access-Control-Allow-Headers에 대응한다(Expose-Headers가 아니다) — 여기 없으면
+    프리플라이트 자체가 막힌다(#3242·#3545 실사고)."""
+    rules = json.loads(cors_file.read_text())
+    all_headers = {h for rule in rules for h in rule.get("responseHeader", [])}
+    required = GcsStorageProvider().required_write_headers(create_only=True)
+    missing = set(required.keys()) - all_headers
+    assert not missing, f"{cors_file.name}: 서명 create-only PUT 필수 헤더 누락(프리플라이트 차단): {missing}"

--- a/backend/tests/test_2806_gcs_attachments_cors_ssot.py
+++ b/backend/tests/test_2806_gcs_attachments_cors_ssot.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import yaml
 
+from tests.gcs_cors_ssot_helpers import assert_cors_file_allows_required_write_headers
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CORS_FILE = _REPO_ROOT / "infra" / "gcs-attachments-cors.json"
 _CLOUDBUILD = _REPO_ROOT / "cloudbuild.yaml"
@@ -81,11 +83,15 @@ def test_cors_file_allows_required_put_headers():
     로 서명해 모든 업로드 PUT에 Content-Type과 x-goog-if-generation-match를 항상 바인딩한다
     (안 보내면 403 SignatureDoesNotMatch). GCS responseHeader는 preflight의
     Access-Control-Allow-Headers에 대응(Expose-Headers 아님) — 여기 없으면 프리플라이트 자체가
-    막힌다. Content-Type은 #2806부터 이미 있었으나 x-goog-if-generation-match는 없었다."""
+    막힌다. Content-Type은 #2806부터 이미 있었으나 x-goog-if-generation-match는 없었다.
+
+    story #3545 — x-goog-if-generation-match 쪽은 이제 하드코딩이 아니라
+    GcsStorageProvider.required_write_headers(create_only=True)(정본)를 직접 읽는
+    공용 헬퍼로 검증한다 — 채널 미디어 버킷 json이 이 헬퍼를 같이 쓴다(#3545)."""
     rules = _load_cors_rules()
     all_headers = {h for rule in rules for h in rule.get("responseHeader", [])}
     assert "Content-Type" in all_headers
-    assert "x-goog-if-generation-match" in all_headers
+    assert_cors_file_allows_required_write_headers(_CORS_FILE)
 
 
 def test_cloudbuild_apply_step_references_the_cors_file_exactly():

--- a/backend/tests/test_3545_gcs_channel_media_cors_ssot.py
+++ b/backend/tests/test_3545_gcs_channel_media_cors_ssot.py
@@ -1,0 +1,93 @@
+"""story #3545 — GCS 채널 미디어 버킷 CORS SSOT(infra/gcs-channel-media-cors.json +
+cloudbuild.yaml apply-gcs-channel-media-cors 스텝) 선언 정합성. test_2806_gcs_
+attachments_cors_ssot.py와 같은 형(순수 정적 검증, 실 gcloud 호출 없음).
+
+원 결함: 이 json이 attachments json에서 복사됐을 때(#3776/3425, 버킷 신설)
+#3242가 이미 겪은 교훈(서명 create-only PUT은 x-goog-if-generation-match를
+responseHeader에 요구)이 안 옮겨졌다 — 에디터 브라우저 이미지 첨부 preflight가
+막혔다(유나 라이브 실측 2026-09-06). 적용 스텝 검증도 origin만 보고 헤더는
+안 봐서 이 회귀가 배포 로그에서 초록으로 지나갔다.
+
+이 파일이 pin하는 것 / 못 잡는 것:
+- pin: json 선언과 cloudbuild 스텝 선언의 정합성(정적 파일 내용).
+- 못 잡는 것: 실제 GCS 버킷에 적용된 라이브 CORS 상태(gcloud 호출 없음 — 그건
+  cloudbuild 배포 스텝 자체의 실행 시점 검증(exit 1 게이트)이 진다), 버킷 밖
+  요인(CSP connect-src·서명 URL 만료·CDN 캐시된 구 preflight 응답 등)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from tests.gcs_cors_ssot_helpers import assert_cors_file_allows_required_write_headers
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CORS_FILE = _REPO_ROOT / "infra" / "gcs-channel-media-cors.json"
+_CLOUDBUILD = _REPO_ROOT / "cloudbuild.yaml"
+
+_DEV_CLOUD_RUN_REGIONAL_ORIGIN = "https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app"
+
+
+def _load_cors_rules() -> list[dict]:
+    return json.loads(_CORS_FILE.read_text())
+
+
+def test_cors_file_allows_put_and_excludes_options():
+    """story 620beefc/#3538이 이 버킷에 서명 PUT을 직접 쏜다. OPTIONS는 GCS가
+    Access-Control-Request-Method 매칭으로 자동 처리하므로 명시하면 안 된다."""
+    rules = _load_cors_rules()
+    all_methods = {m for rule in rules for m in rule.get("method", [])}
+    assert "PUT" in all_methods
+    assert "OPTIONS" not in all_methods
+
+
+def test_cors_file_allows_required_write_headers():
+    """story #3545의 실제 결함 표면 — channel_post_images.py:208이
+    provider.required_write_headers(create_only=True)로 서명해 모든 업로드 PUT에
+    그 헤더(GCS=x-goog-if-generation-match)를 항상 바인딩한다. 여기 없으면
+    프리플라이트 자체가 막힌다(#3242와 같은 클래스, 다른 버킷)."""
+    assert_cors_file_allows_required_write_headers(_CORS_FILE)
+
+
+def test_cloudbuild_apply_step_references_the_cors_file_exactly():
+    """⭐선언 정합성 — apply-gcs-channel-media-cors 스텝이 참조하는 --cors-file
+    경로가 실제 이 파일과 정확히 일치하는지(파일명 드리프트 방지)."""
+    doc = yaml.safe_load(_CLOUDBUILD.read_text())
+    step = next((s for s in doc["steps"] if s["id"] == "apply-gcs-channel-media-cors"), None)
+    assert step is not None, "cloudbuild.yaml에 apply-gcs-channel-media-cors 스텝이 없음"
+    assert step["entrypoint"] == "bash"
+    script = step["args"][1]
+    assert "infra/gcs-channel-media-cors.json" in script
+    assert "gcloud storage buckets update" in script
+
+
+def test_cloudbuild_verify_checks_origin_and_header_fails_closed():
+    """story #3545 — 원 결함의 핵심: 이 스텝의 검증이 origin만 보고 헤더 누락은
+    그냥 지나쳤다. 이제 둘 다 없으면 exit 1로 죽어야 한다(기대 origin·기대 헤더
+    문자열이 스크립트 자체에 있고, 각각 실패 분기에 exit 1이 있는지 pin)."""
+    doc = yaml.safe_load(_CLOUDBUILD.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "apply-gcs-channel-media-cors")
+    script = step["args"][1]
+    assert _DEV_CLOUD_RUN_REGIONAL_ORIGIN in script
+    assert "x-goog-if-generation-match" in script
+    assert script.count("exit 1") >= 2
+
+
+def test_cloudbuild_step_skips_on_prod():
+    """story 620beefc — channel-media 버킷은 dev 전용(prod 미프로비저닝). prod에서
+    이 스텝이 gcloud를 실제로 호출하면 존재하지 않는 버킷 대상으로 실패한다 —
+    조기 skip이 있어야 한다."""
+    doc = yaml.safe_load(_CLOUDBUILD.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "apply-gcs-channel-media-cors")
+    script = step["args"][1]
+    assert '_DEPLOY_ENV}" == "prod"' in script
+    assert "skip" in script.lower()
+
+
+def test_cloudbuild_step_does_not_require_build_or_push():
+    """이미지 빌드와 무관 — waitFor가 build/push에 안 걸려 있어야 배포 지연이 안 생긴다."""
+    doc = yaml.safe_load(_CLOUDBUILD.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "apply-gcs-channel-media-cors")
+    wait_for = step.get("waitFor") or []
+    assert not any("build" in w or "push" in w for w in wait_for)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -397,7 +397,15 @@ steps:
           *https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app*) ;;
           *) echo "FAIL: dev Cloud Run regional origin missing from applied CORS — 배포 검증 실패" >&2; exit 1 ;;
         esac
-        echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
+        # story #3545(2026-09-06) — origin만 보던 검증이 헤더 누락(x-goog-if-generation-
+        # match, 서명 create-only PUT 필수)은 초록으로 지나쳤다(#3242의 채널 미디어
+        # 버킷 재발이 이 사각에서 나왔다). origin과 헤더 둘 다 봐야 실제 프리플라이트
+        # 통과를 보증한다.
+        case "$${applied}" in
+          *x-goog-if-generation-match*) ;;
+          *) echo "FAIL: x-goog-if-generation-match header missing from applied CORS — 서명 PUT preflight가 여전히 막힌다" >&2; exit 1 ;;
+        esac
+        echo "OK: dev Cloud Run regional origin + x-goog-if-generation-match header confirmed in applied CORS"
     waitFor: ['-']
 
   # story #2887 — avatar 전용 버킷 CORS. CORS json(infra/gcs-avatars-cors.json)
@@ -465,7 +473,15 @@ steps:
           *https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app*) ;;
           *) echo "FAIL: dev Cloud Run regional origin missing from applied CORS — 배포 검증 실패" >&2; exit 1 ;;
         esac
-        echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
+        # story #3545(2026-09-06, 유나 라이브 실측) — 이 버킷의 responseHeader가
+        # x-goog-if-generation-match 없이 배포돼(attachments의 #3242 교훈이 신규
+        # 버킷 json에 안 옮겨짐) 에디터 브라우저 이미지 첨부 preflight가 막혔다.
+        # origin만 보던 검증으론 이 회귀가 초록으로 지나갔다 — 헤더도 같이 본다.
+        case "$${applied}" in
+          *x-goog-if-generation-match*) ;;
+          *) echo "FAIL: x-goog-if-generation-match header missing from applied CORS — 서명 PUT preflight가 여전히 막힌다" >&2; exit 1 ;;
+        esac
+        echo "OK: dev Cloud Run regional origin + x-goog-if-generation-match header confirmed in applied CORS"
     waitFor: ['-']
 
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────

--- a/infra/gcs-channel-media-cors.json
+++ b/infra/gcs-channel-media-cors.json
@@ -8,7 +8,7 @@
       "http://localhost:3108"
     ],
     "method": ["GET", "HEAD", "PUT"],
-    "responseHeader": ["Content-Type", "Content-Length"],
+    "responseHeader": ["Content-Type", "Content-Length", "x-goog-if-generation-match"],
     "maxAgeSeconds": 3600
   }
 ]


### PR DESCRIPTION
## 요약
에디터(브라우저)가 초안 이미지 첨부를 서명 create-only PUT으로 직접 쏘면 `channel_post_images.py:208`의 `required_write_headers(create_only=True)`가 요구하는 `x-goog-if-generation-match`를 실어 보낸다. `infra/gcs-channel-media-cors.json`의 `responseHeader`에 그 헤더가 없어 preflight가 "200인데 Access-Control-Allow-* 헤더 0"으로 조용히 거부됐다 — attachments 버킷이 #3242 때 이미 겪은 결함이 새 버킷 json에 복사될 때 안 옮겨진 재발(유나 라이브 실측 2026-09-06).

## 처방
1. `infra/gcs-channel-media-cors.json` responseHeader에 `x-goog-if-generation-match` 추가.
2. `cloudbuild.yaml`의 `apply-gcs-attachments-cors` · `apply-gcs-channel-media-cors` 두 스텝 검증을 origin뿐 아니라 헤더도 보게 넓혔다 — origin만 보는 검증은 이 헤더 회귀를 초록으로 지나쳤다.
3. 가드: `GcsStorageProvider.required_write_headers(create_only=True)`를 정본으로 직접 읽는 공용 헬퍼(`tests/gcs_cors_ssot_helpers.py`)를 신설해 attachments·channel-media 두 CORS json 테스트가 같은 걸 쓰게 했다 — 헤더 하드코딩 두 벌을 없애 세 번째 버킷이 같은 구멍을 못 내게 한다.

## 검증
- 뮤테이션 검증(json 헤더 제거 → RED / cloudbuild 검증 제거 → RED → 각각 복원).
- 관련 pytest(비-destructive, `-k cors`) 19개 그린.
- dev 전용·prod 무접촉(스텝이 prod에서 조기 skip, 새 테스트가 그 skip도 pin).

## 못 잡는 것(선언)
이 테스트는 정적 파일 선언(json·cloudbuild.yaml)만 재고, 실제 GCS 버킷에 적용된 라이브 CORS 상태·CSP `connect-src`·서명 URL 만료·CDN에 캐시된 구 preflight 응답 같은 버킷 밖 요인은 재지 못한다 — 그건 cloudbuild 배포 스텝 자체의 실행 시점 검증(exit 1 게이트)과 배포 후 라이브 확인이 진다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)