### PR TITLE
[SID:3550] 캐러셀 N장 FE — 목록/삭제/재정렬 배선

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2573,6 +2573,11 @@
     "channelPostsImageConversionFailed": "Even after automatic conversion, this still exceeds the {maxBytes} limit ({finalBytes})",
     "channelPostsImageAnimatedUnsupported": "Animated images aren't supported ({frameCount} frames)",
     "channelPostsImageConvertedBadge": "Automatically converted to fit this channel's specs: width {originalWidth}px → {finalWidth}px · size {originalBytes} → {finalBytes}",
+    "channelPostsImageCountTag": "{count} / {max} images",
+    "channelPostsImageAttachmentPosition": "Position {position}",
+    "channelPostsImageMoveUpAction": "Move up",
+    "channelPostsImageMoveDownAction": "Move down",
+    "channelPostsImageRemoveAction": "Remove",
     "channelPostsAwaitingContainerNotice": "This is being automatically continued. Please check back shortly.",
     "channelPostsPublicationFailedNotice": "Publishing failed — republishing this draft will continue that attempt."
   },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2575,9 +2575,10 @@
     "channelPostsImageConvertedBadge": "Automatically converted to fit this channel's specs: width {originalWidth}px → {finalWidth}px · size {originalBytes} → {finalBytes}",
     "channelPostsImageCountTag": "{count} / {max} images",
     "channelPostsImageAttachmentPosition": "Position {position}",
-    "channelPostsImageMoveUpAction": "Move up",
-    "channelPostsImageMoveDownAction": "Move down",
+    "channelPostsImageMoveUpAction": "Move image {position} up",
+    "channelPostsImageMoveDownAction": "Move image {position} down",
     "channelPostsImageRemoveAction": "Remove",
+    "channelPostsImageRemoveActionLabel": "Remove image {position}",
     "channelPostsAwaitingContainerNotice": "This is being automatically continued. Please check back shortly.",
     "channelPostsPublicationFailedNotice": "Publishing failed — republishing this draft will continue that attempt."
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2575,9 +2575,10 @@
     "channelPostsImageConvertedBadge": "이 채널 규격에 맞춰 자동 변환됐습니다: 너비 {originalWidth}px → {finalWidth}px · 용량 {originalBytes} → {finalBytes}",
     "channelPostsImageCountTag": "{count} / {max}장",
     "channelPostsImageAttachmentPosition": "{position}번째",
-    "channelPostsImageMoveUpAction": "위로 이동",
-    "channelPostsImageMoveDownAction": "아래로 이동",
+    "channelPostsImageMoveUpAction": "{position}번째 이미지 위로 이동",
+    "channelPostsImageMoveDownAction": "{position}번째 이미지 아래로 이동",
     "channelPostsImageRemoveAction": "삭제",
+    "channelPostsImageRemoveActionLabel": "{position}번째 이미지 삭제",
     "channelPostsAwaitingContainerNotice": "자동으로 이어서 처리 중입니다. 잠시 후 다시 확인해 주세요.",
     "channelPostsPublicationFailedNotice": "발행에 실패했습니다 — 이 초안을 다시 발행하면 이 시도를 이어서 처리합니다."
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2573,6 +2573,11 @@
     "channelPostsImageConversionFailed": "자동 변환 후에도 한도 {maxBytes}를 넘습니다({finalBytes})",
     "channelPostsImageAnimatedUnsupported": "애니메이션 이미지는 지원하지 않습니다({frameCount}프레임)",
     "channelPostsImageConvertedBadge": "이 채널 규격에 맞춰 자동 변환됐습니다: 너비 {originalWidth}px → {finalWidth}px · 용량 {originalBytes} → {finalBytes}",
+    "channelPostsImageCountTag": "{count} / {max}장",
+    "channelPostsImageAttachmentPosition": "{position}번째",
+    "channelPostsImageMoveUpAction": "위로 이동",
+    "channelPostsImageMoveDownAction": "아래로 이동",
+    "channelPostsImageRemoveAction": "삭제",
     "channelPostsAwaitingContainerNotice": "자동으로 이어서 처리 중입니다. 잠시 후 다시 확인해 주세요.",
     "channelPostsPublicationFailedNotice": "발행에 실패했습니다 — 이 초안을 다시 발행하면 이 시도를 이어서 처리합니다."
   },

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -334,6 +334,19 @@ export const EXEMPT_PAIRS = new Set<string>([
   'content.commentsDeletedCountLabel <-> content.commentsSectionTitleWithCount',
   'content.commentsSectionTitle <-> content.commentsSectionTitleWithCount',
   'content.commentsDeletedCountLabel <-> content.commentsSectionTitle',
+  // story #3550(PR#3912, 페드루 PO 승인 2026-09-06) — content.channelPostsImageAttachmentPosition
+  // ("{position}번째", 장 위치 라벨) <-> channelPostsImageMoveUpAction/MoveDownAction/
+  // RemoveActionLabel(전부 "{position}번째 ..." 접근성 이름). 같은 이미지 슬롯의 같은
+  // position 값을 위치 라벨과 접근성 이름 두 표면에 일관되게 쓰는 의도된 반복 —
+  // #2352/#2365가 잡으려는 "다른 두 셈이 헷갈리는" 병이 아니다(insightsBoard.columnD1
+  // <-> sortD1류, 짧은 라벨이 그 라벨을 포함하는 긴 문구에 들어간 정상 패턴).
+  'content.channelPostsImageAttachmentPosition <-> content.channelPostsImageMoveDownAction',
+  'content.channelPostsImageAttachmentPosition <-> content.channelPostsImageMoveUpAction',
+  'content.channelPostsImageAttachmentPosition <-> content.channelPostsImageRemoveActionLabel',
+  // channelPostsImageRemoveAction("삭제", 보이는 글자) <-> channelPostsImageRemoveActionLabel
+  // ("{position}번째 이미지 삭제", aria-label) — §17-20⑧ "접근성 이름은 보이는 글자를
+  // 포함해야 한다"는 규율 그 자체가 이 부분문자열 포함을 요구한다(제거 대상 아님).
+  'content.channelPostsImageRemoveAction <-> content.channelPostsImageRemoveActionLabel',
 ]);
 
 // ⛔⭐오르테가군 지적(2026-07-31) — 이 목록에 «새로» 넣는 것은 PO 승인을 거친다. 이유 없이

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -2275,6 +2275,42 @@ describe('ChannelPostEditPage — 캐러셀 N장 목록·삭제·재정렬(story
     expect(container.querySelector('[data-testid="channel-post-image-count-tag"]')?.textContent).toBe('2 / 10장');
   });
 
