### PR TITLE
[SID:3548] 이미지 비율 상한 422 ko 문구 「비율 한도는」→「비율 상한은」

### DIFF
--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2553,7 +2553,7 @@
     "channelPostsImageRequiredReason": "이미지 없이 상신할 수 없습니다 — 이 채널은 이미지가 필요합니다.",
     "channelPostsImageUnsupportedFormat": "지원하지 않는 형식입니다: {contentType}(허용: {allowed})",
     "channelPostsImageTooLarge": "{maxBytes} 이하만 첨부할 수 있는데 {sizeBytes}입니다",
-    "channelPostsImageAspectRatioExceeded": "이미지가 너무 길쭉합니다. 비율 한도는 {maxAspectRatio}인데 {aspectRatio}입니다",
+    "channelPostsImageAspectRatioExceeded": "이미지가 너무 길쭉합니다. 비율 상한은 {maxAspectRatio}인데 {aspectRatio}입니다",
     "channelPostsImageAspectRatioTooNarrow": "세로가 너무 깁니다. 비율 하한은 {minAspectRatio}인데 {aspectRatio}입니다",
     "channelPostsImageConversionFailed": "자동 변환 후에도 한도 {maxBytes}를 넘습니다({finalBytes})",
     "channelPostsImageAnimatedUnsupported": "애니메이션 이미지는 지원하지 않습니다({frameCount}프레임)",


### PR DESCRIPTION
## 요약
하한 문구(「비율 하한은」, story #3530)와 경계 낱말을 짝 맞춘다 — "한도"만으론 상한인지 하한인지 안 갈렸다(유나 배포 36 회차 결함).

## 처방
`channelPostsImageAspectRatioExceeded` ko 값만 「비율 한도는」→「비율 상한은」. en은 무변경(원래도 방향 낱말이 없었다), 방향 낱말 자체는 넣지 않는다(3530 REQUIRED 2 ③ 그대로 — "너무 길쭉합니다" 문장이 이미 방향을 말한다).

## 검증
옛 문자열 잔존 0(grep 확인), 이 키를 참조하는 테스트도 없어 갱신 불요. i18n 키 누락 0 / 한자 pin 0 / `vitest run` 6403 전부 그린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)