### PR TITLE
[SID:3544] 조각⑧ — voided 「다시 상신」 다이얼로그 지금 답변 prefill

### DIFF
--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -163,6 +163,12 @@ function stubFetch(opts: {
     comments: {
       id: string; external_comment_id: string; author_display_name: string | null; text: string;
       external_created_at: string | null; captured_at: string; deleted_at: string | null;
+      // story #3544 조각⑧ — 답변 실패 얼굴 테스트용(옵션, 대부분 시나리오는 생략).
+      reply?: {
+        id: string; status: string; external_reply_url: string | null; command_id: string | null;
+        command_status: string | null; failure_kind: string | null;
+        next_attempt_at: string | null; reason_code: string | null;
+      } | null;
     }[];
     active_count: number;
     deleted_count: number;
@@ -176,6 +182,8 @@ function stubFetch(opts: {
   onCommentFollowUp?: (body: unknown) => { status: number; body: unknown };
   onCommentReplyDraft?: (body: unknown) => { status: number; body: unknown };
   onCommentReplySubmit?: () => { status: number; body: unknown };
+  // story #3544 조각⑧ — voided(봉인 불일치) 「다시 상신」의 prefill용 단건 GET.
+  onCommentReplyGet?: () => { status: number; body: unknown };
 }) {
   const versions = opts.versions ?? [VERSION_1];
   const draftDetail: Record<string, unknown> = { ...DRAFT_DETAIL, ...opts.draftDetail };
@@ -370,6 +378,17 @@ function stubFetch(opts: {
             id: 'reply-1', comment_id: 'c1', text: parsedBody.text, status: 'draft', gate_id: null,
             external_reply_id: null, external_reply_url: null, last_error: null, target_comment_state: null,
           },
+        };
+        const ok = result.status < 400;
+        return { ok, status: result.status, json: async () => (ok ? { data: result.body, error: null, meta: null } : result.body) };
+      }
+      // story #3544 조각⑧ — 단건 GET(prefill). '/submit'로 끝나는 POST 분기보다
+      // 먼저 검사하면 안 된다(둘 다 '/replies/{id}'를 포함) — 이 분기는 GET·
+      // '/submit'로 안 끝나는 경우만 잡도록 뒤에 둔다.
+      if (url.includes('/replies/') && !url.endsWith('/submit') && (!init || init.method === undefined || init.method === 'GET')) {
+        const result = opts.onCommentReplyGet?.() ?? {
+          status: 200,
+          body: { id: 'reply-1', comment_id: 'c1', text: '이전 답변 원문', status: 'failed', gate_id: 'gate-1', external_reply_id: null, external_reply_url: null, last_error: null, target_comment_state: null },
         };
         const ok = result.status < 400;
         return { ok, status: result.status, json: async () => (ok ? { data: result.body, error: null, meta: null } : result.body) };
@@ -2975,6 +2994,67 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     await act(async () => { (document.querySelector('[data-testid="comments-reply-submit-button"]') as HTMLButtonElement).click(); });
     await flush();
     expect(document.querySelector('[data-testid="comments-reply-sealed-text"]')?.textContent).toBe('다음 주 월요일에 재입고됩니다');
+  });
+
+  // story #3544 조각⑧(유나 §22-15 ⑧, PO 確定 2026-09-06) — voided(봉인 불일치)
+  // 「다시 상신」 전용 prefill. 일반 「답변」과 달리 다이얼로그가 열리기 전에
+  // 단건 GET으로 «지금 답변» 원문을 가져와 채운다(BFF passthrough 기존 라우트
+  // 재사용, BE 신설 0). 「승인한 답변」과의 diff는 만들지 않는다(못 하는 것).
+  it('⭐「다시 상신」 클릭 — 단건 GET으로 지금 답변 원문을 가져와 textarea를 prefill한다', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: {
+        last_collected_at: '2026-09-05T10:00:00Z', active_count: 1, deleted_count: 0,
+        comments: [{
+          id: 'c1', external_comment_id: 'ext-1', author_display_name: '홍길동', text: '언제 되나요?',
+          external_created_at: null, captured_at: '2026-09-05T10:00:00Z', deleted_at: null,
+          reply: {
+            id: 'reply-1', status: 'failed', external_reply_url: null, command_id: 'cmd-1',
+            command_status: 'voided', failure_kind: null, next_attempt_at: null, reason_code: 'GATE_NOT_APPROVED_OR_RESEALED',
+          },
+        }],
+      },
+      onCommentReplyGet: () => ({
+        status: 200,
+        body: { id: 'reply-1', comment_id: 'c1', text: '승인 뒤 바뀐 지금 답변', status: 'failed', gate_id: 'gate-1', external_reply_id: null, external_reply_url: null, last_error: '봉인 불일치', target_comment_state: null },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const resubmitBtn = container.querySelector('[data-testid="comments-item-reply-resubmit-button"]') as HTMLButtonElement;
+    await act(async () => { resubmitBtn.click(); });
+    await flush();
+
+    const textarea = document.querySelector('#comments-reply-text') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('승인 뒤 바뀐 지금 답변');
+  });
+
+  it('⭐「다시 상신」인데 단건 GET이 실패하면(레이스) 빈 칸으로 열린다(지어내지 않는다)', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: {
+        last_collected_at: '2026-09-05T10:00:00Z', active_count: 1, deleted_count: 0,
+        comments: [{
+          id: 'c1', external_comment_id: 'ext-1', author_display_name: '홍길동', text: '언제 되나요?',
+          external_created_at: null, captured_at: '2026-09-05T10:00:00Z', deleted_at: null,
+          reply: {
+            id: 'reply-1', status: 'failed', external_reply_url: null, command_id: 'cmd-1',
+            command_status: 'voided', failure_kind: null, next_attempt_at: null, reason_code: 'GATE_NOT_APPROVED_OR_RESEALED',
+          },
+        }],
+      },
+      onCommentReplyGet: () => ({ status: 404, body: { detail: 'not found' } }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const resubmitBtn = container.querySelector('[data-testid="comments-item-reply-resubmit-button"]') as HTMLButtonElement;
+    await act(async () => { resubmitBtn.click(); });
+    await flush();
+
+    const textarea = document.querySelector('#comments-reply-text') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('');
   });
 
   it('「답변」 상신 409(대상 삭제) — 서버 문구가 그대로 뜬다', async () => {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -3044,7 +3044,11 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
           },
         }],
       },
