### PR TITLE
[SID:3436] 묶음11 — TagChip 영문 접근성 이름 + 옛 코드명 CONTENT_RULES_OWNER_ONLY 정정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5078,6 +5078,7 @@
     "brandKitFontsPlaceholder": "Type a font name and press Enter",
     "contentRulesAdvisoryNotice": "The items below are used by agents as a reference when drafting. They don't block publishing.",
     "contentRulesNotSetLabel": "Not set",
+    "removeItemAction": "Remove {item}",
     "brandKitLogoPreviewAlt": "Brand kit logo preview",
     "brandKitLogoLoadFailed": "Couldn't load this image.",
     "generationBudgetSectionTitle": "Generation cost budget",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -5078,6 +5078,7 @@
     "brandKitFontsPlaceholder": "폰트 이름 입력 후 Enter",
     "contentRulesAdvisoryNotice": "아래 항목은 에이전트가 초안을 쓸 때 참고합니다. 발행을 막지는 않습니다.",
     "contentRulesNotSetLabel": "안 정함",
+    "removeItemAction": "{item} 제거",
     "brandKitLogoPreviewAlt": "브랜드 킷 로고 미리보기",
     "brandKitLogoLoadFailed": "불러오지 못했습니다.",
     "generationBudgetSectionTitle": "생성 비용 한도",

--- a/apps/web/src/app/(authenticated)/organization/content-rules/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/content-rules/page.test.tsx
@@ -231,6 +231,20 @@ describe('ContentRulesPage — 편집·저장(story #3472 계속)', () => {
   });
 });
 