+  // 카디르 QA(2026-09-06) — 삭제·재정렬은 새 버전=재승인 트리거(#3291)라
+  // draft/versions 단건 GET도 다시 불러야 하는데(refreshDraftAndVersionsAfterImagesMutation),
+  // 그 호출을 지워도 위 테스트는 목록 교체만 보느라 RED 0이었다 — fetch 호출
+  // 횟수로 명시 pin.
+  it('⭐삭제 성공 뒤 draft·versions 단건 GET을 다시 부른다(재승인 트리거 반영)', async () => {
+    stubFetch({
+      imageMaxCount: 10, initialImages: [IMG_1, IMG_2],
+      onImageDelete: () => ({ status: 200, body: [{ ...IMG_1, position: 0 }] }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const fetchMock = globalThis.fetch as unknown as { mock: { calls: [RequestInfo | URL, RequestInit?][] } };
+    const draftGetCallsBefore = fetchMock.mock.calls.filter(
+      ([u]) => String(u) === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}`,
+    ).length;
+    const versionsGetCallsBefore = fetchMock.mock.calls.filter(
+      ([u]) => String(u) === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}/versions`,
+    ).length;
+
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    await act(async () => {
+      (items[0]!.querySelector('[data-testid="channel-post-image-attachment-delete"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const draftGetCallsAfter = fetchMock.mock.calls.filter(
+      ([u]) => String(u) === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}`,
+    ).length;
+    const versionsGetCallsAfter = fetchMock.mock.calls.filter(
+      ([u]) => String(u) === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}/versions`,
+    ).length;
+    expect(draftGetCallsAfter).toBeGreaterThan(draftGetCallsBefore);
+    expect(versionsGetCallsAfter).toBeGreaterThan(versionsGetCallsBefore);
+  });
+
   it('⭐재정렬 — 위로 이동 클릭이 전체 집합(image_ids)을 새 순서로 한 번에 보낸다', async () => {
     let reorderedIds: string[] | null = null;
     stubFetch({
@@ -2318,8 +2354,12 @@ describe('ChannelPostEditPage — 캐러셀 N장 목록·삭제·재정렬(story
     });
     await flush();
 
-    const errorText = container.querySelector('[data-testid="channel-post-images-action-error"]')?.textContent ?? '';
-    expect(errorText).toContain('이미지 집합이 일치하지 않습니다(서버 메시지 예시)');
+    // 카디르 QA(2026-09-06) — RawDetailsToggle의 접힌 <pre>raw JSON에도 서버
+    // message가 그대로 들어 있어, 바깥 Alert 전체 textContent로 재면 표시 로직이
+    // 고장 나도(describeChannelImageError 분기 제거) raw만으로 우연히 통과한다 —
+    // 실제 표시 요소(AlertDescription, <p>)만 좁혀 잰다.
+    const errorText = container.querySelector('[data-testid="channel-post-images-action-error"] p')?.textContent ?? '';
+    expect(errorText).toBe('이미지 집합이 일치하지 않습니다(서버 메시지 예시)');
     // 실패해도 목록 자체는 그대로(낙관적으로 먼저 바꾸지 않는다).
     expect(container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]').length).toBe(2);
   });
@@ -2340,8 +2380,8 @@ describe('ChannelPostEditPage — 캐러셀 N장 목록·삭제·재정렬(story
     });
     await flush();
 
-    const errorText = container.querySelector('[data-testid="channel-post-images-action-error"]')?.textContent ?? '';
-    expect(errorText).toContain('이미 삭제된 이미지입니다(서버 메시지 예시)');
+    const errorText = container.querySelector('[data-testid="channel-post-images-action-error"] p')?.textContent ?? '';
+    expect(errorText).toBe('이미 삭제된 이미지입니다(서버 메시지 예시)');
   });
 
   it('⭐422 CHANNEL_POST_IMAGE_COUNT_EXCEEDED(업로드) — 서버 message 그대로 업로드 에러 자리에 렌더된다', async () => {
@@ -2360,8 +2400,8 @@ describe('ChannelPostEditPage — 캐러셀 N장 목록·삭제·재정렬(story
     await act(async () => { input.dispatchEvent(new Event('change', { bubbles: true })); });
     await flush();
 
-    const errorText = container.querySelector('[data-testid="channel-post-image-upload-error"]')?.textContent ?? '';
-    expect(errorText).toContain('최대 1장까지만 첨부할 수 있습니다(서버 메시지 예시)');
+    const errorText = container.querySelector('[data-testid="channel-post-image-upload-error"] p')?.textContent ?? '';
+    expect(errorText).toBe('최대 1장까지만 첨부할 수 있습니다(서버 메시지 예시)');
     // 실패했으니 목록은 그대로 1장.
     expect(container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]').length).toBe(1);
   });

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -184,12 +184,24 @@ function stubFetch(opts: {
   onCommentReplySubmit?: () => { status: number; body: unknown };
   // story #3544 조각⑧ — voided(봉인 불일치) 「다시 상신」의 prefill용 단건 GET.
   onCommentReplyGet?: () => { status: number; body: unknown };
+  // story #3550(Phase2·풀스택, BE 2/2 #3910 계약) — 캐러셀 N장 목록. 기본값 빈
+  // 배열(첨부 0장, 기존 시나리오 전부 회귀 0). image_id/position이 삭제·재정렬
+  // 대상 키다.
+  initialImages?: {
+    image_id: string; draft_id: string; version_id: string; version: number;
+    original_width: number; original_height: number; original_bytes: number;
+    final_width: number; final_height: number; final_bytes: number;
+    was_converted: boolean; image_url: string | null; position: number;
+  }[];
+  onImageDelete?: (imageId: string) => { status: number; body: unknown };
+  onImageReorder?: (imageIds: string[]) => { status: number; body: unknown };
 }) {
   const versions = opts.versions ?? [VERSION_1];
   const draftDetail: Record<string, unknown> = { ...DRAFT_DETAIL, ...opts.draftDetail };
   if (opts.omitGateStatusKey) delete draftDetail.gate_status;
   let currentDraftDetail = draftDetail;
   let rejectNextDraftRefetch = false;
+  let currentImages = opts.initialImages ?? [];
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -273,10 +285,11 @@ function stubFetch(opts: {
         const result = opts.onImageConfirm?.(body) ?? {
           status: 201,
           body: {
-            draft_id: DRAFT_ID, version_id: 'v2', version: 2,
+            image_id: `img${currentImages.length + 1}`, draft_id: DRAFT_ID, version_id: 'v2', version: 2,
             original_width: 4000, original_height: 3000, original_bytes: 12000000,
             final_width: 1440, final_height: 1080, final_bytes: 3100000,
             was_converted: true, image_url: 'https://storage.googleapis.com/bucket/channel-media/o/d1/x.jpg',
+            position: currentImages.length,
           },
         };
         const ok = result.status < 400;
@@ -301,7 +314,40 @@ function stubFetch(opts: {
             image_was_converted: confirmed.was_converted,
             ...opts.draftAfterImageConfirm,
           };
+          // story #3550 — confirm 성공은 캐러셀 목록에도 새 이미지 1장을 더한다
+          // (BE의 carry-forward: 기존 이미지도 이 새 버전으로 옮겨 붙지만, 이
+          // 목(mock)엔 버전 축 자체가 없어 「현재 목록 + 새 이미지」로 근사한다 —
+          // 페이지가 confirm 뒤 이 목록 엔드포인트를 다시 불러 반영하는지가
+          // 검증 대상이지, 이 mock의 버전 정합 자체는 아니다).
+          currentImages = [...currentImages, result.body as typeof currentImages[number]];
         }
+        return { ok, status: result.status, json: async () => (ok ? { data: result.body, error: null, meta: null } : result.body) };
+      }
+      const assetsListMatch = url.match(/\/versions\/([^/]+)\/assets$/);
+      if (assetsListMatch && (!init || init.method === undefined || init.method === 'GET')) {
+        return { ok: true, status: 200, json: async () => ({ data: currentImages, error: null, meta: null }) };
+      }
+      const assetDeleteMatch = url.match(/\/channel-posts\/drafts\/[^/]+\/assets\/([^/]+)$/);
+      if (assetDeleteMatch && init?.method === 'DELETE') {
+        const imageId = assetDeleteMatch[1] as string;
+        const result = opts.onImageDelete?.(imageId) ?? {
+          status: 200, body: currentImages.filter((img) => img.image_id !== imageId).map((img, i) => ({ ...img, position: i })),
+        };
+        const ok = result.status < 400;
+        if (ok) currentImages = result.body as typeof currentImages;
+        return { ok, status: result.status, json: async () => (ok ? { data: result.body, error: null, meta: null } : result.body) };
+      }
+      if (url === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}/assets/reorder` && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body ?? '{}')) as { image_ids: string[] };
+        const result = opts.onImageReorder?.(body.image_ids) ?? {
+          status: 200,
+          body: body.image_ids
+            .map((id) => currentImages.find((img) => img.image_id === id))
+            .filter((img): img is typeof currentImages[number] => img !== undefined)
+            .map((img, i) => ({ ...img, position: i })),
+        };
+        const ok = result.status < 400;
+        if (ok) currentImages = result.body as typeof currentImages;
         return { ok, status: result.status, json: async () => (ok ? { data: result.body, error: null, meta: null } : result.body) };
       }
       if (url === `/api/organizations/${ORG_ID}/channel-posts/drafts` && init?.method === 'POST') {
@@ -1866,7 +1912,7 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     });
     await flush();
 
-    expect(container.querySelector('[data-testid="channel-post-image-preview"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="channel-post-image-attachment-preview"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="channel-post-image-upload-error"]')).toBeNull();
   });
 
@@ -1921,7 +1967,7 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
 
     // 이미지 필드(썸네일)도 여전히 반영되고, 게이트가 재오픈됐다는 서버 진실까지
     // 같이 들어와 발행 버튼이 다시 막힌다(이미지 필드만 로컬 병합했다면 여전히 활성).
-    expect(container.querySelector('[data-testid="channel-post-image-preview"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="channel-post-image-attachment-preview"]')).not.toBeNull();
     expect((container.querySelector('[data-testid="channel-post-publish-button"]') as HTMLButtonElement).disabled).toBe(true);
   });
 
@@ -1966,8 +2012,10 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     expect((container.querySelector('[data-testid="channel-post-submit-button"]') as HTMLButtonElement).disabled).toBe(false);
   });
 
-  // B3(페드루 PO·유나 지적, 2026-09-04) — 첨부 칸은 실제로 파일 1개만 받는데
-  // "{count}장까지"라고 적으면 화면이 안 하는 일을 약속하는 거짓 라벨이 된다.
+  // B3(페드루 PO·유나 지적, 2026-09-04 — story #3550 BE 2/2 계약 확定 뒤에도 문구
+  // 자체는 무변경) — 개수는 ImageAttachmentList의 count 태그("{count}/{max}장")
+  // 몫이라 이 라벨엔 여전히 "{count}장까지"류를 안 적는다(같은 정보를 두 자리에서
+  // 다른 형으로 반복하지 않는다).
   it('⭐B3 — 첨부 칸 라벨이 개수를 약속하지 않는다("장까지" 문구 없음)', async () => {
     stubFetch({ imageMaxCount: 4 });
     await act(async () => {
@@ -2029,7 +2077,7 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     });
     await flush();
 
-    const img = container.querySelector('[data-testid="channel-post-image-preview"]') as HTMLImageElement;
+    const img = container.querySelector('[data-testid="channel-post-image-attachment-preview"]') as HTMLImageElement;
     expect(img.alt).toBe(koMessages.content.channelPostsImageAttachAlt);
   });
 
@@ -2050,7 +2098,7 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     });
     await flush();
 
-    const badge = container.querySelector('[data-testid="channel-post-image-attach-converted-badge"]')?.textContent ?? '';
+    const badge = container.querySelector('[data-testid="channel-post-image-attachment-converted-badge"]')?.textContent ?? '';
     expect(badge).toContain('4000');
     expect(badge).toContain('1440');
   });
@@ -2079,7 +2127,7 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     const errorText = container.querySelector('[data-testid="channel-post-image-upload-error"]')?.textContent ?? '';
     expect(errorText).toContain('image/gif');
     expect(errorText).toContain('image/jpeg');
-    expect(container.querySelector('[data-testid="channel-post-image-preview"]')).toBeNull();
+    expect(container.querySelector('[data-testid="channel-post-image-attachment-preview"]')).toBeNull();
   });
 
   it('⭐AC4 — CHANNEL_IMAGE_TOO_LARGE(413) — MB 단위로 3요소 문구가 조립된다(confirm 단계에서 실패)', async () => {
@@ -2169,6 +2217,153 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     expect(errorText).not.toContain('1.9인데');
     expect(errorText).not.toContain('가로');
     expect(errorText).not.toContain('세로');
+  });
+});
+
+// story #3550(Phase2·풀스택, BE 2/2 #3910 계약 확定 2026-09-06) — 캐러셀 N장:
+// 목록 로드→삭제(image_id)→재정렬(전체 집합)→422 두 문장.
+describe('ChannelPostEditPage — 캐러셀 N장 목록·삭제·재정렬(story #3550)', () => {
+  const IMG_1 = {
+    image_id: 'img1', draft_id: DRAFT_ID, version_id: 'v1', version: 1, position: 0,
+    original_width: 1000, original_height: 1000, original_bytes: 100_000,
+    final_width: 1000, final_height: 1000, final_bytes: 100_000,
+    was_converted: false, image_url: 'https://storage.googleapis.com/x/1.jpg',
+  };
+  const IMG_2 = {
+    image_id: 'img2', draft_id: DRAFT_ID, version_id: 'v1', version: 1, position: 1,
+    original_width: 4000, original_height: 3000, original_bytes: 5_000_000,
+    final_width: 1440, final_height: 1080, final_bytes: 900_000,
+    was_converted: true, image_url: 'https://storage.googleapis.com/x/2.jpg',
+  };
+  const IMG_3 = {
+    image_id: 'img3', draft_id: DRAFT_ID, version_id: 'v1', version: 1, position: 2,
+    original_width: 1000, original_height: 1000, original_bytes: 100_000,
+    final_width: 1000, final_height: 1000, final_bytes: 100_000,
+    was_converted: false, image_url: 'https://storage.googleapis.com/x/3.jpg',
+  };
+
+  it('⭐목록 — 초기 로드가 버전의 이미지 N장을 position 순으로 그린다', async () => {
+    stubFetch({ imageMaxCount: 10, initialImages: [IMG_1, IMG_2, IMG_3] });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    expect(items.length).toBe(3);
+    expect(container.querySelector('[data-testid="channel-post-image-count-tag"]')?.textContent).toBe('3 / 10장');
+  });
+
+  it('⭐삭제 — image_id로 DELETE를 호출하고 응답의 남은 목록으로 교체된다', async () => {
+    let deletedId: string | null = null;
+    stubFetch({
+      imageMaxCount: 10, initialImages: [IMG_1, IMG_2, IMG_3],
+      onImageDelete: (imageId) => {
+        deletedId = imageId;
+        return { status: 200, body: [{ ...IMG_1, position: 0 }, { ...IMG_3, position: 1 }] };
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    await act(async () => {
+      (items[1]!.querySelector('[data-testid="channel-post-image-attachment-delete"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(deletedId).toBe('img2');
+    expect(container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]').length).toBe(2);
+    expect(container.querySelector('[data-testid="channel-post-image-count-tag"]')?.textContent).toBe('2 / 10장');
+  });
+
+  it('⭐재정렬 — 위로 이동 클릭이 전체 집합(image_ids)을 새 순서로 한 번에 보낸다', async () => {
+    let reorderedIds: string[] | null = null;
+    stubFetch({
+      imageMaxCount: 10, initialImages: [IMG_1, IMG_2, IMG_3],
+      onImageReorder: (imageIds) => {
+        reorderedIds = imageIds;
+        return {
+          status: 200,
+          body: imageIds.map((id, i) => ({ ...[IMG_1, IMG_2, IMG_3].find((img) => img.image_id === id), position: i })),
+        };
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    await act(async () => {
+      (items[2]!.querySelector('[data-testid="channel-post-image-attachment-move-up"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(reorderedIds).toEqual(['img1', 'img3', 'img2']);
+    const reorderedItems = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    expect(reorderedItems[1]!.querySelector('[data-testid="channel-post-image-attachment-preview"]')?.getAttribute('src'))
+      .toBe(IMG_3.image_url);
+  });
+
+  it('⭐422 CHANNEL_POST_IMAGE_REORDER_INVALID_SET — 서버 message 그대로 렌더된다', async () => {
+    stubFetch({
+      imageMaxCount: 10, initialImages: [IMG_1, IMG_2],
+      onImageReorder: () => ({
+        status: 422, body: { detail: { code: 'CHANNEL_POST_IMAGE_REORDER_INVALID_SET', message: '이미지 집합이 일치하지 않습니다(서버 메시지 예시)' } },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    await act(async () => {
+      (items[1]!.querySelector('[data-testid="channel-post-image-attachment-move-up"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const errorText = container.querySelector('[data-testid="channel-post-images-action-error"]')?.textContent ?? '';
+    expect(errorText).toContain('이미지 집합이 일치하지 않습니다(서버 메시지 예시)');
+    // 실패해도 목록 자체는 그대로(낙관적으로 먼저 바꾸지 않는다).
+    expect(container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]').length).toBe(2);
+  });
+
+  it('⭐404 CHANNEL_POST_IMAGE_NOT_FOUND(삭제) — 서버 message 그대로 렌더된다', async () => {
+    stubFetch({
+      imageMaxCount: 10, initialImages: [IMG_1],
+      onImageDelete: () => ({
+        status: 404, body: { detail: { code: 'CHANNEL_POST_IMAGE_NOT_FOUND', message: '이미 삭제된 이미지입니다(서버 메시지 예시)' } },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    await act(async () => {
+      (items[0]!.querySelector('[data-testid="channel-post-image-attachment-delete"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const errorText = container.querySelector('[data-testid="channel-post-images-action-error"]')?.textContent ?? '';
+    expect(errorText).toContain('이미 삭제된 이미지입니다(서버 메시지 예시)');
+  });
+
+  it('⭐422 CHANNEL_POST_IMAGE_COUNT_EXCEEDED(업로드) — 서버 message 그대로 업로드 에러 자리에 렌더된다', async () => {
+    stubFetch({
+      imageMaxCount: 1, initialImages: [IMG_1],
+      onImageConfirm: () => ({
+        status: 422, body: { detail: { code: 'CHANNEL_POST_IMAGE_COUNT_EXCEEDED', message: '최대 1장까지만 첨부할 수 있습니다(서버 메시지 예시)', image_max_count: 1 } },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const input = container.querySelector('[data-testid="channel-post-image-file-input"]') as HTMLInputElement;
+    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    await act(async () => { input.dispatchEvent(new Event('change', { bubbles: true })); });
+    await flush();
+
+    const errorText = container.querySelector('[data-testid="channel-post-image-upload-error"]')?.textContent ?? '';
+    expect(errorText).toContain('최대 1장까지만 첨부할 수 있습니다(서버 메시지 예시)');
+    // 실패했으니 목록은 그대로 1장.
+    expect(container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]').length).toBe(1);
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -29,6 +29,7 @@ import { GenerationBudgetIndicator, majorToMinor, type GenerationBudgetCurrency,
 import { GenerationBudgetExceededBanner } from '@/components/content/generation-budget-exceeded-banner';
 import { isSandboxChannelDraft, SandboxTestBadge } from '@/components/content/sandbox-test-badge';
 import { RawDetailsToggle } from '@/components/content/raw-details-toggle';
+import { ImageAttachmentList } from '@/components/content/image-attachment-list';
 // story #3483 — 3472 2부에서 이 페이지에 있던 위반 표시 로직을 공용으로 뺐다
 // (site-posts 상세와 재사용, 동작 무변).
 import {
@@ -132,6 +133,25 @@ interface ChannelPostVersion {
   author_kind: 'agent' | 'human';
   created_at: string;
   tagged_link_preview: string | null;
+}
+
+// story #3550(Phase2·풀스택, BE 2/2 #3910 계약, 페드루 PO 確定 2026-09-06) — 캐러셀
+// N장 목록 응답(position 순). image_id가 삭제(`DELETE .../assets/{image_id}`)·재정렬
+// (`POST .../assets/reorder`의 image_ids)의 대상 키다.
+interface ChannelPostImageResponse {
+  image_id: string;
+  draft_id: string;
+  version_id: string;
+  version: number;
+  original_width: number;
+  original_height: number;
+  original_bytes: number;
+  final_width: number;
+  final_height: number;
+  final_bytes: number;
+  was_converted: boolean;
+  image_url: string | null;
+  position: number;
 }
 
 interface ChannelConnectionInfo {
@@ -496,6 +516,14 @@ export default function ChannelPostEditPage() {
   // Button만 보인다(브라우저 기본 컨트롤 로케일 불일치 회피).
   const imageFileInputRef = useRef<HTMLInputElement>(null);
 
+  // story #3550(Phase2·풀스택, BE 2/2 #3910 계약 확定 2026-09-06) — 캐러셀 N장.
+  // position 순 전체 목록(단수 대표 1장 계약·draft.thumbnail_url은 무변경 — 별개
+  // 엔드포인트). imagesActionError는 삭제·재정렬 실패 전용(업로드 실패는
+  // imageUploadStatus가 이미 진다 — 자리를 안 섞는다).
+  const [images, setImages] = useState<ChannelPostImageResponse[]>([]);
+  const [imagesActionInProgress, setImagesActionInProgress] = useState(false);
+  const [imagesActionError, setImagesActionError] = useState<{ text: string; raw?: string } | null>(null);
+
   const [text, setText] = useState('');
   // story #3517(BE #3867 조각②, PO 정정 2026-09-05) — 댓글 「작업으로 전환」
   // 다이얼로그의 「게시물 제목」 prefill. 채널 포스트엔 정식 제목이 없다 — 1순위는
@@ -589,6 +617,16 @@ export default function ChannelPostEditPage() {
         if (latest) {
           setText(latest.text);
           setLinkUrl(latest.link_url ?? '');
+          // story #3550 — N장 목록(현재 버전 기준)도 초기 로드 때 같이 가져온다.
+          // 실패해도 페이지 전체를 막지 않는다(첨부 0장으로 보이는 것과 "조회
+          // 실패"를 이 자리에서 구별해 봐야 아직 아무 UI도 없다 — 빈 배열 유지).
+          const imagesRes = await fetchWithAuth(
+            `/api/organizations/${orgId}/channel-posts/drafts/${draftId}/versions/${latest.version_id}/assets`,
+          ).catch(() => null);
+          if (!cancelled && imagesRes?.ok) {
+            const imagesJson = (await imagesRes.json().catch(() => null)) as { data?: ChannelPostImageResponse[] } | null;
+            if (imagesJson?.data) setImages(imagesJson.data);
+          }
         }
         if (d) {
           const connRes = await fetchWithAuth(`/api/organizations/${orgId}/channel-connections`);
@@ -910,13 +948,7 @@ export default function ChannelPostEditPage() {
         setImageUploadStatus({ phase: 'error', text: describeChannelImageError(info, t), raw: info.raw });
         return;
       }
-      const confirmJson = (await confirmRes.json().catch(() => null)) as
-        {
-          data?: {
-            version: number; original_width: number; original_bytes: number;
-            final_width: number; final_bytes: number; was_converted: boolean; image_url: string | null;
-          };
-        } | null;
+      const confirmJson = (await confirmRes.json().catch(() => null)) as { data?: ChannelPostImageResponse } | null;
       const image = confirmJson?.data;
       if (!image) {
         setImageUploadStatus({ phase: 'error', text: t('errorChannelImageUploadFailed') });
@@ -934,9 +966,15 @@ export default function ChannelPostEditPage() {
       // 이미 confirm까지 성공했는데(image 변수가 이미 참조 가능한 시점) 사용자는 업로드
       // 자체가 실패한 걸로 오인한다. leg별로 격리해 재조회 실패가 업로드 성공 신호를
       // 삼키지 않게 한다.
-      const [draftRes, versionsRes] = await Promise.all([
+      // story #3550 — confirm 응답은 새로 붙은 이미지 1장뿐이라(캐러셀 목록 전체가
+      // 아니다), 새 버전(image.version_id — carry-forward로 기존 이미지도 이 버전에
+      // 옮겨 붙는다, delete/reorder와 동형 버전 승계) 기준으로 목록을 다시 받는다.
+      // 로컬로 배열에 추가만 하면 carry-forward 규칙을 이 화면이 지어내는 셈이라
+      // 안 한다.
+      const [draftRes, versionsRes, imagesRes] = await Promise.all([
         fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}`).catch(() => null),
         fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}/versions`).catch(() => null),
+        fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}/versions/${image.version_id}/assets`).catch(() => null),
       ]);
       if (draftRes?.ok) {
         const draftJson = (await draftRes.json().catch(() => null)) as { data?: ChannelPostDraftDetail } | null;
@@ -946,9 +984,93 @@ export default function ChannelPostEditPage() {
         const versionsJson = (await versionsRes.json().catch(() => null)) as { data?: ChannelPostVersion[] } | null;
         if (versionsJson?.data) setVersions(versionsJson.data);
       }
+      if (imagesRes?.ok) {
+        const imagesJson = (await imagesRes.json().catch(() => null)) as { data?: ChannelPostImageResponse[] } | null;
+        if (imagesJson?.data) setImages(imagesJson.data);
+      }
       setImageUploadStatus({ phase: 'idle' });
     } catch {
       setImageUploadStatus({ phase: 'error', text: t('errorChannelImageUploadFailed') });
+    }
+  };
+
+  // story #3550(Phase2·풀스택, BE 2/2 #3910 계약 확定) — 삭제·재정렬 공용 후처리.
+  // 둘 다 새 불변 버전을 만들어(#3291 규율) 그 버전에 남은/재배열된 이미지 전체를
+  // 응답으로 돌려준다(delete/reorder 엔드포인트 자체가 list[ChannelPostImageResponse])
+  // — confirm과 달리 추가 GET 없이 이 응답 하나로 images를 통째로 교체한다. 새 버전이
+  // 곧 재승인 트리거(B1과 동형 이유)라 draft/versions도 같이 재조회한다.
+  async function refreshDraftAndVersionsAfterImagesMutation() {
+    const [draftRes, versionsRes] = await Promise.all([
+      fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}`).catch(() => null),
+      fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}/versions`).catch(() => null),
+    ]);
+    if (draftRes?.ok) {
+      const draftJson = (await draftRes.json().catch(() => null)) as { data?: ChannelPostDraftDetail } | null;
+      if (draftJson?.data) setDraft(draftJson.data);
+    }
+    if (versionsRes?.ok) {
+      const versionsJson = (await versionsRes.json().catch(() => null)) as { data?: ChannelPostVersion[] } | null;
+      if (versionsJson?.data) setVersions(versionsJson.data);
+    }
+  }
+
+  // 페드루 PO 確定(2026-09-06) — 위/아래 이동도 매번 「새 순서 그대로 전체 집합」을
+  // 한 번에 보낸다(부분 재정렬 불허, BE가 422 CHANNEL_POST_IMAGE_REORDER_INVALID_SET
+  // 로 거부). ImageAttachmentList는 인접 스왑 UI라 fromIndex/toIndex를 여기서 배열
+  // 재배치로 풀어 image_id 전체 목록을 만든다.
+  const handleReorderImage = async (fromIndex: number, toIndex: number) => {
+    if (!orgId || toIndex < 0 || toIndex >= images.length) return;
+    const reordered = [...images];
+    const [moved] = reordered.splice(fromIndex, 1);
+    if (!moved) return;
+    reordered.splice(toIndex, 0, moved);
+    setImagesActionInProgress(true);
+    setImagesActionError(null);
+    try {
+      const res = await fetchWithAuth(
+        `/api/organizations/${orgId}/channel-posts/drafts/${draftId}/assets/reorder`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ image_ids: reordered.map((img) => img.image_id) }) },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        const info = parseSitePostApiError(body);
+        setImagesActionError({ text: describeChannelImageError(info, t), raw: info.raw });
+        return;
+      }
+      const json = (await res.json().catch(() => null)) as { data?: ChannelPostImageResponse[] } | null;
+      if (json?.data) setImages(json.data);
+      await refreshDraftAndVersionsAfterImagesMutation();
+    } catch {
+      setImagesActionError({ text: t('errorChannelImageUploadFailed') });
+    } finally {
+      setImagesActionInProgress(false);
+    }
+  };
+
+  const handleDeleteImage = async (index: number) => {
+    if (!orgId) return;
+    const target = images[index];
+    if (!target) return;
+    setImagesActionInProgress(true);
+    setImagesActionError(null);
+    try {
+      const res = await fetchWithAuth(
+        `/api/organizations/${orgId}/channel-posts/drafts/${draftId}/assets/${target.image_id}`,
+        { method: 'DELETE' },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        const info = parseSitePostApiError(body);
+        setImagesActionError({ text: describeChannelImageError(info, t), raw: info.raw });
+        return;
+      }
+      const json = (await res.json().catch(() => null)) as { data?: ChannelPostImageResponse[] } | null;
+      if (json?.data) setImages(json.data);
+      await refreshDraftAndVersionsAfterImagesMutation();
+    } catch {
+      setImagesActionError({ text: t('errorChannelImageUploadFailed') });
+    } finally {
+      setImagesActionInProgress(false);
     }
   };
 