-      onCommentReplyGet: () => ({ status: 404, body: { detail: 'not found' } }),
+      // 카디르 QA(2026-09-06, PR#3902) — 미끼 data.text를 실은 404. 본문에
+      // data.text가 아예 없으면 res.ok 가드를 지워도(버그를 넣어도) 우연히
+      // 빈 칸이 나와 이 테스트가 그 가드를 실제로는 안 잰다 — 실패 응답에도
+      // 그럴싸한 값을 실어야 "res.ok를 본다"는 사실이 진짜로 pin된다.
+      onCommentReplyGet: () => ({ status: 404, body: { data: { text: '지어낸 답변' }, detail: 'not found' } }),
     });
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
     await flush();

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -399,6 +399,32 @@ export default function ChannelPostEditPage() {
       return { ok: false, errorMessage: t('commentsActionErrorGeneric') };
     }
   }, [orgId, loadComments, t]);
+
+  // story #3544 조각⑧(유나 §22-15 ⑧, PO 確定 2026-09-06) — voided(봉인 불일치)
+  // 「다시 상신」 전용. 일반 「답변」(handleOpenReply)과 갈라 두는 이유: 이쪽만
+  // 다이얼로그를 열기 전에 단건 GET으로 «지금 답변» 원문을 먼저 가져와야 한다
+  // (BFF passthrough 기존 라우트 재사용, BE 신설 0). 「승인한 답변」과의 diff는
+  // 만들지 않는다 — 원문 그 자체를 BE가 아직 안 실어서(additive 前) 지어낼 수
+  // 없다(못 하는 것으로 명기).
+  const [replyPrefillText, setReplyPrefillText] = useState<string | undefined>(undefined);
+  const handleOpenReply = useCallback((comment: CommentItem) => {
+    setReplyPrefillText(undefined);
+    setReplyComment(comment);
+  }, []);
+  const handleResubmitReply = useCallback(async (comment: CommentItem) => {
+    let prefill: string | undefined;
+    if (orgId && comment.replyId) {
+      try {
+        const res = await fetchWithAuth(`/api/organizations/${orgId}/comments/${comment.id}/replies/${comment.replyId}`);
+        const body = await res.json().catch(() => null) as { data?: ReplyView } | null;
+        prefill = res.ok ? (body?.data?.text ?? undefined) : undefined;
+      } catch {
+        prefill = undefined;
+      }
+    }
+    setReplyPrefillText(prefill);
+    setReplyComment(comment);
+  }, [orgId]);
   const [versions, setVersions] = useState<ChannelPostVersion[]>([]);
   const [maxTextLength, setMaxTextLength] = useState<number | null | undefined>(undefined);
   // story #3402 ④(AC9) — account_label(없으면 account_id)로 나가는 계정을 승인 카드에
