### PR TITLE
[SID:3547] feat: Facebook Page 발행 어댑터 PR1(BE) — 연결·OAuth·발행·페이지 선택

### DIFF
--- a/backend/alembic/versions/0342_channel_oauth_pending_selections.py
+++ b/backend/alembic/versions/0342_channel_oauth_pending_selections.py
@@ -1,0 +1,48 @@
+"""story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Facebook Page 연결의
+페이지 선택 중간 상태. Facebook Login 콜백은 장기 유저 토큰을 받은 뒤 `/me/accounts`
+로 그 유저가 관리하는 페이지 목록을 받아야 하고, 페이지가 2개 이상이면 사람이 골라야
+한다(1개면 콜백에서 즉시 확정, 0개면 실패) — 기존 `channel_oauth_state.py`(JWT, 단발
+왕복)는 이 "고른 뒤에야 끝나는" 중간 상태를 못 들고 있어 새 서버 임시 테이블을 둔다.
+
+JWT 탈락 사유: 장기 유저 토큰이 브라우저로 나가면 그대로 노출된다. 기존 channel_
+connections 행 재사용 탈락 사유: status 값들을 소비처가 이미 판정에 쓰고 있어(예:
+active/revoked) "아직 페이지 미확정" 상태를 그 안에 끼워 넣으면 그 판정을 오염시키고,
+account_id NOT NULL이라 가짜값을 채워야 한다.
+
+TTL 15분·단회 사용(select 성공 시 즉시 삭제) — 만료분은 새 Cloud Scheduler 잡 0으로
+`/publication-commands` tick에 피기백해 스윕한다(cron.py, 3497/3527과 동형 사상).
+FK 없음(channel_connections·channel_app_credentials와 동일 관례 — 그라운딩 §9)."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0342"
+down_revision = "0341"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "channel_oauth_pending_selections",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("requester_member_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("channel", sa.Text(), nullable=False),
+        sa.Column("encrypted_user_token", sa.Text(), nullable=False),
+        # [{"page_id": "...", "name": "..."}, ...] — 페이지 토큰은 여기 안 둔다(select
+        # 단계가 /me/accounts를 재호출해 그때 얻는다, 캐시된 값을 안 믿는다).
+        sa.Column("candidates", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False, index=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("channel_oauth_pending_selections")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.event_outbox import EventOutbox
 from app.models.delivery_job import DeliveryJob
 from app.models.channel_connection import ChannelConnection
 from app.models.channel_app_credential import ChannelAppCredentials
+from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
 from app.models.gate import Gate
 from app.models.gate_github_check_event import GateGithubCheckEvent
 from app.models.github_installation import GithubInstallation, GithubInstallNonce, GithubWebhookDelivery

--- a/backend/app/models/channel_oauth_pending_selection.py
+++ b/backend/app/models/channel_oauth_pending_selection.py
@@ -1,0 +1,24 @@
+"""story #3547 — `channel_oauth_pending_selections` ORM. 모듈 docstring은 마이그
+0342 참고(중복 재설명 0)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin, TimestampMixin
+
+
+class ChannelOAuthPendingSelection(Base, TimestampMixin, OrgScopedMixin):
+    __tablename__ = "channel_oauth_pending_selections"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    requester_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    channel: Mapped[str] = mapped_column(Text, nullable=False)
+    encrypted_user_token: Mapped[str] = mapped_column(Text, nullable=False)
+    candidates: Mapped[list] = mapped_column(JSONB, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
+from typing import Literal
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -150,6 +151,10 @@ class ChannelConnectionResponse(BaseModel):
     # story #3492 — 붙여넣기(pasted_secret) 재방문 표시(§2 규격 3, app_id_suffix와
     # 동형). oauth 채널은 항상 null(secret_hint 자체를 안 씀).
     secret_hint: str | None = None
+    # story #3547(페드루 PO 確定 2026-09-06) — 콜백 응답이 "연결 생성"과 "페이지 선택
+    # 대기"(PendingSelectionResponse) 둘 중 하나일 수 있어(Facebook Page만 해당) FE가
+    # 판별자로 가른다. additive 기본값이라 기존 threads/instagram 응답·소비자는 무변.
+    kind: Literal["connected"] = "connected"
 
 
 def _to_response(row) -> ChannelConnectionResponse:
@@ -198,6 +203,26 @@ class CallbackRequest(BaseModel):
     state: str
 
 
+class PendingSelectionCandidate(BaseModel):
+    page_id: str
+    name: str
+
+
+class PendingSelectionResponse(BaseModel):
+    """story #3547(BE 계약, 페드루 PO 確定 2026-09-06) — Facebook Page 콜백이 페이지
+    2개 이상을 봤을 때만 나온다(0개=실패·1개=즉시 ChannelConnectionResponse).
+    `kind` 판별자로 FE가 모양 추측 없이 분기한다."""
+    kind: Literal["pending_selection"] = "pending_selection"
+    pending_id: uuid.UUID
+    candidates: list[PendingSelectionCandidate]
+    expires_at: str
+
+
+class FacebookSelectRequest(BaseModel):
+    pending_id: uuid.UUID
+    page_id: str
+
+
 class TestConnectionResponse(BaseModel):
     ok: bool
     account: dict | None = None
@@ -233,6 +258,19 @@ class AppCredentialsStatusResponse(BaseModel):
 
 def _app_id_suffix(app_id: str) -> str:
     return app_id[-4:] if len(app_id) >= 4 else app_id
+
+
+_FACEBOOK_OAUTH_MODULE_PATHS = {
+    "facebook": "app.services.facebook_oauth",
+    "facebook_sandbox": "app.services.facebook_sandbox_oauth",
+}
+
+
+def _facebook_oauth_module(channel: str):
+    """story #3547 — `channel_adapters.py::get_publish_client_module`과 동형 dispatch
+    사상(real/sandbox가 정확히 같은 함수 시그니처를 구현, 새 분기 로직 0)."""
+    import importlib
+    return importlib.import_module(_FACEBOOK_OAUTH_MODULE_PATHS[channel])
 
 
 @router.get("/{org_id}/channel-connections", response_model=list[ChannelConnectionResponse])
@@ -387,12 +425,19 @@ async def authorize_channel_connection(
         # oauth.py 상단 딱지 참고) — code_challenge를 아예 안 넘긴다.
         from app.services.instagram_oauth import build_authorize_url as build_instagram_authorize_url
         url = build_instagram_authorize_url(redirect_uri=_redirect_uri(org_id, channel), state=state, app_id=app_id)
+    elif channel in ("facebook", "facebook_sandbox"):
+        # story #3547 — Facebook Login도 PKCE 미지원(facebook_oauth.py 상단 딱지).
+        build_facebook_authorize_url = _facebook_oauth_module(channel).build_authorize_url
+        url = build_facebook_authorize_url(redirect_uri=_redirect_uri(org_id, channel), state=state, app_id=app_id)
     else:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
     return AuthorizeResponse(url=url, state=state)
 
 
-@router.post("/{org_id}/channel-connections/{channel}/callback", response_model=ChannelConnectionResponse)
+@router.post(
+    "/{org_id}/channel-connections/{channel}/callback",
+    response_model=ChannelConnectionResponse | PendingSelectionResponse,
+)
 async def channel_connection_callback(
     org_id: uuid.UUID,
     channel: str,
@@ -400,7 +445,7 @@ async def channel_connection_callback(
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
-) -> ChannelConnectionResponse:
+) -> ChannelConnectionResponse | PendingSelectionResponse:
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
     resolved = await _require_owner(db, auth, org_id)
@@ -422,7 +467,7 @@ async def channel_connection_callback(
     if adapter is None:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
-    if channel not in ("threads", "instagram"):
+    if channel not in ("threads", "instagram", "facebook", "facebook_sandbox"):
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
     # authorize 단계와 별도로 다시 조회 — 콜백은 브라우저 왕복(수초~수분) 뒤라 그 사이 owner가
@@ -438,6 +483,12 @@ async def channel_connection_callback(
             },
         )
     app_id, app_secret = app_credentials
+
+    if channel in ("facebook", "facebook_sandbox"):
+        return await _facebook_channel_connection_callback(
+            db, org_id=org_id, channel=channel, code=body.code, app_id=app_id, app_secret=app_secret,
+            requester_member_id=resolved.id,
+        )
 
     # story #3320 — instagram_oauth.InstagramOAuthError는 ThreadsOAuthError와 같은
     # .code/.message 속성을 갖는 별도 클래스다(진짜 다른 provider — OAuth 예외는
@@ -489,6 +540,158 @@ async def channel_connection_callback(
         token_expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in),
         refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(","), connected_by=resolved.id,
     )
+    return _to_response(row)
+
+
+async def _facebook_channel_connection_callback(
+    db: AsyncSession, *, org_id: uuid.UUID, channel: str, code: str, app_id: str, app_secret: str,
+    requester_member_id: uuid.UUID,
+) -> ChannelConnectionResponse | PendingSelectionResponse:
+    """story #3547(페드루 PO 確定 2026-09-06) — Facebook Page는 페이지 개수에 따라
+    갈래가 셋(0/1/2+)이다. `_redirect_uri`는 threads/instagram과 같은 채널별 콜백
+    URL 관례(PKCE 없음이라 code_verifier 불요)."""
+    from app.services.facebook_oauth import FacebookOAuthError
+    from app.services.channel_oauth_pending_selection import create_pending_selection
+
+    adapter = get_channel_adapter(channel)
+    oauth_module = _facebook_oauth_module(channel)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        try:
+            short_lived_token, _ = await oauth_module.exchange_code_for_short_lived_token(
+                client, code=code, redirect_uri=_redirect_uri(org_id, channel), app_id=app_id, app_secret=app_secret,
+            )
+            long_lived_token, _expires_in = await oauth_module.exchange_for_long_lived_token(
+                client, short_lived_token=short_lived_token, app_id=app_id, app_secret=app_secret,
+            )
+            pages = await oauth_module.list_pages(client, user_access_token=long_lived_token)
+        except FacebookOAuthError as exc:
+            raise HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message}) from exc
+        finally:
+            del app_secret  # ⛔즉시 소비 후 폐기 — 더 들고 있지 않는다(기존 규율과 동형).
+
+    if not pages:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_FACEBOOK_NO_PAGES_AVAILABLE",
+                "message": "연결할 수 있는 페이지가 없습니다 — 이 계정이 관리하는 Facebook 페이지가 없거나, "
+                           "페이지 목록 권한을 허용하지 않았습니다.",
+            },
+        )
+
+    if len(pages) == 1:
+        page = pages[0]
+        row = await upsert_channel_connection(
+            db, org_id=org_id, channel=channel, account_id=page["page_id"], account_label=page["name"],
+            credential_kind=adapter.credential_kind, access_token=page["access_token"], refresh_token=None,
+            token_expires_at=None,  # 페이지 토큰은 장기 유저 토큰에서 파생 — 별도 만료 불명(⚠️미확認).
+            refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(","), connected_by=requester_member_id,
+        )
+        return _to_response(row)
+
+    now = datetime.now(timezone.utc)
+    candidates = [{"page_id": p["page_id"], "name": p["name"]} for p in pages]
+    pending = await create_pending_selection(
+        db, org_id=org_id, requester_member_id=requester_member_id, channel=channel,
+        user_token=long_lived_token, candidates=candidates, now=now,
+    )
+    return PendingSelectionResponse(
+        pending_id=pending.id,
+        candidates=[PendingSelectionCandidate(**c) for c in candidates],
+        expires_at=pending.expires_at.isoformat(),
+    )
+
+
+@router.post("/{org_id}/channel-connections/facebook/select", response_model=ChannelConnectionResponse)
+async def facebook_select_page_endpoint(
+    org_id: uuid.UUID,
+    body: FacebookSelectRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelConnectionResponse:
+    """story #3547(BE 계약 確定, 페드루 PO 2026-09-06) — 페이지 2개 이상 콜백 뒤 사람이
+    하나를 고르면 이 엔드포인트가 연결 행을 만든다. `/me/accounts`를 여기서 재호출
+    (캐시된 candidates의 페이지 토큰은 안 믿는다 — 콜백 시점엔 후보 id/name만 저장,
+    토큰은 저장 안 함, pending_selection 모듈 docstring)."""
+    from app.services.channel_credential_crypto import decrypt_channel_credential
+    from app.services.channel_oauth_pending_selection import delete_pending_selection, get_pending_selection
+    from app.services.facebook_oauth import FacebookOAuthError
+
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    resolved = await _require_owner(db, auth, org_id)
+
+    pending = await get_pending_selection(db, pending_id=body.pending_id, org_id=org_id)
+    if pending is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_NOT_FOUND",
+                "message": "선택 대기 상태를 찾을 수 없습니다(이미 사용됐거나 존재하지 않습니다).",
+            },
+        )
+    if pending.requester_member_id != resolved.id:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_FORBIDDEN",
+                "message": "이 선택 대기 상태를 시작한 사람만 페이지를 고를 수 있습니다.",
+            },
+        )
+    if pending.expires_at <= datetime.now(timezone.utc):
+        # 삭제는 스윕 몫(삭제 책임 단일화, 페드루 PO 確定) — 여기서 안 지운다.
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_EXPIRED",
+                "message": "15분이 지나 선택 대기 상태가 만료됐습니다. 다시 연결해주세요.",
+            },
+        )
+    if not any(c.get("page_id") == body.page_id for c in pending.candidates):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_INVALID_PAGE",
+                "message": "선택한 페이지가 이 선택 대기 상태의 후보 목록에 없습니다.",
+            },
+        )
+
+    adapter = get_channel_adapter(pending.channel)
+    user_token = decrypt_channel_credential(pending.encrypted_user_token)
+    oauth_module = _facebook_oauth_module(pending.channel)
+    async with httpx.AsyncClient(timeout=15) as client:
+        try:
+            pages = await oauth_module.list_pages(client, user_access_token=user_token)
+        except FacebookOAuthError as exc:
+            # Meta 호출 실패 — 행 유지(페드루 PO 確定, TTL이 상한). 검증 실패와 구분되는
+            # 유일한 축(행이 살아 있어 재시도 가능 vs 검증 실패는 애초에 재시도해도 안 됨).
+            raise HTTPException(
+                status_code=503,
+                detail={"code": "CHANNEL_OAUTH_PROVIDER_UNAVAILABLE", "message": exc.message},
+            ) from exc
+
+    matched = next((p for p in pages if p["page_id"] == body.page_id), None)
+    if matched is None:
+        # 재호출 사이 그 페이지 권한이 회수된 경우 — 검증 실패와 동형으로 취급.
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_INVALID_PAGE",
+                "message": "선택한 페이지를 더는 이 계정에서 관리할 수 없습니다.",
+            },
+        )
+
+    row = await upsert_channel_connection(
+        db, org_id=org_id, channel=pending.channel, account_id=matched["page_id"], account_label=matched["name"],
+        credential_kind=adapter.credential_kind, access_token=matched["access_token"], refresh_token=None,
+        token_expires_at=None, refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(","),
+        connected_by=resolved.id,
+    )
+    # 성공에만 삭제(페드루 PO REQUIRED) — 같은 pending으로 두 번째 성공은 이 삭제가
+    # 먼저 지운 행을 get_pending_selection이 다음 호출에서 못 찾아 자연히 막힌다.
+    await delete_pending_selection(db, pending_id=pending.id)
     return _to_response(row)
 
 

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1319,6 +1319,14 @@ async def publication_commands_tick(
         except Exception as exc:
             logger.exception("comment-collections tick error: %s", exc)
             counts["comment_collections"] = {"error": "unhandled"}
+        # story #3547(2026-09-06) — Facebook Page 페이지 선택 중간 상태(TTL 15분) 만료분
+        # 스윕. 위 두 축과 같은 피기백 사상(새 Cloud Scheduler 잡 0) — 독립 try.
+        try:
+            from app.services.channel_oauth_pending_selection import sweep_expired_pending_selections
+            counts["oauth_pending_selections_swept"] = await sweep_expired_pending_selections(session)
+        except Exception as exc:
+            logger.exception("oauth-pending-selections sweep tick error: %s", exc)
+            counts["oauth_pending_selections_swept"] = {"error": "unhandled"}
         return _ok(counts)
     except Exception as exc:
         logger.exception("publication-commands cron error: %s", exc)

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -212,6 +212,63 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # publish.py::create_media_container의 image_url=None 즉시 거부와 동형 사실).
         image_required=True,
     ),