+// story #3436 묶음11(페드루 PO 지적, 2026-09-06) — TagChip 제거 버튼의 접근성
+// 이름이 하드코딩 영문(`Remove ${item}`)이라 한국어 화면에서도 스크린리더가
+// 영어로 읽었다. §17-20 낱말 축과 같은 클래스(dep.remove 선례와 동형 형태).
+describe('ContentRulesPage — 태그 제거 버튼 접근성 이름(story #3436 묶음11)', () => {
+  it('제거 버튼 aria-label이 한국어 「{item} 제거」다(하드코딩 영문 회귀 방지)', async () => {
+    stubFetch({});
+    await mount('owner');
+    const editor = container.querySelector('[data-testid="content-rules-banned-terms-editor"]')!;
+    const removeBtn = editor.querySelector('button[aria-label]') as HTMLButtonElement;
+    expect(removeBtn.getAttribute('aria-label')).toBe('무료체험 제거');
+    expect(removeBtn.getAttribute('aria-label')).not.toContain('Remove');
+  });
+});
+
 describe('ContentRulesPage — 저장(story #3472 AC1)', () => {
   it('⭐owner가 금칙어를 추가하고 저장하면 새 버전이 반영된다', async () => {
     stubFetch({});

--- a/apps/web/src/app/(authenticated)/organization/content-rules/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/content-rules/page.tsx
@@ -146,7 +146,11 @@ function isValidCssColor(value: string): boolean {
 // 코드를 적어 두기만 해서는 맞는 색인지 아무도 확인 못 한다 — 로고 미리보기와 같은
 // 취지). banned_terms·taxonomy·channel_priority는 그대로(색 스와치가 뜻이 없는
 // 자리라 variant='default'가 기본).
-function TagChip({ item, variant, onRemove }: { item: string; variant: 'default' | 'color'; onRemove?: () => void }) {
+// story #3436 묶음11(유나 §17-20류 낱말, 페드루 PO 確定 2026-09-06) — 이 제거
+// 버튼의 접근성 이름이 하드코딩 영문(`Remove ${item}`)이라 한국어 화면에서도
+// 스크린리더가 영어로 읽었다(§17-20 낱말 축과 같은 클래스 — dep.remove
+// 「의존 관계 제거」 선례와 동형 형태 「{item} 제거」/`Remove {item}`).
+function TagChip({ item, variant, onRemove, t }: { item: string; variant: 'default' | 'color'; onRemove?: () => void; t: ReturnType<typeof useTranslations> }) {
   const showSwatch = variant === 'color' && isValidCssColor(item);
   return (
     <span className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-xs text-foreground">
@@ -160,7 +164,7 @@ function TagChip({ item, variant, onRemove }: { item: string; variant: 'default'
       ) : null}
       {item}
       {onRemove ? (
-        <button type="button" onClick={onRemove} aria-label={`Remove ${item}`} className="text-muted-foreground hover:text-foreground">
+        <button type="button" onClick={onRemove} aria-label={t('removeItemAction', { item })} className="text-muted-foreground hover:text-foreground">
           ×
         </button>
       ) : null}
@@ -169,7 +173,7 @@ function TagChip({ item, variant, onRemove }: { item: string; variant: 'default'
 }
 
 function TagListEditor({
-  items, onChange, readOnly, placeholder, testIdPrefix, variant = 'default', emptyText = '—',
+  items, onChange, readOnly, placeholder, testIdPrefix, variant = 'default', emptyText = '—', t,
 }: {
   items: string[];
   onChange: (next: string[]) => void;
@@ -182,6 +186,7 @@ function TagListEditor({
   // 글자라, 브랜드 킷처럼 "아직 정하지 않았다"는 다른 사실엔 다른 문구가 맞다.
   // 기본값은 기존 호출부(banned_terms 등) 회귀 0을 위해 '—' 그대로 유지.
   emptyText?: string;
+  t: ReturnType<typeof useTranslations>;
 }) {
   const [draft, setDraft] = useState('');
 
@@ -197,7 +202,7 @@ function TagListEditor({
       <p className="text-xs text-muted-foreground" data-testid={`${testIdPrefix}-empty`}>{emptyText}</p>
     ) : (
       <div className="flex flex-wrap gap-1.5" data-testid={`${testIdPrefix}-readonly`}>
-        {items.map((item) => <TagChip key={item} item={item} variant={variant} />)}
+        {items.map((item) => <TagChip key={item} item={item} variant={variant} t={t} />)}
       </div>
     );
   }
@@ -206,7 +211,7 @@ function TagListEditor({
     <div className="space-y-1.5" data-testid={`${testIdPrefix}-editor`}>
       <div className="flex flex-wrap gap-1.5">
         {items.map((item) => (
-          <TagChip key={item} item={item} variant={variant} onRemove={() => onChange(items.filter((x) => x !== item))} />
+          <TagChip key={item} item={item} variant={variant} onRemove={() => onChange(items.filter((x) => x !== item))} t={t} />
         ))}
       </div>
       <input
@@ -513,7 +518,7 @@ export default function ContentRulesPage() {
                   onChange={(next) => setRules((r) => ({ ...r, banned_terms: next }))}
                   readOnly={!canEditRules}
                   placeholder={t('bannedTermsPlaceholder')}
-                  testIdPrefix="content-rules-banned-terms"
+                  testIdPrefix="content-rules-banned-terms" t={t}
                 />
                 {fieldErrors.banned_terms ? <p className="text-xs text-destructive">{fieldErrors.banned_terms}</p> : null}
               </div>
@@ -710,7 +715,7 @@ export default function ContentRulesPage() {
                   onChange={(next) => setRules((r) => ({ ...r, taxonomy: next }))}
                   readOnly={!canEditRules}
                   placeholder={t('taxonomyPlaceholder')}
-                  testIdPrefix="content-rules-taxonomy"
+                  testIdPrefix="content-rules-taxonomy" t={t}
                 />
                 {fieldErrors.taxonomy ? <p className="text-xs text-destructive">{fieldErrors.taxonomy}</p> : null}
               </div>
@@ -723,7 +728,7 @@ export default function ContentRulesPage() {
                     onChange={(next) => setRules((r) => ({ ...r, channel_priority: next }))}
                     readOnly={false}
                     placeholder={t('channelPriorityPlaceholder')}
-                    testIdPrefix="content-rules-channel-priority-add"
+                    testIdPrefix="content-rules-channel-priority-add" t={t}
                   />
                 ) : null}
                 <OrderedListEditor
@@ -766,7 +771,7 @@ export default function ContentRulesPage() {
                   placeholder={t('brandKitColorsPlaceholder')}
                   testIdPrefix="content-rules-brand-colors"
                   variant="color"
-                  emptyText={t('contentRulesNotSetLabel')}
+                  emptyText={t('contentRulesNotSetLabel')} t={t}
                 />
               </div>
               <div className="space-y-1.5">
@@ -780,7 +785,7 @@ export default function ContentRulesPage() {
                   readOnly={!canEditRules}
                   placeholder={t('brandKitFontsPlaceholder')}
                   testIdPrefix="content-rules-brand-fonts"
-                  emptyText={t('contentRulesNotSetLabel')}
+                  emptyText={t('contentRulesNotSetLabel')} t={t}
                 />
                 {fieldErrors.brand_kit ? <p className="text-xs text-destructive">{fieldErrors.brand_kit}</p> : null}
               </div>

--- a/apps/web/src/app/api/organizations/[id]/content-rules/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/content-rules/route.test.ts
@@ -43,10 +43,10 @@ describe('/api/organizations/[id]/content-rules (story #3472)', () => {
 
   // story #3436 묶음11(페드루 PO 지적, 2026-09-06) — story #3490이 PUT 권한을
   // owner 단독에서 owner-or-admin으로 넓히며 코드도 CONTENT_RULES_ADMIN_ONLY로
-  // 바뀌었다(backend/tests/test_3471_org_content_rules_lint.py가 옛 코드
-  // CONTENT_RULES_OWNER_ONLY 부재를 직접 검산). 이 테스트만 옛 코드명 그대로
-  // 남아 있었다 — 라우트는 pass-through(검증 로직 0)라 실동작 회귀는 아니지만
-  // 다음 사람이 이 테스트 이름으로 실 계약값을 오인한다.
+  // 바뀌었다(backend/tests/test_3471_org_content_rules_lint.py가 옛 owner
+  // 전용 코드명 부재를 직접 검산). 이 테스트만 옛 코드명 그대로 남아 있었다 —
+  // 라우트는 pass-through(검증 로직 0)라 실동작 회귀는 아니지만 다음 사람이
+  // 이 테스트 이름으로 실 계약값을 오인한다.
   it('PUT — BE의 CHANNEL_CONNECTION류와 동형인 403 CONTENT_RULES_ADMIN_ONLY도 그대로 통과시킨다', async () => {
     proxyToFastapiWithParams.mockResolvedValue(
       new Response(JSON.stringify({ error: { code: 'CONTENT_RULES_ADMIN_ONLY' } }), {

--- a/apps/web/src/app/api/organizations/[id]/content-rules/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/content-rules/route.test.ts
@@ -41,9 +41,15 @@ describe('/api/organizations/[id]/content-rules (story #3472)', () => {
     expect(resp.status).toBe(200);
   });
 
-  it('PUT — BE의 CHANNEL_CONNECTION류와 동형인 403 CONTENT_RULES_OWNER_ONLY도 그대로 통과시킨다', async () => {
+  // story #3436 묶음11(페드루 PO 지적, 2026-09-06) — story #3490이 PUT 권한을
+  // owner 단독에서 owner-or-admin으로 넓히며 코드도 CONTENT_RULES_ADMIN_ONLY로
+  // 바뀌었다(backend/tests/test_3471_org_content_rules_lint.py가 옛 코드
+  // CONTENT_RULES_OWNER_ONLY 부재를 직접 검산). 이 테스트만 옛 코드명 그대로
+  // 남아 있었다 — 라우트는 pass-through(검증 로직 0)라 실동작 회귀는 아니지만
+  // 다음 사람이 이 테스트 이름으로 실 계약값을 오인한다.
+  it('PUT — BE의 CHANNEL_CONNECTION류와 동형인 403 CONTENT_RULES_ADMIN_ONLY도 그대로 통과시킨다', async () => {
     proxyToFastapiWithParams.mockResolvedValue(
-      new Response(JSON.stringify({ error: { code: 'CONTENT_RULES_OWNER_ONLY' } }), {
+      new Response(JSON.stringify({ error: { code: 'CONTENT_RULES_ADMIN_ONLY' } }), {
         status: 403, headers: { 'Content-Type': 'application/json' },
       }),
     );

--- a/apps/web/src/app/api/organizations/[id]/content-rules/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/content-rules/route.ts
@@ -9,9 +9,11 @@ type RouteParams = { params: Promise<{ id: string }> };
  * /api/v2/organizations/{org_id}/content-rules` → `{org_id, rules, version}`.
  * gate-config/route.ts와 동형(단일 JSON 설정, version 반환).
  *
- * PUT은 휴먼 owner만(BE `_require_owner` 엄격 — admin·에이전트 불가, 403
- * `CONTENT_RULES_OWNER_ONLY`). 검증 로직 0, !ok(403·422 `CONTENT_RULES_INVALID`)
- * 전부 그대로 pass-through.
+ * story #3490(PO 決定 2026-09-05) — PUT은 휴먼 owner **또는 admin**(BE
+ * `_require_owner_or_admin`, 403 `CONTENT_RULES_ADMIN_ONLY` — 옛 코드
+ * `CONTENT_RULES_OWNER_ONLY`는 이제 없다, backend/tests/test_3471_org_content_
+ * rules_lint.py::test_member_put_returns_403_owner_field_untouched 부재 검산).
+ * 검증 로직 0, !ok(403·422 `CONTENT_RULES_INVALID`) 전부 그대로 pass-through.
  */
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;

--- a/apps/web/src/app/api/organizations/[id]/content-rules/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/content-rules/route.ts
@@ -10,9 +10,9 @@ type RouteParams = { params: Promise<{ id: string }> };
  * gate-config/route.ts와 동형(단일 JSON 설정, version 반환).
  *
  * story #3490(PO 決定 2026-09-05) — PUT은 휴먼 owner **또는 admin**(BE
- * `_require_owner_or_admin`, 403 `CONTENT_RULES_ADMIN_ONLY` — 옛 코드
- * `CONTENT_RULES_OWNER_ONLY`는 이제 없다, backend/tests/test_3471_org_content_
- * rules_lint.py::test_member_put_returns_403_owner_field_untouched 부재 검산).
+ * `_require_owner_or_admin`, 403 `CONTENT_RULES_ADMIN_ONLY` — 옛 owner 전용
+ * 코드명은 이제 없다, backend/tests/test_3471_org_content_rules_lint.py::
+ * test_member_put_returns_403_owner_field_untouched 부재 검산).
  * 검증 로직 0, !ok(403·422 `CONTENT_RULES_INVALID`) 전부 그대로 pass-through.
  */
 export async function GET(request: Request, { params }: RouteParams) {


### PR DESCRIPTION
## 요약
두 건 모두 1줄급, 한 PR:
1. 콘텐츠 규칙 화면 `TagChip` 제거 버튼의 `aria-label`이 하드코딩 영문(`Remove ${item}`)이라 한국어 화면에서도 스크린리더가 영어로 읽었다. i18n 키(`removeItemAction` — ko 「{item} 제거」 / en `Remove {item}`)로 교체(`dep.remove` 선례와 동형 형태).
2. `route.test.ts`·`route.ts` 주석에 남아 있던 옛 코드 `CONTENT_RULES_OWNER_ONLY`를 `CONTENT_RULES_ADMIN_ONLY`로 정정 — story #3490이 PUT 권한을 owner 단독에서 owner-or-admin으로 넓히며 이미 바뀐 값이고, `backend/tests/test_3471_org_content_rules_lint.py`가 옛 코드 부재를 직접 검산한다. 라우트 자체는 pass-through(검증 로직 0)라 실동작 회귀는 아니었으나, 테스트 이름과 주석이 죽은 계약값을 정본처럼 보여주고 있었다.

## 검증
- 뮤테이션 검증(aria-label 하드코딩 문자열로 되돌려 RED 확인 → 복원).
- `tsc --noEmit` 0 / `eslint --max-warnings=0` 0 / i18n 키 누락 0 / 한자 pin 0 / `vitest run` 6378 전부 그린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)