@@ -1447,8 +1473,9 @@ export default function ChannelPostEditPage() {
             displayTimezone={displayTimezone}
             onRefresh={handleCommentsRefresh}
             onConvertToTask={setConvertToTaskComment}
-            onReply={setReplyComment}
+            onReply={handleOpenReply}
             onRetryReply={handleRetryReply}
+            onResubmitReply={handleResubmitReply}
           />
         </div>
       ) : null}
@@ -1934,9 +1961,10 @@ export default function ChannelPostEditPage() {
       {replyComment ? (
         <CommentReplyDialog
           comment={replyComment}
-          onClose={() => setReplyComment(null)}
+          onClose={() => { setReplyComment(null); setReplyPrefillText(undefined); }}
           onCreateDraft={handleCreateReplyDraft}
           onSubmit={handleSubmitReply}
+          initialText={replyPrefillText}
         />
       ) : null}
       {/* AC6 — 비활성 이유는 버튼 밖에 둔다(라벨 안에 넣으면 disabled:opacity-50에

--- a/apps/web/src/components/content/comment-convert-to-task-dialog.test.tsx
+++ b/apps/web/src/components/content/comment-convert-to-task-dialog.test.tsx
@@ -44,6 +44,7 @@ const COMMENT: CommentItem = {
   replyExternalUrl: null,
   replyFailureAction: undefined,
   replyCommandId: null,
+  replyId: null,
 };
 
 describe('CommentConvertToTaskDialog', () => {

--- a/apps/web/src/components/content/comment-reply-dialog.test.tsx
+++ b/apps/web/src/components/content/comment-reply-dialog.test.tsx
@@ -34,7 +34,7 @@ afterEach(async () => {
 const COMMENT: CommentItem = {
   id: 'c1', authorDisplayName: '홍길동', bodyText: '언제 재입고되나요?',
   externalCreatedAt: '2026-09-05T10:00:00Z', capturedAt: '2026-09-05T10:00:00Z', deletedAt: null, replyStatus: 'none',
-  replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null,
+  replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null, replyId: null,
 };
 
 const DRAFT_REPLY: ReplyView = {

--- a/apps/web/src/components/content/comment-reply-dialog.tsx
+++ b/apps/web/src/components/content/comment-reply-dialog.tsx
@@ -38,6 +38,12 @@ export interface CommentReplyDialogProps {
   onClose: () => void;
   onCreateDraft: (text: string) => Promise<CommentReplyOutcome>;
   onSubmit: (replyId: string) => Promise<CommentReplyOutcome>;
+  /** story #3544 조각⑧(유나 §22-15 ⑧, PO 確定 2026-09-06) — voided(봉인 불일치)
+   * 「다시 상신」이 여는 자리에서 «지금 답변» 원문을 미리 채운다(호출부가 단건 GET
+   * .../replies/{replyId}로 가져와 넘긴다). 일반 「답변」(새로 시작)은 undefined —
+   * 빈 칸 그대로. 「승인한 답변」과의 diff는 만들지 않는다(BE additive 前 — 못
+   * 하는 것으로 명기, §22-15 ⑧). */
+  initialText?: string;
 }
 
 /**
@@ -47,9 +53,9 @@ export interface CommentReplyDialogProps {
  * 여기서 보여주고, 승인 자체는 이 화면 책임이 아니다(§22-⑤ "승인 카드"는 게이트
  * 인박스의 몫).
  */
-export function CommentReplyDialog({ comment, onClose, onCreateDraft, onSubmit }: CommentReplyDialogProps) {
+export function CommentReplyDialog({ comment, onClose, onCreateDraft, onSubmit, initialText }: CommentReplyDialogProps) {
   const t = useTranslations('content');
-  const [text, setText] = useState('');
+  const [text, setText] = useState(initialText ?? '');
   const [draft, setDraft] = useState<ReplyView | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/apps/web/src/components/content/comments-section.test.tsx
+++ b/apps/web/src/components/content/comments-section.test.tsx
@@ -34,6 +34,7 @@ function baseComment(overrides: Partial<CommentItem>): CommentItem {
     replyExternalUrl: null,
     replyFailureAction: undefined,
     replyCommandId: null,
+    replyId: null,
     ...overrides,
   };
 }
@@ -60,7 +61,7 @@ describe('CommentsSection — 세 얼굴(story #3517 §22-②)', () => {
   it('uncollected(null) — "아직 수집 전"만 뜨고 목록·수집시각은 안 뜬다', async () => {
     const face: CommentsFace = { kind: 'uncollected' };
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-face-uncollected"]')?.textContent).toBe('아직 수집 전입니다.');
     expect(container.querySelector('[data-testid="comments-captured-at"]')).toBeNull();
     expect(container.querySelector('[data-testid="comments-item"]')).toBeNull();
@@ -69,14 +70,14 @@ describe('CommentsSection — 세 얼굴(story #3517 §22-②)', () => {
   it('error(fetch 실패) — "불러오지 못했습니다"만 뜬다(0건과 다른 문구)', async () => {
     const face: CommentsFace = { kind: 'error' };
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-face-error"]')?.textContent).toBe('댓글을 불러오지 못했습니다.');
   });
 
   it('empty([]) — "댓글이 없습니다"+수집시각+제목에 0건(uncollected/error와 다른 문구·표시)', async () => {
     const face: CommentsFace = { kind: 'empty', capturedAt: '2026-09-05T10:00:00Z', comments: [], activeCount: 0, deletedCount: 0, nextAllowedAt: null };
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-face-empty"]')?.textContent).toBe('댓글이 없습니다.');
     expect(container.querySelector('[data-testid="comments-captured-at"]')?.textContent).toContain('09-05');
     expect(container.querySelector('h3')?.textContent).toBe('댓글 0');
@@ -85,7 +86,7 @@ describe('CommentsSection — 세 얼굴(story #3517 §22-②)', () => {
   it('loaded(n건) — 목록·수집시각·제목의 카운트 모두 뜬다', async () => {
     const face = loadedFace([baseComment({})]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelectorAll('[data-testid="comments-item"]').length).toBe(1);
     expect(container.querySelector('[data-testid="comments-item-author"]')?.textContent).toBe('홍길동');
     expect(container.querySelector('h3')?.textContent).toBe('댓글 1');
@@ -97,7 +98,7 @@ describe('CommentsSection — 세 얼굴(story #3517 §22-②)', () => {
   it('activeCount는 서버 전체 수를 쓴다(이 페이지의 comments.length가 아니다)', async () => {
     const face = loadedFace([baseComment({})], { activeCount: 42 });
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('h3')?.textContent).toBe('댓글 42');
   });
 
@@ -107,14 +108,14 @@ describe('CommentsSection — 세 얼굴(story #3517 §22-②)', () => {
   it('작성자 표시명이 없으면(null) "작성자 정보 없음"(공유 「모름」이 아니다)', async () => {
     const face = loadedFace([baseComment({ authorDisplayName: null })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-item-author"]')?.textContent).toBe('작성자 정보 없음');
   });
 
   it('externalCreatedAt이 있으면 그 값을 그대로 보인다(작성 시각)', async () => {
     const face = loadedFace([baseComment({ externalCreatedAt: '2026-09-05T09:00:00Z' })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-item-authored-at"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="comments-item-captured-at"]')).toBeNull();
   });
@@ -125,7 +126,7 @@ describe('CommentsSection — 세 얼굴(story #3517 §22-②)', () => {
   it('externalCreatedAt이 null이면 capturedAt+"수집" 라벨로 폴백한다(지어내지 않되 자리를 비우지 않는다)', async () => {
     const face = loadedFace([baseComment({ externalCreatedAt: null, capturedAt: '2026-09-05T10:30:00Z' })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-item-authored-at"]')).toBeNull();
     const capturedSpan = container.querySelector('[data-testid="comments-item-captured-at"]');
     expect(capturedSpan?.textContent).toContain('수집');
@@ -137,7 +138,7 @@ describe('CommentsSection — 지워진 댓글(story #3517 §22-9)', () => {
   it('deletedAt이 있으면 목록에서 안 빠지고 "원본이 지워졌습니다" 안내가 뜬다', async () => {
     const face = loadedFace([baseComment({ deletedAt: '2026-09-05T11:00:00Z' })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelectorAll('[data-testid="comments-item"]').length).toBe(1);
     expect(container.querySelector('[data-testid="comments-item-deleted-note"]')?.textContent).toBe('원본이 지워졌습니다.');
   });
@@ -146,7 +147,7 @@ describe('CommentsSection — 지워진 댓글(story #3517 §22-9)', () => {
   it('사유("원본이 지워졌습니다")가 본문(comment-body-text)보다 DOM에서 먼저 온다', async () => {
     const face = loadedFace([baseComment({ deletedAt: '2026-09-05T11:00:00Z' })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     const item = container.querySelector('[data-testid="comments-item"]')!;
     const note = item.querySelector('[data-testid="comments-item-deleted-note"]')!;
     const body = item.querySelector('[data-testid="comment-body-text"]')!;
@@ -156,7 +157,7 @@ describe('CommentsSection — 지워진 댓글(story #3517 §22-9)', () => {
   it('deletedAt이 null이면 지워짐 안내가 안 뜬다(회귀 0)', async () => {
     const face = loadedFace([baseComment({ deletedAt: null })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-item-deleted-note"]')).toBeNull();
   });
 
@@ -169,7 +170,7 @@ describe('CommentsSection — 지워진 댓글(story #3517 §22-9)', () => {
       baseComment({ id: 'c2', deletedAt: '2026-09-05T11:05:00Z' }),
     ]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-face-empty"]')?.textContent).toBe('댓글이 없습니다.');
     expect(container.querySelectorAll('[data-testid="comments-item"]').length).toBe(2);
     expect(container.querySelectorAll('[data-testid="comments-item-deleted-note"]').length).toBe(2);
@@ -183,7 +184,7 @@ describe('CommentsSection — 지워진 댓글(story #3517 §22-9)', () => {
   it('지워진 댓글은 짧아도 <summary>에 본문 문자열이 한 글자도 없다(닫힌 채 다 보이는 결함 회귀가드)', async () => {
     const face = loadedFace([baseComment({ deletedAt: '2026-09-05T11:00:00Z', bodyText: '짧은 글' })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     const body = container.querySelector('[data-testid="comment-body-text"]');
     expect(body?.tagName).toBe('DETAILS');
     const summary = body?.querySelector('summary');
@@ -199,7 +200,7 @@ describe('CommentsSection — 지워진 댓글(story #3517 §22-9)', () => {
   it('지워진 댓글엔 작업전환·답변 액션은 안 그려지지만(비활성이 아니라 부재) 답변 상태 칩은 그대로 뜬다', async () => {
     const face = loadedFace([baseComment({ deletedAt: '2026-09-05T11:00:00Z' })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-item-convert-to-task"]')).toBeNull();
     expect(container.querySelector('[data-testid="comments-item-reply"]')).toBeNull();
     expect(container.querySelector('[data-comment-reply-status-chip]')).not.toBeNull();
@@ -208,14 +209,14 @@ describe('CommentsSection — 지워진 댓글(story #3517 §22-9)', () => {
   it('deletedCount>0이면 헤더에 "지워진 댓글 {n}건" 안내가 뜬다(서버 전체 수)', async () => {
     const face = loadedFace([baseComment({ deletedAt: '2026-09-05T11:00:00Z' })], { deletedCount: 3 });
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-deleted-count"]')?.textContent).toBe('지워진 댓글 3건');
   });
 
   it('deletedCount=0이면 그 안내 줄 자체가 안 뜬다', async () => {
     const face = loadedFace([baseComment({})], { deletedCount: 0 });
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-deleted-count"]')).toBeNull();
   });
 });
@@ -226,7 +227,7 @@ describe('CommentsSection — 행 액션(story #3517 조각②)', () => {
   it('지워지지 않은 댓글엔 작업전환·답변 버튼과 답변 상태 칩이 함께 뜬다', async () => {
     const face = loadedFace([baseComment({})]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-item-convert-to-task"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="comments-item-reply"]')).not.toBeNull();
     expect(container.querySelector('[data-comment-reply-status-chip]')?.getAttribute('data-comment-reply-status-chip')).toBe('none');
@@ -238,7 +239,7 @@ describe('CommentsSection — 행 액션(story #3517 조각②)', () => {
   it('replyStatus="published"·replyExternalUrl 있으면 「채널에서 보기」 링크가 뜬다', async () => {
     const face = loadedFace([baseComment({ replyStatus: 'published', replyExternalUrl: 'https://example.com/p/1' })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     const link = container.querySelector('[data-testid="comments-item-reply-external-link"]') as HTMLAnchorElement;
     expect(link?.getAttribute('href')).toBe('https://example.com/p/1');
     expect(link?.textContent).toBe('채널에서 보기');
@@ -249,7 +250,7 @@ describe('CommentsSection — 행 액션(story #3517 조각②)', () => {
   it('replyStatus=null(모르는 status)이면 답변 상태 칩 자리 자체가 안 뜬다', async () => {
     const face = loadedFace([baseComment({ replyStatus: null })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-item-reply-status"]')).toBeNull();
     expect(container.querySelector('[data-comment-reply-status-chip]')).toBeNull();
   });
@@ -257,7 +258,7 @@ describe('CommentsSection — 행 액션(story #3517 조각②)', () => {
   it('replyStatus="submitted"(발행 전)는 replyExternalUrl이 없어야 하고 링크도 안 뜬다', async () => {
     const face = loadedFace([baseComment({ replyStatus: 'submitted' })]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     expect(container.querySelector('[data-testid="comments-item-reply-external-link"]')).toBeNull();
   });
 
@@ -266,7 +267,7 @@ describe('CommentsSection — 행 액션(story #3517 조각②)', () => {
     const onConvertToTask = vi.fn();
     const face = loadedFace([comment]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={onConvertToTask} onReply={() => {}} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={onConvertToTask} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     const btn = container.querySelector('[data-testid="comments-item-convert-to-task"]') as HTMLButtonElement;
     await act(async () => { btn.click(); });
     expect(onConvertToTask).toHaveBeenCalledWith(comment);
@@ -277,7 +278,7 @@ describe('CommentsSection — 행 액션(story #3517 조각②)', () => {
     const onReply = vi.fn();
     const face = loadedFace([comment]);
     const { container, root } = mount();
-    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={onReply} onRetryReply={async () => ({ ok: true })} />)); });
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={onReply} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
     const btn = container.querySelector('[data-testid="comments-item-reply"]') as HTMLButtonElement;
     await act(async () => { btn.click(); });
     expect(onReply).toHaveBeenCalledWith(comment);
@@ -320,7 +321,7 @@ describe('deriveCommentsFace(story #3517, BE #3865/#3876 응답 매핑)', () => 
       comments: [{
         id: 'c1', authorDisplayName: '홍길동', bodyText: '본문',
         externalCreatedAt: '2026-09-05T09:00:00Z', capturedAt: '2026-09-05T10:00:00Z', deletedAt: null,
-        replyStatus: 'none', replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null,
+        replyStatus: 'none', replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null, replyId: null,
       }],
     });
   });
@@ -388,7 +389,7 @@ describe('deriveCommentsFace(story #3517, BE #3865/#3876 응답 매핑)', () => 
       comments: [{
         id: 'c1', authorDisplayName: null, bodyText: 'x',
         externalCreatedAt: null, capturedAt: 't', deletedAt: '2026-09-05T11:00:00Z',
-        replyStatus: 'none', replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null,
+        replyStatus: 'none', replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null, replyId: null,
       }],
     });
   });
@@ -421,7 +422,7 @@ describe('CommentsSection — 답변 실패 얼굴(story #3544, 유나 §22-15)'
         <CommentsSection
           face={face} displayTimezone={TZ}
           onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}}
-          onRetryReply={async () => ({ ok: true })}
+          onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}}
         />,
       ));
     });

--- a/apps/web/src/components/content/comments-section.tsx
+++ b/apps/web/src/components/content/comments-section.tsx
@@ -42,6 +42,10 @@ export interface CommentItem {
   /** dead_letter 재시도 호출에 필요 — command_id가 없으면(레이스) 재시도 버튼을
    * 활성화하지 않는다. */
   replyCommandId: string | null;
+  /** story #3544 조각⑧(유나 §22-15 ⑧, PO 確定 2026-09-06) — voided(봉인 불일치)
+   * 「다시 상신」이 여는 다이얼로그에 «지금 답변»을 prefill하는 데 쓴다(단건 GET
+   * .../replies/{replyId}로 원문을 가져온다). null=이 댓글에 답변 자체가 없다. */
+  replyId: string | null;
 }
 
 // story #3517(유나 §22-②) — 세 얼굴. "미수집"(null)·"댓글 없음"([])·"불러오지 못함"(fetch
@@ -141,6 +145,7 @@ export function deriveCommentsFace(data: RawCommentsResponse): CommentsFace {
       reasonCode: c.reply?.reason_code ?? null,
     }),
     replyCommandId: c.reply?.command_id ?? null,
+    replyId: c.reply?.id ?? null,
   }));
   // story #3517(유나 §22-10, PO 確定 2026-09-05) — "댓글 없음" 판정은 active_count
   // 하나만 본다(comments.length 아님 — 페이지 잘림·지워진 행이 섞이면 틀린다).
@@ -175,6 +180,10 @@ export interface CommentsSectionProps {
   /** story #3544(§22-15) — dead_letter 답변을 공용 publication-commands/{id}/retry로
    * 다시 큐에 올린다(content_kind 무관 기존 엔드포인트, BE 신설 0). */
   onRetryReply: (comment: CommentItem) => Promise<{ ok: true } | { ok: false; errorMessage: string }>;
+  /** story #3544 조각⑧(§22-15 ⑧) — voided(봉인 불일치) 「다시 상신」 전용. 일반
+   * onReply(빈 칸에서 새로 시작)와 달리 다이얼로그를 열기 전에 «지금 답변» 원문을
+   * 먼저 가져와 prefill한다(호출부가 그 조회를 진다). */
+  onResubmitReply: (comment: CommentItem) => void;
 }
 
 function SectionHeader({
@@ -205,7 +214,7 @@ function SectionHeader({
 // story #3517(유나 Design 재리뷰, 2026-09-05) — empty/loaded 둘 다 같은 목록 렌더를
 // 쓴다(§22-9 지워진 행 규칙이 두 얼굴에서 갈리면 안 되므로 한 곳으로 통일).
 function CommentsList({
-  comments, displayTimezone, t, onConvertToTask, onReply, onRetryReply,
+  comments, displayTimezone, t, onConvertToTask, onReply, onRetryReply, onResubmitReply,
 }: {
   comments: CommentItem[];
   displayTimezone: string;
@@ -213,6 +222,7 @@ function CommentsList({
   onConvertToTask: (comment: CommentItem) => void;
   onReply: (comment: CommentItem) => void;
   onRetryReply: (comment: CommentItem) => Promise<{ ok: true } | { ok: false; errorMessage: string }>;
+  onResubmitReply: (comment: CommentItem) => void;
 }) {
   return (
     <ul className="space-y-3">
@@ -289,7 +299,7 @@ function CommentsList({
                 action={comment.replyFailureAction}
                 displayTimezone={displayTimezone}
                 onRetry={comment.replyCommandId ? () => onRetryReply(comment) : undefined}
-                onResubmit={() => onReply(comment)}
+                onResubmit={() => onResubmitReply(comment)}
               />
             ) : null}
             {/* story #3517(BE #3867 조각②, PO 確定 2026-09-05) — §22-9: 지워진
@@ -323,7 +333,7 @@ function CommentsList({
   );
 }
 
-export function CommentsSection({ face, displayTimezone, onRefresh, onConvertToTask, onReply, onRetryReply }: CommentsSectionProps) {
+export function CommentsSection({ face, displayTimezone, onRefresh, onConvertToTask, onReply, onRetryReply, onResubmitReply }: CommentsSectionProps) {
   const t = useTranslations('content');
 
   if (face.kind === 'uncollected') {
@@ -364,7 +374,7 @@ export function CommentsSection({ face, displayTimezone, onRefresh, onConvertToT
             지워진 행(deleted_count>0)은 §22-9 "원래 자리 그대로" 그린다 — "댓글
             없음" 문구가 지워진 행의 존재 자체를 지우면 안 된다. */}
         {face.comments.length > 0 ? (
-          <CommentsList comments={face.comments} displayTimezone={displayTimezone} t={t} onConvertToTask={onConvertToTask} onReply={onReply} onRetryReply={onRetryReply} />
+          <CommentsList comments={face.comments} displayTimezone={displayTimezone} t={t} onConvertToTask={onConvertToTask} onReply={onReply} onRetryReply={onRetryReply} onResubmitReply={onResubmitReply} />
         ) : null}
       </div>
     );
@@ -374,7 +384,7 @@ export function CommentsSection({ face, displayTimezone, onRefresh, onConvertToT
     <div className="space-y-2 border-t border-border pt-3" data-testid="comments-section">
       <SectionHeader t={t} activeCount={face.activeCount} deletedCount={face.deletedCount} capturedAtDisplay={capturedAtDisplay} />
       <CommentsRefreshButton onRefresh={onRefresh} nextAllowedAt={face.nextAllowedAt} />
-      <CommentsList comments={face.comments} displayTimezone={displayTimezone} t={t} onConvertToTask={onConvertToTask} onReply={onReply} onRetryReply={onRetryReply} />
+      <CommentsList comments={face.comments} displayTimezone={displayTimezone} t={t} onConvertToTask={onConvertToTask} onReply={onReply} onRetryReply={onRetryReply} onResubmitReply={onResubmitReply} />
     </div>
   );
 }


### PR DESCRIPTION
## 요약
유나 §22-15 ⑧(PO 確定 2026-09-06) — voided(봉인 불일치) 「다시 상신」이 빈 칸으로 열려 사람이 원문을 기억해 다시 타이핑해야 했다. 단건 GET `.../comments/{cid}/replies/{rid}` → `ReplyView.text`로 «지금 답변» 원문을 가져와 `CommentReplyDialog`에 prefill한다(BFF passthrough 기존 라우트 재사용, **BE 신설 0** — `CommentItem.replyId = c.reply?.id ?? null` 한 줄 추가가 전부).

## 설계
일반 「답변」(빈 칸에서 새로 시작, `handleOpenReply`)과 「다시 상신」(prefill, `handleResubmitReply`)을 별도 핸들러로 가른다 — 전자는 항상 빈 칸이어야 하고, 후자만 다이얼로그를 열기 전에 조회가 필요하다.

**「승인한 답변」과의 diff는 만들지 않는다** — BE가 그 원문 자체를 아직 안 실어서(additive 前) 지어낼 수 없다(못 하는 것으로 명기, §22-15 ⑧ 그대로).

## 검증
- prefill 성공(단건 GET 응답 텍스트가 textarea에 그대로).
- GET 실패(레이스, 404)면 빈 칸으로 열림(지어내지 않는다).
- 뮤테이션 검증(prefill 대입 무력화 → RED 확인 → 복원).
- `tsc --noEmit` 0 / `eslint --max-warnings=0` 0 / i18n 키 누락 0 / 한자 pin 0 / `vitest run` 6406 전부 그린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)