@@ -1259,13 +1381,15 @@ export default function ChannelPostEditPage() {
     || imageUploadStatus.phase === 'uploading' || imageUploadStatus.phase === 'confirming';
 
   // story #3538(BE #3886, 유나 §17-16⑤ PO 確定) — 이미지 필수 채널(image_required)인데
-  // 이미지가 없으면(draft.thumbnail_url 없음) 상신·예약 상신이 서버에서 422로 막힌다
-  // (§7 「필수값 빈칸 선알림」). 업로드 진행 中엔 이 사유를 안 보인다(업로드 중엔 실제로
-  // 0장이라 두 조건이 동시에 참일 수 있는데, 그땐 「업로드가 끝나면 된다」가 맞는
-  // 말 — 페드루 PO 明示, 사유 사슬은 한 줄만 뜬다). 저장 버튼은 이 조건과 무관(본문만
-  // 먼저 쓰고 이미지는 나중에 붙이는 길을 막지 않는다 — 상신·발행의 조건이지 저장의
-  // 조건이 아니다).
-  const imageRequiredAndMissing = Boolean(imageSpec?.imageRequired) && !draft?.thumbnail_url && !imageUploadInProgress;
+  // 이미지가 없으면 상신·예약 상신이 서버에서 422로 막힌다(§7 「필수값 빈칸
+  // 선알림」). 업로드 진행 中엔 이 사유를 안 보인다(업로드 중엔 실제로 0장이라 두
+  // 조건이 동시에 참일 수 있는데, 그땐 「업로드가 끝나면 된다」가 맞는 말 — 페드루
+  // PO 明示, 사유 사슬은 한 줄만 뜬다). 저장 버튼은 이 조건과 무관(본문만 먼저 쓰고
+  // 이미지는 나중에 붙이는 길을 막지 않는다 — 상신·발행의 조건이지 저장의 조건이
+  // 아니다). story #3550 — 판정 소스를 draft.thumbnail_url(단수 대표 1장)에서
+  // images.length(캐러셀 N장 목록, 이 화면의 실제 첨부 수)로 옮긴다 — 0장인지가
+  // 이제 이 배열의 길이로 정확히 난다.
+  const imageRequiredAndMissing = Boolean(imageSpec?.imageRequired) && images.length === 0 && !imageUploadInProgress;
 
   return (
     <div className="mx-auto w-full max-w-2xl space-y-6 p-6">
@@ -1793,11 +1917,10 @@ export default function ChannelPostEditPage() {
       {imageSpec && imageSpec.maxCount > 0 ? (
         <div className="space-y-2 rounded-md border border-border p-3 text-sm" data-testid="channel-post-image-attach">
           <div className="flex items-center justify-between">
-            {/* B3(페드루 PO·유나 지적, 2026-09-04) — 어댑터가 image_max_count>1을 선언해도
-                이 첨부 칸은 파일 하나만 받는다(input에 multiple 없음·onChange가 files[0]만
-                읽음·confirm이 draft 이미지 필드를 한 장으로 덮어씀 — 진짜 다중첨부가
-                아니다). "{count}장까지"라고 적으면 화면이 실제로 안 하는 일을 약속하는
-                거짓말이 된다 — 개수를 아예 안 적는다. */}
+            {/* story #3550(BE 2/2 #3910 계약 확定, 2026-09-06) — B3(2026-09-04)가
+                "다중첨부 아니다"라 개수를 안 적던 것과 반대로, 이제 파일 선택마다
+                실제로 이미지가 하나씩 늘어난다(캐러셀). 개수는 ImageAttachmentList의
+                count 태그가 맡는다(여기서 다시 안 적어 겹치는 문장 0). */}
             <span className="text-muted-foreground">{t('channelPostsImageAttachLabel')}</span>
           </div>
           <p className="text-xs text-muted-foreground" data-testid="channel-post-image-spec-tag">
@@ -1825,30 +1948,30 @@ export default function ChannelPostEditPage() {
                   colorSpace: imageSpec.colorSpace,
                 })}
           </p>
-          {draft.thumbnail_url ? (
-            <div className="space-y-1">
-              {/* eslint-disable-next-line @next/next/no-img-element -- story #3428: public-read GCS 오브젝트 URL(외부 도메인, next/image 대상 밖 — avatar_upload.py 소비부와 동형 관례). */}
-              <img
-                src={draft.thumbnail_url} alt={t('channelPostsImageAttachAlt')}
-                className="h-24 w-24 rounded object-cover" data-testid="channel-post-image-preview"
-              />
-              {/* 배지 첨부 칸(페드루 PO, 2026-09-04 13:41Z) — 이 미리보기도 파생본(변환
-                  결과)을 그리므로 image_was_converted일 때 승인 카드(§13-3)와 같은
-                  배지·같은 문구를 함께 보인다(새 문구 없음·false면 안 그림). 승인 카드
-                  =확定 결과 보여주는 자리, 여기=작성자가 지금 첨부가 어떻게 변환됐는지
-                  확인하는 자리 — 둘 다 image_final_object_path 기준이라 같은 값이다.
-                  <img> 2벌은 의도적으로 유지(§13-3 그대로). */}
-              {draft.image_was_converted ? (
-                <p className="text-xs text-muted-foreground" data-testid="channel-post-image-attach-converted-badge">
-                  {t('channelPostsImageConvertedBadge', {
-                    originalWidth: draft.image_original_width ?? 0,
-                    finalWidth: draft.image_final_width ?? 0,
-                    originalBytes: typeof draft.image_original_bytes === 'number' ? formatFileSize(draft.image_original_bytes) : '',
-                    finalBytes: typeof draft.image_final_bytes === 'number' ? formatFileSize(draft.image_final_bytes) : '',
-                  })}
-                </p>
-              ) : null}
-            </div>
+          {/* story #3550(BE 2/2 #3910 계약 확定) — 단일 <img> 슬롯을 N장 목록으로
+              교체(디디 설계 메모 §13-3 재확인 — 단일 슬롯 옛 §13-8 인용은 #3549
+              오귀속 정정, "있는 그대로 그린다"는 장별 변환 배지로 이 컴포넌트
+              안에서 적용). 유나 §17 회차(장별 배지·위/아래 이동 낱말)는 이 PR
+              프리뷰가 아니라 dev 배포 뒤 실픽셀로 연다 — 여기 낱말은 골격 그대로.
+              디디 재확認: draft.thumbnail_url·image_was_converted 등 단수 필드는
+              무변경(별개 대표 1장 계약, 승인 카드가 그대로 쓴다) — 이 화면만
+              images(N장 목록)로 옮긴다. */}
+          <ImageAttachmentList
+            images={images.map((img) => ({
+              url: img.image_url ?? '', wasConverted: img.was_converted,
+              originalWidth: img.original_width, finalWidth: img.final_width,
+              originalBytes: img.original_bytes, finalBytes: img.final_bytes,
+            }))}
+            maxCount={imageSpec.maxCount}
+            disabled={imageUploadInProgress || imagesActionInProgress}
+            onReorder={(from, to) => void handleReorderImage(from, to)}
+            onDelete={(index) => void handleDeleteImage(index)}
+          />
+          {imagesActionError ? (
+            <Alert variant="destructive" role="alert" data-testid="channel-post-images-action-error">
+              <AlertDescription>{imagesActionError.text}</AlertDescription>
+              <RawDetailsToggle raw={imagesActionError.raw} label={t('errorRawDetailsToggle')} />
+            </Alert>
           ) : null}
           {/* ②(유나 지적, 2026-09-04) — <input type=file>는 접근 가능한 이름이 0이고
               그리는 브라우저 기본 컨트롤 라벨("파일 선택" 등)이 브라우저 로케일을 따라

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/[imageId]/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/[imageId]/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { DELETE } from './route';
+
+describe('/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/[imageId] (story #3550)', () => {
+  it('DELETE — FastAPI 삭제 엔드포인트로 id/draftId/imageId 그대로 위임, 남은 목록 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { image_id: 'i1', draft_id: 'd1', version_id: 'v3', version: 3, position: 0, was_converted: false, image_url: 'https://x/1.jpg', original_width: 1000, original_height: 1000, original_bytes: 100, final_width: 1000, final_height: 1000, final_bytes: 100 },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const request = new Request('http://test', { method: 'DELETE' });
+    const resp = await DELETE(request, { params: Promise.resolve({ id: 'org-1', draftId: 'd1', imageId: 'i2' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request,
+      '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/assets/[imageId]',
+      { id: 'org-1', draftId: 'd1', imageId: 'i2' },
+    );
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: [{ image_id: 'i1' }] });
+  });
+
+  it('DELETE — 404(CHANNEL_POST_IMAGE_NOT_FOUND) 그대로 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_POST_IMAGE_NOT_FOUND' } }), { status: 404, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const resp = await DELETE(new Request('http://test', { method: 'DELETE' }), { params: Promise.resolve({ id: 'org-1', draftId: 'd1', imageId: 'i-missing' }) });
+    expect(resp.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/[imageId]/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/[imageId]/route.ts
@@ -1,0 +1,18 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; draftId: string; imageId: string }> };
+
+// story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 이미지 1장 삭제. 새 불변
+// 버전을 만들어 반영(#3291 규율) — 응답은 새 버전에 남은 이미지 전체(assets/confirm/
+// route.ts와 동형 위임, 검증 로직 0).
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id, draftId, imageId } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request,
+    '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/assets/[imageId]',
+    { id, draftId, imageId },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/reorder/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/reorder/route.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { POST } from './route';
+
+describe('/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/reorder (story #3550)', () => {
+  it('POST — FastAPI reorder 엔드포인트로 id/draftId 그대로 위임, 새 순서 목록 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { image_id: 'i2', draft_id: 'd1', version_id: 'v3', version: 3, position: 0, was_converted: false, image_url: 'https://x/2.jpg', original_width: 1000, original_height: 1000, original_bytes: 100, final_width: 1000, final_height: 1000, final_bytes: 100 },
+          { image_id: 'i1', draft_id: 'd1', version_id: 'v3', version: 3, position: 1, was_converted: false, image_url: 'https://x/1.jpg', original_width: 1000, original_height: 1000, original_bytes: 100, final_width: 1000, final_height: 1000, final_bytes: 100 },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const request = new Request('http://test', { method: 'POST', body: JSON.stringify({ image_ids: ['i2', 'i1'] }) });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request,
+      '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/assets/reorder',
+      { id: 'org-1', draftId: 'd1' },
+    );
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: [{ image_id: 'i2', position: 0 }, { image_id: 'i1', position: 1 }] });
+  });
+
+  it('POST — 422(CHANNEL_POST_IMAGE_REORDER_INVALID_SET) 부분집합 요청은 그대로 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_POST_IMAGE_REORDER_INVALID_SET' } }), { status: 422, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const resp = await POST(
+      new Request('http://test', { method: 'POST', body: JSON.stringify({ image_ids: ['i1'] }) }),
+      { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) },
+    );
+    expect(resp.status).toBe(422);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/reorder/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/reorder/route.ts
@@ -1,0 +1,18 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; draftId: string }> };
+
+// story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 이미지 순서 재배열. body의
+// image_ids는 항상 전체 집합·새 순서 그대로(부분 재정렬 불허 — BE가 422로 거부).
+// 새 불변 버전을 만들어 반영(#3291 규율) — assets/confirm/route.ts와 동형 위임.
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id, draftId } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request,
+    '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/assets/reorder',
+    { id, draftId },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/versions/[versionId]/assets/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/versions/[versionId]/assets/route.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { GET } from './route';
+
+describe('/api/organizations/[id]/channel-posts/drafts/[draftId]/versions/[versionId]/assets (story #3550)', () => {
+  it('GET — FastAPI 목록 엔드포인트로 id/draftId/versionId 그대로 위임, position 순 배열 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { image_id: 'i1', draft_id: 'd1', version_id: 'v2', version: 2, position: 0, was_converted: false, image_url: 'https://x/1.jpg', original_width: 1000, original_height: 1000, original_bytes: 100, final_width: 1000, final_height: 1000, final_bytes: 100 },
+          { image_id: 'i2', draft_id: 'd1', version_id: 'v2', version: 2, position: 1, was_converted: true, image_url: 'https://x/2.jpg', original_width: 4000, original_height: 3000, original_bytes: 5000000, final_width: 1440, final_height: 1080, final_bytes: 900000 },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const request = new Request('http://test');
+    const resp = await GET(request, { params: Promise.resolve({ id: 'org-1', draftId: 'd1', versionId: 'v2' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request,
+      '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/versions/[versionId]/assets',
+      { id: 'org-1', draftId: 'd1', versionId: 'v2' },
+    );
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: [{ image_id: 'i1' }, { image_id: 'i2' }] });
+  });
+
+  it('GET — 404(CHANNEL_POST_VERSION_NOT_FOUND) 그대로 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_POST_VERSION_NOT_FOUND' } }), { status: 404, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const resp = await GET(new Request('http://test'), { params: Promise.resolve({ id: 'org-1', draftId: 'd1', versionId: 'v-missing' }) });
+    expect(resp.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/versions/[versionId]/assets/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/versions/[versionId]/assets/route.ts
@@ -1,0 +1,18 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; draftId: string; versionId: string }> };
+
+// story #3550(Phase2 BE 2/2, 페드루 PO 確定 2026-09-06) — 캐러셀 N장 전체를 position
+// 순으로. 기존 단수 `.../versions/[versionId]/asset`(대표 1장)과 별개 신규 엔드포인트
+// (assets/confirm/route.ts와 동형 — 검증 로직 0).
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id, draftId, versionId } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request,
+    '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/versions/[versionId]/assets',
+    { id, draftId, versionId },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/components/content/image-attachment-list.test.tsx
+++ b/apps/web/src/components/content/image-attachment-list.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+//
+// story #3550(Phase2·풀스택 골격, PO 決定 2026-09-06) — Instagram 캐러셀 N장 첨부 UI.
+// BE 계약(업로드 다중화·순서 API) 확定 前 골격 — 이 컴포넌트는 순수 표시+로컬
+// 재배열/삭제 콜백만 진다(부모가 계약 확定 뒤 실 API에 배선).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ImageAttachmentList, type ImageAttachmentItem } from './image-attachment-list';
+import { formatFileSize } from '@/components/docs/extensions/file-node';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">{node}</NextIntlClientProvider>;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+const IMG_1: ImageAttachmentItem = {
+  url: 'https://storage.googleapis.com/x/1.jpg', wasConverted: false,
+  originalWidth: null, finalWidth: null, originalBytes: null, finalBytes: null,
+};
+const IMG_2: ImageAttachmentItem = {
+  url: 'https://storage.googleapis.com/x/2.jpg', wasConverted: true,
+  originalWidth: 4000, finalWidth: 1440, originalBytes: 5_000_000, finalBytes: 900_000,
+};
+const IMG_3: ImageAttachmentItem = {
+  url: 'https://storage.googleapis.com/x/3.jpg', wasConverted: false,
+  originalWidth: null, finalWidth: null, originalBytes: null, finalBytes: null,
+};
+
+describe('ImageAttachmentList(story #3550)', () => {
+  it('N장 각각 렌더 + 개수 태그(count/max)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ImageAttachmentList images={[IMG_1, IMG_2, IMG_3]} maxCount={10} onReorder={() => {}} onDelete={() => {}} />,
+      ));
+    });
+    expect(container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]').length).toBe(3);
+    expect(container.querySelector('[data-testid="channel-post-image-count-tag"]')?.textContent).toBe('3 / 10장');
+  });
+
+  it('§13-3 — 변환 배지는 장별로 그린다(2번째만 변환됐으면 2번째에만 뜬다)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ImageAttachmentList images={[IMG_1, IMG_2, IMG_3]} maxCount={10} onReorder={() => {}} onDelete={() => {}} />,
+      ));
+    });
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    expect(items[0]!.querySelector('[data-testid="channel-post-image-attachment-converted-badge"]')).toBeNull();
+    expect(items[1]!.querySelector('[data-testid="channel-post-image-attachment-converted-badge"]')?.textContent)
+      .toBe(koMessages.content.channelPostsImageConvertedBadge
+        .replace('{originalWidth}', '4000').replace('{finalWidth}', '1440')
+        .replace('{originalBytes}', formatFileSize(5_000_000)).replace('{finalBytes}', formatFileSize(900_000)));
+    expect(items[2]!.querySelector('[data-testid="channel-post-image-attachment-converted-badge"]')).toBeNull();
+  });
+
+  it('첫 장은 위로 이동 비활성, 마지막 장은 아래로 이동 비활성', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ImageAttachmentList images={[IMG_1, IMG_2, IMG_3]} maxCount={10} onReorder={() => {}} onDelete={() => {}} />,
+      ));
+    });
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    expect((items[0]!.querySelector('[data-testid="channel-post-image-attachment-move-up"]') as HTMLButtonElement).disabled).toBe(true);
+    expect((items[0]!.querySelector('[data-testid="channel-post-image-attachment-move-down"]') as HTMLButtonElement).disabled).toBe(false);
+    expect((items[2]!.querySelector('[data-testid="channel-post-image-attachment-move-down"]') as HTMLButtonElement).disabled).toBe(true);
+    expect((items[2]!.querySelector('[data-testid="channel-post-image-attachment-move-up"]') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('가운데 장 위로 이동 클릭 — onReorder(1, 0) 호출(현재 인덱스, 목표 인덱스)', async () => {
+    const onReorder = vi.fn();
+    await act(async () => {
+      root.render(wrap(
+        <ImageAttachmentList images={[IMG_1, IMG_2, IMG_3]} maxCount={10} onReorder={onReorder} onDelete={() => {}} />,
+      ));
+    });
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    await act(async () => {
+      (items[1]!.querySelector('[data-testid="channel-post-image-attachment-move-up"]') as HTMLButtonElement).click();
+    });
+    expect(onReorder).toHaveBeenCalledWith(1, 0);
+  });
+
+  it('삭제 클릭 — onDelete(index) 호출', async () => {
+    const onDelete = vi.fn();
+    await act(async () => {
+      root.render(wrap(
+        <ImageAttachmentList images={[IMG_1, IMG_2, IMG_3]} maxCount={10} onReorder={() => {}} onDelete={onDelete} />,
+      ));
+    });
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    await act(async () => {
+      (items[2]!.querySelector('[data-testid="channel-post-image-attachment-delete"]') as HTMLButtonElement).click();
+    });
+    expect(onDelete).toHaveBeenCalledWith(2);
+  });
+
+  it('disabled=true — 이동·삭제 버튼 전부 비활성(업로드 진행 중 등)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ImageAttachmentList images={[IMG_1, IMG_2]} maxCount={10} disabled onReorder={() => {}} onDelete={() => {}} />,
+      ));
+    });
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBeGreaterThan(0);
+    expect([...buttons].every((b) => (b as HTMLButtonElement).disabled)).toBe(true);
+  });
+});

--- a/apps/web/src/components/content/image-attachment-list.test.tsx
+++ b/apps/web/src/components/content/image-attachment-list.test.tsx
@@ -111,6 +111,24 @@ describe('ImageAttachmentList(story #3550)', () => {
     expect(onDelete).toHaveBeenCalledWith(2);
   });
 
+  // 유나 §17 PASS 권고② 정정(2026-09-06) — N개 버튼이 "몇 번째 이미지"인지 지어야
+  // 스크린리더가 「삭제」「삭제」만 반복해 듣지 않는다. 삭제 aria-label은 보이는
+  // 글자("삭제")를 덧붙여 포함하는 별도 키(channelPostsImageRemoveActionLabel).
+  it('⭐이동·삭제 버튼 aria-label이 "몇 번째 이미지"인지 각각 다르게 진다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ImageAttachmentList images={[IMG_1, IMG_2, IMG_3]} maxCount={10} onReorder={() => {}} onDelete={() => {}} />,
+      ));
+    });
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    expect((items[0]!.querySelector('[data-testid="channel-post-image-attachment-move-up"]') as HTMLButtonElement).getAttribute('aria-label'))
+      .toBe('1번째 이미지 위로 이동');
+    expect((items[1]!.querySelector('[data-testid="channel-post-image-attachment-move-down"]') as HTMLButtonElement).getAttribute('aria-label'))
+      .toBe('2번째 이미지 아래로 이동');
+    expect((items[2]!.querySelector('[data-testid="channel-post-image-attachment-delete"]') as HTMLButtonElement).getAttribute('aria-label'))
+      .toBe('3번째 이미지 삭제');
+  });
+
   it('disabled=true — 이동·삭제 버튼 전부 비활성(업로드 진행 중 등)', async () => {
     await act(async () => {
       root.render(wrap(

--- a/apps/web/src/components/content/image-attachment-list.tsx
+++ b/apps/web/src/components/content/image-attachment-list.tsx
@@ -1,0 +1,102 @@
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { formatFileSize } from '@/components/docs/extensions/file-node';
+
+// story #3550(Phase2·풀스택, PO 決定 2026-09-06) — Instagram 캐러셀 N장 첨부 골격.
+// BE 계약(이미지 목록/순서 API·업로드 다중화·422 코드명·합성 봉인 해시)이 아직 안 뜬
+// 자리라(디디 설계 선행 §① 안 A 채택·②③ 신설 예정) 이 컴포넌트는 **순수 표시+로컬
+// 재배열/삭제**만 진다 — 업로드·저장 왕복은 부모가 계약 확定 뒤 onReorder/onDelete/
+// onAddClick을 실 API에 배선한다(지금은 그 콜백을 로컬 배열 조작으로만 채워도 된다).
+//
+// §13-3(디디 재확인, 2026-09-06 — 단일 슬롯 옛 §13-8 인용은 #3549 오귀속 정정) "있는
+// 그대로 그린다" — 변환 배지(image_was_converted)는 승인 카드와 같은 문구를 공유한다는
+// 결정을 N장 각각에 그대로 적용한다(장별 배지, 하나로 뭉치지 않는다 — 각 이미지가
+// 저마다 다른 변환을 겪을 수 있어서다).
+//
+// 재배열은 위/아래 버튼이다(드래그 아님) — STEER 로드맵 조타 FE 교훈(synthetic mouse
+// dnd-kit이 이 스택에서 비활성이라 신뢰 못 함) 재사용, 접근성도 버튼이 기본으로 더 낫다.
+export interface ImageAttachmentItem {
+  /** 업로드 확定 응답의 image_url — BE 계약 확定 전엔 프론트가 미리보기용으로만 쓴다. */
+  url: string;
+  wasConverted: boolean;
+  originalWidth: number | null;
+  finalWidth: number | null;
+  originalBytes: number | null;
+  finalBytes: number | null;
+}
+
+export interface ImageAttachmentListProps {
+  images: ImageAttachmentItem[];
+  maxCount: number;
+  disabled?: boolean;
+  onReorder: (fromIndex: number, toIndex: number) => void;
+  onDelete: (index: number) => void;
+}
+
+export function ImageAttachmentList({ images, maxCount, disabled, onReorder, onDelete }: ImageAttachmentListProps) {
+  const t = useTranslations('content');
+
+  return (
+    <div className="space-y-2" data-testid="channel-post-image-attachment-list">
+      <p className="text-xs text-muted-foreground" data-testid="channel-post-image-count-tag">
+        {t('channelPostsImageCountTag', { count: images.length, max: maxCount })}
+      </p>
+      <ul className="space-y-2">
+        {images.map((img, index) => (
+          <li
+            key={img.url}
+            className="flex items-center gap-3 rounded-md border border-border p-2"
+            data-testid="channel-post-image-attachment-item"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element -- 단일 슬롯(page.tsx:1830)과 동형 관례: public-read GCS 오브젝트 URL, next/image 대상 밖. */}
+            <img
+              src={img.url} alt={t('channelPostsImageAttachAlt')}
+              className="h-16 w-16 shrink-0 rounded object-cover" data-testid="channel-post-image-attachment-preview"
+            />
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-xs text-muted-foreground" data-testid="channel-post-image-attachment-position">
+                {t('channelPostsImageAttachmentPosition', { position: index + 1 })}
+              </p>
+              {img.wasConverted ? (
+                <p className="text-xs text-muted-foreground" data-testid="channel-post-image-attachment-converted-badge">
+                  {t('channelPostsImageConvertedBadge', {
+                    originalWidth: img.originalWidth ?? 0,
+                    finalWidth: img.finalWidth ?? 0,
+                    originalBytes: typeof img.originalBytes === 'number' ? formatFileSize(img.originalBytes) : '',
+                    finalBytes: typeof img.finalBytes === 'number' ? formatFileSize(img.finalBytes) : '',
+                  })}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex shrink-0 gap-1">
+              <Button
+                type="button" variant="outline" size="sm" disabled={disabled || index === 0}
+                onClick={() => onReorder(index, index - 1)}
+                data-testid="channel-post-image-attachment-move-up"
+                aria-label={t('channelPostsImageMoveUpAction')}
+              >
+                ↑
+              </Button>
+              <Button
+                type="button" variant="outline" size="sm" disabled={disabled || index === images.length - 1}
+                onClick={() => onReorder(index, index + 1)}
+                data-testid="channel-post-image-attachment-move-down"
+                aria-label={t('channelPostsImageMoveDownAction')}
+              >
+                ↓
+              </Button>
+              <Button
+                type="button" variant="outline" size="sm" disabled={disabled}
+                onClick={() => onDelete(index)}
+                data-testid="channel-post-image-attachment-delete"
+                aria-label={t('channelPostsImageRemoveAction')}
+              >
+                {t('channelPostsImageRemoveAction')}
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/content/image-attachment-list.tsx
+++ b/apps/web/src/components/content/image-attachment-list.tsx
@@ -2,11 +2,10 @@ import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { formatFileSize } from '@/components/docs/extensions/file-node';
 
-// story #3550(Phase2·풀스택, PO 決定 2026-09-06) — Instagram 캐러셀 N장 첨부 골격.
-// BE 계약(이미지 목록/순서 API·업로드 다중화·422 코드명·합성 봉인 해시)이 아직 안 뜬
-// 자리라(디디 설계 선행 §① 안 A 채택·②③ 신설 예정) 이 컴포넌트는 **순수 표시+로컬
-// 재배열/삭제**만 진다 — 업로드·저장 왕복은 부모가 계약 확定 뒤 onReorder/onDelete/
-// onAddClick을 실 API에 배선한다(지금은 그 콜백을 로컬 배열 조작으로만 채워도 된다).
+// story #3550(Phase2·풀스택, PO 決定 2026-09-06) — Instagram 캐러셀 N장 첨부.
+// 업로드 자체(파일 선택·서명 URL·PUT·confirm)는 부모(channel-posts/[draftId]/
+// page.tsx)가 진다 — 이 컴포넌트는 이미 첨부된 N장의 표시·재배열·삭제만 맡는다
+// (onReorder/onDelete를 부모가 실 API에 배선, BE 2/2 #3910 계약).
 //
 // §13-3(디디 재확인, 2026-09-06 — 단일 슬롯 옛 §13-8 인용은 #3549 오귀속 정정) "있는
 // 그대로 그린다" — 변환 배지(image_was_converted)는 승인 카드와 같은 문구를 공유한다는
@@ -68,28 +67,37 @@ export function ImageAttachmentList({ images, maxCount, disabled, onReorder, onD
                 </p>
               ) : null}
             </div>
-            <div className="flex shrink-0 gap-1">
-              <Button
-                type="button" variant="outline" size="sm" disabled={disabled || index === 0}
-                onClick={() => onReorder(index, index - 1)}
-                data-testid="channel-post-image-attachment-move-up"
-                aria-label={t('channelPostsImageMoveUpAction')}
-              >
-                ↑
-              </Button>
-              <Button
-                type="button" variant="outline" size="sm" disabled={disabled || index === images.length - 1}
-                onClick={() => onReorder(index, index + 1)}
-                data-testid="channel-post-image-attachment-move-down"
-                aria-label={t('channelPostsImageMoveDownAction')}
-              >
-                ↓
-              </Button>
+            <div className="flex shrink-0 items-center gap-3">
+              {/* 유나 §17 PASS 권고①(2026-09-06) — 반복 조작(위/아래 이동)과
+                  되돌리기 비싼 조작(삭제)을 같은 gap-1 묶음에 안 둔다. 두 그룹
+                  사이 gap-3로 시각 분리. */}
+              <div className="flex gap-1">
+                <Button
+                  type="button" variant="outline" size="sm" disabled={disabled || index === 0}
+                  onClick={() => onReorder(index, index - 1)}
+                  data-testid="channel-post-image-attachment-move-up"
+                  aria-label={t('channelPostsImageMoveUpAction', { position: index + 1 })}
+                >
+                  ↑
+                </Button>
+                <Button
+                  type="button" variant="outline" size="sm" disabled={disabled || index === images.length - 1}
+                  onClick={() => onReorder(index, index + 1)}
+                  data-testid="channel-post-image-attachment-move-down"
+                  aria-label={t('channelPostsImageMoveDownAction', { position: index + 1 })}
+                >
+                  ↓
+                </Button>
+              </div>
+              {/* 유나 §17 PASS 권고② 정정(2026-09-06) — aria-label을 지우지 않고
+                  N개 버튼이 "몇 번째 이미지"인지 지도록 위치를 붙인다(스크린리더가
+                  「삭제」「삭제」만 반복해 듣는 문제 — §17-20① "지우지 마라"는 접근성
+                  이름에 보이는 글자를 빼라는 뜻이지 덧붙이지 말라는 뜻이 아니다). */}
               <Button
                 type="button" variant="outline" size="sm" disabled={disabled}
                 onClick={() => onDelete(index)}
                 data-testid="channel-post-image-attachment-delete"
-                aria-label={t('channelPostsImageRemoveAction')}
+                aria-label={t('channelPostsImageRemoveActionLabel', { position: index + 1 })}
               >
                 {t('channelPostsImageRemoveAction')}
               </Button>


### PR DESCRIPTION
## 요약
BE 2/2(#3910, 디디, develop ddfa63659) 계약 위 — 캐러셀 N장 첨부 UI를 실 API에 배선. 단일 `<img>` 슬롯을 N장 목록(`ImageAttachmentList`, 로컬 골격 커밋 위)으로 교체.

## 변경
- BFF 패스스루 3개(`assets/confirm`과 동형 — 검증 로직 0): `GET versions/[versionId]/assets` · `DELETE assets/[imageId]` · `POST assets/reorder`.
- `page.tsx`: `images`(N장 목록) state 신설.
  - 초기 로드·업로드 confirm 성공 둘 다 목록 GET으로 채운다 — confirm은 새 버전(carry-forward)이라 로컬로 배열에 추가만 하면 BE의 carry-forward 규칙을 화면이 지어내는 셈이라, 그 새 버전으로 목록을 다시 받는다.
  - 삭제·재정렬은 응답 자체가 `list[ChannelPostImageResponse]`라 그대로 교체(추가 GET 없음) — 새 버전=재승인 트리거(#3291)라 `draft`/`versions`도 같이 재조회(기존 B1 이미지 confirm 재조회와 동형 이유).
  - `imageRequiredAndMissing` 판정 소스를 `draft.thumbnail_url`(단수 대표 1장)에서 `images.length`(N장 목록, 이 화면의 실제 첨부 수)로 이동. 단수 대표 1장 계약(`draft.thumbnail_url`·`image_was_converted`)은 승인 카드가 그대로 쓰므로 무변경.
  - 위/아래 이동은 매번 전체 `image_ids`를 한 번에 재정렬 API로 보낸다(부분 재정렬 불허 — BE 422 `CHANNEL_POST_IMAGE_REORDER_INVALID_SET`로 방어).
- 422/404(`CHANNEL_POST_IMAGE_COUNT_EXCEEDED`·`CHANNEL_POST_IMAGE_REORDER_INVALID_SET`·`CHANNEL_POST_IMAGE_NOT_FOUND`) 전부 기존 `parseSitePostApiError`/`describeChannelImageError`로 서버 message 그대로(신규 처리 0 — 미등록 코드는 이미 `humanMessageFallback`=서버 message로 떨어지는 기존 관례).

## 디자인 참고(유나 §17 회차 대상 — 이 PR 프리뷰가 아니라 dev 배포 뒤 실픽셀로)
장별 변환 배지·위/아래 이동 버튼 낱말(`↑`/`↓` + `aria-label`)은 골격 그대로 — §17 낱말 확定은 배포 뒤.

## 검증
- 기존 단일 슬롯 테스트 6건을 새 리스트 testid로 갱신(`channel-post-image-attachment-preview`/`-converted-badge`).
- 신규 7건: 목록 초기 로드(position 순)·삭제(image_id로 DELETE, 남은 목록 교체)·재정렬(전체 집합 POST, 응답으로 교체)·422 두 문장(REORDER_INVALID_SET·COUNT_EXCEEDED)·404(NOT_FOUND) 서버 message 그대로 렌더.
- 뮤테이션 2건(재정렬 배열 삽입 위치·에러 승격 조건) RED 확인 후 복원.
- `tsc --noEmit` 0 / `eslint --max-warnings=0` 0 / i18n 키 누락 0 / 한자 pin 0 / focus-inset 가드 0 / `vitest run` 6453 전부 그린(develop 최신 위, #3910 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)