+    # story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Facebook Page 피드
+    # 발행. 연결은 「Facebook Login」(그라운딩 확認 — Instagram Login과 별개 제품)
+    # 이라 authorize/callback이 threads·instagram과 다른 흐름(장기 유저 토큰 →
+    # /me/accounts로 페이지 선택, channel_connections.py 참고). ⚠️미확認 딱지
+    # (facebook_oauth.py·facebook_publish.py 상단 참고) — scope/max_text_length/
+    # 이미지 규격은 Meta 공식 문서 지식, 재확認 전 라이브 왕복 금지.
+    "facebook": ChannelAdapterConfig(
+        authorize_url="https://www.facebook.com/v21.0/dialog/oauth",
+        token_url="https://graph.facebook.com/v21.0/oauth/access_token",
+        # pages_show_list=/me/accounts 목록 조회 · pages_manage_posts=피드 발행/삭제
+        # · pages_read_engagement=페이지 permalink류 읽기(⚠️미확認, 그라운딩 대상).
+        scope="pages_show_list,pages_manage_posts,pages_read_engagement",
+        refresh_mode="reissue_from_access_token",
+        credential_kind="oauth",
+        display_name="Facebook Page",
+        max_text_length=63206,  # ⚠️미확認 — Meta 문서 지식(Facebook 피드 게시물 상한).
+        utm_source="facebook",
+        utm_medium="social",
+        supports_unpublish=True,
+        unpublish_required_scope="pages_manage_posts",
+        # Threads류(캐러셀 범위 밖, story 본문 명시)와 동형 — 피드 이미지 1장.
+        image_formats=("image/jpeg", "image/png"),
+        image_max_bytes=10 * 1024 * 1024,
+        image_width_min=320,
+        image_width_max=1440,
+        image_color_space="sRGB",
+        image_max_count=1,
+        # comments/insights는 declare-only 미지원(페드루 PO 明示 2026-09-06) — 빈
+        # insight_metrics·supports_fetch_replies 기본값(False) 그대로.
+        image_required=False,  # Instagram과 달리 텍스트만으로도 피드 발행 가능.
+    ),
+    "facebook_sandbox": ChannelAdapterConfig(
+        authorize_url="https://www.facebook.com/v21.0/dialog/oauth",
+        token_url="https://graph.facebook.com/v21.0/oauth/access_token",
+        scope="pages_show_list,pages_manage_posts,pages_read_engagement",
+        refresh_mode="reissue_from_access_token",
+        # 페드루 PO 確定(2026-09-06) — instagram_sandbox와 달리 credential_kind=
+        # "oauth"(=none이 아님). 페이지 수 마커(:pages-0/:pages-1)를 sandbox 앱
+        # 자격의 app_id 접미로 나르므로, org가 실제로 channel_app_credentials PUT을
+        # 거쳐 그 마커를 등록해야 한다 — 그래서 이 채널은 범용 「/sandbox」 엔드포인트
+        # (credential_kind=="none"만 받음)가 아니라 진짜 authorize→callback 라우터를
+        # 탄다(facebook_sandbox_oauth.py가 Meta 호출부만 페이크로 스왑).
+        credential_kind="oauth",
+        display_name="Facebook Page Sandbox",
+        max_text_length=63206,
+        utm_source="facebook_sandbox",
+        utm_medium="test",
+        supports_unpublish=True,
+        unpublish_required_scope="pages_manage_posts",
+        image_formats=("image/jpeg", "image/png"),
+        image_max_bytes=10 * 1024 * 1024,
+        image_width_min=320,
+        image_width_max=1440,
+        image_color_space="sRGB",
+        image_max_count=1,
+        image_required=False,
+    ),
     # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각①) — Sprintable
     # 호스팅 블로그를 blog kind 어댑터 1호로 등재한다. **동작 무변경** — site_posts.py의
     # 발행 흐름(`publish_site_post_from_draft` 등)은 지금처럼 내부 `site_posts` 테이블에
