### PR TITLE
[SID:3551] 「다시 상신」 prefill GET 실패 시 안내 한 줄

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2257,6 +2257,7 @@
     "commentsConvertClose": "Close",
     "commentsReplyDialogTitle": "Reply",
     "commentsReplyTextLabel": "Reply text",
+    "commentsReplyPrefillFetchFailed": "We couldn't load the previous reply — please write it yourself.",
     "commentsReplyTextPlaceholder": "Write the reply to send to this comment",
     "commentsReplySaveDraftCta": "Save draft",
     "commentsReplySavingDraft": "Saving...",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2257,6 +2257,7 @@
     "commentsConvertClose": "닫기",
     "commentsReplyDialogTitle": "답변",
     "commentsReplyTextLabel": "답변 내용",
+    "commentsReplyPrefillFetchFailed": "이전 답변을 불러오지 못했습니다 — 직접 적어 주세요.",
     "commentsReplyTextPlaceholder": "댓글에 보낼 답변을 입력하세요",
     "commentsReplySaveDraftCta": "초안 저장",
     "commentsReplySavingDraft": "저장하는 중...",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -3030,9 +3030,11 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
 
     const textarea = document.querySelector('#comments-reply-text') as HTMLTextAreaElement;
     expect(textarea.value).toBe('승인 뒤 바뀐 지금 답변');
+    // story #3544 후속⑨ — 성공했으면 「불러오지 못했습니다」 줄은 안 뜬다.
+    expect(document.querySelector('[data-testid="comments-reply-prefill-fetch-failed"]')).toBeNull();
   });
 
