### PR TITLE
[SID:3553] switch-org 뒤 owner project_name null + team_member deleted_at 정합

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -436,12 +436,17 @@ async def _build_app_metadata(
             return await _resolve_explicit_app_metadata(user, session, explicit_pid, org_id)
 
     # 1. last_project_id 우선 → 해당 project의 active team_member (org_id 지정 시 그 org일 때만)
+    # story #3553(페드루 PO 確定, 2026-09-06) — 아래 두 조회 다 `projects` JOIN·deleted_at
+    # 필터가 없어 삭제된 project를 가리키는 옛 team_member 행이 «접근 가능」으로 잡혔다
+    # (first_accessible_project_id branch1·has_project_access는 이미 Project.deleted_at IS NULL을
+    # 본다 — 이 두 곳만 비대칭이었다). 삭제 프로젝트로 착지시키지 않는다.
     member = None
     if getattr(user, "last_project_id", None):
-        q = select(TeamMember).where(
+        q = select(TeamMember).join(Project, TeamMember.project_id == Project.id).where(
             TeamMember.project_id == user.last_project_id,
             or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
             TeamMember.is_active.is_(True),
+            Project.deleted_at.is_(None),
         )
         if org_id is not None:
             q = q.where(TeamMember.org_id == org_id)
@@ -452,9 +457,10 @@ async def _build_app_metadata(
         # ⚠️0746: org_id 지정 시 그 org로 스코프(미지정이면 org 무관 → cross-org 옛 프로젝트 누수).
         # 908075db 단계2(flag-on): 이 **추측** 제거 — flag on이면 member None 유지 → 아래 deterministic
         # 경로(first_accessible/invite/Path4)로 해소. flag off면 기존 추측 그대로(거동 무변경).
-        q = select(TeamMember).where(
+        q = select(TeamMember).join(Project, TeamMember.project_id == Project.id).where(
             or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
             TeamMember.is_active.is_(True),
+            Project.deleted_at.is_(None),
         )
         if org_id is not None:
             q = q.where(TeamMember.org_id == org_id)

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -10,7 +10,7 @@ from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.routers.auth import _OAUTH_CONFIGS
 from app.models.member import Member
-from app.models.project import OrgMember
+from app.models.project import OrgMember, Project
 from app.models.team import TeamMember
 from app.models.user import User
 from app.repositories.human_api_key import HumanApiKeyRepository
@@ -190,10 +190,22 @@ async def get_me(
                     proj_id = uuid.UUID(project_id_str) if project_id_str else org_member.org_id
                 except (ValueError, AttributeError):
                     proj_id = org_member.org_id
+                # story #3553(페드루 PO 라이브 재현, PO Test Org db474a4e·772609ea, 2026-09-06) —
+                # 이 폴백(team_member 행 0인 owner/admin — org 소유만으로 접근)은 project_id는
+                # 채우면서 project_name을 통째로 빼먹어 항상 null로 나갔다(일반 경로 211행의
+                # `member.project.name`은 이 분기를 안 타 무사했다). project_id_str이 실제
+                # project를 가리킬 때만 조회한다(0-project org 폴백=org_member.org_id는 project가
+                # 아니라 조회할 이유가 없다 — project_name=None 그대로가 맞다).
+                project_name: str | None = None
+                if project_id_str:
+                    project_name = (await session.execute(
+                        select(Project.name).where(Project.id == proj_id, Project.deleted_at.is_(None))
+                    )).scalar_one_or_none()
                 return MeResponse(
                     id=org_member.id,
                     org_id=org_member.org_id,
                     project_id=proj_id,
+                    project_name=project_name,
                     user_id=uid,
                     name=name,
                     email=user.email if user else None,

--- a/backend/tests/test_3553_build_app_metadata_deleted_project_team_member_realdb.py
+++ b/backend/tests/test_3553_build_app_metadata_deleted_project_team_member_realdb.py
@@ -1,0 +1,99 @@
+"""story #3553(BE·결함·소형, 페드루 PO 確定, 2026-09-06) — `_build_app_metadata`의 TeamMember
+조회 2곳(last_project_id 우선·가장 오래된 team_member)이 `projects` JOIN·deleted_at 필터
+없이 삭제된 project를 가리키는 team_member 행도 「접근 가능」으로 잡던 결함.
+
+`first_accessible_project_id`(branch1)·`has_project_access`(_project_access_predicate)는
+이미 `Project.deleted_at IS NULL`을 보는데 이 두 조회만 비대칭이었다 — 삭제 프로젝트에
+team_member 행만 남아 있는 유저가 그 죽은 project로 착지하던 클래스(0746과 같은 "cross-org/
+dead 프로젝트 누수" 계열)."""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("35530000-0000-0000-0000-0000000011a1")
+USER = uuid.UUID("35530000-0000-0000-0000-000000011111")
+PROJ_DELETED = uuid.UUID("35530000-0000-0000-0000-000000013331")  # 오래된 team_member가 가리키는 삭제 project
+PROJ_LIVE = uuid.UUID("35530000-0000-0000-0000-000000013332")     # owner org-wide로 접근 가능한 살아있는 project
+TM = uuid.UUID("35530000-0000-0000-0000-000000014441")
+OM = uuid.UUID("35530000-0000-0000-0000-000000015551")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM project_access WHERE member_id='{TM}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S3553Org2','s3553-org2','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{USER}','u2@s3553.test','x','U',true,true,0,false,0)",
+        # 삭제된 project + 그걸 가리키는(가장 오래된) team_member(뷰 0088 — members+project_access
+        # 조합, created_at=members.created_at) 행 — fix 前엔 이게 잡혔다.
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level,deleted_at) VALUES "
+        f"('{PROJ_DELETED}','{ORG}','Deleted','s3553-proj-deleted','warn',now())",
+        f"INSERT INTO members (id,org_id,type,user_id,name,created_at) VALUES "
+        f"('{TM}','{ORG}','human','{USER}','U',now() - interval '10 days')",
+        f"INSERT INTO project_access (id,project_id,member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ_DELETED}','{TM}','granted','member')",
+        # 살아있는 project — owner org-wide로만 접근 가능(team_member 행 없음, first_accessible_
+        # project_id branch3와 동형 — 0746 분기가 이걸로 정확히 해소해야 한다).
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ_LIVE}','{ORG}','Live','s3553-proj-live','warn')",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','owner')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+@pytest.mark.anyio
+async def test_deleted_project_team_member_does_not_block_live_project_resolution():
+    """가장 오래된(유일한) team_member가 삭제된 project를 가리키면, fix 前엔 그 죽은
+    project_id로 착지했다 — fix 後엔 그 team_member를 무시하고(deleted_at 필터) 0746
+    분기의 first_accessible_project_id(owner org-wide)가 살아있는 project로 해소한다."""
+    from app.routers.auth import _build_app_metadata
+    from app.models.user import User as UserModel
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            user = await s.get(UserModel, USER)
+            with patch("app.routers.auth._user_projects_claim", new=AsyncMock(return_value=[])):
+                md = await _build_app_metadata(user, s, org_id=ORG)
+
+        assert md["project_id"] == str(PROJ_LIVE), (
+            f"삭제된 project({PROJ_DELETED})를 가리키는 team_member 행이 여전히 «접근 가능»으로 "
+            f"잡혀 project_id={md['project_id']}로 나갔으면 #3553 그대로 재발 — "
+            "TeamMember 조회에 projects JOIN·deleted_at IS NULL이 빠진 결함."
+        )
+        assert md["role"] == "owner"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_3553_build_app_metadata_deleted_project_team_member_realdb.py
+++ b/backend/tests/test_3553_build_app_metadata_deleted_project_team_member_realdb.py
@@ -97,3 +97,37 @@ async def test_deleted_project_team_member_does_not_block_live_project_resolutio
         assert md["role"] == "owner"
     finally:
         await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_last_project_id_pointing_at_deleted_project_does_not_block_live_project_resolution():
+    """카디르 QA(2026-09-06) — 위 테스트는 `user.last_project_id`가 비어(None) search-1
+    ("last_project_id 우선", :440~448)을 안 태우고 search-2("가장 오래된 team_member",
+    :455~461)만 태워, search-1의 JOIN을 지워도 RED 0이었다(양성대조가 그 분기를 실제로
+    안 잰 것). `users.last_project_id`가 **삭제된 project를 직접 가리키는** 표본으로
+    search-1을 명시적으로 태운다 — fix 前엔 search-1이 그 team_member 행을 그대로
+    찾아 죽은 project_id로 착지했다."""
+    from app.routers.auth import _build_app_metadata
+    from app.models.user import User as UserModel
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text(f"UPDATE users SET last_project_id='{PROJ_DELETED}' WHERE id='{USER}'"))
+            await s.commit()
+
+        async with Session() as s:
+            user = await s.get(UserModel, USER)
+            assert user is not None and user.last_project_id == PROJ_DELETED, "seed 확인 — last_project_id가 의도대로 안 실렸다"
+            with patch("app.routers.auth._user_projects_claim", new=AsyncMock(return_value=[])):
+                md = await _build_app_metadata(user, s, org_id=ORG)
+
+        assert md["project_id"] == str(PROJ_LIVE), (
+            f"user.last_project_id가 삭제된 project({PROJ_DELETED})를 직접 가리키는데 search-1"
+            f"(:440~448)이 그 team_member 행을 여전히 «접근 가능»으로 잡아 project_id="
+            f"{md['project_id']}로 나갔으면 #3553 그대로 재발 — search-1 JOIN·deleted_at 필터 결함."
+        )
+        assert md["role"] == "owner"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_3553_me_owner_fallback_project_name_realdb.py
+++ b/backend/tests/test_3553_me_owner_fallback_project_name_realdb.py
@@ -1,0 +1,132 @@
+"""story #3553(BE·결함·소형, 페드루 PO 라이브 재현, 2026-09-06) — switch-org 뒤 owner인데
+`/api/me`(BFF)·`get_me`(BE)가 role은 정확히 보여주면서 project_name만 null.
+
+## 실측(PO Test Org db474a4e·772609ea po-verification-project, 2026-09-06 02:25Z)
+- org_members(db474a4e, sellerking) = role 'owner'·deleted_at NULL
+- projects(org db474a4e) = 1건 po-verification-project·deleted_at NULL
+- team_members(org db474a4e·이 user) = 0행
+- users.last_project_id = 772609ea(정확) — switch_organization의 first_accessible_project_id가
+  이미 맞는 project로 해소해 굳혀 놓았다.
+
+## 근본 원인
+`get_me()`가 JWT `app_metadata.project_id`로 1차 TeamMember 조회를 하는데, owner라서
+team_member 행이 아예 없으면(org 소유만으로 접근하는 형태) `member=None`이 되어
+org_members 기반 폴백(158행~)으로 떨어진다. 이 폴백은 `project_id`는 project_id_str
+그대로 채우지만(정확), 그 `return MeResponse(...)` 리터럴에 `project_name` 필드가 아예
+없어 스키마 기본값(None)이 조용히 나간다 — 일반 경로(`member.project.name`)는 이 폴백을
+안 타 무사했던 것뿐, project_name이 항상 null인 건 이 폴백 특유의 결함이었다.
+
+## 처방
+폴백에서 project_id_str이 실제 project를 가리킬 때만 Project를 1회 더 읽어 project_name을
+채운다(0-project org 폴백은 project_id_str이 애초에 없어 조회 안 함 — None 그대로가 맞다).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("35530000-0000-0000-0000-0000000001a1")  # owner뿐·team_member 0행(PO Test Org 표본)
+ORG_EMPTY = uuid.UUID("35530000-0000-0000-0000-0000000001b1")  # 0-project org(회귀 0 확인용)
+USER = uuid.UUID("35530000-0000-0000-0000-000000001111")
+OM = uuid.UUID("35530000-0000-0000-0000-0000000002a1")
+OM_EMPTY = uuid.UUID("35530000-0000-0000-0000-0000000002b1")
+PROJ = uuid.UUID("35530000-0000-0000-0000-000000003333")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM members WHERE org_id IN ('{ORG}','{ORG_EMPTY}')",
+        f"DELETE FROM org_members WHERE org_id IN ('{ORG}','{ORG_EMPTY}')",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id IN ('{ORG}','{ORG_EMPTY}')",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES "
+        f"('{ORG}','S3553Org','s3553-org','free'),('{ORG_EMPTY}','S3553EmptyOrg','s3553-org-empty','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{USER}','u@s3553.test','x','U',true,true,0,false,0)",
+        # ORG: owner인데 team_member 행 없음(PO Test Org 실측 그대로) — 프로젝트 1개.
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','owner')",
+        f"INSERT INTO members (id,org_id,type,user_id,name) VALUES "
+        f"('{OM}','{ORG}','human','{USER}','U')",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','PO Verification Project','s3553-proj','warn')",
+        # ORG_EMPTY: owner인데 project 자체가 0개 — project_id claim이 ""로 온다(회귀 0 대조군).
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM_EMPTY}','{ORG_EMPTY}','{USER}','owner')",
+        f"INSERT INTO members (id,org_id,type,user_id,name) VALUES "
+        f"('{OM_EMPTY}','{ORG_EMPTY}','human','{USER}','U')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+def _auth(org_id: uuid.UUID, project_id_str: str):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(USER), email="u@s3553.test",
+        claims={"app_metadata": {"org_id": str(org_id), "project_id": project_id_str}},
+        org_id=str(org_id),
+    )
+
+
+@pytest.mark.anyio
+async def test_owner_without_team_member_gets_project_name_from_fallback():
+    from app.routers.me import get_me
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            resp = await get_me(member_id=None, session=s, auth=_auth(ORG, str(PROJ)))
+
+        assert resp.role == "owner"
+        assert resp.project_id == PROJ
+        assert resp.project_name == "PO Verification Project", (
+            f"owner·team_member 0행 폴백이 project_id({resp.project_id})는 정확히 채우면서 "
+            f"project_name={resp.project_name!r}로 비어 있으면 #3553 그대로 재발 — 폴백 응답에 "
+            "project_name 필드가 없어 스키마 기본값(None)이 조용히 나가는 결함."
+        )
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_owner_zero_project_org_still_returns_none_project_name_no_regression():
+    """0-project org(project_id claim="")는 project_id_str이 애초에 없어 Project 조회를
+    안 한다 — project_name=None 그대로가 맞다(회귀 0 확인, #2873과 같은 축)."""
+    from app.routers.me import get_me
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            resp = await get_me(member_id=None, session=s, auth=_auth(ORG_EMPTY, ""))
+
+        assert resp.project_name is None
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## 요약
PO 라이브 재현(PO Test Org `db474a4e`·`772609ea` po-verification-project, 2026-09-06) — switch-org 뒤 owner(team_member 행 0, org 소유만으로 접근)인 유저가 `role=owner`는 정확히 받으면서 `project_name`만 `null`.

## (나) `me.py::get_me` — org_members 폴백에 `project_name` 필드 누락
JWT `project_id`(정확)로 1차 TeamMember 조회 → team_member 행이 없으면(owner뿐) org_members 폴백으로 떨어지는데, 그 `return MeResponse(...)` 리터럴에 `project_name`이 아예 없어 스키마 기본값(`None`)이 조용히 나갔다. `project_id_str`이 실제 project를 가리킬 때만 Project를 1회 더 읽어 채운다(0-project org 폴백은 조회 안 함 — `None` 그대로가 맞다).

## ① `auth.py::_build_app_metadata` — TeamMember 조회 2곳 `deleted_at` 정합
"last_project_id 우선"·"가장 오래된 team_member" 두 조회가 `projects` JOIN도 `deleted_at` 필터도 없어, 삭제된 project를 가리키는 team_member 행만 있는 유저가 그 죽은 project로 착지할 수 있었다. `first_accessible_project_id`(branch1)·`has_project_access`는 이미 `Project.deleted_at IS NULL`을 보는 것과 비대칭 — 0746과 같은 계열의 결함.

## 스코프 밖(PO 확定)
Path4(org_members 폴백, `org_id`가 아예 없는 최초 로그인류에서만 실행) — 트레이스 결과 이 경로 도달 시점엔 `org_id`가 항상 `None`(바로 위 0746 분기가 `org_id is not None` 케이스를 먼저 가로챔)이라 "org_id 가드"를 넣어도 no-op. 진짜 쟁점(org 문맥 없는 최초 로그인이 가장 오래된 멤버십을 고르는 설계)은 별도 논의로 story #3553 본문에 적어만 둠 — `users.last_org_id` 영속이 이후 refresh를 덮어써 오늘 행동엔 영향 없음.

## 검증(realdb, 로컬 postgres throwaway DB — CI와 동일 realdb 관례)
- `get_me` 폴백 회귀 2건: owner+프로젝트1 → `project_name` 실림 / 0-project org → `None` 유지(회귀 0). 뮤테이션(project_name 필드 제거) RED 확인 — PO 라이브 증상을 정확히 재현.
- `_build_app_metadata` 회귀 1건: 삭제된 project를 가리키는(가장 오래된) team_member를 무시하고 owner org-wide로 살아있는 project에 해소. 뮤테이션(JOIN·필터 제거) RED 확인.
- 기존 0746/908075db/2873 관련 테스트 14건 전부 그린(회귀 0).
- 무관 실패 2클러스터(`test_2223_backfill_script_db_url_fallback`·`test_s7_2_epic_dod`) 확인 — 미변경 origin/develop에서도 동일하게 실패(로컬 환경 이슈, 이 PR과 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)