### PR TITLE
[SID:3554] feat: Instagram 릴스(영상) 발행 — MP4 파서·커버 재사용·REELS 컨테이너

### DIFF
--- a/backend/alembic/versions/0344_channel_post_videos.py
+++ b/backend/alembic/versions/0344_channel_post_videos.py
@@ -1,0 +1,42 @@
+"""story #3554(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Instagram 릴스(영상)
+마스터 원장 신설. 커버는 새 테이블이 아니라 기존 `channel_post_images`(position=0)를
+재사용한다(PO 明示) — 이 마이그가 새로 여는 건 영상 본편 저장뿐."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0344"
+down_revision = "0343"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "channel_post_videos",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("draft_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("original_object_path", sa.Text(), nullable=False),
+        sa.Column("original_sha256", sa.Text(), nullable=False),
+        sa.Column("original_content_type", sa.Text(), nullable=False),
+        sa.Column("original_bytes", sa.BigInteger(), nullable=False),
+        sa.Column("duration_seconds", sa.Float(), nullable=False),
+        sa.Column("width", sa.Integer(), nullable=False),
+        sa.Column("height", sa.Integer(), nullable=False),
+        sa.Column("codec", sa.Text(), nullable=False),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("version_id", name="uq_channel_post_videos_version"),
+    )
+    op.create_index("ix_channel_post_videos_org_id", "channel_post_videos", ["org_id"])
+    op.create_index("ix_channel_post_videos_draft_id", "channel_post_videos", ["draft_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_channel_post_videos_draft_id", table_name="channel_post_videos")
+    op.drop_index("ix_channel_post_videos_org_id", table_name="channel_post_videos")
+    op.drop_table("channel_post_videos")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -145,6 +145,7 @@ from app.models.channel_post_version import ChannelPostVersion
 from app.models.channel_publication import ChannelPublication
 from app.models.publication_command import PublicationCommand
 from app.models.channel_post_image import ChannelPostImage
+from app.models.channel_post_video import ChannelPostVideo
 from app.models.campaign import Campaign
 from app.models.org_content_rule import OrgContentRule
 from app.models.publication_attempt import PublicationAttempt

--- a/backend/app/models/channel_post_video.py
+++ b/backend/app/models/channel_post_video.py
@@ -1,0 +1,53 @@
+"""story #3554(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Instagram 릴스(영상)
+마스터 원장. `ChannelPostImage`(620beefc)와 달리 서버 측 변환(재인코딩)을 하지
+않는다(ffmpeg류 의존 0 — PO 明示, Cloud Run 이미지 반경 확대를 피함) — 순수
+파이썬 MP4 박스 파서(`channel_post_videos.py::parse_mp4_metadata`)로 규격(길이·
+해상도·코덱 fourcc)만 읽어 어댑터 선언과 대조하고, 통과하면 원본을 그대로
+"나가는" 파생본으로 쓴다(그래서 derived_* 컬럼이 없다 — 이미지 파이프와의
+유일한 구조 차이).
+
+버전당 영상은 최대 1개(`UniqueConstraint(version_id)`, 캐러셀처럼 N개로 열
+필요가 없다 — 릴스는 항상 본편 1편+커버 1장 조합). 커버는 이 테이블이 아니라
+기존 `ChannelPostImage`(position=0)를 그대로 재사용한다(PO 明示 "커버=별개
+이미지 에셋·기존 이미지 파이프") — 새 테이블·새 업로드 경로를 커버용으로
+따로 만들지 않는다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, Float, Integer, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ChannelPostVideo(Base):
+    __tablename__ = "channel_post_videos"
+    __table_args__ = (
+        UniqueConstraint("version_id", name="uq_channel_post_videos_version"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    draft_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    version_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    original_object_path: Mapped[str] = mapped_column(Text, nullable=False)
+    original_sha256: Mapped[str] = mapped_column(Text, nullable=False)
+    original_content_type: Mapped[str] = mapped_column(Text, nullable=False)
+    original_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+
+    # MP4 박스 파서(mvhd/tkhd/stsd)로 읽은 값 — 어댑터 규격(video_max_seconds·
+    # video_aspect_target·video_codecs) 대조에 쓴다. 파싱 실패 자체는 저장 前
+    # 422로 거부되므로(fail-closed) 이 세 컬럼은 항상 채워진 채로만 커밋된다.
+    duration_seconds: Mapped[float] = mapped_column(Float, nullable=False)
+    width: Mapped[int] = mapped_column(Integer, nullable=False)
+    height: Mapped[int] = mapped_column(Integer, nullable=False)
+    codec: Mapped[str] = mapped_column(Text, nullable=False)
+
+    created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -79,6 +79,21 @@ from app.services.channel_post_images import (
     public_url_for_object_path,
     reorder_channel_post_images,
 )
+from app.services.channel_post_videos import (
+    ChannelVideoAspectRatioError,
+    ChannelVideoCodecUnsupportedError,
+    ChannelVideoDurationExceededError,
+    ChannelVideoDurationTooShortError,
+    ChannelVideoObjectNotFoundError,
+    ChannelVideoPathNotScopedError,
+    ChannelVideoTooLargeError,
+    ChannelVideoUnparsableError,
+    ChannelVideoUnsupportedError,
+    ChannelVideoUnsupportedFormatError,
+    ChannelVideoUploadFailedError,
+    confirm_channel_post_video_upload,
+    create_channel_post_video_upload_url,
+)
 from app.services.generation_budget import GenerationBudgetExceededError
 from app.services.member_resolver import resolve_member
 
@@ -309,6 +324,39 @@ class ConfirmChannelPostImageUploadRequest(BaseModel):
     object_path: str
 
 
+class CreateChannelPostVideoUploadUrlRequest(BaseModel):
+    content_type: str
+
+
+class ChannelPostVideoUploadUrlResponse(BaseModel):
+    upload_url: str
+    object_path: str
+    expires_at: str
+    max_bytes: int
+    required_put_headers: dict[str, str] = {}
+
+
+class ConfirmChannelPostVideoUploadRequest(BaseModel):
+    object_path: str
+
+
+class ChannelPostVideoResponse(BaseModel):
+    # story #3554(Phase2, 페드루 PO 確定 2026-09-06) — 릴스 영상 마스터. 규격
+    # 검증에 실제로 쓰인 값(duration_seconds·width/height·codec)을 그대로 실어
+    # FE가 "무엇이·얼마까지·지금 얼마"(§13 규격 문구 3요소) 배지를 조립할 수 있게
+    # 한다(image_row와 동형 원칙 — 서버가 문구를 짓지 않고 값만 낸다).
+    video_id: uuid.UUID
+    draft_id: uuid.UUID
+    version_id: uuid.UUID
+    version: int
+    duration_seconds: float
+    width: int
+    height: int
+    codec: str
+    original_bytes: int
+    video_url: str | None = None
+
+
 class ReorderChannelPostImagesRequest(BaseModel):
     # story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 부분 재정렬 불허·항상
     # 전체 집합(현재 버전 이미지 id 전부, 새 순서 그대로)을 명시로 받는다.
@@ -497,6 +545,141 @@ async def post_channel_post_image_upload_url(
     except ChannelImageUploadFailedError as exc:
         raise HTTPException(status_code=502, detail={"code": "CHANNEL_IMAGE_UPLOAD_FAILED", "message": str(exc)}) from exc
     return ChannelPostImageUploadUrlResponse(**result)
+
+
+def _video_response(version, video_row) -> ChannelPostVideoResponse:
+    return ChannelPostVideoResponse(
+        video_id=video_row.id,
+        draft_id=version.draft_id, version_id=version.id, version=version.version,
+        duration_seconds=video_row.duration_seconds, width=video_row.width, height=video_row.height,
+        codec=video_row.codec, original_bytes=video_row.original_bytes,
+        video_url=public_url_for_object_path(video_row.original_object_path),
+    )
+
+
+@router.post(
+    "/{org_id}/channel-posts/drafts/{draft_id}/assets/video/upload-url",
+    response_model=ChannelPostVideoUploadUrlResponse,
+)
+async def post_channel_post_video_upload_url(
+    org_id: uuid.UUID, draft_id: uuid.UUID, body: CreateChannelPostVideoUploadUrlRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelPostVideoUploadUrlResponse:
+    """story #3554(Phase2, 페드루 PO 確定 2026-09-06) — 이미지 업로드-url 엔드포인트와
+    동형 2단계(signed URL 발급→FE 직접 PUT→confirm)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    draft = await get_channel_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail={"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(draft_id)})
+
+    try:
+        result = await create_channel_post_video_upload_url(
+            org_id=org_id, draft_id=draft_id, channel=draft.channel, content_type=body.content_type,
+        )
+    except ChannelImageStorageNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=503, detail={"code": "CHANNEL_IMAGE_STORAGE_NOT_CONFIGURED", "message": str(exc)},
+        ) from exc
+    except ChannelVideoUnsupportedError as exc:
+        raise HTTPException(
+            status_code=422, detail={"code": "CHANNEL_VIDEO_UNSUPPORTED", "message": str(exc), "channel": exc.channel},
+        ) from exc
+    except ChannelVideoUnsupportedFormatError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_VIDEO_UNSUPPORTED_FORMAT", "message": str(exc),
+                "content_type": exc.content_type, "allowed_formats": list(exc.allowed),
+            },
+        ) from exc
+    except ChannelVideoUploadFailedError as exc:
+        raise HTTPException(status_code=502, detail={"code": "CHANNEL_VIDEO_UPLOAD_FAILED", "message": str(exc)}) from exc
+    return ChannelPostVideoUploadUrlResponse(**result)
+
+
+@router.post(
+    "/{org_id}/channel-posts/drafts/{draft_id}/assets/video/confirm",
+    response_model=ChannelPostVideoResponse, status_code=201,
+)
+async def post_channel_post_video_confirm(
+    org_id: uuid.UUID, draft_id: uuid.UUID, body: ConfirmChannelPostVideoUploadRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelPostVideoResponse:
+    """story #3554(Phase2, 페드루 PO 確定 2026-09-06①~④) — 업로드 확인+MP4 규격
+    검증(순수 파이썬 박스 파서, ffmpeg 없음)+계보. 이 호출도 새 버전을 만든다
+    (이미지 confirm과 동형 — 텍스트 편집과 같은 불변 버전 축)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    member_id = uuid.UUID(auth.user_id)
+    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+
+    try:
+        version, video_row = await confirm_channel_post_video_upload(
+            db, org_id=org_id, draft_id=draft_id, object_path=body.object_path,
+            member_id=member_id, member_kind=actor_type,
+        )
+    except ChannelPostDraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail={"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(exc)}) from exc
+    except ChannelVideoUnsupportedError as exc:
+        raise HTTPException(
+            status_code=422, detail={"code": "CHANNEL_VIDEO_UNSUPPORTED", "message": str(exc), "channel": exc.channel},
+        ) from exc
+    except ChannelVideoPathNotScopedError as exc:
+        raise HTTPException(status_code=403, detail={"code": "CHANNEL_VIDEO_PATH_NOT_SCOPED", "message": str(exc)}) from exc
+    except ChannelVideoObjectNotFoundError as exc:
+        raise HTTPException(status_code=404, detail={"code": "CHANNEL_VIDEO_OBJECT_NOT_FOUND", "message": str(exc)}) from exc
+    except ChannelVideoTooLargeError as exc:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "code": "CHANNEL_VIDEO_TOO_LARGE", "message": str(exc),
+                "size_bytes": exc.size_bytes, "max_bytes": exc.max_bytes,
+            },
+        ) from exc
+    except ChannelVideoUnparsableError as exc:
+        raise HTTPException(status_code=422, detail={"code": "CHANNEL_VIDEO_UNPARSABLE", "message": str(exc)}) from exc
+    except ChannelVideoDurationExceededError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_VIDEO_DURATION_EXCEEDED", "message": str(exc),
+                "duration_seconds": exc.duration_seconds, "max_seconds": exc.max_seconds,
+            },
+        ) from exc
+    except ChannelVideoDurationTooShortError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_VIDEO_DURATION_TOO_SHORT", "message": str(exc),
+                "duration_seconds": exc.duration_seconds, "min_seconds": exc.min_seconds,
+            },
+        ) from exc
+    except ChannelVideoAspectRatioError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_VIDEO_ASPECT_RATIO_REJECTED", "message": str(exc),
+                "aspect_ratio": exc.aspect_ratio, "target": exc.target, "tolerance": exc.tolerance,
+            },
+        ) from exc
+    except ChannelVideoCodecUnsupportedError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_VIDEO_CODEC_UNSUPPORTED", "message": str(exc),
+                "codec": exc.codec, "allowed_codecs": list(exc.allowed),
+            },
+        ) from exc
+    except ChannelVideoUploadFailedError as exc:
+        raise HTTPException(status_code=502, detail={"code": "CHANNEL_VIDEO_UPLOAD_FAILED", "message": str(exc)}) from exc
+    return _video_response(version, video_row)
 
 
 @router.post(

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -107,6 +107,20 @@ class ChannelAdapterConfig:
     # 등, TEXT-only 허용) 회귀 0. True면 submit(상신) 단계에서 이미지 0장을 즉시 422로
     # 막는다 — 승인 게이트를 낭비하고 발행 시점에야 죽는 것을 방지.
     image_required: bool = False
+    # story #3554(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — 릴스(영상) 규격
+    # 선언(image_*와 동형 관례: 0/빈값=이 채널은 영상 미지원). video_max_bytes<=0이면
+    # 영상 업로드 자체가 422 CHANNEL_VIDEO_UNSUPPORTED(image_max_count<=0과 동형
+    # 판단). video_codecs는 MP4 `stsd` 박스 fourcc(avc1=H.264·hvc1/hev1=HEVC) —
+    # 오디오 코덱은 순수 파이썬 파서로 미검증(PO 明示, 문구에 그대로 노출).
+    video_max_bytes: int = 0
+    video_max_seconds: float = 0.0
+    video_min_seconds: float = 0.0
+    # 9:16(세로) 목표비에서 허용 오차(±) — width/height 원시 비율로 판정(image_aspect_
+    # min/max와 다른 표현 형태인 이유: 릴스는 목표비 1개+오차뿐이라 상하한 2값보다
+    # "목표±오차"가 그라운딩·Meta 문서 그대로를 코드에 옮기기 쉬움).
+    video_aspect_target: float = 0.0
+    video_aspect_tolerance: float = 0.0
+    video_codecs: tuple[str, ...] = ()
 
 
 CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
@@ -201,6 +215,16 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # 용량·해상도)은 장별로 그대로 각각 적용된다(channel_post_images.py의 검증이
         # 이미지 1건 처리라 여러 번 호출되는 구조, 새 루프 불요).
         image_max_count=10,
+        # story #3554(Phase2, 페드루 PO 確定 2026-09-06①) — Meta 문서 지식(⚠️미확認,
+        # 재확認 전 라이브 금지) — 릴스 3~90초·9:16(±5% 허용 오차)·MP4/MOV 컨테이너
+        # (H.264/HEVC만 파서로 검증, 오디오 코덱은 미검증 선언). 100MB는 Graph API
+        # 업로드 한도 문서값 그대로.
+        video_max_bytes=100 * 1024 * 1024,
+        video_max_seconds=90.0,
+        video_min_seconds=3.0,
+        video_aspect_target=9 / 16,
+        video_aspect_tolerance=0.05,
+        video_codecs=("avc1", "hvc1", "hev1"),
         supports_fetch_replies=True,
         supports_reply=True,
         reply_required_scope="instagram_business_manage_comments",
@@ -416,6 +440,14 @@ if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
         # story #3550 — 위 instagram과 동형 정정(1→10, sandbox가 실 provider보다
         # 관대하면 안 된다는 기존 관례 그대로 같은 값 유지).
         image_max_count=10,
+        # story #3554 — 위 instagram과 동형(sandbox가 실 provider보다 관대하면 안
+        # 된다는 기존 관례 그대로 같은 값).
+        video_max_bytes=100 * 1024 * 1024,
+        video_max_seconds=90.0,
+        video_min_seconds=3.0,
+        video_aspect_target=9 / 16,
+        video_aspect_tolerance=0.05,
+        video_codecs=("avc1", "hvc1", "hev1"),
         # 페드루 PO REQUIRED(2026-09-06, #3874 리뷰) — 위 instagram과 동형 정정
         # (impressions 폐기, views로 대체).
         insight_metrics=("views", "reach", "engagements"),

--- a/backend/app/services/channel_post_images.py
+++ b/backend/app/services/channel_post_images.py
@@ -436,13 +436,28 @@ async def confirm_channel_post_image_upload(
     if latest is None:
         raise ChannelPostDraftNotFoundError(draft_id)
 
-    # story #3550(PO 確定 ①) — 기존(=carry-forward 대상) 이미지들의 sha256 + 이번에
-    # 새로 붙는 이미지의 sha256을 position 순으로 이어 합성 봉인 해시를 만든다. N=1
-    # (existing_images가 0장이던 첫 첨부)이면 compute_image_seal_hash가 항등을 돌려줘
-    # Phase1 단일-이미지 봉인 의미와 완전히 같다(회귀 0).
-    new_position = len(existing_images)
-    ordered_hashes = [img.final_sha256 for img in existing_images] + [final_sha256]
-    composite_sha256 = compute_image_seal_hash(ordered_hashes)
+    # story #3554(Phase2, 페드루 PO 確定 2026-09-06③) — 이 draft에 영상이 이미
+    # 붙어 있으면 이 호출은 캐러셀 첨부가 아니라 "커버 교체"다(PO 明示 "커버=별개
+    # 이미지 에셋·기존 이미지 파이프" — 새 업로드 경로를 안 만드는 대신, 여기서
+    # 영상 유무로 두 모드를 가른다). 커버는 항상 position=0 슬롯 하나뿐 — 옛
+    # 커버를 캐리포워드하지 않고 이번 것으로 완전히 대체한다(캐러셀의 "추가"와
+    # 다른 의미 축). 봉인은 `[video_sha256, cover_sha256]`(순서 고정) — 지연
+    # import는 channel_post_videos.py가 이 모듈을 모듈 레벨에서 import하는
+    # 순환을 피하기 위함(channel_posts.py의 기존 관례와 동형).
+    from app.services.channel_post_videos import _copy_video_row, get_channel_post_video_for_version
+
+    existing_video = await get_channel_post_video_for_version(db, version_id=latest.id)
+    if existing_video is not None:
+        new_position = 0
+        composite_sha256 = compute_image_seal_hash([existing_video.original_sha256, final_sha256])
+    else:
+        # story #3550(PO 確定 ①) — 기존(=carry-forward 대상) 이미지들의 sha256 + 이번에
+        # 새로 붙는 이미지의 sha256을 position 순으로 이어 합성 봉인 해시를 만든다. N=1
+        # (existing_images가 0장이던 첫 첨부)이면 compute_image_seal_hash가 항등을 돌려줘
+        # Phase1 단일-이미지 봉인 의미와 완전히 같다(회귀 0).
+        new_position = len(existing_images)
+        ordered_hashes = [img.final_sha256 for img in existing_images] + [final_sha256]
+        composite_sha256 = compute_image_seal_hash(ordered_hashes)
 
     new_version, _channel, _violations = await create_channel_post_draft_version(
         db, org_id=org_id, work_item_id=draft.work_item_id, connection_id=draft.connection_id,
@@ -450,13 +465,16 @@ async def confirm_channel_post_image_upload(
         author_member_id=member_id, author_kind=member_kind, image_sha256=composite_sha256,
     )
 
-    # story #3550(PO 確定 ②) — create_channel_post_draft_version()의 자체 carry-forward
-    # 훅(image_sha256이 sentinel일 때만 발동)은 여기서 안 탄다(위에서 합성값을 명시로
-    # 넘겼으므로) — 기존 이미지 행들을 새 version_id로 직접 복제한다(파일 재업로드·
-    # 재변환 없음, object_path·sha256·position 그대로 — 단일 이미지 carry-forward
-    # 패턴(channel_posts.py::create_channel_post_draft_version)을 N장으로 그대로 확장).
-    for existing in existing_images:
-        db.add(_copy_image_row(existing, new_version_id=new_version.id, new_position=existing.position))
+    if existing_video is not None:
+        db.add(_copy_video_row(existing_video, new_version_id=new_version.id))
+    else:
+        # story #3550(PO 確定 ②) — create_channel_post_draft_version()의 자체 carry-forward
+        # 훅(image_sha256이 sentinel일 때만 발동)은 여기서 안 탄다(위에서 합성값을 명시로
+        # 넘겼으므로) — 기존 이미지 행들을 새 version_id로 직접 복제한다(파일 재업로드·
+        # 재변환 없음, object_path·sha256·position 그대로 — 단일 이미지 carry-forward
+        # 패턴(channel_posts.py::create_channel_post_draft_version)을 N장으로 그대로 확장).
+        for existing in existing_images:
+            db.add(_copy_image_row(existing, new_version_id=new_version.id, new_position=existing.position))
 
     image_row = ChannelPostImage(
         id=uuid.uuid4(), org_id=org_id, draft_id=draft_id, version_id=new_version.id, position=new_position,

--- a/backend/app/services/channel_post_videos.py
+++ b/backend/app/services/channel_post_videos.py
@@ -1,0 +1,429 @@
+"""story #3554(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Instagram 릴스(영상)
+마스터 업로드·규격 검증·계보.
+
+`channel_post_images.py`(620beefc)와 같은 2단계(signed URL 발급 → FE 직접 PUT →
+confirm)를 그대로 재사용한다(같은 GCS 버킷·같은 object_path 스코프 관례). 유일한
+구조 차이 — **서버 자동 변환을 하지 않는다**(ffmpeg류 의존 0, 페드루 PO 決定
+2026-09-06④ — Cloud Run 이미지·빌드 반경 확대를 피함). 대신 순수 파이썬 MP4/MOV
+박스(ISO Base Media File Format) 파서로 규격(길이·해상도·비디오 코덱 fourcc)만
+읽어 어댑터 선언과 대조한다 — 파싱 실패는 fail-closed 422(「조용한 통과 0」, PO
+明示). **오디오 코덱은 미검증 선언**(문구에 그대로 노출, 파서가 audio track을
+안 읽는다).
+
+봉인 축 — `ChannelPostVersion.image_sha256`(→`Gate.sealed_media_sha256`, #3550
+안 A와 같은 컬럼·같은 재사용 관례) 하나에 **항상 2원소 합성**
+`compute_image_seal_hash([video_sha256, cover_sha256 or ""])`을 담는다(순서
+고정 — 영상=0·커버=1). 이미지 캐러셀의 N=1 항등 분기와 겹치지 않는다(영상
+모드는 원소가 항상 2개라 그 분기를 절대 안 탄다 — 두 모드가 값 공간에서
+자연히 분리).
+
+커버는 **새 테이블이 아니라 기존 `ChannelPostImage`(position=0) 그대로 재사용**
+(PO 明示 "커버=별개 이미지 에셋·기존 이미지 파이프") — `channel_post_images.py::
+confirm_channel_post_image_upload`가 "이 draft에 영상이 이미 있으면 캐러셀이
+아니라 커버 교체"로 분기해 이 모듈의 봉인 재계산 규칙을 그대로 따른다."""
+from __future__ import annotations
+
+import hashlib
+import struct
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.channel_post_video import ChannelPostVideo
+from app.models.channel_post_version import ChannelPostVersion
+from app.services.channel_adapters import get_channel_adapter
+from app.services.channel_post_images import (
+    UPLOAD_URL_TTL,
+    _copy_image_row,
+    _require_bucket,
+    compute_image_seal_hash,
+    get_channel_post_image_for_version,
+)
+from app.services.channel_posts import (
+    ChannelPostDraftNotFoundError,
+    create_channel_post_draft_version,
+    get_channel_post_draft,
+)
+from app.services.storage import get_storage_provider
+
+_MIME_TO_EXT: dict[str, str] = {"video/mp4": "mp4", "video/quicktime": "mov"}
+
+
+class ChannelVideoUnsupportedError(Exception):
+    """이 채널 어댑터가 영상을 아예 선언 안 함(video_max_bytes<=0) — image_max_
+    count<=0과 동형 판단."""
+
+    def __init__(self, *, channel: str):
+        self.channel = channel
+        super().__init__(f"채널 {channel!r}은 영상 첨부를 지원하지 않습니다")
+
+
+class ChannelVideoUnsupportedFormatError(Exception):
+    def __init__(self, *, content_type: str, allowed: tuple[str, ...]):
+        self.content_type = content_type
+        self.allowed = allowed
+        super().__init__(f"지원하지 않는 영상 형식입니다: {content_type!r}(허용: {list(allowed)})")
+
+
+class ChannelVideoPathNotScopedError(Exception):
+    def __init__(self, *, object_path: str):
+        self.object_path = object_path
+        super().__init__(f"이 draft 소유 업로드 경로가 아님: {object_path}")
+
+
+class ChannelVideoObjectNotFoundError(Exception):
+    def __init__(self, *, object_path: str):
+        self.object_path = object_path
+        super().__init__(f"업로드된 객체를 찾을 수 없습니다(PUT 미완료?): {object_path}")
+
+
+class ChannelVideoTooLargeError(Exception):
+    def __init__(self, *, size_bytes: int, max_bytes: int):
+        self.size_bytes = size_bytes
+        self.max_bytes = max_bytes
+        super().__init__(f"{size_bytes}bytes가 영상 업로드 상한 {max_bytes}bytes를 초과했습니다")
+
+
+class ChannelVideoUnparsableError(Exception):
+    """MP4/MOV 박스 구조를 읽을 수 없음(손상됐거나 지원하지 않는 컨테이너 —
+    fail-closed, PO 明示 「조용한 통과 0」)."""
+
+    def __init__(self):
+        super().__init__("영상 규격을 읽을 수 없습니다")
+
+
+class ChannelVideoDurationExceededError(Exception):
+    def __init__(self, *, duration_seconds: float, max_seconds: float):
+        self.duration_seconds = duration_seconds
+        self.max_seconds = max_seconds
+        super().__init__(f"영상 길이 {duration_seconds:.1f}초가 상한 {max_seconds:.0f}초를 초과했습니다")
+
+
+class ChannelVideoDurationTooShortError(Exception):
+    def __init__(self, *, duration_seconds: float, min_seconds: float):
+        self.duration_seconds = duration_seconds
+        self.min_seconds = min_seconds
+        super().__init__(f"영상 길이 {duration_seconds:.1f}초가 하한 {min_seconds:.0f}초에 못 미칩니다")
+
+
+class ChannelVideoAspectRatioError(Exception):
+    def __init__(self, *, aspect_ratio: float, target: float, tolerance: float):
+        self.aspect_ratio = aspect_ratio
+        self.target = target
+        self.tolerance = tolerance
+        super().__init__(
+            f"영상 비율 {aspect_ratio:.3f}이 목표 {target:.3f}(±{tolerance:.2f})를 벗어났습니다(변환 불가)"
+        )
+
+
+class ChannelVideoCodecUnsupportedError(Exception):
+    def __init__(self, *, codec: str, allowed: tuple[str, ...]):
+        self.codec = codec
+        self.allowed = allowed
+        super().__init__(f"지원하지 않는 영상 코덱입니다: {codec!r}(허용: {list(allowed)})")
+
+
+class ChannelVideoUploadFailedError(Exception):
+    def __init__(self, *, object_path: str):
+        self.object_path = object_path
+        super().__init__(f"영상 업로드 실패: {object_path}")
+
+
+@dataclass(frozen=True)
+class MP4Metadata:
+    duration_seconds: float
+    width: int
+    height: int
+    codec: str
+
+
+def _iter_boxes(buf: bytes, start: int, end: int):
+    """ISO Base Media File Format 박스 순회(top-level만, 재귀 X — 호출부가 필요한
+    컨테이너 박스의 payload 범위를 다시 이 함수에 넘겨 한 단계씩 내려간다).
+    size==0(파일 끝까지)·size==1(다음 8바이트가 64비트 largesize) 둘 다 처리."""
+    pos = start
+    while pos + 8 <= end:
+        size = struct.unpack(">I", buf[pos:pos + 4])[0]
+        box_type = buf[pos + 4:pos + 8]
+        header_size = 8
+        if size == 1:
+            if pos + 16 > end:
+                raise ChannelVideoUnparsableError()
+            size = struct.unpack(">Q", buf[pos + 8:pos + 16])[0]
+            header_size = 16
+        elif size == 0:
+            size = end - pos
+        if size < header_size or pos + size > end:
+            raise ChannelVideoUnparsableError()
+        yield box_type, pos + header_size, pos + size
+        pos += size
+
+
+def _find_box(buf: bytes, box_type: bytes, start: int, end: int) -> tuple[int, int] | None:
+    for bt, p_start, p_end in _iter_boxes(buf, start, end):
+        if bt == box_type:
+            return p_start, p_end
+    return None
+
+
+def _find_all_boxes(buf: bytes, box_type: bytes, start: int, end: int) -> list[tuple[int, int]]:
+    return [(p_start, p_end) for bt, p_start, p_end in _iter_boxes(buf, start, end) if bt == box_type]
+
+
+def _parse_mvhd_duration_seconds(buf: bytes, start: int, end: int) -> float:
+    if end - start < 4:
+        raise ChannelVideoUnparsableError()
+    version = buf[start]
+    if version == 1:
+        off = start + 4 + 8 + 8  # version+flags, creation_time(8), modification_time(8)
+        if off + 4 + 8 > end:
+            raise ChannelVideoUnparsableError()
+        timescale = struct.unpack(">I", buf[off:off + 4])[0]
+        duration = struct.unpack(">Q", buf[off + 4:off + 12])[0]
+    else:
+        off = start + 4 + 4 + 4  # version+flags, creation_time(4), modification_time(4)
+        if off + 4 + 4 > end:
+            raise ChannelVideoUnparsableError()
+        timescale = struct.unpack(">I", buf[off:off + 4])[0]
+        duration = struct.unpack(">I", buf[off + 4:off + 8])[0]
+    if timescale <= 0:
+        raise ChannelVideoUnparsableError()
+    return duration / timescale
+
+
+def _parse_tkhd_dimensions(buf: bytes, start: int, end: int) -> tuple[int, int]:
+    if end - start < 4:
+        raise ChannelVideoUnparsableError()
+    version = buf[start]
+    # version+flags(4) + creation+modification+track_ID+reserved+duration
+    fixed = 4 + (8 + 8 + 4 + 4 + 8) if version == 1 else 4 + (4 + 4 + 4 + 4 + 4)
+    # + reserved(8) + layer(2) + alternate_group(2) + volume(2) + reserved(2) + matrix(36)
+    offset = start + fixed + 8 + 2 + 2 + 2 + 2 + 36
+    if offset + 8 > end:
+        raise ChannelVideoUnparsableError()
+    width_fixed = struct.unpack(">I", buf[offset:offset + 4])[0]
+    height_fixed = struct.unpack(">I", buf[offset + 4:offset + 8])[0]
+    return width_fixed >> 16, height_fixed >> 16
+
+
+def _parse_hdlr_handler_type(buf: bytes, start: int, end: int) -> bytes:
+    offset = start + 4 + 4  # version+flags(4) + pre_defined(4)
+    if offset + 4 > end:
+        raise ChannelVideoUnparsableError()
+    return buf[offset:offset + 4]
+
+
+def _parse_stsd_codec(buf: bytes, start: int, end: int) -> str:
+    offset = start + 4  # version+flags(4)
+    if offset + 4 > end:
+        raise ChannelVideoUnparsableError()
+    entry_count = struct.unpack(">I", buf[offset:offset + 4])[0]
+    offset += 4
+    if entry_count < 1 or offset + 8 > end:
+        raise ChannelVideoUnparsableError()
+    # 첫 샘플 엔트리: size(4) + format fourcc(4).
+    fourcc = buf[offset + 4:offset + 8]
+    return fourcc.decode("ascii", errors="replace")
+
+
+def parse_mp4_metadata(raw: bytes) -> MP4Metadata:
+    """MP4/MOV(ISOBMFF) 박스 트리에서 `moov/mvhd`(길이)·비디오 `trak`의 `tkhd`
+    (해상도)·`stsd`(코덱 fourcc)만 읽는다. 오디오 트랙·코덱은 안 본다(PO 明示
+    미검증 선언). 구조가 예상과 다르면(박스 부재·경계 초과·손상) 전부
+    `ChannelVideoUnparsableError`로 수렴 — 조용한 통과 0."""
+    try:
+        n = len(raw)
+        moov = _find_box(raw, b"moov", 0, n)
+        if moov is None:
+            raise ChannelVideoUnparsableError()
+        moov_start, moov_end = moov
+
+        mvhd = _find_box(raw, b"mvhd", moov_start, moov_end)
+        if mvhd is None:
+            raise ChannelVideoUnparsableError()
+        duration_seconds = _parse_mvhd_duration_seconds(raw, *mvhd)
+
+        video_trak: tuple[int, int, tuple[int, int]] | None = None
+        for trak_start, trak_end in _find_all_boxes(raw, b"trak", moov_start, moov_end):
+            mdia = _find_box(raw, b"mdia", trak_start, trak_end)
+            if mdia is None:
+                continue
+            hdlr = _find_box(raw, b"hdlr", *mdia)
+            if hdlr is None:
+                continue
+            if _parse_hdlr_handler_type(raw, *hdlr) == b"vide":
+                video_trak = (trak_start, trak_end, mdia)
+                break
+        if video_trak is None:
+            raise ChannelVideoUnparsableError()
+        trak_start, trak_end, mdia = video_trak
+
+        tkhd = _find_box(raw, b"tkhd", trak_start, trak_end)
+        if tkhd is None:
+            raise ChannelVideoUnparsableError()
+        width, height = _parse_tkhd_dimensions(raw, *tkhd)
+        if width <= 0 or height <= 0:
+            raise ChannelVideoUnparsableError()
+
+        minf = _find_box(raw, b"minf", *mdia)
+        if minf is None:
+            raise ChannelVideoUnparsableError()
+        stbl = _find_box(raw, b"stbl", *minf)
+        if stbl is None:
+            raise ChannelVideoUnparsableError()
+        stsd = _find_box(raw, b"stsd", *stbl)
+        if stsd is None:
+            raise ChannelVideoUnparsableError()
+        codec = _parse_stsd_codec(raw, *stsd)
+    except (struct.error, IndexError) as exc:
+        raise ChannelVideoUnparsableError() from exc
+
+    return MP4Metadata(duration_seconds=duration_seconds, width=width, height=height, codec=codec)
+
+
+def _object_path(*, org_id: uuid.UUID, draft_id: uuid.UUID, ext: str) -> str:
+    return f"channel-media/{org_id}/{draft_id}/{uuid.uuid4().hex}.{ext}"
+
+
+async def create_channel_post_video_upload_url(
+    *, org_id: uuid.UUID, draft_id: uuid.UUID, channel: str, content_type: str,
+) -> dict:
+    bucket = _require_bucket()
+    adapter = get_channel_adapter(channel)
+    if adapter is None or adapter.video_max_bytes <= 0:
+        raise ChannelVideoUnsupportedError(channel=channel)
+    if content_type not in _MIME_TO_EXT:
+        raise ChannelVideoUnsupportedFormatError(content_type=content_type, allowed=tuple(_MIME_TO_EXT))
+    ext = _MIME_TO_EXT[content_type]
+    object_path = _object_path(org_id=org_id, draft_id=draft_id, ext=ext)
+    provider = get_storage_provider()
+    upload_url = await provider.signed_write_url(
+        bucket, object_path, ttl=UPLOAD_URL_TTL, content_type=content_type, create_only=True,
+    )
+    if upload_url is None:
+        raise ChannelVideoUploadFailedError(object_path=object_path)
+    return {
+        "upload_url": upload_url,
+        "object_path": object_path,
+        "expires_at": (datetime.now(timezone.utc) + UPLOAD_URL_TTL).isoformat(),
+        "max_bytes": adapter.video_max_bytes,
+        "required_put_headers": provider.required_write_headers(create_only=True),
+    }
+
+
+async def confirm_channel_post_video_upload(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID, object_path: str,
+    member_id: uuid.UUID, member_kind: str,
+) -> tuple[ChannelPostVersion, ChannelPostVideo]:
+    """story #3554(PO 確定①~④) — 업로드 확인+MP4 규격 검증+계보. attach와 동형
+    (confirm_channel_post_image_upload의 새-버전 패턴 재사용) — 매 호출이 새
+    `ChannelPostVersion`을 만들고, 기존 커버(있으면)를 새 버전으로 복제한 뒤 영상
+    행을 추가한다. 봉인 해시는 항상 `[video_sha256, cover_sha256 or ""]`(순서
+    고정, N=1 항등 분기를 안 탄다 — compute_image_seal_hash에 늘 2원소를 준다)."""
+    draft = await get_channel_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise ChannelPostDraftNotFoundError(draft_id)
+
+    adapter = get_channel_adapter(draft.channel)
+    if adapter is None or adapter.video_max_bytes <= 0:
+        raise ChannelVideoUnsupportedError(channel=draft.channel)
+
+    bucket = _require_bucket()
+    expected_prefix = f"channel-media/{org_id}/{draft_id}/"
+    if not object_path.startswith(expected_prefix) or "/" in object_path[len(expected_prefix):]:
+        raise ChannelVideoPathNotScopedError(object_path=object_path)
+
+    provider = get_storage_provider()
+    size = await provider.head_object(bucket, object_path)
+    if size is None:
+        raise ChannelVideoObjectNotFoundError(object_path=object_path)
+    if size > adapter.video_max_bytes:
+        await provider.delete_object(bucket, object_path)
+        raise ChannelVideoTooLargeError(size_bytes=size, max_bytes=adapter.video_max_bytes)
+
+    raw = await provider.download_object(bucket, object_path)
+    original_sha256 = hashlib.sha256(raw).hexdigest()
+
+    metadata = parse_mp4_metadata(raw)
+
+    if metadata.duration_seconds > adapter.video_max_seconds:
+        raise ChannelVideoDurationExceededError(
+            duration_seconds=metadata.duration_seconds, max_seconds=adapter.video_max_seconds,
+        )
+    if metadata.duration_seconds < adapter.video_min_seconds:
+        raise ChannelVideoDurationTooShortError(
+            duration_seconds=metadata.duration_seconds, min_seconds=adapter.video_min_seconds,
+        )
+    aspect_ratio = metadata.width / metadata.height
+    if adapter.video_aspect_target > 0 and abs(aspect_ratio - adapter.video_aspect_target) > adapter.video_aspect_tolerance:
+        raise ChannelVideoAspectRatioError(
+            aspect_ratio=aspect_ratio, target=adapter.video_aspect_target, tolerance=adapter.video_aspect_tolerance,
+        )
+    if adapter.video_codecs and metadata.codec not in adapter.video_codecs:
+        raise ChannelVideoCodecUnsupportedError(codec=metadata.codec, allowed=adapter.video_codecs)
+
+    latest = (await db.execute(
+        select(ChannelPostVersion)
+        .where(ChannelPostVersion.draft_id == draft_id)
+        .order_by(ChannelPostVersion.version.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    if latest is None:
+        raise ChannelPostDraftNotFoundError(draft_id)
+
+    existing_cover = await get_channel_post_image_for_version(db, version_id=latest.id)
+    cover_sha256 = existing_cover.final_sha256 if existing_cover is not None else ""
+    composite_sha256 = compute_image_seal_hash([original_sha256, cover_sha256])
+
+    new_version, _channel, _violations = await create_channel_post_draft_version(
+        db, org_id=org_id, work_item_id=draft.work_item_id, connection_id=draft.connection_id,
+        text=latest.text, link_url=latest.link_url,
+        author_member_id=member_id, author_kind=member_kind, image_sha256=composite_sha256,
+    )
+
+    if existing_cover is not None:
+        db.add(_copy_image_row(existing_cover, new_version_id=new_version.id, new_position=existing_cover.position))
+
+    video_row = ChannelPostVideo(
+        id=uuid.uuid4(), org_id=org_id, draft_id=draft_id, version_id=new_version.id,
+        original_object_path=object_path, original_sha256=original_sha256,
+        original_content_type=_content_type_for_ext(object_path), original_bytes=size,
+        duration_seconds=metadata.duration_seconds, width=metadata.width, height=metadata.height,
+        codec=metadata.codec, created_by=member_id,
+    )
+    db.add(video_row)
+    await db.commit()
+    await db.refresh(video_row)
+    return new_version, video_row
+
+
+def _content_type_for_ext(object_path: str) -> str:
+    for content_type, ext in _MIME_TO_EXT.items():
+        if object_path.endswith(f".{ext}"):
+            return content_type
+    return "application/octet-stream"
+
+
+async def get_channel_post_video_for_version(
+    db: AsyncSession, *, version_id: uuid.UUID,
+) -> ChannelPostVideo | None:
+    return (await db.execute(
+        select(ChannelPostVideo).where(ChannelPostVideo.version_id == version_id)
+    )).scalar_one_or_none()
+
+
+def _copy_video_row(existing: ChannelPostVideo, *, new_version_id: uuid.UUID) -> ChannelPostVideo:
+    """channel_posts.py의 텍스트-편집 carry-forward·channel_post_images.py의
+    커버 교체 두 곳이 공유하는 유일한 영상 행 복제 지점(`channel_post_images.py::
+    _copy_image_row`와 동형 관례) — 재업로드·재파싱 없음, object_path·sha256·
+    규격 메타 그대로 새 version_id로."""
+    return ChannelPostVideo(
+        id=uuid.uuid4(), org_id=existing.org_id, draft_id=existing.draft_id, version_id=new_version_id,
+        original_object_path=existing.original_object_path, original_sha256=existing.original_sha256,
+        original_content_type=existing.original_content_type, original_bytes=existing.original_bytes,
+        duration_seconds=existing.duration_seconds, width=existing.width, height=existing.height,
+        codec=existing.codec, created_by=existing.created_by,
+    )

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -525,6 +525,17 @@ async def create_channel_post_draft_version(
         if prior_images:
             await db.flush()
 
+        # story #3554(Phase2, 페드루 PO 確定 2026-09-06) — 영상(릴스) draft도 텍스트만
+        # 편집하면 이 sentinel 경로를 탄다(image_sha256 인자 생략) — 위 이미지 캐리
+        # 포워드와 동형으로 영상 행도 새 version_id로 복제해야 발행 시점에 「빈손」이
+        # 안 된다(위 B1 교훈과 동일 재발 방지).
+        from app.services.channel_post_videos import _copy_video_row, get_channel_post_video_for_version
+
+        prior_video = await get_channel_post_video_for_version(db, version_id=prior_latest.id)
+        if prior_video is not None:
+            db.add(_copy_video_row(prior_video, new_version_id=version.id))
+            await db.flush()
+
     await _reseal_gate_on_new_version(
         db, org_id=org_id, work_item_id=work_item_id, version=version, connection_id=draft.connection_id,
     )
@@ -1192,18 +1203,34 @@ async def publish_channel_post_draft(
     # 존재로 판단 — latest.image_sha256만으로는 「나가는 파생본」 경로를 못 구하므로
     # 행 자체를 조회한다.
     image_public_urls: list[str] = []
+    video_row = None
+    video_public_url: str | None = None
     if latest.image_sha256 is not None:
         from app.services.channel_post_images import list_channel_post_images_for_version, public_url_for_object_path
+        from app.services.channel_post_videos import get_channel_post_video_for_version
 
         image_rows = await list_channel_post_images_for_version(db, version_id=latest.id)
         image_public_urls = [
             url for row in image_rows if (url := public_url_for_object_path(row.final_object_path)) is not None
         ]
+        # story #3554(Phase2, 페드루 PO 確定 2026-09-06④) — 릴스(영상). 영상 마스터
+        # 존재 여부로 REELS 경로를 가른다 — 커버는 `channel_post_images` position=0
+        # 재사용이라 위 `image_public_urls`에 커버 1장이 섞여 들어올 수 있지만, 그
+        # 경우도 "영상 있음"이 우선이라 REELS로만 나간다(아래 dispatch 참고).
+        video_row = await get_channel_post_video_for_version(db, version_id=latest.id)
+        if video_row is not None:
+            video_public_url = public_url_for_object_path(video_row.original_object_path)
     has_image = len(image_public_urls) > 0
+    has_video = video_row is not None
     # 기존 단일-이미지 호출부(threads/facebook/sandbox 등 — 전부 image_max_count<=1이라
     # 여기까지 2장 이상으로 도달할 수 없다, confirm_channel_post_image_upload의 업로드
-    # 시점 거부가 이미 막는다)와의 하위호환 — image_url은 항상 "첫 장"(N=0이면 None).
+    # 시점 거부가 이미 막는다)와의 하위호환 — image_url은 항상 "첫 장"(N=0이면 None,
+    # 영상 모드면 이 값은 "커버" — REELS dispatch는 이 변수가 아니라 video_public_url을 쓴다).
     image_public_url: str | None = image_public_urls[0] if image_public_urls else None
+    # story 620beefc(AC5)의 기존 "이미지 있으면 비동기" 게이트를 릴스까지 넓힌 축
+    # 이름 — REELS 컨테이너도 IMAGE/CAROUSEL과 동형으로 항상 비동기(Meta "처리 대기"
+    # 폴링 필요, 3539 processing 축 그대로 재사용).
+    has_async_media = has_image or has_video
 
     # 발행 직전 재검증③(연결 활성) — 초안 생성/상신과 같은 헬퍼.
     connection = await _get_active_connection(db, org_id=org_id, connection_id=draft.connection_id)
@@ -1339,7 +1366,22 @@ async def publish_channel_post_draft(
             just_created_container = row.external_container_id is None
             if just_created_container:
                 try:
-                    if len(image_public_urls) > 1:
+                    if has_video:
+                        # story #3554(Phase2, PO 確定 ④) — 릴스는 이미지/캐러셀과
+                        # 완전히 별도 컨테이너 함수(create_reels_container류) — 어댑터가
+                        # 안 구현했으면(미확認 방어) 명시 실패.
+                        create_reels_container = getattr(_publish_client, "create_reels_container", None)
+                        if create_reels_container is None:
+                            raise ThreadsPublishError(
+                                "CHANNEL_REELS_UNSUPPORTED",
+                                f"{draft.channel} 채널은 릴스(영상) 발행을 지원하지 않습니다",
+                                status_code=422,
+                            )
+                        container_id = await create_reels_container(
+                            client, access_token=access_token, threads_user_id=connection.account_id,
+                            text=text_to_post, video_url=video_public_url, cover_url=image_public_url,
+                        )
+                    elif len(image_public_urls) > 1:
                         # story #3550(Phase2, PO 確定 ④) — 캐러셀(2장 이상)은 별도
                         # 함수(instagram_publish.py::create_carousel_container류) —
                         # image_max_count<=1인 채널(threads/facebook/sandbox 등)은
@@ -1377,8 +1419,8 @@ async def publish_channel_post_draft(
                 row.error_code = None
                 row.last_error = None
                 await db.commit()
-                if has_image:
-                    # story 620beefc(AC5, PO 決定) — IMAGE 컨테이너는 비동기(그라운딩
+                if has_async_media:
+                    # story 620beefc(AC5, PO 決定)·#3554(릴스로 확장) — IMAGE/REELS 컨테이너는 비동기(그라운딩
                     # §② Meta 권장 "평균 30초 대기"). 막 만든 컨테이너를 이 자리에서
                     # 곧바로 poll하지 않는다 — container_created 그대로 반환, 호출부
                     # (cron 워커·즉시발행 라우터 둘 다)가 command를 pending(next_
@@ -1386,8 +1428,8 @@ async def publish_channel_post_draft(
                     # 기존 워커 재사용).
                     return row
 
-            if has_image:
-                # story 620beefc(AC5) — 재진입(다음 tick)마다 컨테이너 상태를 먼저
+            if has_async_media:
+                # story 620beefc(AC5)·#3554(릴스로 확장) — 재진입(다음 tick)마다 컨테이너 상태를 먼저
                 # 확인한다. FINISHED여야만 publish 호출로 진행 — Meta 문서: 완료 前
                 # publish는 실패한다.
                 try:

--- a/backend/app/services/instagram_publish.py
+++ b/backend/app/services/instagram_publish.py
@@ -132,6 +132,41 @@ async def create_carousel_container(
     return str(creation_id)
 
 
+async def create_reels_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    video_url: str | None, cover_url: str | None = None,
+) -> str:
+    """story #3554(Phase2, 페드루 PO 確定 2026-09-06④) — 릴스(영상) 발행.
+    `create_carousel_container`와 동형(부모 컨테이너 1개만 만들고 그 creation_id를
+    반환 — 오케스트레이션은 get_container_status·publish_container를 무변경 재사용).
+    `media_type=REELS`·`video_url`·`cover_url`(선택, 없으면 Meta가 자동 프레임을
+    고른다). caption 파라미터명은 이미지/캐러셀과 동일.
+
+    ⚠️미확認(instagram_publish.py 상단 딱지와 동형 — 컨테이너 파라미터명은 Meta
+    문서 지식, 재확認 전 라이브 왕복 금지)."""
+    if video_url is None:
+        raise ThreadsPublishError(
+            "INSTAGRAM_REELS_VIDEO_REQUIRED", "릴스 발행은 영상이 필수입니다", status_code=422,
+        )
+    params = {"access_token": access_token, "media_type": "REELS", "video_url": video_url}
+    if cover_url:
+        params["cover_url"] = cover_url
+    if text:
+        params["caption"] = text
+    resp = await client.post(_MEDIA_CONTAINER_URL_TMPL.format(ig_user_id=threads_user_id), params=params)
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "INSTAGRAM_CREATE_REELS_CONTAINER_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    creation_id = body.get("id")
+    if not creation_id:
+        raise ThreadsPublishError(
+            "INSTAGRAM_CREATE_REELS_CONTAINER_MISSING_ID", "id missing in response", status_code=resp.status_code,
+        )
+    return str(creation_id)
+
+
 _CONTAINER_STATUS_FINISHED = "FINISHED"
 _CONTAINER_STATUS_IN_PROGRESS = "IN_PROGRESS"
 _CONTAINER_STATUS_ERROR = "ERROR"

--- a/backend/app/services/instagram_sandbox_publish.py
+++ b/backend/app/services/instagram_sandbox_publish.py
@@ -25,6 +25,12 @@ from app.services.threads_publish import ThreadsPublishError
 _MARKER_429 = "[sandbox:429]"
 _MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
 _MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
+# story #3554(Phase2, 페드루 PO 確定 2026-09-06⑤) — 릴스 전용 마커 2종. "processing-
+# failed"는 Meta 쪽 비동기 영상 처리 실패(코덱은 통과했지만 인코딩 파이프라인
+# 자체가 거부하는 케이스, 예: 손상된 프레임)를 흉내낸다 — 서버 업로드 시점 파서
+# 검증(codec-rejected와 다른 축)과 구분해 둔다.
+_MARKER_REELS_PROCESSING_FAILED = "[sandbox:reels-processing-failed]"
+_MARKER_REELS_CODEC_REJECTED = "[sandbox:reels-codec-rejected]"
 
 
 async def create_container(
@@ -76,6 +82,42 @@ async def create_carousel_container(
                 "SANDBOX_INSTAGRAM_CAROUSEL_CHILD_FAILED", f"sandbox: {marker} 마커 시뮬레이션", status_code=502,
             )
     return f"sandbox-ig-carousel-{uuid.uuid4().hex}"
+
+
+async def create_reels_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    video_url: str | None, cover_url: str | None = None,
+) -> str:
+    """story #3554(Phase2, 페드루 PO 確定 2026-09-06④⑤) — instagram_publish.py::
+    create_reels_container와 동형 계약. `[sandbox:reels-processing-failed]`·
+    `[sandbox:reels-codec-rejected]` 마커로 Meta 쪽 비동기 처리 실패를 흉내낸다
+    (업로드 시점 파서 검증과 별개 축 — 여긴 "파서는 통과했지만 provider가 나중에
+    거부"하는 케이스)."""
+    if _MARKER_429 in text:
+        raise ThreadsPublishError("SANDBOX_INSTAGRAM_RATE_LIMITED", "sandbox: [sandbox:429] 마커 시뮬레이션", status_code=429)
+    if _MARKER_PROVIDER_ERROR in text:
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_PROVIDER_ERROR", "sandbox: [sandbox:provider-error] 마커 시뮬레이션", status_code=502,
+        )
+    if _MARKER_EXPIRED_TOKEN in text:
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_TOKEN_EXPIRED", "sandbox: [sandbox:expired-token] 마커 시뮬레이션", status_code=401,
+        )
+    if _MARKER_REELS_PROCESSING_FAILED in text:
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_REELS_PROCESSING_FAILED",
+            "sandbox: [sandbox:reels-processing-failed] 마커 시뮬레이션", status_code=502,
+        )
+    if _MARKER_REELS_CODEC_REJECTED in text:
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_REELS_CODEC_REJECTED",
+            "sandbox: [sandbox:reels-codec-rejected] 마커 시뮬레이션", status_code=422,
+        )
+    if video_url is None:
+        raise ThreadsPublishError(
+            "INSTAGRAM_REELS_VIDEO_REQUIRED", "릴스 발행은 영상이 필수입니다", status_code=422,
+        )
+    return f"sandbox-ig-reels-{uuid.uuid4().hex}"
 
 
 async def get_container_status(

--- a/backend/tests/test_3554_instagram_reels.py
+++ b/backend/tests/test_3554_instagram_reels.py
@@ -1,0 +1,610 @@
+"""story #3554(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — Instagram 릴스(영상)
+발행. PO 못박음 5가지:
+① 어댑터 규격 선언(video_max_bytes·video_max_seconds/min_seconds·video_aspect_
+   target/tolerance·video_codecs).
+② 업로드는 3425 경로 재사용(signed URL→confirm)+sha256. 커버는 기존 이미지
+   파이프 재사용(별개 테이블 X).
+③ 봉인 합성 해시 `[video_sha256, cover_sha256 or ""]`(순서 고정) — 커버
+   추가/제거/교체 전부 재승인.
+④ `create_reels_container`(media_type=REELS)+processing 폴링(3539 축 재사용).
+⑤ sandbox 마커(processing-failed·codec-rejected).
+
+MP4 픽스처는 실 ffmpeg 없이 순수 파이썬으로 최소 유효 ISOBMFF 박스 트리를
+직접 조립한다(파서가 실제로 요구하는 필드만 — moov/mvhd·trak/mdia/hdlr·
+trak/tkhd·trak/mdia/minf/stbl/stsd, mdat은 더미).
+
+세팅 헬퍼는 test_620beefc_channel_post_image.py 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import struct
+import uuid
+
+import pytest
+
+from tests.test_620beefc_channel_post_image import (
+    _approve_gate_directly,
+    _client_for,
+    _create_draft,
+    _jpeg_bytes,
+    _put_raw_object,
+    _seed_connection,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+    _upload_and_confirm,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+_CHANNEL_MEDIA_BUCKET = "test-channel-media-3554"
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage(monkeypatch, tmp_path):
+    """test_3550_instagram_carousel.py와 동형 픽스처(다른 버킷명으로 격리)."""
+    import app.services.channel_post_images as cpi_module
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage_object_path_fix(monkeypatch):
+    import tests.test_620beefc_channel_post_image as base_test_module
+
+    monkeypatch.setattr(base_test_module, "_CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _instagram_sandbox_video_config(monkeypatch):
+    """test_3550_instagram_carousel.py::_instagram_sandbox_ten_images와 동형 —
+    SANDBOX_CHANNEL_ENABLED 조건부 블록에 기대지 않고 이 테스트 파일이 필요로
+    하는 정확한 video_* 값을 직접 주입한다(import 순서 무관하게 결정적)."""
+    import app.services.channel_adapters as adapters_mod
+
+    ig_sandbox_cfg = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual", credential_kind="none", display_name="Instagram Sandbox",
+        max_text_length=2200, utm_source="instagram_sandbox", utm_medium="test",
+        image_formats=("image/jpeg",), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91, image_aspect_min=0.8,
+        image_width_min=320, image_width_max=1440, image_color_space="sRGB",
+        image_max_count=10,
+        video_max_bytes=100 * 1024 * 1024, video_max_seconds=90.0, video_min_seconds=3.0,
+        video_aspect_target=9 / 16, video_aspect_tolerance=0.05,
+        video_codecs=("avc1", "hvc1", "hev1"),
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "instagram_sandbox", ig_sandbox_cfg)
+    yield
+
+
+# ─── MP4(ISOBMFF) 최소 유효 픽스처 조립 ──────────────────────────────────────
+
+
+def _box(box_type: bytes, payload: bytes) -> bytes:
+    return struct.pack(">I", 8 + len(payload)) + box_type + payload
+
+
+def _build_mvhd(*, timescale: int, duration: int) -> bytes:
+    payload = b"\x00\x00\x00\x00"  # version(0)+flags
+    payload += struct.pack(">I", 0)  # creation_time
+    payload += struct.pack(">I", 0)  # modification_time
+    payload += struct.pack(">I", timescale)
+    payload += struct.pack(">I", duration)
+    return _box(b"mvhd", payload)
+
+
+def _build_tkhd(*, width: int, height: int) -> bytes:
+    payload = b"\x00\x00\x00\x00"  # version(0)+flags
+    payload += struct.pack(">I", 0)  # creation_time
+    payload += struct.pack(">I", 0)  # modification_time
+    payload += struct.pack(">I", 1)  # track_ID
+    payload += struct.pack(">I", 0)  # reserved
+    payload += struct.pack(">I", 0)  # duration
+    payload += b"\x00" * 8  # reserved
+    payload += b"\x00" * 2  # layer
+    payload += b"\x00" * 2  # alternate_group
+    payload += b"\x00" * 2  # volume
+    payload += b"\x00" * 2  # reserved
+    payload += b"\x00" * 36  # matrix
+    payload += struct.pack(">I", width << 16)
+    payload += struct.pack(">I", height << 16)
+    return _box(b"tkhd", payload)
+
+
+def _build_hdlr(handler_type: bytes) -> bytes:
+    payload = b"\x00\x00\x00\x00"  # version(0)+flags
+    payload += struct.pack(">I", 0)  # pre_defined
+    payload += handler_type
+    payload += b"\x00" * 12  # reserved
+    payload += b"\x00"  # name(빈 문자열, null-terminated)
+    return _box(b"hdlr", payload)
+
+
+def _build_stsd(fourcc: bytes) -> bytes:
+    payload = b"\x00\x00\x00\x00"  # version(0)+flags
+    payload += struct.pack(">I", 1)  # entry_count
+    payload += struct.pack(">I", 16)  # entry size(임의 — 파서는 fourcc만 읽는다)
+    payload += fourcc
+    return _box(b"stsd", payload)
+
+
+def _build_trak(*, width: int, height: int, handler_type: bytes, fourcc: bytes) -> bytes:
+    tkhd = _build_tkhd(width=width, height=height)
+    hdlr = _build_hdlr(handler_type)
+    stsd = _build_stsd(fourcc)
+    stbl = _box(b"stbl", stsd)
+    minf = _box(b"minf", stbl)
+    mdia = _box(b"mdia", hdlr + minf)
+    return _box(b"trak", tkhd + mdia)
+
+
+def _build_mp4(
+    *, duration_seconds: float, width: int, height: int, codec: bytes = b"avc1",
+    timescale: int = 600, include_audio_track: bool = False,
+) -> bytes:
+    duration = round(duration_seconds * timescale)
+    mvhd = _build_mvhd(timescale=timescale, duration=duration)
+    video_trak = _build_trak(width=width, height=height, handler_type=b"vide", fourcc=codec)
+    traks = video_trak
+    if include_audio_track:
+        audio_trak = _build_trak(width=0, height=0, handler_type=b"soun", fourcc=b"mp4a")
+        traks = audio_trak + video_trak  # 오디오 먼저 — 비디오 트랙 선택이 이걸 건너뛰는지 검증
+    moov = _box(b"moov", mvhd + traks)
+    ftyp = _box(b"ftyp", b"isom" + struct.pack(">I", 0) + b"isomiso2avc1mp41")
+    mdat = _box(b"mdat", b"\x00" * 16)  # 더미(파서가 안 읽음)
+    return ftyp + moov + mdat
+
+
+_CHANNEL_MEDIA_OBJECT_EXT: dict[str, str] = {"video/mp4": "mp4", "video/quicktime": "mov"}
+
+
+def _object_path_for_video(org_id, draft_id, *, content_type: str = "video/mp4") -> str:
+    ext = _CHANNEL_MEDIA_OBJECT_EXT.get(content_type, "bin")
+    return f"channel-media/{org_id}/{draft_id}/{uuid.uuid4().hex}.{ext}"
+
+
+async def _upload_and_confirm_video(client, org_id, draft_id, raw: bytes, *, content_type: str = "video/mp4"):
+    object_path = _object_path_for_video(org_id, draft_id, content_type=content_type)
+    await _put_raw_object(object_path, raw, content_type=content_type)
+    return await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/video/confirm",
+        json={"object_path": object_path},
+    )
+
+
+_VALID_9_16 = {"width": 720, "height": 1280}  # 720/1280 = 0.5625 = 9/16 정확히.
+
+
+# ─── ① 파서 단위(순수 함수, DB 불요) ─────────────────────────────────────────
+
+
+def test_parse_mp4_metadata_reads_duration_width_height_codec():
+    from app.services.channel_post_videos import parse_mp4_metadata
+
+    raw = _build_mp4(duration_seconds=10.0, width=720, height=1280, codec=b"avc1")
+    meta = parse_mp4_metadata(raw)
+    assert meta.duration_seconds == pytest.approx(10.0, abs=0.01)
+    assert (meta.width, meta.height) == (720, 1280)
+    assert meta.codec == "avc1"
+
+
+def test_parse_mp4_metadata_skips_audio_track_picks_video():
+    from app.services.channel_post_videos import parse_mp4_metadata
+
+    raw = _build_mp4(duration_seconds=5.0, width=720, height=1280, codec=b"hvc1", include_audio_track=True)
+    meta = parse_mp4_metadata(raw)
+    assert meta.codec == "hvc1"
+    assert (meta.width, meta.height) == (720, 1280)
+
+
+def test_parse_mp4_metadata_missing_moov_raises_unparsable():
+    from app.services.channel_post_videos import ChannelVideoUnparsableError, parse_mp4_metadata
+
+    raw = _box(b"ftyp", b"isom") + _box(b"mdat", b"\x00" * 8)
+    with pytest.raises(ChannelVideoUnparsableError):
+        parse_mp4_metadata(raw)
+
+
+def test_parse_mp4_metadata_corrupt_bytes_raises_unparsable():
+    from app.services.channel_post_videos import ChannelVideoUnparsableError, parse_mp4_metadata
+
+    with pytest.raises(ChannelVideoUnparsableError):
+        parse_mp4_metadata(b"not an mp4 file at all, just garbage bytes")
+
+
+def test_parse_mp4_metadata_moov_size_lies_past_buffer_end_raises_unparsable():
+    """박스 size 필드가 실제 버퍼 길이를 넘어서게 거짓말하면(잘림·손상 파일의
+    전형적 신호) fail-closed로 거부해야 한다 — 조용히 잘라 읽으면 안 된다."""
+    from app.services.channel_post_videos import ChannelVideoUnparsableError, parse_mp4_metadata
+
+    lying_moov = struct.pack(">I", 10_000) + b"moov" + b"\x00" * 4  # size=10000인데 실제론 12바이트뿐
+    with pytest.raises(ChannelVideoUnparsableError):
+        parse_mp4_metadata(lying_moov)
+
+
+# ─── ①③ 업로드 확인+규격 검증 ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_video_upload_confirm_success_stores_metadata_and_composite_seal():
+    from app.main import app
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.services.channel_post_images import compute_image_seal_hash
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r = await _upload_and_confirm_video(client, org_id, draft_id, raw)
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["duration_seconds"] == pytest.approx(6.0, abs=0.01)
+        assert (body["width"], body["height"]) == (720, 1280)
+        assert body["codec"] == "avc1"
+
+        video_sha256 = __import__("hashlib").sha256(raw).hexdigest()
+        async with Session() as s:
+            version = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(body["version_id"]))
+            )).scalar_one()
+        assert version.image_sha256 == compute_image_seal_hash([video_sha256, ""])
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_video_duration_exceeded_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _build_mp4(duration_seconds=95.0, **_VALID_9_16)
+            r = await _upload_and_confirm_video(client, org_id, draft_id, raw)
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_VIDEO_DURATION_EXCEEDED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_video_duration_too_short_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _build_mp4(duration_seconds=1.0, **_VALID_9_16)
+            r = await _upload_and_confirm_video(client, org_id, draft_id, raw)
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_VIDEO_DURATION_TOO_SHORT"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_video_aspect_ratio_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _build_mp4(duration_seconds=10.0, width=1000, height=1000)  # 1:1, 목표 0.5625와 크게 벗어남
+            r = await _upload_and_confirm_video(client, org_id, draft_id, raw)
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_VIDEO_ASPECT_RATIO_REJECTED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_video_codec_unsupported_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _build_mp4(duration_seconds=10.0, codec=b"mp4v", **_VALID_9_16)
+            r = await _upload_and_confirm_video(client, org_id, draft_id, raw)
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_VIDEO_CODEC_UNSUPPORTED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_video_corrupt_upload_rejected_422_unparsable():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r = await _upload_and_confirm_video(client, org_id, draft_id, b"garbage not mp4")
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_VIDEO_UNPARSABLE"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ②③ 커버(기존 이미지 파이프 재사용)·carry-forward ───────────────────────
+
+
+@pytest.mark.anyio
+async def test_cover_attach_after_video_computes_composite_and_replaces_not_appends():
+    """PO 明示 ③ — 커버는 별개 이미지 에셋(기존 파이프)이지만 캐러셀처럼 "추가"
+    되지 않고 "교체"된다(항상 position=0 슬롯 하나). 두 번째 커버 첨부 뒤에도
+    이미지 행이 정확히 1개여야 한다."""
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.services.channel_post_images import compute_image_seal_hash
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            video_raw = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, video_raw)
+            assert r_video.status_code == 201, r_video.text
+            video_sha256 = __import__("hashlib").sha256(video_raw).hexdigest()
+
+            cover1_raw = _jpeg_bytes(800, 1000, color=(10, 20, 30))
+            r_cover1 = await _upload_and_confirm(client, org_id, draft_id, cover1_raw, content_type="image/jpeg")
+            assert r_cover1.status_code == 201, r_cover1.text
+            version1_id = r_cover1.json()["version_id"]
+
+        async with Session() as s:
+            images_v1 = list((await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(version1_id))
+            )).scalars().all())
+            version1 = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(version1_id))
+            )).scalar_one()
+        assert len(images_v1) == 1
+        assert images_v1[0].position == 0
+        assert version1.image_sha256 == compute_image_seal_hash([video_sha256, images_v1[0].final_sha256])
+
+        async with _client_for(app) as client:
+            cover2_raw = _jpeg_bytes(800, 1000, color=(200, 210, 220))
+            r_cover2 = await _upload_and_confirm(client, org_id, draft_id, cover2_raw, content_type="image/jpeg")
+            assert r_cover2.status_code == 201, r_cover2.text
+            version2_id = r_cover2.json()["version_id"]
+
+        async with Session() as s:
+            images_v2 = list((await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == uuid.UUID(version2_id))
+            )).scalars().all())
+            version2 = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(version2_id))
+            )).scalar_one()
+        assert len(images_v2) == 1, "커버는 교체다 — 두 번째 첨부 뒤에도 이미지 행은 1개여야 한다"
+        assert images_v2[0].position == 0
+        assert version2.image_sha256 == compute_image_seal_hash([video_sha256, images_v2[0].final_sha256])
+        assert version2.image_sha256 != version1.image_sha256, "커버 교체가 봉인을 안 깼다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_text_only_edit_after_video_and_cover_carries_forward_both():
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.services.channel_post_videos import get_channel_post_video_for_version
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            video_raw = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            await _upload_and_confirm_video(client, org_id, draft_id, video_raw)
+            cover_raw = _jpeg_bytes(800, 1000)
+            r_cover = await _upload_and_confirm(client, org_id, draft_id, cover_raw, content_type="image/jpeg")
+            assert r_cover.status_code == 201, r_cover.text
+            version_before_id = r_cover.json()["version_id"]
+
+            # 텍스트만 편집(같은 connection_id·work_item_id → 같은 draft, image_sha256
+            # 인자 생략 → sentinel 경로 → 영상·커버 둘 다 캐리포워드돼야 한다).
+            r_edit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json={"work_item_id": str(story_id), "connection_id": str(connection_id), "text": "본문만 편집했습니다"},
+            )
+            assert r_edit.status_code == 201, r_edit.text
+            version_after_id = r_edit.json()["version_id"]
+
+        async with Session() as s:
+            before = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(version_before_id))
+            )).scalar_one()
+            after = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(version_after_id))
+            )).scalar_one()
+            after_video = await get_channel_post_video_for_version(s, version_id=after.id)
+            after_images = list((await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == after.id)
+            )).scalars().all())
+        assert after_video is not None, "텍스트 편집이 영상을 떨어뜨렸다"
+        assert len(after_images) == 1, "텍스트 편집이 커버를 떨어뜨렸다"
+        assert after.image_sha256 == before.image_sha256, "캐리포워드인데 봉인이 바뀌었다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ④ REELS 컨테이너 발행(sandbox, 종단) ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_publish_dispatches_to_reels_container_for_video_instagram_sandbox():
+    from app.main import app
+    from app.models.channel_publication import ChannelPublication
+    from sqlalchemy import select as sa_select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+            from app.models.participation import ParticipationRole
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+            s.add(role)
+            await s.commit()
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            video_raw = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, video_raw)
+            assert r_video.status_code == 201, r_video.text
+            version_id = r_video.json()["version_id"]
+
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit",
+                json={"version_id": version_id},
+            )
+            assert r_submit.status_code == 200, r_submit.text
+            gate_id = r_submit.json()["gate_id"]
+
+        async with Session() as s:
+            await _approve_gate_directly(s, uuid.UUID(gate_id))
+
+        async with _client_for(app) as client:
+            r_publish_1 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+            )
+            assert r_publish_1.status_code == 200, r_publish_1.text
+            assert r_publish_1.json()["processing"] is True
+
+        async with Session() as s:
+            pub = (await s.execute(
+                sa_select(ChannelPublication).where(ChannelPublication.version_id == uuid.UUID(version_id))
+            )).scalar_one()
+        assert pub.external_container_id is not None and pub.external_container_id.startswith("sandbox-ig-reels-"), (
+            "REELS 컨테이너가 아니라 다른 경로(IMAGE/CAROUSEL)로 샜다"
+        )
+
+        async with _client_for(app) as client:
+            r_publish_2 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+            )
+        assert r_publish_2.status_code == 200, r_publish_2.text
+        body = r_publish_2.json()
+        assert body["processing"] is False
+        assert body["external_id"] is not None and body["external_id"].startswith("sandbox-ig-media-")
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1331,6 +1331,11 @@
       "file": "tests/test_3550_instagram_carousel.py",
       "sec": 60.0,
       "source": "story-3550-instagram-carousel-be(#3910 CI authz 가드 fix — cross-project 404 테스트 2건 추가 뒤 재측정 — 로컬 raw pytest 21건 9.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값. 실 CI 샤드 7 로그 실측: 19건 25.13s — 여유 충분 확인됨, story #3550 그라운딩 코멘트 참고)"
+    },
+    {
+      "file": "tests/test_3554_instagram_reels.py",
+      "sec": 45.0,
+      "source": "story-3554-instagram-reels-be(PR 개설 前 선제 등재 — 로컬 raw pytest 14건 7.40s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 배경
블루프린트 §7 Phase 2 「Instagram·Facebook Page 발행(이미지·릴스·캐러셀)」의 마지막 축. #3320(이미지 1장)·#3550(캐러셀)에 이어 영상(릴스)을 연다. #3910(base) 머지 뒤 develop(ddfa63659) 위로 rebase 완료 — base=develop, head=5641e2873.

## 구현(PO 확定 5가지)
**① 어댑터 규격 선언** — `video_max_bytes`(100MB)·`video_max_seconds`(90)·`video_min_seconds`(3)·`video_aspect_target`(9/16)±`video_aspect_tolerance`(0.05)·`video_codecs`(avc1/hvc1/hev1). instagram·instagram_sandbox 동일 선언(sandbox가 실 provider보다 관대하면 안 된다는 기존 관례).

**② 업로드** — 기존 이미지 업로드 경로(signed URL→FE PUT→confirm) 그대로 재사용+sha256. **서버 자동 변환(ffmpeg) 없음** — 순수 파이썬 MP4/MOV(ISOBMFF) 박스 파서(`channel_post_videos.py::parse_mp4_metadata`)로 `mvhd`(길이)·`tkhd`(해상도)·`hdlr`(비디오 트랙 식별, 오디오 트랙 스킵)·`stsd`(코덱 fourcc)만 읽어 어댑터 선언과 대조합니다. 파싱 실패는 fail-closed 422 `CHANNEL_VIDEO_UNPARSABLE`(조용한 통과 0). 오디오 코덱은 미검증 선언.

**③ 봉인** — `ChannelPostVersion.image_sha256`(#3550과 같은 컬럼 재사용)에 항상 `[video_sha256, cover_sha256 or ""]`(순서 고정) 합성(`compute_image_seal_hash` 그대로 재사용 — N=1 항등 분기와 자연히 안 겹칩니다, 영상 모드는 항상 2원소). **커버는 새 테이블 없이 기존 `ChannelPostImage`(position=0) 재사용** — `confirm_channel_post_image_upload`가 "이 draft에 영상이 있으면 캐러셀 첨부가 아니라 커버 교체"로 분기합니다(추가가 아니라 교체, 항상 1행 유지). 텍스트만 편집하는 캐리포워드 경로도 영상 행까지 확장했습니다.

**⚠️비차단 확認(페드루 PO 2026-09-06 04:17)** — 영상 있는 버전에 이미지를 또 confirm하면 **캐러셀 첨부가 아니라 "커버 교체"**로 읽힙니다: 기존 커버(있으면)는 새 버전으로 복제되지 **않고**, 이번에 confirm된 이미지 1장만 position=0으로 들어가며 봉인은 `[video_sha256, 새_cover_sha256]`로 재계산됩니다 — 즉 "2번째 이미지 confirm 호출"이 캐러셀처럼 2장 누적되는 게 아니라 커버 슬롯 하나를 덮어씁니다. 이 동작은 `test_cover_attach_after_video_computes_composite_and_replaces_not_appends`(test_3554_instagram_reels.py)가 정확히 검증합니다 — 커버를 두 번째로 confirm해도 이미지 행이 여전히 1개(교체)이고 봉인 해시가 바뀌는 것(재승인 트리거)까지 확인. 코드 변경 없음, head 그대로.

**④ 컨테이너** — `create_reels_container`(`media_type=REELS`·`video_url`·`cover_url`) 신설(instagram_publish.py·instagram_sandbox_publish.py 둘 다). `channel_posts.py` 발행 오케스트레이션이 `has_video`로 IMAGE/CAROUSEL 경로와 분기하고, 기존 `has_image` 비동기 게이트를 `has_async_media`로 확장(REELS도 항상 비동기, #3539의 processing 축 그대로 재사용).

**⑤ sandbox 마커** — `[sandbox:reels-processing-failed]`·`[sandbox:reels-codec-rejected]` 추가(기존 substring-in-text 패턴 그대로).

## ⚠️미확認
릴스 컨테이너 파라미터명(`media_type=REELS`·`video_url`·`cover_url`)은 Meta 문서 지식(instagram_publish.py 상단 기존 딱지와 동형 — 재확認 전 라이브 왕복 금지).

## 테스트
14건(파서 단위 5·업로드 검증 5·커버 교체+carry-forward 2·종단 발행 1) + 뮤테이션 3종(duration/aspect/codec 검사 제거·커버 append로 변질·REELS 디스패치 제거) 각 RED 확인 후 원복. 마이그 0344 실 Postgres upgrade/downgrade 왕복 확인. 회귀 162건(3550/620beefc/3320/3536/3414/3474/3525/5b27b32f/f8f7cb0f/3545) 전체 통과. shard-weights 등재·lint 통과.

## 다음
FE(영상 슬롯·커버 선택)는 별도 스토리(미르코). 실 IG는 App Review 뒤.