@@ -407,6 +464,8 @@ _PUBLISH_CLIENT_MODULE_PATHS: dict[str, str] = {
     "instagram_sandbox": "app.services.instagram_sandbox_publish",
     "threads": "app.services.threads_publish",
     "instagram": "app.services.instagram_publish",
+    "facebook": "app.services.facebook_publish",
+    "facebook_sandbox": "app.services.facebook_sandbox_publish",
 }
 
 

--- a/backend/app/services/channel_app_credentials.py
+++ b/backend/app/services/channel_app_credentials.py
@@ -27,6 +27,12 @@ _PLATFORM_SETTINGS_COLUMNS = {
     # (신규 컬럼 0·조직 상수 0, 스토리 본문 「결제 게이트 0」과 같은 취지의 「앱 등록
     # 게이트 0」).
     "instagram": ("threads_platform_app_id", "threads_platform_encrypted_app_secret"),
+    # story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Facebook Login도
+    # 같은 Meta 개발자 앱에 제품만 추가하면 되는 축(instagram과 동일 근거·같은
+    # platform_settings 컬럼 재사용, 새 컬럼 0). 이 공용 앱 경로를 쓰려면 그 앱에
+    # Facebook Login 제품이 켜져 있어야 한다 — 조직이 자기 앱을 등록(①단계 우선)
+    # 하면 이 축과 무관.
+    "facebook": ("threads_platform_app_id", "threads_platform_encrypted_app_secret"),
 }
 
 

