### PR TITLE
[SID:3559] feat: 연결 응답 video_* 6종 + draft 상세 video_url additive

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -148,6 +148,16 @@ class ChannelConnectionResponse(BaseModel):
     # 「올리기 전에」 안내를 만들 수 있게 노출(max_text_length·image_max_count와 동형
     # 관례 — 상수 하드코딩 X).
     image_required: bool = False
+    # story #3559(Phase2·BE·소형, 페드루 PO 確定 2026-09-06) — 어댑터가 이미 선언한
+    # 영상(릴스) 규격(story #3554)을 image_* 6종과 동형 관례로 노출(additive). 미지원
+    # 채널(어댑터 None 또는 video_max_bytes=0)은 0/0.0/[](§17-16 "0이면 0으로 적는다"
+    # 그대로 — image_*와 다른 새 관례를 만들지 않는다).
+    video_max_bytes: int = 0
+    video_max_seconds: float = 0.0
+    video_min_seconds: float = 0.0
+    video_aspect_target: float = 0.0
+    video_aspect_tolerance: float = 0.0
+    video_codecs: list[str] = []
     # story #3492 — 붙여넣기(pasted_secret) 재방문 표시(§2 규격 3, app_id_suffix와
     # 동형). oauth 채널은 항상 null(secret_hint 자체를 안 씀).
     secret_hint: str | None = None
@@ -189,6 +199,12 @@ def _to_response(row) -> ChannelConnectionResponse:
         image_color_space=adapter.image_color_space if adapter is not None else "",
         image_max_count=adapter.image_max_count if adapter is not None else 0,
         image_required=adapter.image_required if adapter is not None else False,
+        video_max_bytes=adapter.video_max_bytes if adapter is not None else 0,
+        video_max_seconds=adapter.video_max_seconds if adapter is not None else 0.0,
+        video_min_seconds=adapter.video_min_seconds if adapter is not None else 0.0,
+        video_aspect_target=adapter.video_aspect_target if adapter is not None else 0.0,
+        video_aspect_tolerance=adapter.video_aspect_tolerance if adapter is not None else 0.0,
+        video_codecs=list(adapter.video_codecs) if adapter is not None else [],
         secret_hint=row.secret_hint,
     )
 

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -93,6 +93,7 @@ from app.services.channel_post_videos import (
     ChannelVideoUploadFailedError,
     confirm_channel_post_video_upload,
     create_channel_post_video_upload_url,
+    get_channel_post_video_for_version,
 )
 from app.services.generation_budget import GenerationBudgetExceededError
 from app.services.member_resolver import resolve_member
@@ -290,6 +291,12 @@ class ChannelPostDraftListItem(BaseModel):
     # "이 응답에선 안 쟀다"·[]="쟀는데 위반 0"(null≠0 원칙 그대로, site_posts.py::
     # SitePostDraftListItem.violations와 동형).
     violations: list[dict] | None = None
+    # story #3559(Phase2·BE·소형, 페드루 PO 確定 2026-09-06) — violations와 동형 관례
+    # (단건 조회 전용, `_to_draft_list_item()`은 항상 None을 남기고 단건 엔드포인트가
+    # 이 필드를 나중에 채운다 — N+1 방지, 목록에서 매 행마다 영상 조회를 안 돈다).
+    # 최신 버전에 영상(릴스) 행이 있으면 그 원본 공개 URL(asset 단건 응답과 같은 값),
+    # 없으면(이미지만 있거나 아무것도 없는 draft) null. 커버는 기존 thumbnail_url 그대로.
+    video_url: str | None = None
 
 
 class ChannelPostVersionHistoryItem(BaseModel):
