### PR TITLE
[SID:3550] feat: Instagram 캐러셀(이미지 2~10장) BE — 저장·봉인·거부·발행

### DIFF
--- a/backend/alembic/versions/0343_channel_post_images_carousel_position.py
+++ b/backend/alembic/versions/0343_channel_post_images_carousel_position.py
@@ -1,0 +1,36 @@
+"""story #3550(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Instagram 캐러셀
+(이미지 2~10장) 저장 모델. `channel_post_images`의 `UniqueConstraint(version_id)`
+(버전당 이미지 1행 하드 제약, story 620beefc)를 완화해 버전당 N행을 허용하고,
+`position`(0..N-1) 컬럼으로 순서를 명시한다.
+
+봉인 축(`ChannelPostVersion.image_sha256`, `Gate.sealed_media_sha256`)은 이 마이그와
+무관 — 이미 있는 단일 Text 컬럼 그대로 두고, N장일 때는 그 컬럼에 "순서 포함 합성
+해시"(position 순으로 이어붙인 각 sha256을 재해시, N=1은 항등)를 담는다(디디 설계
+메모·PO 確定 안 A — Gate는 site_posts.py 등과 공유하는 테이블이라 스키마 변경
+반경을 이 스토리 스코프 밖으로 둔다)."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0343"
+down_revision = "0342"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_post_images",
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.drop_constraint("uq_channel_post_images_version", "channel_post_images", type_="unique")
+    op.create_unique_constraint(
+        "uq_channel_post_images_version_position", "channel_post_images", ["version_id", "position"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_channel_post_images_version_position", "channel_post_images", type_="unique")
+    op.create_unique_constraint("uq_channel_post_images_version", "channel_post_images", ["version_id"])
+    op.drop_column("channel_post_images", "position")

--- a/backend/app/models/channel_post_image.py
+++ b/backend/app/models/channel_post_image.py
@@ -1,6 +1,13 @@
 """story 620beefc(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — 채널 포스트 이미지
-원본+파생본 원장. `ChannelPostVersion`과 1:1(version_id UNIQUE, Phase1
-`image_max_count=1`) — 한 버전이 봉인하는 이미지는 최대 하나.
+원본+파생본 원장. Phase1은 `ChannelPostVersion`과 1:1(version_id UNIQUE,
+`image_max_count=1`)이었다 — 한 버전이 봉인하는 이미지는 최대 하나.
+
+story #3550(Phase2, 페드루 PO 確定 2026-09-06, 마이그 0343) — Instagram 캐러셀
+(2~10장) 지원으로 1:1 제약을 1:N(`UniqueConstraint(version_id, position)`)으로
+완화. `position`(0-indexed)이 순서를 명시 — 봉인 해시(`ChannelPostVersion.
+image_sha256`)는 이 순서대로 이어붙인 합성값(N=1은 항등, `channel_post_images.py
+::compute_image_seal_hash`)이라 순서 재배열도 이미지 바꿔치기와 동형으로 봉인을
+깬다(디디 설계 메모·PO 確定 안 A).
 
 원본은 항상 보존한다(계보, PO 決定 ③ "원본 보존 + 파생본 별도 행"). 파생본이 필요
 없었으면(원본이 이미 어댑터 규격 안) `derived_*`는 전부 None — "나가는(발행에 실제로
@@ -21,13 +28,16 @@ from app.core.database import Base
 class ChannelPostImage(Base):
     __tablename__ = "channel_post_images"
     __table_args__ = (
-        UniqueConstraint("version_id", name="uq_channel_post_images_version"),
+        UniqueConstraint("version_id", "position", name="uq_channel_post_images_version_position"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     draft_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     version_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    # story #3550(마이그 0343) — 0-indexed. 봉인 해시가 이 순서를 그대로 잠근다(§ 모듈
+    # docstring) — 재배열=바꿔치기와 동형으로 판정돼야 하므로 이 값을 신뢰의 SSOT로 쓴다.
+    position: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
 
     original_object_path: Mapped[str] = mapped_column(Text, nullable=False)
     original_sha256: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -66,6 +66,7 @@ from app.services.channel_post_images import (
     ChannelImageUnsupportedFormatError,
     ChannelImageUndecodableError,
     ChannelImageUploadFailedError,
+    ChannelPostImageCountExceededError,
     confirm_channel_post_image_upload,
     create_channel_post_image_upload_url,
     get_channel_post_image_for_version,
@@ -316,6 +317,9 @@ class ChannelPostImageResponse(BaseModel):
     final_bytes: int
     was_converted: bool
     image_url: str | None = None
+    # story #3550(Phase2, 페드루 PO 確定 2026-09-06) — 캐러셀 순서(0-indexed). FE
+    # 다중 슬롯 UI(별도 스토리)가 이 값으로 정렬·삭제 대상을 가른다.
+    position: int = 0
 
 
 class SubmitChannelPostDraftRequest(BaseModel):
@@ -424,6 +428,7 @@ def _image_response(version, image_row) -> ChannelPostImageResponse:
         final_width=image_row.final_width, final_height=image_row.final_height,
         final_bytes=image_row.final_bytes, was_converted=image_row.was_converted,
         image_url=public_url_for_object_path(image_row.final_object_path),
+        position=image_row.position,
     )
 
 
@@ -512,6 +517,17 @@ async def post_channel_post_image_confirm(
     except ChannelImageUnsupportedError as exc:
         raise HTTPException(
             status_code=422, detail={"code": "CHANNEL_IMAGE_UNSUPPORTED", "message": str(exc), "channel": exc.channel},
+        ) from exc
+    except ChannelPostImageCountExceededError as exc:
+        # story #3550(PO 確定 ③) — 어댑터 image_max_count 초과(예: Threads/Facebook
+        # 2번째 이미지, Instagram 11번째 이미지). 변환으로 못 고치는 축(ASPECT_RATIO_
+        # EXCEEDED·UNDECODABLE과 동형 판단) — 서버 거부.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_POST_IMAGE_COUNT_EXCEEDED", "message": str(exc),
+                "image_max_count": exc.image_max_count,
+            },
         ) from exc
     except ChannelImagePathNotScopedError as exc:
         raise HTTPException(status_code=403, detail={"code": "CHANNEL_IMAGE_PATH_NOT_SCOPED", "message": str(exc)}) from exc

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -314,6 +314,11 @@ class ReorderChannelPostImagesRequest(BaseModel):
 
 
 class ChannelPostImageResponse(BaseModel):
+    # story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — additive. 목록 응답이
+    # 이 id를 안 실으면 FE가 삭제(`DELETE .../assets/{image_id}`)·재정렬(`POST
+    # .../assets/reorder`의 image_ids)을 부를 대상을 아예 못 얻는다(대표 1장 단건
+    # 조회 계약은 무변경 — 이 필드가 추가돼도 그 엔드포인트 응답 모양은 그대로).
+    image_id: uuid.UUID
     draft_id: uuid.UUID
     version_id: uuid.UUID
     version: int
@@ -433,6 +438,7 @@ async def post_channel_post_draft_version(
 
 def _image_response(version, image_row) -> ChannelPostImageResponse:
     return ChannelPostImageResponse(
+        image_id=image_row.id,
         draft_id=version.draft_id, version_id=version.id, version=version.version,
         original_width=image_row.original_width, original_height=image_row.original_height,
         original_bytes=image_row.original_bytes,

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -67,10 +67,15 @@ from app.services.channel_post_images import (
     ChannelImageUndecodableError,
     ChannelImageUploadFailedError,
     ChannelPostImageCountExceededError,
+    ChannelPostImageNotFoundError,
+    ChannelPostImageReorderInvalidSetError,
     confirm_channel_post_image_upload,
     create_channel_post_image_upload_url,
+    delete_channel_post_image,
     get_channel_post_image_for_version,
+    list_channel_post_images_for_version,
     public_url_for_object_path,
+    reorder_channel_post_images,
 )
 from app.services.generation_budget import GenerationBudgetExceededError
 from app.services.member_resolver import resolve_member
@@ -300,6 +305,12 @@ class ChannelPostImageUploadUrlResponse(BaseModel):
 
 class ConfirmChannelPostImageUploadRequest(BaseModel):
     object_path: str
+
+
+class ReorderChannelPostImagesRequest(BaseModel):
+    # story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 부분 재정렬 불허·항상
+    # 전체 집합(현재 버전 이미지 id 전부, 새 순서 그대로)을 명시로 받는다.
+    image_ids: list[uuid.UUID]
 
 
 class ChannelPostImageResponse(BaseModel):
@@ -604,6 +615,103 @@ async def get_channel_post_image_for_version_endpoint(
     if image_row is None:
         raise HTTPException(status_code=404, detail={"code": "CHANNEL_POST_IMAGE_NOT_FOUND", "message": str(version_id)})
     return _image_response(version, image_row)
+
+
+@router.get(
+    "/{org_id}/channel-posts/drafts/{draft_id}/versions/{version_id}/assets",
+    response_model=list[ChannelPostImageResponse],
+)
+async def list_channel_post_images_for_version_endpoint(
+    org_id: uuid.UUID, draft_id: uuid.UUID, version_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[ChannelPostImageResponse]:
+    """story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 캐러셀 N장 전체를
+    position 순으로. 위 `.../asset`(단수, 대표 1장만 — 기존 FE 계약 무변경)과 별도
+    엔드포인트로 신설(FE N장 슬롯 UI가 이 목록으로 썸네일을 그리고 삭제·재정렬 대상
+    image_id를 얻는다, `list_channel_post_images_for_version` 서비스 함수 그대로 노출)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    version = (await db.execute(
+        select(ChannelPostVersion).where(
+            ChannelPostVersion.id == version_id, ChannelPostVersion.draft_id == draft_id,
+        )
+    )).scalar_one_or_none()
+    if version is None:
+        raise HTTPException(status_code=404, detail={"code": "CHANNEL_POST_VERSION_NOT_FOUND", "message": str(version_id)})
+
+    image_rows = await list_channel_post_images_for_version(db, version_id=version_id)
+    return [_image_response(version, row) for row in image_rows]
+
+
+@router.delete(
+    "/{org_id}/channel-posts/drafts/{draft_id}/assets/{image_id}",
+    response_model=list[ChannelPostImageResponse],
+)
+async def delete_channel_post_image_endpoint(
+    org_id: uuid.UUID, draft_id: uuid.UUID, image_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[ChannelPostImageResponse]:
+    """story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 이미지 1장 삭제.
+    attach(confirm)와 대칭축: 새 불변 버전을 만들어 반영한다(원본 행 삭제 X) —
+    #3291 승인 불변화 규율대로 이미지 집합 변화 자체가 재승인 트리거. 응답은
+    새 버전에 남은 이미지 전체(0장이면 빈 배열)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    member_id = uuid.UUID(auth.user_id)
+    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+
+    try:
+        new_version, remaining = await delete_channel_post_image(
+            db, org_id=org_id, draft_id=draft_id, image_id=image_id,
+            member_id=member_id, member_kind=actor_type,
+        )
+    except ChannelPostDraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail={"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(exc)}) from exc
+    except ChannelPostImageNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail={"code": "CHANNEL_POST_IMAGE_NOT_FOUND", "message": str(exc)},
+        ) from exc
+    return [_image_response(new_version, row) for row in remaining]
+
+
+@router.post(
+    "/{org_id}/channel-posts/drafts/{draft_id}/assets/reorder",
+    response_model=list[ChannelPostImageResponse],
+)
+async def reorder_channel_post_images_endpoint(
+    org_id: uuid.UUID, draft_id: uuid.UUID, body: ReorderChannelPostImagesRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[ChannelPostImageResponse]:
+    """story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 이미지 순서 재배열.
+    `image_ids`는 새 순서 그대로 **전체 집합**(부분 재정렬 불허). delete와 동형으로
+    새 불변 버전을 만들어 반영 — 순서 자체가 합성 해시 입력이라 재정렬도 재승인
+    트리거(#3291 규율)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    member_id = uuid.UUID(auth.user_id)
+    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+
+    try:
+        new_version, ordered = await reorder_channel_post_images(
+            db, org_id=org_id, draft_id=draft_id, image_ids=body.image_ids,
+            member_id=member_id, member_kind=actor_type,
+        )
+    except ChannelPostDraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail={"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(exc)}) from exc
+    except ChannelPostImageReorderInvalidSetError as exc:
+        raise HTTPException(
+            status_code=422, detail={"code": "CHANNEL_POST_IMAGE_REORDER_INVALID_SET", "message": str(exc)},
+        ) from exc
+    return [_image_response(new_version, row) for row in ordered]
 
 
 def _to_draft_list_item(

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -13,7 +13,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.channel_post_version import ChannelPostVersion
+from app.models.pm import Story
 from app.services.content_rules import get_org_content_rules, lint_content
+from app.services.project_auth import require_project_access
 from app.services.channel_posts import (
     ChannelConnectionNotActiveError,
     ChannelImageContainerFailedError,
@@ -652,6 +654,34 @@ async def list_channel_post_images_for_version_endpoint(
     return [_image_response(version, row) for row in image_rows]
 
 
+async def _require_channel_post_draft_project_access(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID, member_id: uuid.UUID,
+):
+    """story #3550 BE 2/2 authz 가드 후속(#3910 CI, test_authz_project_scope_coverage.py
+    ::test_no_new_unguarded_id_mutation_routes) — draft는 project-소속 리소스
+    (work_item_id→Story.project_id)라 org_id 일치만으로는 same-org cross-project
+    IDOR가 남는다(리소스 fetch가 project를 안 좁힘). 삭제·재정렬 둘 다 이 헬퍼로
+    통일(같은 리소스 축, 페드루 PO 明示) — `require_project_access`(project_auth.py
+    SSOT)가 실패 시 404(존재-비노출 관례). 반환값은 이후 서비스 호출이 재조회
+    없이 쓸 수 있게 draft 자체."""
+    not_found = HTTPException(
+        status_code=404, detail={"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(draft_id)},
+    )
+    draft = await get_channel_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise not_found
+    story = (await db.execute(
+        select(Story).where(Story.id == draft.work_item_id, Story.org_id == org_id)
+    )).scalar_one_or_none()
+    if story is None:
+        raise not_found
+    await require_project_access(
+        db, user_id=member_id, project_id=story.project_id, org_id=org_id,
+        not_found_detail={"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(draft_id)},
+    )
+    return draft
+
+
 @router.delete(
     "/{org_id}/channel-posts/drafts/{draft_id}/assets/{image_id}",
     response_model=list[ChannelPostImageResponse],
@@ -671,6 +701,8 @@ async def delete_channel_post_image_endpoint(
 
     member_id = uuid.UUID(auth.user_id)
     actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+
+    await _require_channel_post_draft_project_access(db, org_id=org_id, draft_id=draft_id, member_id=member_id)
 
     try:
         new_version, remaining = await delete_channel_post_image(
@@ -705,6 +737,8 @@ async def reorder_channel_post_images_endpoint(
 
     member_id = uuid.UUID(auth.user_id)
     actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+
+    await _require_channel_post_draft_project_access(db, org_id=org_id, draft_id=draft_id, member_id=member_id)
 
     try:
         new_version, ordered = await reorder_channel_post_images(

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -196,7 +196,11 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         image_width_min=320,
         image_width_max=1440,
         image_color_space="sRGB",
-        image_max_count=1,
+        # story #3550(Phase2, 페드루 PO 確定 2026-09-06) — 캐러셀 2~10장(Meta 문서
+        # 지식·⚠️미확認, 재확認 전 라이브 금지). 1→10 상향이 유일한 변경 — 규격(비율·
+        # 용량·해상도)은 장별로 그대로 각각 적용된다(channel_post_images.py의 검증이
+        # 이미지 1건 처리라 여러 번 호출되는 구조, 새 루프 불요).
+        image_max_count=10,
         supports_fetch_replies=True,
         supports_reply=True,
         reply_required_scope="instagram_business_manage_comments",
@@ -409,7 +413,9 @@ if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
         image_width_min=320,
         image_width_max=1440,
         image_color_space="sRGB",
-        image_max_count=1,
+        # story #3550 — 위 instagram과 동형 정정(1→10, sandbox가 실 provider보다
+        # 관대하면 안 된다는 기존 관례 그대로 같은 값 유지).
+        image_max_count=10,
         # 페드루 PO REQUIRED(2026-09-06, #3874 리뷰) — 위 instagram과 동형 정정
         # (impressions 폐기, views로 대체).
         insight_metrics=("views", "reach", "engagements"),

--- a/backend/app/services/channel_post_images.py
+++ b/backend/app/services/channel_post_images.py
@@ -162,6 +162,33 @@ class ChannelImageUploadFailedError(Exception):
         super().__init__(f"파생본 업로드 실패: {object_path}")
 
 
+class ChannelPostImageCountExceededError(Exception):
+    """story #3550(Phase2, 페드루 PO 確定 2026-09-06 ③) — 어댑터 `image_max_count`
+    초과 첨부 시도(예: Threads/Facebook은 여전히 1장, Instagram은 10장). 변환으로
+    못 고치는 축(ASPECT/UNDECODABLE과 동형 판단) — 서버가 명시 거부한다. 이 검사가
+    처음 생기기 前엔 `UniqueConstraint(version_id)`가 스키마 레벨에서 2번째 이미지
+    자체를 IntegrityError로 막아 이런 명시 코드가 필요 없었다(마이그 0343으로 그
+    제약이 (version_id, position)으로 완화되며 이 축이 새로 필요해졌다)."""
+
+    def __init__(self, *, image_max_count: int):
+        self.image_max_count = image_max_count
+        super().__init__(f"이미지는 최대 {image_max_count}장까지 첨부할 수 있습니다")
+
+
+def compute_image_seal_hash(ordered_final_sha256s: list[str]) -> str:
+    """story #3550(Phase2, 페드루 PO 確定 2026-09-06 ①) — `ChannelPostVersion.
+    image_sha256`(→`Gate.sealed_media_sha256`)에 담을 값. **N=1은 항등**(그 이미지의
+    sha256 그대로) — 이미 승인된 단일-이미지 게이트·버전이 이 스토리 배포 순간
+    "변조"로 뒤집히면 안 된다(기존 봉인 의미 무변경, PO 明示 못박음). N≥2부터
+    position 순으로 이어붙인 각 sha256 문자열을 그대로 합쳐 재해시 — 어느 한 장이
+    바뀌거나 두 장의 순서가 바뀌면 합성 입력 문자열 자체가 달라져 합성값도 달라진다
+    (「이미지 1장 바꿔치기」·「순서 재배열」 둘 다 승인 불변화 #3291 규율의 양성대조
+    통과 — 디디 설계 메모에서 실측 확認)."""
+    if len(ordered_final_sha256s) == 1:
+        return ordered_final_sha256s[0]
+    return hashlib.sha256("".join(ordered_final_sha256s).encode("utf-8")).hexdigest()
+
+
 def _require_bucket() -> str:
     if not CHANNEL_MEDIA_BUCKET:
         raise ChannelImageStorageNotConfiguredError()
@@ -298,6 +325,20 @@ async def confirm_channel_post_image_upload(
     if adapter is None or adapter.image_max_count <= 0:
         raise ChannelImageUnsupportedError(channel=draft.channel)
 
+    # story #3550(PO 確定 ③) — 개수 상한은 다운로드·디코드·변환(비용 큰 작업) 前에
+    # 즉시 거부한다(어차피 실패할 요청에 GCS 다운로드+PIL 변환을 낭비 안 함).
+    latest_for_count = (await db.execute(
+        select(ChannelPostVersion)
+        .where(ChannelPostVersion.draft_id == draft_id)
+        .order_by(ChannelPostVersion.version.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    existing_images: list[ChannelPostImage] = []
+    if latest_for_count is not None:
+        existing_images = await list_channel_post_images_for_version(db, version_id=latest_for_count.id)
+    if len(existing_images) >= adapter.image_max_count:
+        raise ChannelPostImageCountExceededError(image_max_count=adapter.image_max_count)
+
     bucket = _require_bucket()
     expected_prefix = f"channel-media/{org_id}/{draft_id}/"
     if not object_path.startswith(expected_prefix) or "/" in object_path[len(expected_prefix):]:
@@ -373,23 +414,44 @@ async def confirm_channel_post_image_upload(
 
     final_sha256 = derived_sha256 or original_sha256
 
-    latest = (await db.execute(
-        select(ChannelPostVersion)
-        .where(ChannelPostVersion.draft_id == draft_id)
-        .order_by(ChannelPostVersion.version.desc())
-        .limit(1)
-    )).scalar_one_or_none()
+    latest = latest_for_count
     if latest is None:
         raise ChannelPostDraftNotFoundError(draft_id)
+
+    # story #3550(PO 確定 ①) — 기존(=carry-forward 대상) 이미지들의 sha256 + 이번에
+    # 새로 붙는 이미지의 sha256을 position 순으로 이어 합성 봉인 해시를 만든다. N=1
+    # (existing_images가 0장이던 첫 첨부)이면 compute_image_seal_hash가 항등을 돌려줘
+    # Phase1 단일-이미지 봉인 의미와 완전히 같다(회귀 0).
+    new_position = len(existing_images)
+    ordered_hashes = [img.final_sha256 for img in existing_images] + [final_sha256]
+    composite_sha256 = compute_image_seal_hash(ordered_hashes)
 
     new_version, _channel, _violations = await create_channel_post_draft_version(
         db, org_id=org_id, work_item_id=draft.work_item_id, connection_id=draft.connection_id,
         text=latest.text, link_url=latest.link_url,
-        author_member_id=member_id, author_kind=member_kind, image_sha256=final_sha256,
+        author_member_id=member_id, author_kind=member_kind, image_sha256=composite_sha256,
     )
 
+    # story #3550(PO 確定 ②) — create_channel_post_draft_version()의 자체 carry-forward
+    # 훅(image_sha256이 sentinel일 때만 발동)은 여기서 안 탄다(위에서 합성값을 명시로
+    # 넘겼으므로) — 기존 이미지 행들을 새 version_id로 직접 복제한다(파일 재업로드·
+    # 재변환 없음, object_path·sha256·position 그대로 — 단일 이미지 carry-forward
+    # 패턴(channel_posts.py::create_channel_post_draft_version)을 N장으로 그대로 확장).
+    for existing in existing_images:
+        db.add(ChannelPostImage(
+            id=uuid.uuid4(), org_id=existing.org_id, draft_id=existing.draft_id,
+            version_id=new_version.id, position=existing.position,
+            original_object_path=existing.original_object_path, original_sha256=existing.original_sha256,
+            original_content_type=existing.original_content_type, original_bytes=existing.original_bytes,
+            original_width=existing.original_width, original_height=existing.original_height,
+            derived_object_path=existing.derived_object_path, derived_sha256=existing.derived_sha256,
+            derived_content_type=existing.derived_content_type, derived_bytes=existing.derived_bytes,
+            derived_width=existing.derived_width, derived_height=existing.derived_height,
+            created_by=existing.created_by,
+        ))
+
     image_row = ChannelPostImage(
-        id=uuid.uuid4(), org_id=org_id, draft_id=draft_id, version_id=new_version.id,
+        id=uuid.uuid4(), org_id=org_id, draft_id=draft_id, version_id=new_version.id, position=new_position,
         original_object_path=object_path, original_sha256=original_sha256,
         original_content_type=original_mime, original_bytes=size,
         original_width=width, original_height=height,
@@ -413,6 +475,24 @@ def public_url_for_object_path(object_path: str) -> str | None:
 async def get_channel_post_image_for_version(
     db: AsyncSession, *, version_id: uuid.UUID,
 ) -> ChannelPostImage | None:
+    """story #3550 — N장(캐러셀) 버전에서도 안 죽게 position=0(첫 장)만 대표로
+    돌려준다. 이 함수·`GET .../asset` 엔드포인트의 단일-이미지 계약은 무변경(FE
+    다중 슬롯 UI는 별도 스토리, PO 明示 — 마이그 0343 前엔 `.scalar_one_or_none()`
+    이었으나 그 제약(UNIQUE(version_id))이 완화된 지금 N>1에 그대로 두면
+    MultipleResultsFound로 죽는다)."""
     return (await db.execute(
         select(ChannelPostImage).where(ChannelPostImage.version_id == version_id)
-    )).scalar_one_or_none()
+        .order_by(ChannelPostImage.position).limit(1)
+    )).scalars().first()
+
+
+async def list_channel_post_images_for_version(
+    db: AsyncSession, *, version_id: uuid.UUID,
+) -> list[ChannelPostImage]:
+    """story #3550 — 캐러셀 소비부(발행 오케스트레이션·carry-forward·봉인 재계산)용
+    position 순 전체 목록. `get_channel_post_image_for_version`(단일, FE 기존 계약)
+    과 별도 함수로 분리 — 호출부가 "대표 1장"과 "전체 N장"을 헷갈리지 않게."""
+    return list((await db.execute(
+        select(ChannelPostImage).where(ChannelPostImage.version_id == version_id)
+        .order_by(ChannelPostImage.position)
+    )).scalars().all())

--- a/backend/app/services/channel_post_images.py
+++ b/backend/app/services/channel_post_images.py
@@ -175,6 +175,24 @@ class ChannelPostImageCountExceededError(Exception):
         super().__init__(f"이미지는 최대 {image_max_count}장까지 첨부할 수 있습니다")
 
 
+class ChannelPostImageNotFoundError(Exception):
+    """story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 삭제 대상 image_id가
+    이 draft 최신 버전의 이미지 집합에 없음(이미 삭제됐거나 다른 draft 소속 등)."""
+
+    def __init__(self, *, image_id: uuid.UUID):
+        self.image_id = image_id
+        super().__init__(f"이미지를 찾을 수 없습니다: {image_id}")
+
+
+class ChannelPostImageReorderInvalidSetError(Exception):
+    """전달된 image_ids 집합이 최신 버전의 실제 이미지 집합과 정확히 일치하지 않음
+    (누락·중복·다른 버전/미존재 id 포함 등) — 부분 재정렬은 허용하지 않는다("나머지는
+    그대로"라는 암묵 규칙을 두지 않기 위해 항상 전체 집합을 명시로 받는다)."""
+
+    def __init__(self):
+        super().__init__("image_ids가 현재 이미지 집합과 정확히 일치해야 합니다(누락·중복·불일치 없이)")
+
+
 def compute_image_seal_hash(ordered_final_sha256s: list[str]) -> str:
     """story #3550(Phase2, 페드루 PO 確定 2026-09-06 ①) — `ChannelPostVersion.
     image_sha256`(→`Gate.sealed_media_sha256`)에 담을 값. **N=1은 항등**(그 이미지의
@@ -438,17 +456,7 @@ async def confirm_channel_post_image_upload(
     # 재변환 없음, object_path·sha256·position 그대로 — 단일 이미지 carry-forward
     # 패턴(channel_posts.py::create_channel_post_draft_version)을 N장으로 그대로 확장).
     for existing in existing_images:
-        db.add(ChannelPostImage(
-            id=uuid.uuid4(), org_id=existing.org_id, draft_id=existing.draft_id,
-            version_id=new_version.id, position=existing.position,
-            original_object_path=existing.original_object_path, original_sha256=existing.original_sha256,
-            original_content_type=existing.original_content_type, original_bytes=existing.original_bytes,
-            original_width=existing.original_width, original_height=existing.original_height,
-            derived_object_path=existing.derived_object_path, derived_sha256=existing.derived_sha256,
-            derived_content_type=existing.derived_content_type, derived_bytes=existing.derived_bytes,
-            derived_width=existing.derived_width, derived_height=existing.derived_height,
-            created_by=existing.created_by,
-        ))
+        db.add(_copy_image_row(existing, new_version_id=new_version.id, new_position=existing.position))
 
     image_row = ChannelPostImage(
         id=uuid.uuid4(), org_id=org_id, draft_id=draft_id, version_id=new_version.id, position=new_position,
@@ -496,3 +504,116 @@ async def list_channel_post_images_for_version(
         select(ChannelPostImage).where(ChannelPostImage.version_id == version_id)
         .order_by(ChannelPostImage.position)
     )).scalars().all())
+
+
+def _copy_image_row(existing: ChannelPostImage, *, new_version_id: uuid.UUID, new_position: int) -> ChannelPostImage:
+    """attach(confirm_channel_post_image_upload)·delete·reorder 셋이 공유하는 유일한
+    행 복제 지점(계보 필드 나열이 세 곳에서 각자 드리프트하지 않게 — 파일 재업로드·
+    재변환 없음, object_path·sha256는 그대로 복제)."""
+    return ChannelPostImage(
+        id=uuid.uuid4(), org_id=existing.org_id, draft_id=existing.draft_id,
+        version_id=new_version_id, position=new_position,
+        original_object_path=existing.original_object_path, original_sha256=existing.original_sha256,
+        original_content_type=existing.original_content_type, original_bytes=existing.original_bytes,
+        original_width=existing.original_width, original_height=existing.original_height,
+        derived_object_path=existing.derived_object_path, derived_sha256=existing.derived_sha256,
+        derived_content_type=existing.derived_content_type, derived_bytes=existing.derived_bytes,
+        derived_width=existing.derived_width, derived_height=existing.derived_height,
+        created_by=existing.created_by,
+    )
+
+
+async def delete_channel_post_image(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID, image_id: uuid.UUID,
+    member_id: uuid.UUID, member_kind: str,
+) -> tuple[ChannelPostVersion, list[ChannelPostImage]]:
+    """story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 이미지 1장 삭제.
+    attach와 대칭축: 원본 행을 지우지 않고 **새 불변 버전**을 만들어 나머지 이미지를
+    position 0..N-2로 재부여+복제하고 합성 해시를 재계산한다(#3291 승인 불변화
+    규율 — 이미지 집합이 바뀌면 그 자체가 재승인 트리거, delete도 attach와 동형).
+    남는 이미지가 0장이면 image_sha256=None(첫 draft의 "이미지 없음" 상태와 동일 —
+    compute_image_seal_hash에 빈 리스트를 주지 않는다, sha256("")은 그 의미가 아니다)."""
+    draft = await get_channel_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise ChannelPostDraftNotFoundError(draft_id)
+
+    latest = (await db.execute(
+        select(ChannelPostVersion)
+        .where(ChannelPostVersion.draft_id == draft_id)
+        .order_by(ChannelPostVersion.version.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    existing_images = await list_channel_post_images_for_version(db, version_id=latest.id) if latest else []
+    remaining = [img for img in existing_images if img.id != image_id]
+    if len(remaining) == len(existing_images):
+        raise ChannelPostImageNotFoundError(image_id=image_id)
+
+    composite_sha256 = (
+        compute_image_seal_hash([img.final_sha256 for img in remaining]) if remaining else None
+    )
+
+    new_version, _channel, _violations = await create_channel_post_draft_version(
+        db, org_id=org_id, work_item_id=draft.work_item_id, connection_id=draft.connection_id,
+        text=latest.text, link_url=latest.link_url,
+        author_member_id=member_id, author_kind=member_kind, image_sha256=composite_sha256,
+    )
+
+    new_rows = [
+        _copy_image_row(existing, new_version_id=new_version.id, new_position=position)
+        for position, existing in enumerate(remaining)
+    ]
+    for row in new_rows:
+        db.add(row)
+    await db.commit()
+    for row in new_rows:
+        await db.refresh(row)
+    return new_version, new_rows
+
+
+async def reorder_channel_post_images(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID, image_ids: list[uuid.UUID],
+    member_id: uuid.UUID, member_kind: str,
+) -> tuple[ChannelPostVersion, list[ChannelPostImage]]:
+    """story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 이미지 순서 재배열.
+    `image_ids`는 새 순서 그대로 **전체 집합**(현재 버전의 이미지 id 전부, 누락·중복
+    ·불일치 없이)을 받는다(부분 재정렬 불허). delete와 동형으로 새 버전을 만들어
+    반영 — 순서 자체가 합성 해시 입력이라 재정렬도 재승인 트리거(#3291 규율,
+    compute_image_seal_hash 모듈 docstring의 "순서 재배열도 바꿔치기와 동형" 그대로)."""
+    draft = await get_channel_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise ChannelPostDraftNotFoundError(draft_id)
+
+    latest = (await db.execute(
+        select(ChannelPostVersion)
+        .where(ChannelPostVersion.draft_id == draft_id)
+        .order_by(ChannelPostVersion.version.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    existing_images = await list_channel_post_images_for_version(db, version_id=latest.id) if latest else []
+    existing_by_id = {img.id: img for img in existing_images}
+    if (
+        len(image_ids) != len(existing_images)
+        or len(set(image_ids)) != len(image_ids)
+        or set(image_ids) != set(existing_by_id.keys())
+    ):
+        raise ChannelPostImageReorderInvalidSetError()
+
+    ordered = [existing_by_id[image_id] for image_id in image_ids]
+    composite_sha256 = compute_image_seal_hash([img.final_sha256 for img in ordered])
+
+    new_version, _channel, _violations = await create_channel_post_draft_version(
+        db, org_id=org_id, work_item_id=draft.work_item_id, connection_id=draft.connection_id,
+        text=latest.text, link_url=latest.link_url,
+        author_member_id=member_id, author_kind=member_kind, image_sha256=composite_sha256,
+    )
+
+    new_rows = [
+        _copy_image_row(existing, new_version_id=new_version.id, new_position=position)
+        for position, existing in enumerate(ordered)
+    ]
+    for row in new_rows:
+        db.add(row)
+    await db.commit()
+    for row in new_rows:
+        await db.refresh(row)
+    return new_version, new_rows

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -498,13 +498,16 @@ async def create_channel_post_draft_version(
     # 새 version_id로 복제한다 — 파일 재업로드·재변환 없음(object_path·sha256 그대로,
     # 계보만 이어붙임).
     if image_sha256 is _IMAGE_SHA256_CARRY_FORWARD and prior_latest is not None:
-        prior_image = (await db.execute(
-            select(ChannelPostImage).where(ChannelPostImage.version_id == prior_latest.id)
-        )).scalar_one_or_none()
-        if prior_image is not None:
+        # story #3550(Phase2, PO 確定 ②) — 캐러셀(N장)로 확장: 직전 버전에 이미지가
+        # 여러 장이면(position 0..N-1) 전부 복제한다. Phase1(N=1)엔 이 루프가 정확히
+        # 1회 도는 것과 동형(회귀 0).
+        from app.services.channel_post_images import list_channel_post_images_for_version
+
+        prior_images = await list_channel_post_images_for_version(db, version_id=prior_latest.id)
+        for prior_image in prior_images:
             db.add(ChannelPostImage(
                 id=uuid.uuid4(), org_id=prior_image.org_id, draft_id=prior_image.draft_id,
-                version_id=version.id,
+                version_id=version.id, position=prior_image.position,
                 original_object_path=prior_image.original_object_path,
                 original_sha256=prior_image.original_sha256,
                 original_content_type=prior_image.original_content_type,
@@ -519,6 +522,7 @@ async def create_channel_post_draft_version(
                 derived_height=prior_image.derived_height,
                 created_by=prior_image.created_by,
             ))
+        if prior_images:
             await db.flush()
 
     await _reseal_gate_on_new_version(
@@ -1182,21 +1186,24 @@ async def publish_channel_post_draft(
     if existing is not None and existing.status == "published":
         return existing
 
-    # story 620beefc(AC5) — 이 버전에 이미지가 붙어 있으면 IMAGE 컨테이너 경로(비동기),
-    # 아니면 기존 TEXT 경로(동기, 완전 무변경). 이미지 유무는 channel_post_images 행
-    # (버전당 1건, Phase1)의 존재로 판단 — latest.image_sha256만으로는 「나가는 파생본」
-    # 경로를 못 구하므로 행 자체를 조회한다.
-    image_public_url: str | None = None
+    # story 620beefc(AC5)·#3550(캐러셀 확장) — 이 버전에 이미지가 붙어 있으면 IMAGE
+    # (또는 CAROUSEL) 컨테이너 경로(비동기), 아니면 기존 TEXT 경로(동기, 완전 무변경).
+    # 이미지 유무·장수는 channel_post_images 행(position 순, N=1이면 Phase1과 동형)의
+    # 존재로 판단 — latest.image_sha256만으로는 「나가는 파생본」 경로를 못 구하므로
+    # 행 자체를 조회한다.
+    image_public_urls: list[str] = []
     if latest.image_sha256 is not None:
-        from app.models.channel_post_image import ChannelPostImage
-        from app.services.channel_post_images import public_url_for_object_path
+        from app.services.channel_post_images import list_channel_post_images_for_version, public_url_for_object_path
 
-        image_row = (await db.execute(
-            select(ChannelPostImage).where(ChannelPostImage.version_id == latest.id)
-        )).scalar_one_or_none()
-        if image_row is not None:
-            image_public_url = public_url_for_object_path(image_row.final_object_path)
-    has_image = image_public_url is not None
+        image_rows = await list_channel_post_images_for_version(db, version_id=latest.id)
+        image_public_urls = [
+            url for row in image_rows if (url := public_url_for_object_path(row.final_object_path)) is not None
+        ]
+    has_image = len(image_public_urls) > 0
+    # 기존 단일-이미지 호출부(threads/facebook/sandbox 등 — 전부 image_max_count<=1이라
+    # 여기까지 2장 이상으로 도달할 수 없다, confirm_channel_post_image_upload의 업로드
+    # 시점 거부가 이미 막는다)와의 하위호환 — image_url은 항상 "첫 장"(N=0이면 None).
+    image_public_url: str | None = image_public_urls[0] if image_public_urls else None
 
     # 발행 직전 재검증③(연결 활성) — 초안 생성/상신과 같은 헬퍼.
     connection = await _get_active_connection(db, org_id=org_id, connection_id=draft.connection_id)
@@ -1332,10 +1339,30 @@ async def publish_channel_post_draft(
             just_created_container = row.external_container_id is None
             if just_created_container:
                 try:
-                    container_id = await create_container(
-                        client, access_token=access_token, threads_user_id=connection.account_id,
-                        text=text_to_post, image_url=image_public_url,
-                    )
+                    if len(image_public_urls) > 1:
+                        # story #3550(Phase2, PO 確定 ④) — 캐러셀(2장 이상)은 별도
+                        # 함수(instagram_publish.py::create_carousel_container류) —
+                        # image_max_count<=1인 채널(threads/facebook/sandbox 등)은
+                        # confirm_channel_post_image_upload가 업로드 시점에 이미
+                        # 2번째 이미지를 거부해 여기 이 분기에 절대 안 온다. 그래도
+                        # 그 어댑터가 create_carousel_container를 안 구현했으면
+                        # (미확認 방어) 조용히 image_url=1장짜리로 새는 대신 명시 실패.
+                        create_carousel_container = getattr(_publish_client, "create_carousel_container", None)
+                        if create_carousel_container is None:
+                            raise ThreadsPublishError(
+                                "CHANNEL_CAROUSEL_UNSUPPORTED",
+                                f"{draft.channel} 채널은 이미지 2장 이상(캐러셀)을 지원하지 않습니다",
+                                status_code=422,
+                            )
+                        container_id = await create_carousel_container(
+                            client, access_token=access_token, threads_user_id=connection.account_id,
+                            text=text_to_post, image_urls=image_public_urls,
+                        )
+                    else:
+                        container_id = await create_container(
+                            client, access_token=access_token, threads_user_id=connection.account_id,
+                            text=text_to_post, image_url=image_public_url,
+                        )
                 except ThreadsPublishError as exc:
                     error_code, mapped_exc = _classify_threads_error(exc, connection_id=connection.id)
                     row.status = "failed"

--- a/backend/app/services/instagram_publish.py
+++ b/backend/app/services/instagram_publish.py
@@ -52,11 +52,12 @@ async def create_container(
     client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
     image_url: str | None = None,
 ) -> str:
-    """미디어 컨테이너 생성 → creation_id. IG는 이미지 필수(피드 이미지 1장, 캐러셀/
-    릴스는 조각① 스코프 밖 — 그라운딩 확認) — `image_url`이 None이면(Threads의
-    TEXT-only 경로와 달리) 호출부가 이미지 없는 초안을 여기까지 보내면 안 된다는
-    뜻이라 즉시 거부한다(사일런트 미디어 없는 컨테이너를 만들지 않는다). `text`는
-    캡션(`caption` 파라미터명 — Threads의 `text`와 다름, IG 실 파라미터명)."""
+    """미디어 컨테이너 생성 → creation_id(이미지 1장 전용, 단일-이미지 피드). 캐러셀
+    (2장 이상)은 `create_carousel_container`(아래, story #3550) — 릴스는 여전히
+    스코프 밖. `image_url`이 None이면(Threads의 TEXT-only 경로와 달리) 호출부가
+    이미지 없는 초안을 여기까지 보내면 안 된다는 뜻이라 즉시 거부한다(사일런트
+    미디어 없는 컨테이너를 만들지 않는다). `text`는 캡션(`caption` 파라미터명 —
+    Threads의 `text`와 다름, IG 실 파라미터명)."""
     if image_url is None:
         raise ThreadsPublishError(
             "INSTAGRAM_IMAGE_REQUIRED", "Instagram 발행은 이미지가 필수입니다(피드 이미지 1장)", status_code=422,
@@ -74,6 +75,59 @@ async def create_container(
     if not creation_id:
         raise ThreadsPublishError(
             "INSTAGRAM_CREATE_CONTAINER_MISSING_ID", "id missing in response", status_code=resp.status_code,
+        )
+    return str(creation_id)
+
+
+async def create_carousel_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str, image_urls: list[str],
+) -> str:
+    """story #3550(Phase2, 페드루 PO 確定 2026-09-06 ④) — 캐러셀(2장 이상) 발행.
+    자식 컨테이너 N개(각 `is_carousel_item=true`)를 순서대로 먼저 만들고, 부모
+    컨테이너 1개(`media_type=CAROUSEL`, `children=`자식id 콤마join)를 만들어 그
+    creation_id를 반환한다 — 오케스트레이션(channel_posts.py)은 이 반환값을 기존
+    단일-이미지 creation_id와 완전히 동일하게 취급한다(get_container_status·
+    publish_container 무변경, 부모 id 하나만 알면 되는 계약이라).
+
+    **원자성**(그라운딩 §·PO 明示) — 자식 하나라도 실패하면 그 자리에서 즉시 예외를
+    던진다(부모 컨테이너를 아예 안 만든다). 호출부의 기존 실패 처리(row.status=
+    "failed", 재시도 큐)가 그대로 "부분 발행 0"을 보장한다 — 이 함수 안에 별도
+    롤백 로직 불요(부모가 없으면 그 자식들은 Meta 쪽에도 고아 컨테이너로만 남고
+    피드에 절대 안 뜬다, 발행이 아니라 준비 단계라 사용자에게 보이는 결과 없음).
+
+    ⚠️미확認(instagram_publish.py 상단 딱지와 동형 — 컨테이너 파라미터명은 Meta
+    문서 지식, 재확認 전 라이브 왕복 금지)."""
+    child_ids: list[str] = []
+    for image_url in image_urls:
+        resp = await client.post(
+            _MEDIA_CONTAINER_URL_TMPL.format(ig_user_id=threads_user_id),
+            params={"access_token": access_token, "image_url": image_url, "is_carousel_item": "true"},
+        )
+        if resp.status_code != 200:
+            raise ThreadsPublishError(
+                "INSTAGRAM_CREATE_CAROUSEL_CHILD_FAILED", resp.text[:500], status_code=resp.status_code,
+            )
+        child_body = resp.json()
+        child_id = child_body.get("id")
+        if not child_id:
+            raise ThreadsPublishError(
+                "INSTAGRAM_CREATE_CAROUSEL_CHILD_MISSING_ID", "id missing in response", status_code=resp.status_code,
+            )
+        child_ids.append(str(child_id))
+
+    params = {"access_token": access_token, "media_type": "CAROUSEL", "children": ",".join(child_ids)}
+    if text:
+        params["caption"] = text
+    resp = await client.post(_MEDIA_CONTAINER_URL_TMPL.format(ig_user_id=threads_user_id), params=params)
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "INSTAGRAM_CREATE_CAROUSEL_PARENT_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    creation_id = body.get("id")
+    if not creation_id:
+        raise ThreadsPublishError(
+            "INSTAGRAM_CREATE_CAROUSEL_PARENT_MISSING_ID", "id missing in response", status_code=resp.status_code,
         )
     return str(creation_id)
 

--- a/backend/app/services/instagram_sandbox_publish.py
+++ b/backend/app/services/instagram_sandbox_publish.py
@@ -51,6 +51,33 @@ async def create_container(
     return f"sandbox-ig-creation-{uuid.uuid4().hex}"
 
 
+async def create_carousel_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str, image_urls: list[str],
+) -> str:
+    """story #3550(Phase2, 페드루 PO 確定 2026-09-06) — instagram_publish.py::
+    create_carousel_container와 동형 계약(결정적·상태 없음). 자식 N번째 실패
+    마커(1-indexed) — `[sandbox:carousel-child-{n}-failed]`를 text에 심으면 그
+    번째 자식에서 예외를 던져 부모 컨테이너가 아예 안 만들어진다(원자성 재현,
+    「자식 하나 실패=부모도 실패」는 실측 아님·Meta 문서 지식 가정)."""
+    if _MARKER_429 in text:
+        raise ThreadsPublishError("SANDBOX_INSTAGRAM_RATE_LIMITED", "sandbox: [sandbox:429] 마커 시뮬레이션", status_code=429)
+    if _MARKER_PROVIDER_ERROR in text:
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_PROVIDER_ERROR", "sandbox: [sandbox:provider-error] 마커 시뮬레이션", status_code=502,
+        )
+    if _MARKER_EXPIRED_TOKEN in text:
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_TOKEN_EXPIRED", "sandbox: [sandbox:expired-token] 마커 시뮬레이션", status_code=401,
+        )
+    for index, _image_url in enumerate(image_urls, start=1):
+        marker = f"[sandbox:carousel-child-{index}-failed]"
+        if marker in text:
+            raise ThreadsPublishError(
+                "SANDBOX_INSTAGRAM_CAROUSEL_CHILD_FAILED", f"sandbox: {marker} 마커 시뮬레이션", status_code=502,
+            )
+    return f"sandbox-ig-carousel-{uuid.uuid4().hex}"
+
+
 async def get_container_status(
     client: httpx.AsyncClient, *, access_token: str, creation_id: str,
 ) -> tuple[str, str | None]:

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -110,6 +110,12 @@ ID_MUTATION_PROJECT_GUARDS: frozenset[str] = frozenset(PROJECT_GUARD_FUNCTIONS -
     # project 접근권을 검증하던 동일 IDOR 경계를 delete_asset(신규 DELETE)이 재사용한다 — 이름이
     # assets.py 에만 있음을 확인 후 편입(grep 0건, 타 모듈 동명 함수와 충돌 리스크 없음).
     "_scope_filter",
+    # story #3550 BE 2/2(2026-09-06, #3910 CI 후속) — channel_posts.py 모듈-로컬 헬퍼
+    # (assets.py::_scope_filter와 동형 편입 사유). draft(work_item_id→Story.project_id)
+    # 선조회 뒤 `require_project_access`를 실제로 호출한다(delete_channel_post_image_
+    # endpoint·reorder_channel_post_images_endpoint 둘 다 공유) — 이름이 channel_posts.py
+    # 에만 있음을 확인 후 편입(grep 0건, 타 모듈 동명 함수와 충돌 리스크 없음).
+    "_require_channel_post_draft_project_access",
 }
 
 # Depends(...) 콜러블 — 결과 id가 caller auth에서 서버-파생돼 클라이언트가 스푸핑할 여지가

--- a/backend/tests/test_3550_instagram_carousel.py
+++ b/backend/tests/test_3550_instagram_carousel.py
@@ -1,0 +1,514 @@
+"""story #3550(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Instagram 캐러셀(이미지
+2~10장). PO 못박음 4가지:
+① N=1 항등 — 이미 봉인된 단일-이미지 버전이 이 스토리로 "변조" 판정되면 안 된다.
+② 저장 구조 — UNIQUE(version_id, position)·순서 재배열도 바꿔치기와 동형으로 봉인을
+   깬다.
+③ N > image_max_count 거부는 서버(422 CHANNEL_POST_IMAGE_COUNT_EXCEEDED).
+④ Instagram 캐러셀 컨테이너(부모+children) — sandbox 어댑터 동형 선언·자식 실패=
+   원자성(부모 0건).
+
+세팅 헬퍼는 test_620beefc_channel_post_image.py 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.test_620beefc_channel_post_image import (
+    _client_for,
+    _create_draft,
+    _jpeg_bytes,
+    _seed_connection,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+    _upload_and_confirm,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+_CHANNEL_MEDIA_BUCKET = "test-channel-media-3550"
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage(monkeypatch, tmp_path):
+    """test_620beefc_channel_post_image.py의 동형 픽스처(중복 재발명 대신 이 파일도
+    같은 기법 — 다른 버킷명으로 격리)."""
+    import app.services.channel_post_images as cpi_module
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage_object_path_fix(monkeypatch):
+    """test_620beefc의 `_put_raw_object`/`_object_path_for`가 모듈 상수
+    `_CHANNEL_MEDIA_BUCKET`(그 파일 자체)을 쓰므로, 이 파일에서 재사용할 때도 같은
+    이름의 버킷이어야 앞뒤가 맞는다 — 두 파일이 같은 상수명을 각자 갖되 여기서는
+    import한 헬퍼가 그 파일의 전역을 참조하므로, monkeypatch로 그 값을 이 파일의
+    버킷명과 맞춘다."""
+    import tests.test_620beefc_channel_post_image as base_test_module
+
+    monkeypatch.setattr(base_test_module, "_CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _instagram_sandbox_ten_images(monkeypatch):
+    """story #3320 test 파일의 `_enable_sandbox_flag`와 동형 — 이미 등재돼 있을 수도
+    없을 수도 있는 조건부 블록(SANDBOX_CHANNEL_ENABLED, 모듈 import 시점 1회 평가)에
+    기대지 않고 이 테스트 파일이 필요로 하는 정확한 값(image_max_count=10)을 직접
+    주입한다(import 순서 무관하게 결정적)."""
+    import app.services.channel_adapters as adapters_mod
+
+    ig_sandbox_cfg = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual", credential_kind="none", display_name="Instagram Sandbox",
+        max_text_length=2200, utm_source="instagram_sandbox", utm_medium="test",
+        image_formats=("image/jpeg",), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91, image_aspect_min=0.8,
+        image_width_min=320, image_width_max=1440, image_color_space="sRGB",
+        image_max_count=10,
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "instagram_sandbox", ig_sandbox_cfg)
+    yield
+
+
+async def _upload_n_images(client, org_id, draft_id, n: int, *, size=(800, 1000)):
+    """n장을 순서대로 업로드·confirm한다. 각 confirm 응답을 리스트로 반환."""
+    responses = []
+    for i in range(n):
+        raw = _jpeg_bytes(*size, color=(10 * i, 50, 80))
+        r = await _upload_and_confirm(client, org_id, draft_id, raw, content_type="image/jpeg")
+        responses.append(r)
+    return responses
+
+
+# ─── ① N=1 항등 ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_single_image_seal_hash_is_identity_not_a_hash_of_hash():
+    """페드루 PO 못박음① — N=1이면 ChannelPostVersion.image_sha256이 그 이미지의
+    final_sha256과 정확히 같아야 한다(합성 해시를 한 번 더 씌우면 안 됨 — 기존
+    승인된 단일-이미지 게이트가 이 스토리 배포로 「변조」로 뒤집히는 회귀)."""
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from app.models.channel_post_version import ChannelPostVersion
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            [r1] = await _upload_n_images(client, org_id, draft_id, 1)
+        assert r1.status_code == 201, r1.text
+        assert r1.json()["position"] == 0
+
+        async with Session() as s:
+            version = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+                .order_by(ChannelPostVersion.version.desc()).limit(1)
+            )).scalar_one()
+            image = (await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == version.id)
+            )).scalar_one()
+        assert version.image_sha256 == image.final_sha256, "N=1인데 합성 해시가 씌워졌다(항등 위반)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ② 저장 구조 — position·합성 해시·양성대조(바꿔치기·재배열) ────────────────
+
+
+@pytest.mark.anyio
+async def test_three_images_get_sequential_positions_and_composite_seal_hash():
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.services.channel_post_images import compute_image_seal_hash
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r1, r2, r3 = await _upload_n_images(client, org_id, draft_id, 3)
+        for r in (r1, r2, r3):
+            assert r.status_code == 201, r.text
+        assert [r.json()["position"] for r in (r1, r2, r3)] == [0, 1, 2]
+
+        async with Session() as s:
+            latest_version = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+                .order_by(ChannelPostVersion.version.desc()).limit(1)
+            )).scalar_one()
+            images = list((await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == latest_version.id)
+                .order_by(ChannelPostImage.position)
+            )).scalars().all())
+        assert len(images) == 3
+        assert [img.position for img in images] == [0, 1, 2]
+        expected = compute_image_seal_hash([img.final_sha256 for img in images])
+        assert latest_version.image_sha256 == expected
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+def test_compute_image_seal_hash_positive_control_swap_and_reorder_both_break_seal():
+    """페드루 PO 못박음② 양성대조(순수 함수, DB 불요) — 1장 바꿔치기·순서 재배열
+    둘 다 합성 해시를 바꿔야 한다(디디 설계 메모에서 실측한 그대로 코드로 pin)."""
+    from app.services.channel_post_images import compute_image_seal_hash
+
+    original = ["aaa111", "bbb222", "ccc333"]
+    swapped_position_2 = ["aaa111", "XXXXXX", "ccc333"]
+    reordered = ["ccc333", "bbb222", "aaa111"]
+
+    base = compute_image_seal_hash(original)
+    assert base != compute_image_seal_hash(swapped_position_2), "2번째 이미지 바꿔치기가 봉인을 안 깼다"
+    assert base != compute_image_seal_hash(reordered), "순서 재배열이 봉인을 안 깼다"
+
+
+def test_compute_image_seal_hash_single_element_is_identity():
+    from app.services.channel_post_images import compute_image_seal_hash
+
+    assert compute_image_seal_hash(["only-one-hash"]) == "only-one-hash"
+
+
+@pytest.mark.anyio
+async def test_text_only_edit_after_carousel_carries_forward_all_images_with_positions():
+    """텍스트만 편집한 새 버전(이미지 재첨부 없음)도 N장 전부를 새 version_id로
+    복제해야 한다 — 단일-이미지 carry-forward 버그(channel_posts.py 주석 참고)의
+    N장 버전 재발 방지."""
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.services.channel_posts import create_channel_post_draft_version, get_channel_post_draft
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            await _upload_n_images(client, org_id, draft_id, 2)
+
+        async with Session() as s:
+            draft = await get_channel_post_draft(s, org_id=org_id, draft_id=uuid.UUID(draft_id))
+            latest_before = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+                .order_by(ChannelPostVersion.version.desc()).limit(1)
+            )).scalar_one()
+            new_version, _channel, _violations = await create_channel_post_draft_version(
+                s, org_id=org_id, work_item_id=draft.work_item_id, connection_id=draft.connection_id,
+                text="본문만 고침", link_url=latest_before.link_url,
+                author_member_id=human_id, author_kind="human",
+            )
+            images = list((await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == new_version.id)
+                .order_by(ChannelPostImage.position)
+            )).scalars().all())
+        assert len(images) == 2, "텍스트만 편집했는데 캐러셀 2장이 새 버전으로 안 이어졌다"
+        assert [img.position for img in images] == [0, 1]
+        assert new_version.image_sha256 == latest_before.image_sha256, "carry-forward인데 봉인 해시가 바뀌었다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ③ N > image_max_count 서버 거부 ───────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_eleventh_image_upload_rejected_with_422_count_exceeded():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            responses = await _upload_n_images(client, org_id, draft_id, 10)
+            for r in responses:
+                assert r.status_code == 201, r.text
+            r11 = (await _upload_n_images(client, org_id, draft_id, 1))[0]
+        assert r11.status_code == 422, r11.text
+        body = r11.json()
+        assert body["error"]["code"] == "CHANNEL_POST_IMAGE_COUNT_EXCEEDED"
+        assert body["error"]["image_max_count"] == 10
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_second_image_on_threads_rejected_max_count_one_regression():
+    """회귀 0 — Threads는 여전히 image_max_count=1(이 스토리로 안 바뀜), 2번째
+    이미지는 여전히 거부돼야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="threads")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r1, r2 = await _upload_n_images(client, org_id, draft_id, 2)
+        assert r1.status_code == 201, r1.text
+        assert r2.status_code == 422, r2.text
+        assert r2.json()["error"]["code"] == "CHANNEL_POST_IMAGE_COUNT_EXCEEDED"
+        assert r2.json()["error"]["image_max_count"] == 1
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ④ Instagram 캐러셀 컨테이너(부모+children)·sandbox 미러·원자성 ───────────
+
+
+@pytest.mark.anyio
+async def test_instagram_publish_client_module_declares_create_carousel_container():
+    import app.services.instagram_publish as instagram_publish
+    import app.services.instagram_sandbox_publish as instagram_sandbox_publish
+
+    assert hasattr(instagram_publish, "create_carousel_container")
+    assert hasattr(instagram_sandbox_publish, "create_carousel_container")
+
+
+@pytest.mark.anyio
+async def test_create_carousel_container_builds_parent_with_children_ids():
+    from app.services.instagram_publish import create_carousel_container
+
+    responses = iter([
+        {"id": "child-1"}, {"id": "child-2"}, {"id": "child-3"}, {"id": "parent-999"},
+    ])
+
+    class _FakeResponse:
+        def __init__(self, body):
+            self.status_code = 200
+            self._body = body
+        def json(self):
+            return self._body
+        @property
+        def text(self):
+            return str(self._body)
+
+    calls = []
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            calls.append(params)
+            return _FakeResponse(next(responses))
+
+    creation_id = await create_carousel_container(
+        _FakeClient(), access_token="tok", threads_user_id="ig-user-1", text="캡션",
+        image_urls=["https://x/1.jpg", "https://x/2.jpg", "https://x/3.jpg"],
+    )
+    assert creation_id == "parent-999"
+    assert len(calls) == 4
+    for child_call in calls[:3]:
+        assert child_call["is_carousel_item"] == "true"
+    parent_call = calls[3]
+    assert parent_call["media_type"] == "CAROUSEL"
+    assert parent_call["children"] == "child-1,child-2,child-3"
+    assert parent_call["caption"] == "캡션"
+
+
+@pytest.mark.anyio
+async def test_create_carousel_container_child_failure_never_creates_parent():
+    """원자성(그라운딩·PO 明示) — 자식 하나 실패하면 부모 컨테이너 호출 자체가 안
+    일어난다(발행 0)."""
+    from app.services.instagram_publish import create_carousel_container
+    from app.services.threads_publish import ThreadsPublishError
+
+    class _FakeFailResponse:
+        status_code = 502
+        text = "provider down"
+        def json(self):
+            return {}
+
+    class _FakeOkResponse:
+        status_code = 200
+        text = "{}"
+        def json(self):
+            return {"id": "child-1"}
+
+    calls = []
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            calls.append(params)
+            if len(calls) == 2:
+                return _FakeFailResponse()
+            return _FakeOkResponse()
+
+    with pytest.raises(ThreadsPublishError):
+        await create_carousel_container(
+            _FakeClient(), access_token="tok", threads_user_id="ig-user-1", text="",
+            image_urls=["https://x/1.jpg", "https://x/2.jpg", "https://x/3.jpg"],
+        )
+    # 2번째 자식에서 실패 — 3번째 자식·부모(4번째 콜) 자체가 안 불렸다.
+    assert len(calls) == 2
+    assert all("media_type" not in c for c in calls), "부모(CAROUSEL) 콜이 일어났다(원자성 위반)"
+
+
+@pytest.mark.anyio
+async def test_sandbox_carousel_child_failure_marker_blocks_all_captures_atomically():
+    """라이브 대역 — instagram_sandbox로 3장 캐러셀 발행 시도, 2번째 자식 실패
+    마커를 심으면 published 0(원자성), 정상 마커 없는 3장은 published 1."""
+    from app.services.instagram_sandbox_publish import create_carousel_container
+    from app.services.threads_publish import ThreadsPublishError
+
+    ok = await create_carousel_container(
+        None, access_token="tok", threads_user_id="ig-user", text="정상 캡션",
+        image_urls=["u1", "u2", "u3"],
+    )
+    assert ok.startswith("sandbox-ig-carousel-")
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await create_carousel_container(
+            None, access_token="tok", threads_user_id="ig-user",
+            text="캡션 [sandbox:carousel-child-2-failed]", image_urls=["u1", "u2", "u3"],
+        )
+    assert exc_info.value.code == "SANDBOX_INSTAGRAM_CAROUSEL_CHILD_FAILED"
+
+
+@pytest.mark.anyio
+async def test_publish_endpoint_dispatches_to_carousel_for_two_plus_images_instagram_sandbox():
+    """종단 — instagram_sandbox 초안에 이미지 3장 → 승인 → 발행 200·external_id·
+    published_at(라이브 카디르 런북 재료와 동형 축, 여기선 코드 테스트로 pin)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+            from app.models.participation import ParticipationRole
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+            s.add(role)
+            await s.commit()
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            responses = await _upload_n_images(client, org_id, draft_id, 3)
+            for r in responses:
+                assert r.status_code == 201, r.text
+            version_id = responses[-1].json()["version_id"]
+
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit",
+                json={"version_id": version_id},
+            )
+            assert r_submit.status_code == 200, r_submit.text
+            gate_id = r_submit.json()["gate_id"]
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select as sa_select
+
+            gate = (await s.execute(sa_select(Gate).where(Gate.id == uuid.UUID(gate_id)))).scalar_one()
+            gate.status = "approved"
+            gate.resolver_id = uuid.uuid4()
+            gate.resolved_at = datetime.now(timezone.utc)
+            await s.commit()
+
+        async with _client_for(app) as client:
+            # 이미지(캐러셀 포함) 발행은 항상 2틱 — 1틱=컨테이너 생성(processing=True,
+            # 즉시 반환)·2틱=publish_container까지(instagram_sandbox_publish.py::
+            # get_container_status가 이미 결정적으로 FINISHED라 별도 mock 불요, 그래도
+            # channel_posts.py 오케스트레이션이 "이미지 있으면 1틱은 무조건 반환"이라
+            # 실제로 2번 불러야 한다 — test_620beefc_channel_post_image.py::
+            # test_image_publish_finished_tick_completes와 동형 계약).
+            r_publish_1 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+            )
+            assert r_publish_1.status_code == 200, r_publish_1.text
+            assert r_publish_1.json()["processing"] is True
+
+            r_publish_2 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+            )
+        assert r_publish_2.status_code == 200, r_publish_2.text
+        body = r_publish_2.json()
+        assert body["processing"] is False
+        assert body["external_id"] is not None and body["external_id"].startswith("sandbox-ig-media-")
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3550_instagram_carousel.py
+++ b/backend/tests/test_3550_instagram_carousel.py
@@ -766,3 +766,50 @@ async def test_list_images_for_version_endpoint_returns_ordered_positions():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_response_carries_image_id_usable_for_delete_and_reorder():
+    """페드루 PO 확定(2026-09-06, BE 2/2 대조 후속) — ChannelPostImageResponse에
+    image_id가 없으면 FE가 삭제·재정렬 호출 대상을 목록 응답만으로 못 얻는다.
+    목록 각 항목의 image_id가 실제로 DB 행의 id와 일치하고, 그 값을 그대로
+    DELETE에 넘겨 성공하는 것까지 왕복 확인(응답 모양뿐 아니라 실제 소비까지)."""
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r1, r2 = await _upload_n_images(client, org_id, draft_id, 2)
+            version_id = r2.json()["version_id"]
+
+            async with Session() as s:
+                db_images = list((await s.execute(
+                    select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(version_id))
+                    .order_by(ChannelPostImage.position)
+                )).scalars().all())
+
+            r_list = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/versions/{version_id}/assets",
+            )
+            rows = r_list.json()
+            assert [row["image_id"] for row in rows] == [str(img.id) for img in db_images]
+
+            r_delete = await client.request(
+                "DELETE",
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/{rows[0]['image_id']}",
+            )
+        assert r_delete.status_code == 200, r_delete.text
+        assert len(r_delete.json()) == 1, "목록 응답의 image_id가 실제 삭제 대상으로 통해야 한다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3550_instagram_carousel.py
+++ b/backend/tests/test_3550_instagram_carousel.py
@@ -512,3 +512,257 @@ async def test_publish_endpoint_dispatches_to_carousel_for_two_plus_images_insta
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# ─── BE 2/2(디디·페드루 PO 確定 2026-09-06) — 삭제·재정렬 ─────────────────────────
+
+
+@pytest.mark.anyio
+async def test_delete_middle_image_renumbers_remaining_and_recomputes_seal():
+    """3장 중 가운데(position 1) 삭제 → 남은 2장이 새 버전에서 [0,1]로 재부여되고
+    합성 해시가 남은 순서(원래 상대 순서 유지)로 재계산돼야 한다. 옛 버전 행은
+    그대로 남아 있어야 한다(삭제=새 버전, 원본 불변 원칙)."""
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.services.channel_post_images import compute_image_seal_hash
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r1, r2, r3 = await _upload_n_images(client, org_id, draft_id, 3)
+            old_version_id = r3.json()["version_id"]
+
+            async with Session() as s:
+                old_images = list((await s.execute(
+                    select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(old_version_id))
+                    .order_by(ChannelPostImage.position)
+                )).scalars().all())
+            middle_image_id = str(old_images[1].id)
+            kept_hashes = [old_images[0].final_sha256, old_images[2].final_sha256]
+
+            r_delete = await client.request(
+                "DELETE", f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/{middle_image_id}",
+            )
+        assert r_delete.status_code == 200, r_delete.text
+        remaining = r_delete.json()
+        assert [row["position"] for row in remaining] == [0, 1]
+
+        async with Session() as s:
+            old_images_after = list((await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(old_version_id))
+            )).scalars().all())
+            assert len(old_images_after) == 3, "옛 버전 행이 삭제 처리로 건드려지면 안 된다(불변)"
+
+            new_version_id = remaining[0]["version_id"]
+            new_version = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(new_version_id))
+            )).scalar_one()
+            new_images = list((await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(new_version_id))
+                .order_by(ChannelPostImage.position)
+            )).scalars().all())
+        assert [img.final_sha256 for img in new_images] == kept_hashes
+        assert new_version.image_sha256 == compute_image_seal_hash(kept_hashes)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_only_remaining_image_sets_seal_to_none_and_empty_list():
+    """1장뿐인 draft에서 그 1장을 삭제 → 새 버전은 이미지 0장·image_sha256=None(첫
+    draft의 "이미지 없음" 상태와 동일 — sha256("")이 아니다)."""
+    from app.main import app
+    from app.models.channel_post_version import ChannelPostVersion
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            (r1,) = await _upload_n_images(client, org_id, draft_id, 1)
+            image_id = r1.json()
+
+            async with Session() as s:
+                from app.models.channel_post_image import ChannelPostImage
+                row = (await s.execute(
+                    select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(image_id["version_id"]))
+                )).scalar_one()
+            r_delete = await client.request(
+                "DELETE", f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/{row.id}",
+            )
+        assert r_delete.status_code == 200, r_delete.text
+        assert r_delete.json() == []
+
+        async with Session() as s:
+            new_version = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+                .order_by(ChannelPostVersion.version.desc()).limit(1)
+            )).scalar_one()
+        assert new_version.image_sha256 is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_unknown_image_id_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            await _upload_n_images(client, org_id, draft_id, 1)
+
+            r_delete = await client.request(
+                "DELETE",
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/{uuid.uuid4()}",
+            )
+        assert r_delete.status_code == 404, r_delete.text
+        assert r_delete.json()["error"]["code"] == "CHANNEL_POST_IMAGE_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reorder_two_images_swaps_positions_and_recomputes_seal():
+    from app.main import app
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.services.channel_post_images import compute_image_seal_hash
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r1, r2 = await _upload_n_images(client, org_id, draft_id, 2)
+
+            async with Session() as s:
+                from app.models.channel_post_image import ChannelPostImage
+                images = list((await s.execute(
+                    select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(r2.json()["version_id"]))
+                    .order_by(ChannelPostImage.position)
+                )).scalars().all())
+            first_id, second_id = str(images[0].id), str(images[1].id)
+            reversed_hashes = [images[1].final_sha256, images[0].final_sha256]
+
+            r_reorder = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/reorder",
+                json={"image_ids": [second_id, first_id]},
+            )
+        assert r_reorder.status_code == 200, r_reorder.text
+        reordered = r_reorder.json()
+        assert [row["position"] for row in reordered] == [0, 1]
+
+        async with Session() as s:
+            new_version = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(reordered[0]["version_id"]))
+            )).scalar_one()
+        assert new_version.image_sha256 == compute_image_seal_hash(reversed_hashes)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reorder_with_missing_or_duplicate_id_rejected_422():
+    from app.main import app
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r1, r2 = await _upload_n_images(client, org_id, draft_id, 2)
+
+            async with Session() as s:
+                from app.models.channel_post_image import ChannelPostImage
+                images = list((await s.execute(
+                    select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(r2.json()["version_id"]))
+                    .order_by(ChannelPostImage.position)
+                )).scalars().all())
+            first_id, second_id = str(images[0].id), str(images[1].id)
+
+            r_missing = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/reorder",
+                json={"image_ids": [first_id]},
+            )
+            r_duplicate = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/reorder",
+                json={"image_ids": [first_id, first_id]},
+            )
+        for r in (r_missing, r_duplicate):
+            assert r.status_code == 422, r.text
+            assert r.json()["error"]["code"] == "CHANNEL_POST_IMAGE_REORDER_INVALID_SET"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_images_for_version_endpoint_returns_ordered_positions():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r1, r2, r3 = await _upload_n_images(client, org_id, draft_id, 3)
+            version_id = r3.json()["version_id"]
+
+            r_list = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/versions/{version_id}/assets",
+            )
+        assert r_list.status_code == 200, r_list.text
+        rows = r_list.json()
+        assert [row["position"] for row in rows] == [0, 1, 2]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3550_instagram_carousel.py
+++ b/backend/tests/test_3550_instagram_carousel.py
@@ -813,3 +813,105 @@ async def test_list_response_carries_image_id_usable_for_delete_and_reorder():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# ─── authz(#3910 CI 후속, 페드루 PO 明示 2026-09-06) — project-scope 가드 ───────────
+
+
+@pytest.mark.anyio
+async def test_delete_image_cross_project_member_gets_404_not_authorized():
+    """test_authz_project_scope_coverage.py::test_no_new_unguarded_id_mutation_routes
+    후속 — draft가 project-소속 리소스(work_item_id→Story.project_id)임을 실제
+    런타임으로도 검증한다. project A에만 TeamMember로 소속된(org role="member",
+    owner/admin 아님) human이 project B 소속 story의 draft 이미지를 지우려 하면
+    same-org라도 404여야 한다(존재-비노출 관례, cross-project IDOR 막힘 실증)."""
+    from app.main import app
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_a_id = await _seed_org(s)
+            project_b = Project(id=uuid.uuid4(), org_id=org_id, name="Project B")
+            s.add(project_b)
+            await s.commit()
+            project_b_id = project_b.id
+
+            human_id = await _seed_human(s, org_id, project_a_id, role="member")
+            s.add(TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_a_id,
+                user_id=human_id, type="human", name="Project A member",
+            ))
+            await s.commit()
+
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_b_id)  # project B 소속 story
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            [r1] = await _upload_n_images(client, org_id, draft_id, 1)
+            image_id = r1.json()["image_id"]
+
+            r_delete = await client.request(
+                "DELETE", f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/{image_id}",
+            )
+        assert r_delete.status_code == 404, r_delete.text
+        assert r_delete.json()["error"]["code"] == "CHANNEL_POST_DRAFT_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reorder_cross_project_member_gets_404_not_authorized():
+    """delete와 같은 헬퍼(_require_channel_post_draft_project_access) 공유 확인 —
+    reorder도 동일 IDOR 경계에서 막혀야 한다(POST라 authz 스캐너 대상은 아니지만
+    페드루 PO 明示 "같은 세계")."""
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from app.models.project import Project
+    from app.models.team import TeamMember
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_a_id = await _seed_org(s)
+            project_b = Project(id=uuid.uuid4(), org_id=org_id, name="Project B")
+            s.add(project_b)
+            await s.commit()
+            project_b_id = project_b.id
+
+            human_id = await _seed_human(s, org_id, project_a_id, role="member")
+            s.add(TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_a_id,
+                user_id=human_id, type="human", name="Project A member",
+            ))
+            await s.commit()
+
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_b_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r1, r2 = await _upload_n_images(client, org_id, draft_id, 2)
+
+            async with Session() as s:
+                images = list((await s.execute(
+                    select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(r2.json()["version_id"]))
+                    .order_by(ChannelPostImage.position)
+                )).scalars().all())
+            first_id, second_id = str(images[0].id), str(images[1].id)
+
+            r_reorder = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/reorder",
+                json={"image_ids": [second_id, first_id]},
+            )
+        assert r_reorder.status_code == 404, r_reorder.text
+        assert r_reorder.json()["error"]["code"] == "CHANNEL_POST_DRAFT_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1329,8 +1329,8 @@
     },
     {
       "file": "tests/test_3550_instagram_carousel.py",
-      "sec": 55.0,
-      "source": "story-3550-instagram-carousel-be(BE 2/2 삭제·재정렬 6건 추가 뒤 재측정 — 로컬 raw pytest 18건 8.62s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 55s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 60.0,
+      "source": "story-3550-instagram-carousel-be(#3910 CI authz 가드 fix — cross-project 404 테스트 2건 추가 뒤 재측정 — 로컬 raw pytest 21건 9.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값. 실 CI 샤드 7 로그 실측: 19건 25.13s — 여유 충분 확인됨, story #3550 그라운딩 코멘트 참고)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1326,6 +1326,11 @@
       "file": "tests/test_3547_facebook_page_connection.py",
       "sec": 45.0,
       "source": "story-3547-facebook-page-adapter-be(PR 개설 前 선제 등재 — 로컬 raw pytest 16건 7.51s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3550_instagram_carousel.py",
+      "sec": 35.0,
+      "source": "story-3550-instagram-carousel-be(PR 개설 前 선제 등재 — 로컬 raw pytest 12건 5.48s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 35s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1329,8 +1329,8 @@
     },
     {
       "file": "tests/test_3550_instagram_carousel.py",
-      "sec": 35.0,
-      "source": "story-3550-instagram-carousel-be(PR 개설 前 선제 등재 — 로컬 raw pytest 12건 5.48s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 35s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 55.0,
+      "source": "story-3550-instagram-carousel-be(BE 2/2 삭제·재정렬 6건 추가 뒤 재측정 — 로컬 raw pytest 18건 8.62s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 55s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 배경
블루프린트 §7 Phase 2 「Instagram·Facebook Page 발행(이미지·릴스·캐러셀)」. 디디 설계 선행 메모(스토리 코멘트)에서 봉인 해시 축을 두 안으로 좁혔고, PO가 안 A(순서 포함 합성 해시, Gate 스키마 무변경)로 確定 — 4가지를 못박음. 이 PR은 그 4가지 그대로 구현(BE만, FE는 별도 순서로 미르코군이 이어받음).

## 구현
**① N=1 항등** — `compute_image_seal_hash()`가 이미지 1장이면 그 sha256을 그대로 반환(합성 해시 재적용 없음). 기존 승인된 단일-이미지 게이트·버전이 이 배포로 "변조" 판정되지 않는다 — 기존 테스트 60건(`test_620beefc_channel_post_image.py`) 전부 무변경으로 통과가 그 증거.

**② 저장 구조** — `channel_post_images.UniqueConstraint(version_id)` → `UniqueConstraint(version_id, position)`(마이그 0343). N≥2부터 position 순으로 이어붙인 sha256을 재해시해 `ChannelPostVersion.image_sha256`(→`Gate.sealed_media_sha256`, 스키마 무변경)에 담는다. 이미지 바꿔치기·순서 재배열 둘 다 봉인을 깨는 것을 양성대조로 pin. 텍스트만 편집한 새 버전도 N장 전부를 새 version_id로 carry-forward(기존 단일-이미지 버그 처방·`channel_posts.py` 주석 참고를 N장으로 확장).

**③ 서버 거부** — `image_max_count` 초과 첨부는 422 `CHANNEL_POST_IMAGE_COUNT_EXCEEDED`(다운로드·디코드·변환 前에 즉시 거부, 비용 낭비 없음). Threads/Facebook은 여전히 1장(회귀 테스트로 pin).

**④ 컨테이너** — `create_carousel_container`(instagram_publish.py·instagram_sandbox_publish.py 신설) — 자식 N개(`is_carousel_item=true`) → 부모 1개(`media_type=CAROUSEL`, `children=`) → 부모 creation_id 반환. 자식 하나 실패 시 부모 컨테이너 호출 자체가 안 일어나 원자성 보장(발행 0). `image_max_count` 1→10(instagram·instagram_sandbox만). sandbox는 `[sandbox:carousel-child-N-failed]` 마커로 원자성을 라이브에서도 실측 가능.

## ⚠️미확認
캐러셀 컨테이너 파라미터명(`is_carousel_item`·`media_type=CAROUSEL`·`children`)은 Meta 공식 문서 지식(instagram_publish.py 상단 기존 딱지와 동형) — 재확認 전 라이브 왕복 금지.

## 테스트
12건(항등·양성대조 2·저장구조·carry-forward·개수거부 2·컨테이너 조립·원자성·sandbox 마커·종단 발행) + 뮤테이션 4종(N=1 항등 되돌림·순서 무시(sorted) 되돌림·개수거부 제거·자식실패 무시) 각 RED 확인 후 원복. 마이그 0343 실 Postgres upgrade/downgrade 왕복 확인. 회귀 139건(620beefc/3320/3536/3414/3474/3525/5b27b32f/f8f7cb0f/3545) 전체 통과. shard-weights 등재·lint 통과.

## 다음
FE(N장 슬롯 UI, §13-3 "미리보기 그대로 그린다" 확장)는 별도 순서로 미르코군.