-  it('⭐「다시 상신」인데 단건 GET이 실패하면(레이스) 빈 칸으로 열린다(지어내지 않는다)', async () => {
+  it('⭐「다시 상신」인데 단건 GET이 실패하면(레이스) 빈 칸으로 열리고, 후속⑨(유나 관찰) — 「불러오지 못했습니다」 한 줄이 textarea 위에 뜬다(일반 답변의 원래 빈 칸과 구분)', async () => {
     stubFetch({
       draftDetail: PUBLISHED_DRAFT,
       commentsResponse: {
@@ -3061,6 +3063,32 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
 
     const textarea = document.querySelector('#comments-reply-text') as HTMLTextAreaElement;
     expect(textarea.value).toBe('');
+    expect(document.querySelector('[data-testid="comments-reply-prefill-fetch-failed"]')?.textContent)
+      .toBe(koMessages.content.commentsReplyPrefillFetchFailed);
+  });
+
+  it('일반 「답변」(새로 시작) — 빈 칸이지만 후속⑨ 줄은 안 뜬다(원래 빈 칸이지 불러오다 실패한 게 아니다)', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: {
+        last_collected_at: '2026-09-05T10:00:00Z', active_count: 1, deleted_count: 0,
+        comments: [{
+          id: 'c1', external_comment_id: 'ext-1', author_display_name: '홍길동', text: '언제 되나요?',
+          external_created_at: null, captured_at: '2026-09-05T10:00:00Z', deleted_at: null,
+          reply: null,
+        }],
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const replyBtn = container.querySelector('[data-testid="comments-item-reply"]') as HTMLButtonElement;
+    await act(async () => { replyBtn.click(); });
+    await flush();
+
+    const textarea = document.querySelector('#comments-reply-text') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('');
+    expect(document.querySelector('[data-testid="comments-reply-prefill-fetch-failed"]')).toBeNull();
   });
 
   it('「답변」 상신 409(대상 삭제) — 서버 문구가 그대로 뜬다', async () => {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -407,22 +407,32 @@ export default function ChannelPostEditPage() {
   // 만들지 않는다 — 원문 그 자체를 BE가 아직 안 실어서(additive 前) 지어낼 수
   // 없다(못 하는 것으로 명기).
   const [replyPrefillText, setReplyPrefillText] = useState<string | undefined>(undefined);
+  // story #3544 후속⑨(유나 관찰, PO 確定 2026-09-06) — replyPrefillText가
+  // undefined인 이유가 「일반 답변(새로 시작)이라 원래 빈 칸」인지 「다시 상신인데
+  // 단건 GET이 실패했다」인지를 이 플래그로 가른다(둘 다 undefined라 그 필드
+  // 하나로는 못 가른다).
+  const [replyPrefillFetchFailed, setReplyPrefillFetchFailed] = useState(false);
   const handleOpenReply = useCallback((comment: CommentItem) => {
     setReplyPrefillText(undefined);
+    setReplyPrefillFetchFailed(false);
     setReplyComment(comment);
   }, []);
   const handleResubmitReply = useCallback(async (comment: CommentItem) => {
     let prefill: string | undefined;
+    let fetchFailed = true;
     if (orgId && comment.replyId) {
       try {
         const res = await fetchWithAuth(`/api/organizations/${orgId}/comments/${comment.id}/replies/${comment.replyId}`);
         const body = await res.json().catch(() => null) as { data?: ReplyView } | null;
         prefill = res.ok ? (body?.data?.text ?? undefined) : undefined;
+        fetchFailed = !res.ok;
       } catch {
         prefill = undefined;
+        fetchFailed = true;
       }
     }
     setReplyPrefillText(prefill);
+    setReplyPrefillFetchFailed(fetchFailed);
     setReplyComment(comment);
   }, [orgId]);
   const [versions, setVersions] = useState<ChannelPostVersion[]>([]);
@@ -1961,10 +1971,11 @@ export default function ChannelPostEditPage() {
       {replyComment ? (
         <CommentReplyDialog
           comment={replyComment}
-          onClose={() => { setReplyComment(null); setReplyPrefillText(undefined); }}
+          onClose={() => { setReplyComment(null); setReplyPrefillText(undefined); setReplyPrefillFetchFailed(false); }}
           onCreateDraft={handleCreateReplyDraft}
           onSubmit={handleSubmitReply}
           initialText={replyPrefillText}
+          prefillFetchFailed={replyPrefillFetchFailed}
         />
       ) : null}
       {/* AC6 — 비활성 이유는 버튼 밖에 둔다(라벨 안에 넣으면 disabled:opacity-50에

--- a/apps/web/src/components/content/comment-reply-dialog.tsx
+++ b/apps/web/src/components/content/comment-reply-dialog.tsx
@@ -44,6 +44,11 @@ export interface CommentReplyDialogProps {
    * 빈 칸 그대로. 「승인한 답변」과의 diff는 만들지 않는다(BE additive 前 — 못
    * 하는 것으로 명기, §22-15 ⑧). */
   initialText?: string;
+  /** story #3544 후속⑨(유나 관찰, PO 確定 2026-09-06) — 조각⑧의 단건 GET이 실패하면
+   * initialText는 undefined로 남아 일반 「답변」(새로 시작)의 빈 칸과 글자가 같아진다
+   * — 「불러오다 실패했다」와 「원래 빈 칸이다」를 사람이 못 가른다. 이 플래그가 true면
+   * textarea 위에 한 줄을 보여준다(실패해도 손으로 쓸 수는 있어 액션 0). */
+  prefillFetchFailed?: boolean;
 }
 
 /**
@@ -53,7 +58,7 @@ export interface CommentReplyDialogProps {
  * 여기서 보여주고, 승인 자체는 이 화면 책임이 아니다(§22-⑤ "승인 카드"는 게이트
  * 인박스의 몫).
  */
-export function CommentReplyDialog({ comment, onClose, onCreateDraft, onSubmit, initialText }: CommentReplyDialogProps) {
+export function CommentReplyDialog({ comment, onClose, onCreateDraft, onSubmit, initialText, prefillFetchFailed }: CommentReplyDialogProps) {
   const t = useTranslations('content');
   const [text, setText] = useState(initialText ?? '');
   const [draft, setDraft] = useState<ReplyView | null>(null);
@@ -157,6 +162,11 @@ export function CommentReplyDialog({ comment, onClose, onCreateDraft, onSubmit, 
               <label className="text-xs font-medium text-muted-foreground" htmlFor="comments-reply-text">
                 {t('commentsReplyTextLabel')}
               </label>
+              {prefillFetchFailed ? (
+                <p className="text-xs text-muted-foreground" data-testid="comments-reply-prefill-fetch-failed">
+                  {t('commentsReplyPrefillFetchFailed')}
+                </p>
+              ) : null}
               <textarea
                 id="comments-reply-text"
                 value={text}


### PR DESCRIPTION
## 요약
유나 관찰(2026-09-06, story b88119e9 후속⑨) — 3544 조각⑧(#3902 머지 済)의 「다시 상신」 단건 GET이 실패하면 initialText가 undefined로 남아, 일반 「답변」(새로 시작)의 원래 빈 칸과 사람 눈에 글자가 똑같다. 「불러오다 실패했다」와 「원래 빈 칸이다」를 가를 방법이 없었다.

## 변경
- `comment-reply-dialog.tsx`: `prefillFetchFailed?: boolean` prop 추가 — textarea 위에 한 줄(`commentsReplyPrefillFetchFailed`). 실패해도 손으로 쓸 수 있어 액션 0.
- `page.tsx`: `handleResubmitReply`가 `fetchFailed`를 `replyPrefillText`와 별도 상태로 추적(둘 다 `undefined`가 되는 두 경우 — "일반 답변" vs "GET 실패" — 를 한 필드로는 못 가르므로).
- i18n: `commentsReplyPrefillFetchFailed` — ko 「이전 답변을 불러오지 못했습니다 — 직접 적어 주세요.」(유나 낱말) · en은 초안 — Design PASS 때 유나 確定.

## 검증
- 기존 GET-실패 테스트(레이스 시나리오)에 안내 줄 검증 추가.
- 신규: 성공 케이스는 줄이 안 뜸 / 일반 「답변」(새로 시작)은 원래 빈 칸이라 줄이 안 뜸 — 2건.
- 뮤테이션 2건(fetchFailed 판정 로직·렌더 조건) RED 확인 후 복원.
- `tsc --noEmit` 0 / `eslint --max-warnings=0` 0 / i18n 키 누락 0 / 한자 pin 0 / `vitest run` 6409 전부 그린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)