--- a/backend/app/services/channel_oauth_pending_selection.py
+++ b/backend/app/services/channel_oauth_pending_selection.py
@@ -1,0 +1,63 @@
+"""story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Facebook Page 연결의
+페이지 선택 중간 상태 CRUD. 모듈 설계 근거는 마이그 0342 docstring 참고(중복 0).
+
+삭제는 성공에만(페드루 PO REQUIRED, 2026-09-06) — `/me/accounts` 재호출이 일시
+실패(네트워크·Meta 5xx)해도 pending 행을 지우면 사람이 OAuth를 처음부터 다시 해야
+한다. 검증 실패(page_id∉candidates·requester 불일치)·Meta 호출 실패 둘 다 행을
+유지하고, expires_at(TTL 15분)이 최종 상한 노릇을 한다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+from app.services.channel_credential_crypto import encrypt_channel_credential
+
+PENDING_SELECTION_TTL = timedelta(minutes=15)
+
+
+async def create_pending_selection(
+    db: AsyncSession, *, org_id: uuid.UUID, requester_member_id: uuid.UUID, channel: str,
+    user_token: str, candidates: list[dict], now: datetime,
+) -> ChannelOAuthPendingSelection:
+    """candidates=[{"page_id": str, "name": str}, ...] — 페이지 토큰은 여기 안 실림
+    (select 단계가 /me/accounts를 재호출해 얻는다)."""
+    row = ChannelOAuthPendingSelection(
+        id=uuid.uuid4(), org_id=org_id, requester_member_id=requester_member_id, channel=channel,
+        encrypted_user_token=encrypt_channel_credential(user_token), candidates=candidates,
+        expires_at=now + PENDING_SELECTION_TTL,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def get_pending_selection(
+    db: AsyncSession, *, pending_id: uuid.UUID, org_id: uuid.UUID,
+) -> ChannelOAuthPendingSelection | None:
+    return (await db.execute(
+        select(ChannelOAuthPendingSelection).where(
+            ChannelOAuthPendingSelection.id == pending_id, ChannelOAuthPendingSelection.org_id == org_id,
+        )
+    )).scalar_one_or_none()
+
+
+async def delete_pending_selection(db: AsyncSession, *, pending_id: uuid.UUID) -> None:
+    """성공 경로 전용 — 실패·검증거부 경로는 이 함수를 안 부른다(모듈 docstring)."""
+    await db.execute(delete(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.id == pending_id))
+    await db.commit()
+
+
+async def sweep_expired_pending_selections(db: AsyncSession, *, now: datetime | None = None) -> int:
+    """cron.py `/publication-commands` tick 피기백(새 Cloud Scheduler 잡 0, 3497/3527과
+    동형 사상) — expires_at이 지난 행을 지운다. 반환값=삭제 건수(tick 응답 카운트용)."""
+    now = now or datetime.now(timezone.utc)
+    result = await db.execute(
+        delete(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.expires_at <= now)
+    )
+    await db.commit()
+    return result.rowcount or 0

--- a/backend/app/services/facebook_oauth.py
+++ b/backend/app/services/facebook_oauth.py
@@ -1,0 +1,112 @@
+"""story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Facebook Login 서버
+OAuth 교환 + 페이지 목록 조회. `instagram_oauth.py`(story #3320)와 동형 구조 —
+app_id/secret은 호출부(`channel_app_credentials.py`의 3단 우선순위)가 해석해 넘긴다.
+
+⚠️미확認 딱지(instagram_oauth.py 상단 관례와 동형) — 아래 엔드포인트·응답 shape은
+디디의 일반 Meta Graph API 지식이며, 이 조각 착수 시점 PO의 실 문서 재확認 대상이다
+(threads_oauth.py 최초 작성 시 지식-컷오프 추정이 실제로 틀렸던 선례가 있다 — 재확認
+전 라이브 왕복 금지). code_challenge(PKCE)는 안 보낸다 — 서버가 app_secret을 쥔
+confidential client 흐름이라(authorize→callback 전 구간 이 백엔드가 처리) instagram_
+oauth.py와 같은 판단.
+
+흐름: authorize(코드 부여) → callback(단기 유저 토큰, 평면 응답 — Threads류와 동형,
+Instagram의 `data` 배열과 다름) → 단기→장기(≈60일) 유저 토큰 교환 → `list_pages`
+(`/me/accounts`)로 이 유저가 관리하는 페이지 목록+각 페이지 토큰을 받는다(페이지
+토큰은 유저 토큰에서 파생돼 별도 교환 콜이 불요 — 이것도 ⚠️미확認, Meta 문서
+지식)."""
+from __future__ import annotations
+
+import httpx
+
+_AUTHORIZE_BASE = "https://www.facebook.com/v21.0/dialog/oauth"
+_GRAPH_BASE = "https://graph.facebook.com/v21.0"
+_TOKEN_URL = _GRAPH_BASE + "/oauth/access_token"
+_ACCOUNTS_URL = _GRAPH_BASE + "/me/accounts"
+
+
+class FacebookOAuthError(Exception):
+    """code→token/장기교환/페이지목록 실패. .code/.message가 ThreadsOAuthError·
+    InstagramOAuthError와 동형 속성(라우터가 같은 except 튜플로 묶어 처리)."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, app_id: str) -> str:
+    from urllib.parse import urlencode
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    cfg = CHANNEL_ADAPTERS["facebook"]
+    params = {
+        "client_id": app_id, "redirect_uri": redirect_uri, "scope": cfg.scope,
+        "response_type": "code", "state": state,
+    }
+    return f"{_AUTHORIZE_BASE}?{urlencode(params)}"
+
+
+async def exchange_code_for_short_lived_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, app_id: str, app_secret: str,
+) -> tuple[str, str]:
+    """authorization code → (access_token, "") — Facebook 콜백은 IG-scoped user_id류
+    필드를 안 준다(그라운딩 확認), 두 번째 원소는 threads_oauth.py/instagram_oauth.py
+    와 시그니처를 맞추기 위한 빈 문자열(list_pages가 실제 계정 식별을 대신한다)."""
+    resp = await client.get(
+        _TOKEN_URL,
+        params={
+            "client_id": app_id, "client_secret": app_secret, "redirect_uri": redirect_uri, "code": code,
+        },
+    )
+    if resp.status_code != 200:
+        raise FacebookOAuthError("FACEBOOK_TOKEN_EXCHANGE_FAILED", resp.text[:500])
+    body = resp.json()
+    access_token = body.get("access_token")
+    if not access_token:
+        raise FacebookOAuthError("FACEBOOK_TOKEN_EXCHANGE_MISSING_FIELDS", "access_token missing")
+    return access_token, ""
+
+
+async def exchange_for_long_lived_token(
+    client: httpx.AsyncClient, *, short_lived_token: str, app_id: str, app_secret: str,
+) -> tuple[str, int]:
+    """단기 유저 토큰 → (장기 유저 access_token, expires_in초, ≈60일). instagram_
+    oauth.py와 달리 app_id가 이 호출에도 필요하다(그라운딩 확認 — fb_exchange_token
+    grant는 client_id/client_secret 둘 다 요구)."""
+    resp = await client.get(
+        _TOKEN_URL,
+        params={
+            "grant_type": "fb_exchange_token", "client_id": app_id, "client_secret": app_secret,
+            "fb_exchange_token": short_lived_token,
+        },
+    )
+    if resp.status_code != 200:
+        raise FacebookOAuthError("FACEBOOK_LONG_LIVED_EXCHANGE_FAILED", resp.text[:500])
+    body = resp.json()
+    access_token = body.get("access_token")
+    expires_in = body.get("expires_in")
+    if not access_token or not expires_in:
+        raise FacebookOAuthError("FACEBOOK_LONG_LIVED_EXCHANGE_MISSING_FIELDS", "access_token/expires_in missing")
+    return access_token, int(expires_in)
+
+
+async def list_pages(client: httpx.AsyncClient, *, user_access_token: str) -> list[dict]:
+    """`GET /me/accounts` — 장기 유저 토큰으로 그 유저가 관리하는 페이지 목록을 받는다.
+    반환은 `[{"page_id": str, "name": str, "access_token": str}, ...]`(원본 응답의
+    `id`를 `page_id`로 정규화 — 이 코드베이스 관례상 다른 축과 이름 충돌 방지, 새
+    의미 추가 아님). 페이지 토큰이 이미 이 응답에 포함돼(그라운딩 ⚠️미확認) 별도
+    교환 콜이 불요하다."""
+    resp = await client.get(_ACCOUNTS_URL, params={"access_token": user_access_token})
+    if resp.status_code != 200:
+        raise FacebookOAuthError("FACEBOOK_LIST_PAGES_FAILED", resp.text[:500])
+    body = resp.json()
+    entries = body.get("data")
+    if entries is None:
+        raise FacebookOAuthError("FACEBOOK_LIST_PAGES_MISSING_FIELD", "data missing in response")
+    pages = []
+    for entry in entries:
+        page_id, name, page_token = entry.get("id"), entry.get("name"), entry.get("access_token")
+        if not page_id or not page_token:
+            continue
+        pages.append({"page_id": str(page_id), "name": name or str(page_id), "access_token": page_token})
+    return pages

