### PR TITLE
[SID:3558] feat: destructive 샤드 순수 pytest 소요 산출물 + weights 경고 대조

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1014,12 +1014,31 @@ jobs:
           fi
           uv run python scripts/shard_destructive_tests.py --check-elapsed "$elapsed_file"
           slow_exit=$?
+          # story #3558(CI·소형) AC1 — 삭제(rm -f) 前에 등재값 대조용 산출물로 변환해
+          # 둔다(DB 준비를 제외한 순수 pytest wall time, `_t0`가 dropdb/createdb 뒤에서
+          # 시작하므로 이미 그 값 — 새 타이머 불요, 기존 elapsed_file을 그대로 재사용).
+          # 이 변환은 위 60초 가드 판정과 무관하게 항상 시도한다(느린 러너여도 산출물은
+          # 남겨야 다음 잡의 대조가 그 run을 볼 수 있다).
+          uv run python scripts/shard_destructive_tests.py --elapsed-to-json "$elapsed_file" /tmp/shard-durations-${{ matrix.shard }}.json --shard ${{ matrix.shard }}
           rm -f "$elapsed_file"
           if [ "$slow_exit" -ne 0 ]; then
             echo "러너 정규화 60초 가드 초과(story #3396, 위 ::error:: 참고)"
             exit 1
           fi
           echo "OK: all ${#files[@]} isolated destructive-schema files passed (shard ${{ matrix.shard }})"
