### PR TITLE
[SID:3528] fix: 자가회수 스윕 orphan 판정을 「30분 안에 도래하는 열린 행 0」으로 넓힘

### DIFF
--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -362,10 +362,19 @@ async def _sweep_orphaned_active_publications_for_self_recovery(db: AsyncSession
     탈락하나, 그 회수는 별건 후보로 관찰만 하고 여기선 다루지 않는다 — 「행 0」만).
 
     매 틱마다 활성(`_is_publication_active`)·댓글 지원 채널(`supports_fetch_replies`)
-    ·org 상한 안(`_within_org_continuous_poll_cap`)이면서 pending/in_progress 행이
-    0인 publication에 due_at=now 씨앗 행을 심는다(UNIQUE 멱등 — 동시 틱 경합 방어,
-    한 틱 삽입 상한 `_SELF_RECOVERY_SWEEP_SEED_LIMIT`건 — 남는 orphan은 다음 틱이
-    이어서 잡는다, 이미 씨앗 심긴 건 pending 행이 생겨 다음 스캔에서 자동 제외).
+    ·org 상한 안(`_within_org_continuous_poll_cap`)이면서 **30분 안에 도래하는 열린
+    (pending/in_progress) 행이 0인** publication에 due_at=now 씨앗 행을 심는다
+    (UNIQUE 멱등 — 동시 틱 경합 방어, 한 틱 삽입 상한 `_SELF_RECOVERY_SWEEP_SEED_LIMIT`
+    건 — 남는 orphan은 다음 틱이 이어서 잡는다, 이미 씨앗 심긴 건 pending 행이 생겨
+    다음 스캔에서 자동 제외).
+
+    페드루 PO REQUIRED(2026-09-06, dev DB oneoff 실측·publication 7291bad8) —
+    orphan 판정을 "열린 행이 0"에서 "**30분 안에 도래하는** 열린 행이 0"으로 넓힌다.
+    좁은 판정은 실측 갭을 놓쳤다 — #3882 배포 前 마지막 due 3창(+1h) 캡처가 끝난
+    publication은 +1d/+7d 창이 아직 pending으로 남아 있어 "열린 행 0"을 절대
+    만족 못 하는데, 그 pending 행들은 며칠 뒤에나 도래해 그 사이 30분 지속폴링
+    체인은 영영 시작 안 된다(마지막 캡처가 #3882 前이라 재생성 콜 자체가 없었던
+    탓). "30분 안에 도래" 기준이면 이런 publication도 정확히 걸린다.
 
     페드루 PO REQUIRED(2026-09-06, PR#3900 리뷰) — orphan 후보 판정을 SQL 한
     쿼리로 민다(NOT EXISTS + 상관 서브쿼리 MAX 집계 + LIMIT). orphan이 0인 정상
@@ -383,15 +392,23 @@ async def _sweep_orphaned_active_publications_for_self_recovery(db: AsyncSession
         return 0
 
     freshness_cutoff = now - _CONTINUOUS_POLL_INTERVAL
-    has_open_row = (
+    due_soon_cutoff = now + _CONTINUOUS_POLL_INTERVAL
+    has_open_row_due_soon = (
         select(func.count()).select_from(CommentCollectionSchedule).where(
             CommentCollectionSchedule.publication_id == ChannelPublication.id,
             CommentCollectionSchedule.status.in_(("pending", "in_progress")),
+            CommentCollectionSchedule.due_at <= due_soon_cutoff,
         ).correlate(ChannelPublication).scalar_subquery()
     )
-    last_activity_at = (
+    # 신선도 가드(회귀 방지, 변경 없음) — "방금 이 틱에서 정상 처리된" publication을
+    # orphan으로 오판해 중복 씨앗을 심지 않게 한다. MAX(due_at)를 전체 행이 아니라
+    # "이미 도래한"(due_at<=now) 행으로만 좁힌다 — 아니면 +1d/+7d처럼 먼 미래
+    # pending 행의 due_at이 MAX를 차지해 "최근 활동 없음"을 절대 못 보게 된다(위
+    # 7291bad8 갭과 같은 함정 — 이 필터가 그걸 피한다).
+    last_actionable_activity_at = (
         select(func.max(CommentCollectionSchedule.due_at)).where(
             CommentCollectionSchedule.publication_id == ChannelPublication.id,
+            CommentCollectionSchedule.due_at <= now,
         ).correlate(ChannelPublication).scalar_subquery()
     )
 
@@ -400,8 +417,8 @@ async def _sweep_orphaned_active_publications_for_self_recovery(db: AsyncSession
             ChannelPublication.channel.in_(comment_capable_channels),
             ChannelPublication.published_at.is_not(None),
             ChannelPublication.published_at >= now - _ACTIVE_PUBLISHED_WITHIN,
-            has_open_row == 0,
-            or_(last_activity_at.is_(None), last_activity_at < freshness_cutoff),
+            has_open_row_due_soon == 0,
+            or_(last_actionable_activity_at.is_(None), last_actionable_activity_at < freshness_cutoff),
         ).order_by(ChannelPublication.published_at.desc())
         .limit(_SELF_RECOVERY_SWEEP_SEED_LIMIT)
     )).scalars().all()

--- a/backend/tests/test_3528_self_recovery_sweep.py
+++ b/backend/tests/test_3528_self_recovery_sweep.py
@@ -173,6 +173,86 @@ async def test_publication_with_open_row_is_not_reseeded():
 
 
 @pytest.mark.anyio
+async def test_orphan_with_only_far_future_pending_window_still_gets_seeded():
+    """페드루 PO REQUIRED(2026-09-06, dev DB oneoff 실측 publication 7291bad8) —
+    「열린 행 0」 판정의 실측 갭 재현. #3882 배포 前 마지막 due 3창(+1h) 캡처가 끝난
+    publication은 +1d/+7d 창이 아직 pending으로 남아 "열린 행 0"을 절대 만족 못
+    하는데, 그 pending 행은 며칠 뒤에나 도래해 그 사이 지속폴링(30분 주기)이 영영
+    시작 안 된다. orphan 판정이 「30분 안에 도래하는 열린 행 0」으로 넓혀졌으면
+    이 표본도 씨앗을 받아야 한다."""
+    from app.services.channel_post_comments import process_due_comment_collections
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    engine, Session = await _session_factory()
+    try:
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-7291bad8")
+            # +1h창 캡처(수 시간 전, #3882 배포 前 상황 재현) — freshness 가드가
+            # "이미 도래한" 행만 보게 하는 축을 이 행으로 검증(먼 미래 pending의
+            # due_at에 가려지면 안 된다).
+            await _seed_terminal_schedule_row(
+                s, org_id=org_id, publication_id=pub.id, external_id="media-7291bad8",
+                due_at=now - timedelta(hours=5),
+            )
+            # +1d창 — 아직 pending, 며칠 뒤에나 도래(열린 행은 있지만 30분 안이
+            # 아니다).
+            s.add(CommentCollectionSchedule(
+                id=uuid.uuid4(), org_id=org_id, publication_id=pub.id, channel="sandbox",
+                external_id="media-7291bad8", due_at=now + timedelta(days=1), status="pending",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_comment_collections(s, now=now)
+        assert counts["self_recovery_seeded"] == 1, counts
+
+        async with Session() as s:
+            rows = await _count_schedule_rows(s, publication_id=pub.id)
+            new_pending = [r for r in rows if r.status == "pending" and r.due_at <= now + timedelta(minutes=1)]
+            assert len(new_pending) == 1, "30분 안 도래 씨앗 행이 안 생겼다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publication_with_open_row_due_within_30min_is_not_reseeded():
+    """열린 행이 있어도 30분 밖(먼 미래)이면 씨앗을 받아야 하지만(위 테스트),
+    반대로 30분 **안**에 도래하는 열린 행이 있으면 정상 체인이 곧 스스로 처리할
+    것이므로 씨앗을 심으면 안 된다."""
+    from app.services.channel_post_comments import process_due_comment_collections
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    engine, Session = await _session_factory()
+    try:
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-due-soon")
+            await _seed_terminal_schedule_row(
+                s, org_id=org_id, publication_id=pub.id, external_id="media-due-soon", due_at=now - timedelta(hours=5),
+            )
+            s.add(CommentCollectionSchedule(
+                id=uuid.uuid4(), org_id=org_id, publication_id=pub.id, channel="sandbox",
+                external_id="media-due-soon", due_at=now + timedelta(minutes=10), status="pending",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_comment_collections(s, now=now)
+        assert counts["self_recovery_seeded"] == 0, counts
+
+        async with Session() as s:
+            rows = await _count_schedule_rows(s, publication_id=pub.id)
+            assert len(rows) == 2, "30분 안에 도래하는 열린 행이 있는데 씨앗이 추가됐다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_normal_state_sweep_costs_exactly_one_query_and_seeds_zero():
     """페드루 PO REQUIRED(2026-09-06, PR#3900 리뷰) — orphan이 0인 정상 상태(다른
     publication들이 전부 열린 행을 가진 상태)에서 스윕 자체의 비용이 SQL 쿼리

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1319,8 +1319,8 @@
     },
     {
       "file": "tests/test_3528_self_recovery_sweep.py",
-      "sec": 20.0,
-      "source": "story-3528-self-recovery-sweep(라이브 FAIL 핫픽스, PR#3900 REQUIRED 1 반영 — 로컬 raw pytest 6건 3.6s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 25.0,
+      "source": "story-3528-orphan-window-widen([SID:3528] 별 PR, dev DB oneoff 실측 7291bad8 REQUIRED 반영 — 로컬 raw pytest 8건 4.09s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 25s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
       "file": "tests/test_3547_facebook_page_connection.py",


### PR DESCRIPTION
## 배경
dev DB oneoff 실측(publication `7291bad8`) — 라이브에서 #3900의 자가회수 스윕이 침묵한 원인을 원본 행으로 확인.

`7291bad8` 스케줄 5행: +1h/+최초2행 captured(마지막 captured_at=19:50:05Z), **+1d/+7d 창은 아직 pending**(각각 익일·+7일 도래). 기존 orphan 판정("열린 행이 0건")은 이 publication을 orphan으로 못 본다 — pending 행이 실제로 있으니까. 하지만 그 pending 행들은 며칠 뒤에나 도래하고, 그 사이 30분 지속폴링 체인은 시작될 계기가 없다(마지막 캡처가 #3882 배포 前이라 재생성 콜 자체가 없었다). 배포 前에 활성이던 publication 전부 이 클래스에 속한다.

## 변경
- orphan 정의: 「pending/in_progress 행이 0건」 → 「pending/in_progress 행 중 `due_at <= now + 30분`인 것이 0건」
- 신선도 가드(방금 처리된 publication을 orphan으로 오판해 중복 씨앗 방지): `MAX(due_at)` 집계 범위를 전체 행에서 **이미 도래한(`due_at<=now`) 행**으로 좁힘 — 안 그러면 먼 미래 pending 행의 `due_at`이 MAX를 차지해 "최근 활동 없음"을 절대 못 본다(7291bad8에서 실제로 걸렸던 함정 — +7d 행의 due_at이 미래라 신선도 판정 자체가 항상 "너무 이르다"로 나왔을 것).

## 테스트
- 신규 2건: 먼 창(+1d)만 pending인 7291bad8류 표본 → 씨앗 1(실측 표본 재현) / 30분 내 열린 행이 있으면 → 씨앗 0
- 기존 6건 무변경으로 통과
- 뮤테이션 2종(주 조건 되돌림·신선도 필터 되돌림) 각 RED 확인 후 원복
- 회귀 79건(3528/3527/3516/3414) 전체 통과. shard-weights 갱신·lint 통과.

## 다음
착지 뒤 다음 배포에서 카디르군 재판정.