--- a/backend/app/services/facebook_publish.py
+++ b/backend/app/services/facebook_publish.py
@@ -1,0 +1,115 @@
+"""story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Facebook Page 피드
+발행. `channel_posts.py`(story 620beefc)의 create_container→get_container_status→
+publish_container 3단계 오케스트레이션은 Threads/Instagram의 "비동기 컨테이너"
+API에 맞춘 계약인데, Facebook Page 피드 발행(`/{page-id}/feed`·`/{page-id}/photos`)
+은 둘 다 **단일 콜·동기** 응답이다(⚠️미확認 — Meta 문서 지식, 재확認 전 라이브
+금지, instagram_oauth.py 상단 딱지와 동형).
+
+그래서 실제 POST 호출은 `create_container`가 전부 하고 `get_container_status`/
+`publish_container`는 "이미 끝났다"만 알리는 얇은 계약 어댑터다 — 이러면 채널_posts.py
+쪽 오케스트레이션 코드를 전혀 안 건드리고도(새 분기 0) 기존 재시도/동시성 안전망을
+그대로 물려받는다: `create_container` 성공 직후 `row.external_container_id`+
+`status="container_created"`가 즉시 커밋되므로(channel_posts.py:1348-1352),
+재시도 시 `just_created_container`가 False가 돼 `create_container`를 다시 안 부르고
+`publish_container`(no-op, 같은 id 반환)만 다시 타 — 중복 게시 0."""
+from __future__ import annotations
+
+import httpx
+
+_GRAPH_BASE = "https://graph.facebook.com/v21.0"
+
+_CONTAINER_STATUS_FINISHED = "FINISHED"
+
+
+class FacebookPublishError(Exception):
+    """threads_publish.py::ThreadsPublishError·instagram_publish.py와 동형 속성
+    (.status_code) — publication_command.py/channel_posts.py의 기존 except
+    ThreadsPublishError 분기가 이 예외도 그대로 처리하게, 여기서도 그 클래스를
+    재사용한다(신규 예외 클래스 발명 0)."""
+
+
+async def create_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    image_url: str | None = None,
+) -> str:
+    """`threads_user_id`는 기존 관례 재사용(실제로는 Page ID, channel_connection.
+    account_id에 저장된 값 — 파라미터명은 dispatcher 계약을 그대로 따른다, 새 이름
+    발명 0). 이미지 있으면 `/{page-id}/photos`(caption=text)·없으면 `/{page-id}/feed`
+    (message=text) 단일 콜로 **이미 발행까지 끝낸다** — 반환값은 Meta가 준 실제
+    post id(모듈 docstring 참고 — publish_container는 이 값을 그대로 되돌려줄 뿐
+    추가 호출을 안 한다)."""
+    from app.services.threads_publish import ThreadsPublishError
+
+    if image_url:
+        url = f"{_GRAPH_BASE}/{threads_user_id}/photos"
+        params = {"access_token": access_token, "url": image_url, "caption": text}
+    else:
+        url = f"{_GRAPH_BASE}/{threads_user_id}/feed"
+        params = {"access_token": access_token, "message": text}
+    resp = await client.post(url, params=params)
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "FACEBOOK_CREATE_POST_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    # /photos 응답은 {"id": <photo_id>, "post_id": <page_post_id>} — 페이지 피드에
+    # 실제로 뜨는 건 post_id 쪽(⚠️미확認, Meta 문서 지식). /feed 응답은 {"id": <post_id>}뿐.
+    post_id = body.get("post_id") or body.get("id")
+    if not post_id:
+        raise ThreadsPublishError(
+            "FACEBOOK_CREATE_POST_MISSING_ID", "id/post_id missing in response", status_code=resp.status_code,
+        )
+    return str(post_id)
+
+
+async def get_container_status(
+    client: httpx.AsyncClient, *, access_token: str, creation_id: str,
+) -> tuple[str, str | None]:
+    """`create_container`가 이미 실제로 발행까지 끝냈으므로(모듈 docstring) 여기는
+    항상 FINISHED — 진짜 폴링(HTTP 호출) 0건."""
+    return _CONTAINER_STATUS_FINISHED, None
+
+
+async def publish_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, creation_id: str,
+) -> str:
+    """no-op(모듈 docstring) — `creation_id`가 이미 실제 post id다. 추가 API 호출 0건
+    (중복 게시 방지가 여기 있다: 재시도로 이 함수가 여러 번 불려도 새 게시물이
+    안 생긴다)."""
+    return creation_id
+
+
+async def get_publishing_limit(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str,
+) -> tuple[int, int, int]:
+    """⚠️미확認 — Facebook Page 피드에는 Instagram/Threads의 `content_publishing_
+    limit`류 공개 조회 API가 확認되지 않는다(그라운딩 대상, PO 재확認 필요). 없는
+    걸 있는 척 조회하지 않고(no-fiction) 고정된 "항상 통과" 값을 선언한다 — 실
+    Meta측 한도에 걸리면 create_container 호출 자체가 4xx/429로 실패하고, 그건
+    기존 ThreadsPublishError 매핑(429→CHANNEL_RATE_LIMITED)이 그대로 잡는다."""
+    return 0, 1_000_000, 86400
+
+
+async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> None:
+    """`DELETE /{post-id}` — Facebook Graph API 공개 문서화 삭제 엔드포인트(⚠️미확認,
+    재확認 필요하나 Instagram과 달리 이 엔드포인트 자체의 존재는 Meta 문서에서
+    통상적으로 다뤄지는 축이라 instagram_publish.py::delete_media의 미구현 판단과는
+    다르게 구현한다 — supports_unpublish=True 선언과 짝)."""
+    from app.services.threads_publish import ThreadsPublishError
+
+    resp = await client.delete(f"{_GRAPH_BASE}/{media_id}", params={"access_token": access_token})
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "FACEBOOK_DELETE_POST_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+
+
+async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> str | None:
+    """`GET /{post-id}?fields=permalink_url` — threads_publish.py와 동형(값 없으면
+    None, 예외로 승격 안 함)."""
+    resp = await client.get(
+        f"{_GRAPH_BASE}/{media_id}", params={"fields": "permalink_url", "access_token": access_token},
+    )
+    if resp.status_code != 200:
+        return None
+    return resp.json().get("permalink_url")