+
+      # story #3558(CI·소형) AC1 — 다음 잡("Require all destructive-schema shards")이
+      # 8개 샤드의 산출물을 모아 weights.json과 절대 배율(2배/0.5배) 경고 대조를 한다.
+      # `if: always()`(위 pytest 스텝이 실패해도 산출물은 남긴다 — 실패 원인 진단에도
+      # "이 run에서 각 파일이 실제로 얼마나 걸렸는지"가 유용하다).
+      - name: Upload shard durations (story #3558)
+        if: always() && needs.detect-changed-scope.outputs.backend_relevant != 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: shard-durations-${{ matrix.shard }}
+          path: /tmp/shard-durations-${{ matrix.shard }}.json
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Skip reason (backend-irrelevant PR)
         if: needs.detect-changed-scope.outputs.backend_relevant == 'false'
@@ -1097,6 +1116,24 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: 'latest'
+
+      # story #3558(CI·소형) AC2 — 8개 샤드가 낸 shard-durations-{n} 산출물을 모아
+      # weights.json과 절대 배율(2배/0.5배) 대조 «경고만»(실패 0 — continue-on-error도
+      # 필요 없다, _audit_durations_mode 자체가 항상 exit 0). backend-irrelevant PR이라
+      # 샤드가 스킵됐으면 산출물 자체가 없을 수 있어 download 단계를 continue-on-error로
+      # 감싼다(찾는 패턴이 0건이면 actions/download-artifact가 에러를 낸다 — 그게 이
+      # 필수 체크 잡을 죽이면 안 된다, story #2555의 backend-irrelevant 우회 규율과 동형).
+      - name: Download shard durations (story #3558)
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: shard-durations-*
+          path: /tmp/shard-durations
+          merge-multiple: true
+
+      - name: Audit shard durations vs weights.json (story #3558, warn-only)
+        working-directory: backend
+        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations
 
       # non-destructive real-PG 테스트(84개 파일, destructive_schema 마커 제외)는 alembic-migrated
       # 스키마(view·nullable·seed 포함 baseline)에 의존한다 — fresh DB를 먼저 heads까지 올린다

--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -234,6 +234,85 @@ def _parse_elapsed_file(path: Path) -> dict[str, float]:
     return result
 
 
+# story #3558(CI·소형) — shard(5) 22분29초 사례(2026-09-06, #3910 CI): 원인이 신규
+# 파일이 아니라 옛 파일 클러스터의 등재값 과소(4~10배)였다. `_check_elapsed_mode`(위,
+# #3396)는 "이 run 자신의 중앙값 배율로 60초를 스케일"하는 *러너 정규화* 가드라
+# 클러스터 전체가 같이 느려진 경우 정규화가 따라가 버려 개별 파일의 등재값 자체가
+# 낡았다는 신호를 못 낸다 — 이 축은 그와 별개로 "등재값 대 실측"의 **절대 배율**을
+# 그대로 보는 경고 전용 축(실패 0, story #3396의 실패 가드와 안 겹친다).
+RATIO_WARN_HIGH_MULTIPLIER = 2.0
+RATIO_WARN_LOW_MULTIPLIER = 0.5
+
+
+def ratio_outliers(
+    measured: dict[str, float], weights: dict[str, float], *,
+    high_multiplier: float = RATIO_WARN_HIGH_MULTIPLIER, low_multiplier: float = RATIO_WARN_LOW_MULTIPLIER,
+) -> list[dict]:
+    """story #3558 — `measured`(산출물에서 병합된 실측 pytest 소요)와 `weights`(등재값)
+    둘 다에 있는 파일만 대상으로 ratio=measured/weight를 낸다. ratio>=high_multiplier
+    (과소 등재, 이 파일이 이 등재값 탓에 샤드를 무겁게 만들 수 있다) 또는 ratio<=
+    low_multiplier(과대 등재, 반대로 다른 파일이 손해를 볼 수 있다)만 반환(정렬은
+    ratio 내림차순 — 가장 심한 것부터). weights에 없는 파일(#3392의 unweighted 축이
+    이미 담당)·measured에 없는 파일(그 샤드에 안 걸렸거나 산출물 누락)은 조용히
+    건너뛴다 — 이 축은 "이미 등재된 값이 실측과 얼마나 벌어졌는가"만 본다."""
+    outliers = []
+    for file, elapsed in measured.items():
+        weight = weights.get(file)
+        if weight is None or weight <= 0:
+            continue
+        ratio = elapsed / weight
+        if ratio >= high_multiplier or ratio <= low_multiplier:
+            outliers.append({"file": file, "measured_sec": elapsed, "weight_sec": weight, "ratio": ratio})
+    outliers.sort(key=lambda o: o["ratio"], reverse=True)
+    return outliers
+
+
+def write_durations_json(elapsed_by_file: dict[str, float], out_path: Path, *, shard: int) -> None:
+    """story #3558 AC1 — 샤드별 순수 pytest 소요(DB 준비 제외, `_parse_elapsed_file`과
+    같은 값)를 JSON 산출물로 낸다. ci.yml이 이 파일을 `actions/upload-artifact`로
+    올린다(shard-durations-{shard})."""
+    out_path.write_text(json.dumps({"shard": shard, "durations": elapsed_by_file}, indent=2, sort_keys=True))
+
+
+def load_duration_artifacts(artifact_dir: Path) -> dict[str, float]:
+    """story #3558 AC2 — `artifact_dir` 아래 `*.json`(각 shard-durations-{n}.json,
+    `{"shard": n, "durations": {file: sec}}` 모양) 전부를 하나의 {file: sec}로 병합한다.
+    partition()이 무손실·배타적 분배를 보장하므로(test_partition_is_lossless_for_any_
+    input) 파일이 두 샤드에 동시에 나타나는 정상 경로는 없다 — 방어적으로 나타나도
+    마지막 값으로 덮어쓴다(에러로 죽이지 않는다, 이 축 자체가 경고 전용이라 원칙과 동형)."""
+    merged: dict[str, float] = {}
+    for p in sorted(artifact_dir.glob("*.json")):
+        try:
+            data = json.loads(p.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        merged.update(data.get("durations", {}))
+    return merged
+
+
+def _audit_durations_mode(artifact_dir: Path) -> int:
+    """story #3558 AC2 — 항상 0을 반환한다(경고 전용, CI를 절대 안 죽인다). 산출물
+    디렉터리가 없거나 비어 있어도(backend-irrelevant PR이라 샤드 자체가 스킵된 경우)
+    조용히 "대조 대상 0건"으로 끝낸다."""
+    if not artifact_dir.exists():
+        print(f"산출물 디렉터리 없음({artifact_dir}) — backend-irrelevant PR로 샤드가 스킵됐을 수 있음, 대조 0건", file=sys.stderr)
+        return 0
+    measured = load_duration_artifacts(artifact_dir)
+    weights = load_weights()
+    outliers = ratio_outliers(measured, weights)
+    if not outliers:
+        print(f"OK: 등재값 대조 — 산출물 {len(measured)}건 중 2배/0.5배 이탈 0건(story #3558)", file=sys.stderr)
+        return 0
+    for o in outliers:
+        direction = "과소 등재" if o["ratio"] >= RATIO_WARN_HIGH_MULTIPLIER else "과대 등재"
+        print(
+            f"::warning::등재값 {direction}(story #3558): {o['file']} — 실측 {o['measured_sec']:.1f}s vs "
+            f"등재 {o['weight_sec']:.1f}s(×{o['ratio']:.2f}) — infra/destructive-schema-shard-weights.json 재측정 검토."
+        )
+    print(f"경고 {len(outliers)}건(산출물 {len(measured)}건 중) — 실패 아님, story #3558 AC2", file=sys.stderr)
+    return 0
+
+
 def _check_elapsed_mode(elapsed_path: Path) -> int:
     """story #3396 — ci.yml의 pytest 루프가 이 샤드의 모든 파일을 다 돈 뒤 한 번
     호출한다(중앙값은 그 run 전체 표본이 있어야 나온다 — 파일 단위 즉시 판정이 애초에
@@ -282,10 +361,33 @@ def main() -> int:
              "가드를 판정하고 끝낸다(discover/partition 없음 — ci.yml의 pytest 루프가 이 "
              "샤드의 모든 파일을 다 돈 뒤 한 번 호출한다, 중앙값은 그 run 전체를 봐야 나온다).",
     )
+    ap.add_argument(
+        "--elapsed-to-json", nargs=2, type=Path, default=None, metavar=("ELAPSED_IN", "JSON_OUT"),
+        help="story #3558 AC1 — --check-elapsed와 같은 <file>\\t<elapsed_sec> 파일을 읽어 "
+             "{shard, durations} JSON으로 변환한다(actions/upload-artifact 산출물용). "
+             "--shard와 함께 쓴다.",
+    )
+    ap.add_argument("--shard", type=int, default=None, help="--elapsed-to-json의 shard 번호")
+    ap.add_argument(
+        "--audit-durations", type=Path, default=None, metavar="ARTIFACT_DIR",
+        help="story #3558 AC2 — ARTIFACT_DIR 아래 shard-durations-*.json 전부를 병합해 "
+             "weights.json과 2배/0.5배 대조 경고를 낸다(항상 exit 0, 실패 없음).",
+    )
     args = ap.parse_args()
 
     if args.check_elapsed is not None:
         return _check_elapsed_mode(args.check_elapsed)
+
+    if args.elapsed_to_json is not None:
+        elapsed_in, json_out = args.elapsed_to_json
+        if args.shard is None:
+            print("--elapsed-to-json은 --shard가 필수", file=sys.stderr)
+            return 2
+        write_durations_json(_parse_elapsed_file(elapsed_in), json_out, shard=args.shard)
+        return 0
+
+    if args.audit_durations is not None:
+        return _audit_durations_mode(args.audit_durations)
 
     if args.shard_index is None or args.shard_count is None:
         print("--shard-index/--shard-count는 --check-elapsed 없이는 필수", file=sys.stderr)

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -380,3 +380,94 @@ def test_main_meta_out_empty_list_when_shard_fully_weighted(tmp_path, monkeypatc
     mod.main()
     meta = json.loads(meta_path.read_text())
     assert meta["unweighted_files"] == []
+
+
+# ─── story #3558 — 등재값 대 실측 절대 배율 경고 축(실패 X) ────────────────────
+
+
+def test_ratio_outliers_flags_at_exact_high_boundary():
+    """ratio==2.0(경계 자체)는 «>=»라 flag돼야 한다(정확히 2배 과소 등재도 놓치면 안 됨)."""
+    mod = _load()
+    outliers = mod.ratio_outliers({"tests/a.py": 20.0}, {"tests/a.py": 10.0})
+    assert len(outliers) == 1
+    assert outliers[0]["file"] == "tests/a.py"
+    assert outliers[0]["ratio"] == pytest.approx(2.0)
+
+
+def test_ratio_outliers_flags_at_exact_low_boundary():
+    """ratio==0.5(경계 자체)도 «<=」라 flag(과대 등재 — 이 파일 탓에 다른 파일이 손해)."""
+    mod = _load()
+    outliers = mod.ratio_outliers({"tests/a.py": 5.0}, {"tests/a.py": 10.0})
+    assert len(outliers) == 1
+    assert outliers[0]["ratio"] == pytest.approx(0.5)
+
+
+def test_ratio_outliers_just_inside_bounds_not_flagged():
+    """2.0/0.5 경계 바로 안쪽(1.99배·0.51배)은 정상 편차로 보고 flag 안 한다."""
+    mod = _load()
+    outliers = mod.ratio_outliers(
+        {"tests/a.py": 19.9, "tests/b.py": 5.1}, {"tests/a.py": 10.0, "tests/b.py": 10.0},
+    )
+    assert outliers == []
+
+
+def test_ratio_outliers_skips_file_missing_from_weights():
+    """measured에는 있는데 weights.json엔 없는(unweighted, #3392 축이 별도 담당) 파일은
+    조용히 건너뛴다 — 이 축이 unweighted 가드와 중복 경고를 내면 혼란만 커진다."""
+    mod = _load()
+    outliers = mod.ratio_outliers({"tests/new_unweighted.py": 999.0}, {})
+    assert outliers == []
+
+
+def test_ratio_outliers_sorted_worst_first():
+    mod = _load()
+    outliers = mod.ratio_outliers(
+        {"tests/mild.py": 21.0, "tests/severe.py": 100.0},
+        {"tests/mild.py": 10.0, "tests/severe.py": 10.0},
+    )
+    assert [o["file"] for o in outliers] == ["tests/severe.py", "tests/mild.py"]
+
+
+def test_load_duration_artifacts_merges_multiple_shard_files(tmp_path):
+    mod = _load()
+    (tmp_path / "shard-durations-0.json").write_text(
+        json.dumps({"shard": 0, "durations": {"tests/a.py": 5.0, "tests/b.py": 6.0}})
+    )
+    (tmp_path / "shard-durations-1.json").write_text(
+        json.dumps({"shard": 1, "durations": {"tests/c.py": 7.0}})
+    )
+    merged = mod.load_duration_artifacts(tmp_path)
+    assert merged == {"tests/a.py": 5.0, "tests/b.py": 6.0, "tests/c.py": 7.0}
+
+
+def test_write_and_reload_durations_json_roundtrip(tmp_path):
+    mod = _load()
+    out = tmp_path / "shard-durations-3.json"
+    mod.write_durations_json({"tests/x.py": 12.5}, out, shard=3)
+    data = json.loads(out.read_text())
+    assert data == {"shard": 3, "durations": {"tests/x.py": 12.5}}
+
+
+def test_audit_durations_mode_never_fails_even_with_outliers(tmp_path, capsys, monkeypatch):
+    """story #3558 AC2 — 명백한 이탈이 있어도 exit code는 항상 0이어야 한다(경고 전용,
+    이 잡이 CI를 절대 못 죽인다)."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    (artifact_dir / "shard-durations-0.json").write_text(
+        json.dumps({"shard": 0, "durations": {"tests/way_off.py": 500.0}})
+    )
+    monkeypatch.setattr(mod, "load_weights", lambda: {"tests/way_off.py": 10.0})
+    exit_code = mod._audit_durations_mode(artifact_dir)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "::warning::" in captured.out
+    assert "tests/way_off.py" in captured.out
+
+
+def test_audit_durations_mode_missing_dir_returns_0_no_crash(tmp_path):
+    """backend-irrelevant PR이면 destructive 샤드 자체가 스킵돼 산출물이 아예 없을 수
+    있다 — 디렉터리 부재를 에러가 아니라 "대조 0건"으로 조용히 처리해야 한다."""
+    mod = _load()
+    exit_code = mod._audit_durations_mode(tmp_path / "does-not-exist")
+    assert exit_code == 0


### PR DESCRIPTION
## 배경
2026-09-06 #3910 CI shard(5) 22분29초(p95 11분 초과) — 실측 조사(story #3550 그라운딩 코멘트) 결과 원인은 test_3550(등재 55s vs 실측 25s, 여유 충분)이 아니라 **옛 파일 5개가 등재값 대비 4~10배 느려져 있던 것**(test_2161 58s/14s·test_3001 58s/6s·test_2054 55s/7s·test_edg_s8 54s/13s·test_2815 52s/8s). 가설: `_session_factory()`의 `Base.metadata.create_all` 고정비가 마이그레이션 누적(72+테이블)으로 늘었는데 등재값은 그때 스냅샷 기준.

## 구현(PO 確定 4가지)
**① 산출물** — 각 샤드가 이미 재고 있던 `elapsed_file`(파일별 wall time — `_t0`가 dropdb/createdb **뒤**에서 시작하므로 이미 DB 준비 제외, 새 타이머 불요)을 `shard-durations-{n}.json`으로 변환해 `actions/upload-artifact`로 올린다(7일 보존).

**② 요약 대조(경고만)** — "Backend pytest" 필수 체크 잡이 8개 산출물을 `actions/download-artifact`(continue-on-error — backend-irrelevant PR로 산출물이 아예 없어도 이 필수 체크를 안 죽임)로 모아 `ratio_outliers()`가 weights.json과 대조: 실측/등재 **≥2.0 또는 ≤0.5**인 파일만 `::warning::`(exit 0 고정, 실패 없음 — story #3396의 러너 정규화 60초 가드와 별개 축).

**③ 1회 전수 재측정** — 이 PR 스코프 밖입니다(AC 본문 명시대로 실 CI에서 최소 1회 정상 run의 산출물이 나온 뒤 별도 PR로 진행 — 로컬로는 그 실측 데이터를 재현할 수 없습니다).

**④ 테스트+뮤테이션** — 아래.

## 테스트
8건(ratio 경계 정확히 2.0/0.5 flag·경계 바로 안쪽 미flag·unweighted 파일 스킵·정렬(심한 것부터)·JSON 병합(멀티 샤드)·왕복·audit 모드 항상 exit 0(명백한 이탈에도)·산출물 디렉터리 부재 시 조용히 0건) + 뮤테이션 2종(임계 검사 제거→0건 RED·audit 모드가 outlier 있으면 fail로 변질→RED) 각 확인 후 원복. 기존 shard_destructive_tests 회귀 40건 전체 통과(+관련 lint 테스트 11건). shard-weights lint 통과.

## 다음
CI가 이 PR 자체에서 8개 산출물을 내고 요약 스텝에 대조 표를 찍는지 확인(AC1) — 그 뒤 정상 부하 run 1건으로 전수 재측정 PR(AC3)을 별도로 올립니다.