@@ -1133,6 +1140,12 @@ async def get_channel_post_draft_detail_endpoint(
     item.violations = lint_content(
         rule_row.rules if rule_row else None, text=latest_version.text, link_url=latest_version.link_url,
     )
+
+    # story #3559 — video_url도 violations와 동형(단건 전용, N+1 방지로 목록 쿼리에는
+    # 안 실림). asset 단건 응답(get_channel_post_video_for_version_endpoint)과 정확히
+    # 같은 값(같은 서비스 함수+같은 public_url_for_object_path 호출).
+    video_row = await get_channel_post_video_for_version(db, version_id=latest_version.id)
+    item.video_url = public_url_for_object_path(video_row.original_object_path) if video_row else None
     return item
 
 

--- a/backend/tests/test_3559_video_fields_additive.py
+++ b/backend/tests/test_3559_video_fields_additive.py
@@ -1,0 +1,321 @@
+"""story #3559(Phase2·BE·소형, 페드루 PO 確定 2026-09-06) — #3554 후속. PO 확定 2가지:
+① 연결 응답(`ChannelConnectionResponse`/`_to_response()`)에 어댑터가 이미 선언한
+   영상 규격 6종을 image_* 6종과 동형 관례로 노출(additive) — 미지원 채널은 0/0.0/[].
+② draft 상세(`ChannelPostDraftListItem.video_url`)에 최신 버전의 영상 원본 공개
+   URL을 additive로 싣는다 — violations와 동형(단건 전용, N+1 방지로 목록엔 항상
+   None).
+
+세팅 헬퍼는 test_620beefc_channel_post_image.py 재사용, MP4 픽스처 조립은
+test_3554_instagram_reels.py의 순수 파이썬 박스 빌더 재사용(중복 재발명 금지).
+instagram_sandbox가 아니라 **instagram**(실 어댑터, 조건부 등재 불요)을 쓴다 —
+video_* 검증엔 sandbox 마커·조건부 config 주입이 불필요."""
+from __future__ import annotations
+
+import os
+import struct
+import uuid
+
+import pytest
+
+from tests.test_620beefc_channel_post_image import (
+    _client_for,
+    _create_draft,
+    _jpeg_bytes,
+    _put_raw_object,
+    _seed_connection,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+    _upload_and_confirm,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+_CHANNEL_MEDIA_BUCKET = "test-channel-media-3559"
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage(monkeypatch, tmp_path):
+    """test_3554_instagram_reels.py와 동형 픽스처(다른 버킷명으로 격리)."""
+    import app.services.channel_post_images as cpi_module
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage_object_path_fix(monkeypatch):
+    import tests.test_620beefc_channel_post_image as base_test_module
+
+    monkeypatch.setattr(base_test_module, "_CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    yield
+
+
+# ─── MP4(ISOBMFF) 최소 유효 픽스처 조립 — test_3554_instagram_reels.py와 동형 ────
+
+
+def _box(box_type: bytes, payload: bytes) -> bytes:
+    return struct.pack(">I", 8 + len(payload)) + box_type + payload
+
+
+def _build_mvhd(*, timescale: int, duration: int) -> bytes:
+    payload = b"\x00\x00\x00\x00" + struct.pack(">I", 0) * 2 + struct.pack(">I", timescale) + struct.pack(">I", duration)
+    return _box(b"mvhd", payload)
+
+
+def _build_tkhd(*, width: int, height: int) -> bytes:
+    payload = b"\x00\x00\x00\x00" + struct.pack(">I", 0) * 5
+    payload += b"\x00" * 8 + b"\x00" * 2 * 4 + b"\x00" * 36
+    payload += struct.pack(">I", width << 16) + struct.pack(">I", height << 16)
+    return _box(b"tkhd", payload)
+
+
+def _build_hdlr(handler_type: bytes) -> bytes:
+    payload = b"\x00\x00\x00\x00" + struct.pack(">I", 0) + handler_type + b"\x00" * 12 + b"\x00"
+    return _box(b"hdlr", payload)
+
+
+def _build_stsd(fourcc: bytes) -> bytes:
+    payload = b"\x00\x00\x00\x00" + struct.pack(">I", 1) + struct.pack(">I", 16) + fourcc
+    return _box(b"stsd", payload)
+
+
+def _build_trak(*, width: int, height: int, handler_type: bytes, fourcc: bytes) -> bytes:
+    m = _box(b"mdia", _build_hdlr(handler_type) + _box(b"minf", _box(b"stbl", _build_stsd(fourcc))))
+    return _box(b"trak", _build_tkhd(width=width, height=height) + m)
+
+
+def _build_mp4(*, duration_seconds: float, width: int, height: int, codec: bytes = b"avc1", timescale: int = 600) -> bytes:
+    duration = round(duration_seconds * timescale)
+    moov = _box(b"moov", _build_mvhd(timescale=timescale, duration=duration) + _build_trak(
+        width=width, height=height, handler_type=b"vide", fourcc=codec,
+    ))
+    ftyp = _box(b"ftyp", b"isom" + struct.pack(">I", 0) + b"isomiso2avc1mp41")
+    return ftyp + moov + _box(b"mdat", b"\x00" * 16)
+
+
+async def _upload_and_confirm_video(client, org_id, draft_id, raw: bytes, *, content_type: str = "video/mp4"):
+    ext = {"video/mp4": "mp4", "video/quicktime": "mov"}.get(content_type, "bin")
+    object_path = f"channel-media/{org_id}/{draft_id}/{uuid.uuid4().hex}.{ext}"
+    await _put_raw_object(object_path, raw, content_type=content_type)
+    return await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/video/confirm",
+        json={"object_path": object_path},
+    )
+
+
+_VALID_9_16 = {"width": 720, "height": 1280}
+
+
+# ─── ① 연결 응답 video_* 6종 ─────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_connection_response_exposes_instagram_video_spec():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            await _seed_connection(s, org_id, channel="instagram")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+        assert r.status_code == 200, r.text
+        row = r.json()[0]
+        assert row["video_max_bytes"] == 100 * 1024 * 1024
+        assert row["video_max_seconds"] == 90.0
+        assert row["video_min_seconds"] == 3.0
+        assert row["video_aspect_target"] == pytest.approx(9 / 16)
+        assert row["video_aspect_tolerance"] == 0.05
+        assert row["video_codecs"] == ["avc1", "hvc1", "hev1"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_connection_response_video_unsupported_channel_returns_zero_defaults():
+    """threads는 영상 미선언(video_max_bytes=0) — image_* 관례(§17-16) 그대로
+    0/0.0/[](null이 아니다 — "0건 허용"과 "모른다"는 다르다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            await _seed_connection(s, org_id, channel="threads")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+        assert r.status_code == 200, r.text
+        row = r.json()[0]
+        assert row["video_max_bytes"] == 0
+        assert row["video_max_seconds"] == 0.0
+        assert row["video_min_seconds"] == 0.0
+        assert row["video_aspect_target"] == 0.0
+        assert row["video_aspect_tolerance"] == 0.0
+        assert row["video_codecs"] == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ② draft 상세 video_url additive ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_draft_detail_video_url_present_when_video_confirmed():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, raw)
+            assert r_video.status_code == 201, r_video.text
+            expected_video_url = r_video.json()["video_url"]
+            assert expected_video_url is not None
+
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+        assert r_detail.status_code == 200, r_detail.text
+        assert r_detail.json()["video_url"] == expected_video_url
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_draft_detail_video_url_null_when_no_media():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+        assert r_detail.status_code == 200, r_detail.text
+        assert r_detail.json()["video_url"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_draft_detail_video_url_null_when_only_image_attached():
+    """이미지만 있는 draft(썸네일=커버 이미지 파이프 재사용)도 video_url은 null —
+    thumbnail_url과 video_url은 서로 다른 축(이미지 vs 영상)이라 섞이면 안 된다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _jpeg_bytes(800, 1000)
+            r_image = await _upload_and_confirm(client, org_id, draft_id, raw, content_type="image/jpeg")
+            assert r_image.status_code == 201, r_image.text
+            assert r_image.json()["image_url"] is not None
+
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+        assert r_detail.status_code == 200, r_detail.text
+        body = r_detail.json()
+        assert body["thumbnail_url"] is not None
+        assert body["video_url"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_endpoint_never_leaks_video_url_even_with_video_confirmed():
+    """N+1 방지(story #3559 明示) — video_url은 목록 응답엔 항상 None(violations와
+    동형 관례). 영상이 실제로 confirm돼 있어도 목록 쿼리는 그 값을 안 채운다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="instagram")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, raw)
+            assert r_video.status_code == 201, r_video.text
+
+            r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+        assert r_list.status_code == 200, r_list.text
+        rows = r_list.json()
+        assert len(rows) == 1
+        assert rows[0]["video_url"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1336,6 +1336,11 @@
       "file": "tests/test_3554_instagram_reels.py",
       "sec": 45.0,
       "source": "story-3554-instagram-reels-be(PR 개설 前 선제 등재 — 로컬 raw pytest 14건 7.40s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요 — #3558 전수 재측정(run 34011626732) 당시 이 PR 미머지라 그 산출물엔 없음)"
+    },
+    {
+      "file": "tests/test_3559_video_fields_additive.py",
+      "sec": 40.0,
+      "source": "story-3559-video-fields-additive(PR 개설 前 선제 등재 — 로컬 raw pytest 6건 6.53s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 배경
#3554 후속(미르코 그라운딩 ②④, #3911 head 5641e2873 실측 확定 갭) — `channel_adapters.py`가 이미 선언한 영상 규격 6종이 연결 응답 어디에도 안 실리고(FE `videoSpec`이 읽을 자리 0), draft 상세도 재생용 `video_url`이 없어(영상 asset 단건 응답에만 있음) 승인 카드/상세가 영상을 재생할 수 없던 갭 두 곳을 채웁니다.

그라운딩 확認(디디, 2026-09-06) — `available-channels`(`AvailableChannelItem`)도 확인했으나 미디어 규격 필드 자체가 0개라 이 두 자리 외엔 video_*를 실을 응답이 없습니다.

## 구현(PO 確定, additive만)
**① 연결 응답** — `ChannelConnectionResponse`/`_to_response()`에 image_* 6종과 동형 관례로 `video_max_bytes`·`video_max_seconds`·`video_min_seconds`·`video_aspect_target`·`video_aspect_tolerance`·`video_codecs` 추가. 미지원 채널(어댑터 None 또는 `video_max_bytes=0`)은 0/0.0/[](§17-16 "0이면 0으로 적는다" 그대로).

**② draft 상세 `video_url`** — `ChannelPostDraftListItem.video_url`을 **`violations`와 동형 관례**로 추가: `_to_draft_list_item()`은 항상 `None`을 남기고(N+1 방지 — 목록에서 매 행마다 영상 조회를 안 돕니다) 단건 상세 엔드포인트(`get_channel_post_draft_detail_endpoint`)가 `get_channel_post_video_for_version`으로 나중에 채웁니다(`violations`를 `lint_content`로 채우는 것과 정확히 같은 자리·같은 패턴).

저장·봉인·발행 경로·마이그 0 변경.

## 테스트
6건 — 연결 응답 지원(instagram)/미지원(threads) 2갈래·draft 상세 video_url 있음(영상 confirm 済)/없음(미디어 0)/이미지만(커버만 있고 영상 없음) 3갈래·목록 응답에서 video_url이 영상이 있어도 항상 None인지. 뮤테이션 2종(`_to_response`에서 video 필드 6줄 제거→RED·상세 엔드포인트의 video_url 조인 2줄 제거→RED) 각 확인 후 원복. 회귀 141건(3554/3550/620beefc/3320/3536/5b27b32f/f8f7cb0f) 전체 통과. shard-weights 등재·lint 통과.

## 다음
authz 커버리지 가드는 신규 라우트 0건이라 무관. 실 라이브(3554 런북 표본으로 6종+video_url 확認)는 배포 뒤 PO 손.