--- a/backend/app/services/facebook_sandbox_oauth.py
+++ b/backend/app/services/facebook_sandbox_oauth.py
@@ -1,0 +1,55 @@
+"""story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Facebook Page 연결
+sandbox. `facebook_oauth.py`와 정확히 같은 함수 시그니처(라우터가 채널로 모듈만
+바꿔 끼우는 기존 dispatch 관례 — `channel_adapters.py::get_publish_client_module`
+과 동형 사상, 새 분기 로직 0)를 인프로세스 결정적 응답으로 구현한다(sandbox_
+publish.py "같은 코드 경로·가짜 데이터" 철학).
+
+**페이지 수 마커**(페드루 PO 確定) — sandbox 앱 자격(`channel_app_credentials`,
+channel="facebook_sandbox")의 `app_id` 접미로 정한다: `:pages-0`(0개)·`:pages-1`
+(1개)·접미 없음(기본 2개). 실제 authorize→callback→(필요시)select 라우터 코드
+전체가 real과 완전히 동일하게 타야 하므로(그래야 셋 갈래가 전부 라이브 왕복으로
+실측된다) app_id를 별도 파라미터로 안 넘기고 이 모듈이 발급하는 가짜 토큰 문자열에
+그대로 실어 옮긴다(`list_pages`가 그 토큰에서 되읽는다 — app_id 자체는 비밀이 아님,
+channel_app_credential.py 모델 주석 참고).
+
+list_pages가 돌려주는 페이지 이름·id는 결정적 고정값이다(페드루 PO 明示 2026-09-06
+— 라이브 판정이 이름을 대조한다)."""
+from __future__ import annotations
+
+import httpx
+
+_PAGES_0_SUFFIX = ":pages-0"
+_PAGES_1_SUFFIX = ":pages-1"
+_FAKE_TOKEN_PREFIX = "sandbox-fb-user-token"
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, app_id: str) -> str:
+    """sandbox는 실제로 이 URL을 브라우저가 방문하지 않는다(테스트/QA가 callback을
+    직접 호출) — 값 자체는 authorize 응답 계약(AuthorizeResponse.url)을 채우기
+    위한 자리표시자."""
+    return f"https://sandbox.local/facebook-oauth?state={state}"
+
+
+async def exchange_code_for_short_lived_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, app_id: str, app_secret: str,
+) -> tuple[str, str]:
+    return f"{_FAKE_TOKEN_PREFIX}:{app_id}", ""
+
+
+async def exchange_for_long_lived_token(
+    client: httpx.AsyncClient, *, short_lived_token: str, app_id: str, app_secret: str,
+) -> tuple[str, int]:
+    # 장기 토큰에 app_id를 그대로 옮겨 싣는다 — list_pages가 이 값에서 마커를 읽는다.
+    return short_lived_token, 5_184_000  # 60일(초) — facebook_oauth.py와 동형 근사.
+
+
+async def list_pages(client: httpx.AsyncClient, *, user_access_token: str) -> list[dict]:
+    """결정적 고정 후보(페드루 PO 明示) — 이름·id는 절대 안 바뀐다."""
+    if user_access_token.endswith(_PAGES_0_SUFFIX):
+        return []
+    if user_access_token.endswith(_PAGES_1_SUFFIX):
+        return [{"page_id": "sandbox-page-1", "name": "Sandbox Page 1", "access_token": "sandbox-page-token-1"}]
+    return [
+        {"page_id": "sandbox-page-1", "name": "Sandbox Page 1", "access_token": "sandbox-page-token-1"},
+        {"page_id": "sandbox-page-2", "name": "Sandbox Page 2", "access_token": "sandbox-page-token-2"},
+    ]

--- a/backend/app/services/facebook_sandbox_publish.py
+++ b/backend/app/services/facebook_sandbox_publish.py
@@ -1,0 +1,64 @@
+"""story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — dev 전용 Facebook Page
+샌드박스 발행 클라이언트. `facebook_publish.py`와 정확히 같은 함수 시그니처(신규
+판정 로직 0) — 결정적·상태 없음(sandbox_publish.py·instagram_sandbox_publish.py와
+동형 설계 계약). comments/insights 함수는 아예 안 둔다(declare-only, supports_
+fetch_replies/insight_metrics를 어댑터에서 선언 안 함 — 페드루 PO 明示 2026-09-06)."""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+
+from app.services.threads_publish import ThreadsPublishError
+
+_MARKER_429 = "[sandbox:429]"
+_MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
+_MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
+
+
+async def create_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    image_url: str | None = None,
+) -> str:
+    if _MARKER_429 in text:
+        raise ThreadsPublishError("SANDBOX_FACEBOOK_RATE_LIMITED", "sandbox: [sandbox:429] 마커 시뮬레이션", status_code=429)
+    if _MARKER_PROVIDER_ERROR in text:
+        raise ThreadsPublishError(
+            "SANDBOX_FACEBOOK_PROVIDER_ERROR", "sandbox: [sandbox:provider-error] 마커 시뮬레이션", status_code=502,
+        )
+    if _MARKER_EXPIRED_TOKEN in text:
+        raise ThreadsPublishError(
+            "SANDBOX_FACEBOOK_TOKEN_EXPIRED", "sandbox: [sandbox:expired-token] 마커 시뮬레이션", status_code=401,
+        )
+    return f"sandbox-fb-post-{uuid.uuid4().hex}"
+
+
+async def get_container_status(
+    client: httpx.AsyncClient, *, access_token: str, creation_id: str,
+) -> tuple[str, str | None]:
+    return "FINISHED", None
+
+
+async def publish_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, creation_id: str,
+) -> str:
+    # facebook_publish.py와 동형 — create_container가 이미 "발행"까지 끝냈다는 계약이라
+    # sandbox도 같은 id를 그대로 되돌려준다(추가 상태 생성 0).
+    return creation_id
+
+
+async def get_publishing_limit(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str,
+) -> tuple[int, int, int]:
+    return 0, 100, 86400
+
+
+async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> str | None:
+    return f"https://sandbox.invalid/facebook/{media_id}"
+
+
+async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> None:
+    # facebook_publish.py와 달리 supports_unpublish=True 선언과 짝을 맞춰 실제로
+    # "삭제됨"을 시뮬레이션한다(sandbox_publish.py의 threads 계열과 동형 — 실
+    # provider가 지원 확認된 능력은 sandbox도 성공으로 흉내낸다).
+    return None

