### PR TITLE
[SID:3556] feat: 릴스 영상 업로드 BFF 패스스루(upload-url·confirm)

### DIFF
--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/confirm/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/confirm/route.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { POST } from './route';
+
+describe('/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/confirm (story #3556)', () => {
+  it('POST — FastAPI video confirm 엔드포인트로 draftId를 그대로 위임, 201 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          video_id: 'vid1', draft_id: 'd1', version_id: 'v2', version: 2,
+          duration_seconds: 12.5, width: 1080, height: 1920, codec: 'avc1',
+          original_bytes: 20000000, video_url: 'https://storage.googleapis.com/bucket/channel-media/o/d1/x.mp4',
+        }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const request = new Request('http://test', { method: 'POST' });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request,
+      '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/confirm',
+      { id: 'org-1', draftId: 'd1' },
+    );
+    expect(resp.status).toBe(201);
+  });
+
+  it('POST — 422(CHANNEL_VIDEO_DURATION_EXCEEDED) 같은 !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify({ detail: { code: 'CHANNEL_VIDEO_DURATION_EXCEEDED', message: '90초를 넘습니다', max_seconds: 90 } }),
+        { status: 422, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const resp = await POST(new Request('http://test', { method: 'POST' }), { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+    expect(resp.status).toBe(422);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/confirm/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/confirm/route.ts
@@ -1,0 +1,21 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; draftId: string }> };
+
+// story #3556(Phase2·FE, BE #3554/#3911 계약) — 릴스 영상 업로드 2단계(확인+MP4
+// 메타 파싱+규격 검증+계보 기록, 새 ChannelPostVersion 생성). 이미지 confirm
+// BFF(story #3428)와 동형 — 백엔드
+// backend/app/routers/channel_posts.py::post_channel_post_video_confirm으로 그대로
+// 위임.
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id, draftId } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request,
+    '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/confirm',
+    { id, draftId },
+  );
+  if (!_r.ok) return _r;
+  // 백엔드가 201로 새 버전 생성을 알린다(assets/confirm/route.ts와 동일 이유).
+  return apiSuccess(await _r.json(), undefined, _r.status);
+}

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/upload-url/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/upload-url/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { POST } from './route';
+
+describe('/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/upload-url (story #3556)', () => {
+  it('POST — FastAPI video upload-url 엔드포인트로 draftId를 그대로 위임', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify({ upload_url: 'https://gcs/put', object_path: 'channel-media/o/d/x.mp4', expires_at: '2026-09-06T12:10:00Z', max_bytes: 104857600, required_put_headers: {} }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const request = new Request('http://test', { method: 'POST' });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request,
+      '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/upload-url',
+      { id: 'org-1', draftId: 'd1' },
+    );
+    expect(resp.status).toBe(200);
+  });
+
+  it('POST — 422(CHANNEL_VIDEO_UNSUPPORTED) 같은 !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify({ detail: { code: 'CHANNEL_VIDEO_UNSUPPORTED', message: '이 채널은 영상을 지원하지 않습니다', channel: 'threads' } }),
+        { status: 422, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const resp = await POST(new Request('http://test', { method: 'POST' }), { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+    expect(resp.status).toBe(422);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/upload-url/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/upload-url/route.ts
@@ -1,0 +1,20 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; draftId: string }> };
+
+// story #3556(Phase2·FE, BE #3554/#3911 계약) — 릴스 영상 업로드 1단계(signed URL
+// 발급). 이미지 upload-url BFF(story #3428)와 동형 — 검증 로직 0, 백엔드
+// backend/app/routers/channel_posts.py::post_channel_post_video_upload_url로 그대로
+// 위임. 실제 PUT은 이 BFF를 거치지 않는다(브라우저가 응답의 upload_url로 GCS에 직접
+// PUT — storage/base.py D3 원칙).
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id, draftId } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request,
+    '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]/assets/video/upload-url',
+    { id, draftId },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}


### PR DESCRIPTION
## 배경
PO 지시(2026-09-06) — #3554/#3911(BE) 라이브 런북(PO Test Org 퍼펫티어 owner 세션)이 BFF 쿠키 인증 경로만 쓸 수 있는데, 영상 업로드 라우트가 BFF에 없어(백엔드 직행은 CORS로 막힘, 실측) 배포 뒤에도 런북을 못 돌리는 갭을 먼저 닫는다. 편집기 본체(videoSpec·video_url 등 BE additive 착지 뒤 rebase)는 별도 PR로 이어간다.

## 구현
형제 `assets/upload-url`·`assets/confirm` BFF(story #3428)와 완전 동형 — `proxyToFastapiWithParams`로 `backend/app/routers/channel_posts.py::post_channel_post_video_upload_url`/`post_channel_post_video_confirm`에 그대로 위임, 검증 로직 0.

- `POST .../assets/video/upload-url`
- `POST .../assets/video/confirm`

## 테스트
- 각 라우트 200/201 pass-through + 422 pass-through(2건씩, 4건 총).

## 검증
tsc 0·eslint 0·vitest 6459 전부 그린.

## Design
BFF-only(순수 위임, UI 변경 0) — PO 「PASS (BFF-only)」.