--- a/backend/tests/test_3547_facebook_page_connection.py
+++ b/backend/tests/test_3547_facebook_page_connection.py
@@ -1,0 +1,525 @@
+"""story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Facebook Page 연결
+(BE PR1). threads/instagram(test_3373·test_3320)과 동형 세팅 헬퍼 재사용(중복
+재발명 0). 세 갈래(0/1/2+ 페이지)·select 5실패코드·자가회수 스윕·「삭제는 성공에만」
+뮤테이션이 이 파일의 척추.
+
+facebook_sandbox_oauth.py는 실 HTTP 없이 인프로세스 결정적으로 답한다 — 그래서 이
+파일의 대부분은 목 없이 진짜 authorize→callback→select 라우터 코드를 그대로 태운다
+(페드루 PO 明示 — "같은 코드 경로·가짜 데이터" 철학을 시험 자체로 검증)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.test_3373_channel_connections import (
+    _seed_org, _seed_human, _session_factory, _client_for, _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+    monkeypatch.setattr(config_module.settings, "channel_oauth_state_secret", "test-channel-oauth-state-secret")
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _register_facebook_sandbox_app_credentials(session, *, org_id, updated_by, app_id="sandbox-app-id"):
+    """facebook_sandbox는 platform fallback이 없다(channel_app_credentials.py의
+    _PLATFORM_SETTINGS_COLUMNS에 의도적으로 미등재 — org마다 다른 페이지-수 마커를
+    고를 수 있어야 한다). org가 직접 등록해야 authorize가 진입한다."""
+    from app.services.channel_app_credentials import upsert_channel_app_credentials
+
+    return await upsert_channel_app_credentials(
+        session, org_id=org_id, channel="facebook_sandbox", app_id=app_id, app_secret="sandbox-secret",
+        updated_by=updated_by,
+    )
+
+
+async def _authorize_and_callback(client, org_id: str, *, channel="facebook_sandbox", code="auth-code"):
+    r_auth = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/{channel}/authorize")
+    assert r_auth.status_code == 200, r_auth.text
+    state = r_auth.json()["state"]
+    return await client.post(
+        f"/api/v2/organizations/{org_id}/channel-connections/{channel}/callback",
+        json={"code": code, "state": state},
+    )
+
+
+# ─── 어댑터 dispatch(get_publish_client_module) ──────────────────────────────
+
+
+def test_get_publish_client_module_dispatches_facebook_and_facebook_sandbox():
+    from app.services.channel_adapters import get_publish_client_module
+    import app.services.facebook_publish as facebook_publish
+    import app.services.facebook_sandbox_publish as facebook_sandbox_publish
+
+    assert get_publish_client_module("facebook") is facebook_publish
+    assert get_publish_client_module("facebook_sandbox") is facebook_sandbox_publish
+
+
+# ─── facebook_oauth.py 단위 ───────────────────────────────────────────────────
+
+
+def test_facebook_build_authorize_url_never_sends_pkce_params():
+    from app.services.facebook_oauth import build_authorize_url
+
+    url = build_authorize_url(redirect_uri="https://x/callback", state="s", app_id="app-id")
+    assert "code_challenge" not in url
+    assert "client_id=app-id" in url
+    assert url.startswith("https://www.facebook.com/v21.0/dialog/oauth?")
+
+
+@pytest.mark.anyio
+async def test_facebook_list_pages_normalizes_id_to_page_id_and_skips_incomplete_entries():
+    from app.services.facebook_oauth import list_pages
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"data": [
+                {"id": "111", "name": "Page A", "access_token": "tok-a"},
+                {"id": "222", "name": "Page B"},  # access_token 없음 — 스킵.
+            ]}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    pages = await list_pages(_FakeClient(), user_access_token="user-token")
+    assert pages == [{"page_id": "111", "name": "Page A", "access_token": "tok-a"}]
+
+
+# ─── facebook_sandbox_oauth.py — 페이지 수 마커 ───────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_facebook_sandbox_list_pages_marker_branches():
+    from app.services.facebook_sandbox_oauth import list_pages
+
+    zero = await list_pages(None, user_access_token="sandbox-fb-user-token:app:pages-0")
+    one = await list_pages(None, user_access_token="sandbox-fb-user-token:app:pages-1")
+    default_two = await list_pages(None, user_access_token="sandbox-fb-user-token:app")
+
+    assert zero == []
+    assert [p["page_id"] for p in one] == ["sandbox-page-1"]
+    assert [p["page_id"] for p in default_two] == ["sandbox-page-1", "sandbox-page-2"]
+    # 결정적 고정값(페드루 PO 明示) — 라이브 판정이 이름을 대조한다.
+    assert default_two[0]["name"] == "Sandbox Page 1"
+    assert default_two[1]["name"] == "Sandbox Page 2"
+
+
+# ─── 콜백 3갈래(0/1/2+) — 실 authorize→callback 라우터 코드, HTTP 왕복 ────────
+
+
+@pytest.mark.anyio
+async def test_callback_zero_pages_returns_422_no_pending_row():
+    from app.main import app
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _register_facebook_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id, app_id="app:pages-0")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await _authorize_and_callback(client, org_id)
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_FACEBOOK_NO_PAGES_AVAILABLE"
+
+        async with Session() as s:
+            rows = (await s.execute(select(ChannelOAuthPendingSelection))).scalars().all()
+            assert rows == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_callback_one_page_connects_immediately_no_pending_row():
+    from app.main import app
+    from app.models.channel_connection import ChannelConnection
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _register_facebook_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id, app_id="app:pages-1")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await _authorize_and_callback(client, org_id)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["kind"] == "connected"
+        assert body["account_id"] == "sandbox-page-1"
+        assert body["account_label"] == "Sandbox Page 1"
+
+        async with Session() as s:
+            conn = (await s.execute(select(ChannelConnection).where(ChannelConnection.org_id == org_id))).scalar_one()
+            assert conn.encrypted_access_token is not None
+            pending_rows = (await s.execute(select(ChannelOAuthPendingSelection))).scalars().all()
+            assert pending_rows == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_callback_two_pages_returns_pending_selection_no_connection_row():
+    from app.main import app
+    from app.models.channel_connection import ChannelConnection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _register_facebook_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await _authorize_and_callback(client, org_id)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["kind"] == "pending_selection"
+        assert {c["page_id"] for c in body["candidates"]} == {"sandbox-page-1", "sandbox-page-2"}
+        assert body["pending_id"]
+        assert body["expires_at"]
+
+        async with Session() as s:
+            conns = (await s.execute(select(ChannelConnection).where(ChannelConnection.org_id == org_id))).scalars().all()
+            assert conns == [], "2개+ 갈래는 콜백에서 연결 행을 만들면 안 된다(select가 만든다)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── select — 성공 + 5실패코드 ─────────────────────────────────────────────────
+
+
+async def _setup_pending_two_pages(app, Session, *, org_id, owner_id):
+    async with Session() as s:
+        await _register_facebook_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id)
+    _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+    async with _client_for(app) as client:
+        r = await _authorize_and_callback(client, org_id)
+    assert r.status_code == 200, r.text
+    return r.json()["pending_id"]
+
+
+@pytest.mark.anyio
+async def test_select_success_creates_connection_and_deletes_pending_row():
+    from app.main import app
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_pages(app, Session, org_id=org_id, owner_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook/select",
+                json={"pending_id": pending_id, "page_id": "sandbox-page-2"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["kind"] == "connected"
+        assert body["account_id"] == "sandbox-page-2"
+        assert body["account_label"] == "Sandbox Page 2"
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.id == uuid.UUID(pending_id))
+            )).scalar_one_or_none()
+            assert row is None, "성공했는데 pending 행이 안 지워졌다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_not_found_for_random_pending_id():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook/select",
+                json={"pending_id": str(uuid.uuid4()), "page_id": "x"},
+            )
+        assert r.status_code == 404, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_OAUTH_PENDING_SELECTION_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_forbidden_when_requester_mismatch():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            other_owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_pages(app, Session, org_id=org_id, owner_id=owner_id)
+
+        # 다른 owner로 세션을 다시 세팅 — pending은 첫 owner가 만들었다.
+        _setup_org_scoped_app(app, Session, org_id, user_id=other_owner_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook/select",
+                json={"pending_id": pending_id, "page_id": "sandbox-page-1"},
+            )
+        assert r.status_code == 403, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_OAUTH_PENDING_SELECTION_FORBIDDEN"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_expired_row_kept_not_deleted():
+    """페드루 PO 確定 — 만료는 select가 안 지운다(스윕 몫, 삭제 책임 단일화)."""
+    from app.main import app
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_pages(app, Session, org_id=org_id, owner_id=owner_id)
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.id == uuid.UUID(pending_id))
+            )).scalar_one()
+            row.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook/select",
+                json={"pending_id": pending_id, "page_id": "sandbox-page-1"},
+            )
+        assert r.status_code == 404, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_OAUTH_PENDING_SELECTION_EXPIRED"
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.id == uuid.UUID(pending_id))
+            )).scalar_one_or_none()
+            assert row is not None, "만료 select가 행을 지워버렸다(스윕 몫이어야 한다)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_invalid_page_id_not_in_candidates():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_pages(app, Session, org_id=org_id, owner_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook/select",
+                json={"pending_id": pending_id, "page_id": "not-a-real-page"},
+            )
+        assert r.status_code == 400, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_OAUTH_PENDING_SELECTION_INVALID_PAGE"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_provider_unavailable_keeps_pending_row_for_retry():
+    """페드루 PO REQUIRED — Meta(/me/accounts) 재호출 실패는 행을 지우지 않는다(TTL이
+    상한, 사람이 재시도할 수 있게)."""
+    from app.main import app
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from app.services.facebook_oauth import FacebookOAuthError
+    import app.services.facebook_sandbox_oauth as fb_sandbox_oauth
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_pages(app, Session, org_id=org_id, owner_id=owner_id)
+
+        with patch.object(
+            fb_sandbox_oauth, "list_pages",
+            AsyncMock(side_effect=FacebookOAuthError("FACEBOOK_LIST_PAGES_FAILED", "provider down")),
+        ):
+            async with _client_for(app) as client:
+                r = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-connections/facebook/select",
+                    json={"pending_id": pending_id, "page_id": "sandbox-page-1"},
+                )
+        assert r.status_code == 503, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_OAUTH_PROVIDER_UNAVAILABLE"
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.id == uuid.UUID(pending_id))
+            )).scalar_one_or_none()
+            assert row is not None, "Meta 호출 실패인데 행이 지워졌다(재시도 불가능해짐)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_twice_with_same_pending_second_call_not_found():
+    """페드루 PO 確定 — 「삭제는 성공에만」의 자연스러운 귀결: 같은 pending으로 두 번째
+    성공은 첫 성공의 삭제가 막는다(뮤테이션 대상 아래 참고)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_pages(app, Session, org_id=org_id, owner_id=owner_id)
+
+        async with _client_for(app) as client:
+            r1 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook/select",
+                json={"pending_id": pending_id, "page_id": "sandbox-page-1"},
+            )
+            r2 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook/select",
+                json={"pending_id": pending_id, "page_id": "sandbox-page-2"},
+            )
+        assert r1.status_code == 200, r1.text
+        assert r2.status_code == 404, r2.text
+        assert r2.json()["error"]["code"] == "CHANNEL_OAUTH_PENDING_SELECTION_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 자가회수 스윕 ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_sweep_deletes_expired_pending_selections_keeps_fresh_ones():
+    from app.services.channel_oauth_pending_selection import create_pending_selection, sweep_expired_pending_selections
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            expired = await create_pending_selection(
+                s, org_id=org_id, requester_member_id=owner_id, channel="facebook_sandbox",
+                user_token="t", candidates=[{"page_id": "p1", "name": "P1"}], now=now - timedelta(minutes=30),
+            )
+            fresh = await create_pending_selection(
+                s, org_id=org_id, requester_member_id=owner_id, channel="facebook_sandbox",
+                user_token="t", candidates=[{"page_id": "p2", "name": "P2"}], now=now,
+            )
+
+        async with Session() as s:
+            deleted = await sweep_expired_pending_selections(s, now=now)
+        assert deleted == 1
+
+        async with Session() as s:
+            remaining_ids = {r.id for r in (await s.execute(select(ChannelOAuthPendingSelection))).scalars().all()}
+        assert expired.id not in remaining_ids
+        assert fresh.id in remaining_ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_publication_commands_tick_wires_the_sweep():
+    """cron.py::publication_commands_tick 응답에 oauth_pending_selections_swept
+    카운트가 있어야 배선이 실제로 됐다는 뜻(3497/3527과 동형 피기백 검증 사상)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            await _seed_org(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        from app.dependencies.database import get_worker_db
+        app.dependency_overrides[get_worker_db] = _db
+
+        import app.routers.cron as cron_module
+        with patch.object(cron_module, "verify_cron", lambda request: None):
+            async with _client_for(app) as client:
+                r = await client.post("/api/v2/internal/cron/publication-commands")
+        assert r.status_code == 200, r.text
+        assert "oauth_pending_selections_swept" in r.json()["data"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1321,6 +1321,11 @@
       "file": "tests/test_3528_self_recovery_sweep.py",
       "sec": 20.0,
       "source": "story-3528-self-recovery-sweep(라이브 FAIL 핫픽스, PR#3900 REQUIRED 1 반영 — 로컬 raw pytest 6건 3.6s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3547_facebook_page_connection.py",
+      "sec": 45.0,
+      "source": "story-3547-facebook-page-adapter-be(PR 개설 前 선제 등재 — 로컬 raw pytest 16건 7.51s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 배경
블루프린트 §7 Phase 2 「Instagram·Facebook Page 발행」. Facebook Page는 Facebook Login(Instagram Login과 별개 제품) → `/me/accounts` 페이지 선택이 필요해 threads/instagram 콜백의 단발 왕복과 다른 흐름이 필요하다(그라운딩 ①~⑤, PO 確定 채택 — 스토리 코멘트 참고).

## 변경
- 마이그 0342: `channel_oauth_pending_selections`(페이지 선택 중간 상태, TTL 15분·단회 사용)
- `facebook_oauth.py`/`facebook_sandbox_oauth.py`: OAuth 교환 + `/me/accounts` 목록 조회. sandbox는 real과 정확히 같은 시그니처를 인프로세스 결정적으로 구현(페이지 수는 sandbox 앱 자격 `app_id` 접미 `:pages-0`/`:pages-1`/기본 2)
- `facebook_publish.py`/`facebook_sandbox_publish.py`: 피드 발행 — `create_container`가 실제 POST(`/feed`·`/photos`)를 끝내고 `publish_container`는 no-op(중복 게시 0, 재시도 안전)
- `channel_adapters.py`: `facebook`/`facebook_sandbox` 어댑터 등록(unpublish 지원, comments/insights declare-only 미지원)
- `channel_app_credentials.py`: `facebook`은 threads/instagram과 같은 platform 공용 Meta 앱 컬럼 재사용. `facebook_sandbox`는 의도적으로 미등재(org별 마커 선택 강제)
- `channel_connections.py`: 콜백이 페이지 수로 3갈래(0=422·1=즉시 연결·2+=`PendingSelectionResponse`), 새 `POST .../channel-connections/facebook/select`(5실패코드), `ChannelConnectionResponse.kind`(additive 판별자)
- `cron.py`: 만료 pending 스윕을 `/publication-commands` tick에 피기백(새 Cloud Scheduler 잡 0)

## select 실패 코드
`CHANNEL_OAUTH_PENDING_SELECTION_NOT_FOUND`(404)·`_EXPIRED`(404, 삭제는 스윕 몫)·`_FORBIDDEN`(403)·`_INVALID_PAGE`(400)·`CHANNEL_OAUTH_PROVIDER_UNAVAILABLE`(503, 행 유지·재시도 가능)

## ⚠️미확認 딱지
OAuth 응답 shape·publishing limit 조회·delete/permalink 엔드포인트는 Meta 공식 문서 지식이며 재확認 전 라이브 왕복 금지(instagram_oauth.py 상단 관례와 동형). 실 Page 발행은 Meta App Review 게이팅(휴먼 항목, 스코프 밖).

## 테스트
16건(어댑터 dispatch·oauth 단위·sandbox 마커 3갈래·콜백 3갈래 HTTP 왕복·select 성공+5실패코드·중복성공차단·스윕) + 뮤테이션 2종(delete 순서 위반·스윕 비활성화) 각 RED 확인 후 원복. 마이그 0342 실 Postgres upgrade/downgrade 왕복 확인. 회귀 116건(3373/3320×2/3414) 전체 통과. shard-weights 등재·lint 통과.

## 다음
3549(FE, 미르코) — BE 계약(kind 판별자·select 실패코드) 확定 완료, 이 PR 머지 前에도 목 테스트로 병행 가능.