### PR TITLE
[SID:3564] fix: 캐러셀 가득 차도 첨부 트리거가 활성이던 결함 수정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2567,6 +2567,7 @@
     "channelPostsImageConfirming": "Confirming…",
     "channelPostsImageUploadInProgressReason": "You can't save or submit until the image upload finishes.",
     "channelPostsImageRequiredReason": "You can't submit without an image — this channel requires an image.",
+    "channelPostsImageMaxCountReachedReason": "You can attach up to {max} images.",
     "channelPostsImageUnsupportedFormat": "Unsupported format — {contentType} (allowed: {allowed})",
     "channelPostsImageTooLarge": "Only {maxBytes} or less can be attached, but this is {sizeBytes}",
     "channelPostsImageAspectRatioExceeded": "This image is too elongated. The maximum aspect ratio is {maxAspectRatio}, but this is {aspectRatio}",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2567,6 +2567,7 @@
     "channelPostsImageConfirming": "확인 중…",
     "channelPostsImageUploadInProgressReason": "이미지 업로드가 끝날 때까지 저장·상신을 할 수 없습니다.",
     "channelPostsImageRequiredReason": "이미지 없이 상신할 수 없습니다 — 이 채널은 이미지가 필요합니다.",
+    "channelPostsImageMaxCountReachedReason": "최대 {max}장까지 첨부할 수 있습니다.",
     "channelPostsImageUnsupportedFormat": "지원하지 않는 형식입니다: {contentType}(허용: {allowed})",
     "channelPostsImageTooLarge": "{maxBytes} 이하만 첨부할 수 있는데 {sizeBytes}입니다",
     "channelPostsImageAspectRatioExceeded": "이미지가 너무 길쭉합니다. 비율 상한은 {maxAspectRatio}인데 {aspectRatio}입니다",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -2407,6 +2407,58 @@ describe('ChannelPostEditPage — 캐러셀 N장 목록·삭제·재정렬(story
   });
 });
 
+// story #3564(유나 24회차 결함②·§5-2, 페드루 PO 確定 2026-09-06) — 캐러셀이 가득
+// 차도(images.length>=maxCount) 「이미지 선택」 트리거가 활성 상태였다(§5-2 "그려진
+// 컨트롤은 할 수 있다는 단정" 위반). maxCount=10 채널에서 검증한다.
+describe('ChannelPostEditPage — 캐러셀 가득 참 트리거 비활성(story #3564)', () => {
+  function makeImages(count: number) {
+    return Array.from({ length: count }, (_, i) => ({
+      image_id: `img${i + 1}`, draft_id: DRAFT_ID, version_id: 'v1', version: 1, position: i,
+      original_width: 1000, original_height: 1000, original_bytes: 100_000,
+      final_width: 1000, final_height: 1000, final_bytes: 100_000,
+      was_converted: false, image_url: `https://storage.googleapis.com/x/${i + 1}.jpg`,
+    }));
+  }
+
+  it('⭐9/10장 — 트리거 활성·사유 문구 없음', async () => {
+    stubFetch({ imageMaxCount: 10, initialImages: makeImages(9) });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect((container.querySelector('[data-testid="channel-post-image-attach-trigger"]') as HTMLButtonElement).disabled).toBe(false);
+    expect(container.querySelector('[data-testid="channel-post-image-max-count-reached-reason"]')).toBeNull();
+  });
+
+  it('⭐10/10장 — 트리거 비활성 + 「최대 10장까지 첨부할 수 있습니다.」', async () => {
+    stubFetch({ imageMaxCount: 10, initialImages: makeImages(10) });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect((container.querySelector('[data-testid="channel-post-image-attach-trigger"]') as HTMLButtonElement).disabled).toBe(true);
+    expect(container.querySelector('[data-testid="channel-post-image-max-count-reached-reason"]')?.textContent)
+      .toBe('최대 10장까지 첨부할 수 있습니다.');
+  });
+
+  it('⭐10장에서 한 장 삭제 — 같은 마운트에서 트리거가 재활성된다', async () => {
+    stubFetch({
+      imageMaxCount: 10, initialImages: makeImages(10),
+      onImageDelete: () => ({ status: 200, body: makeImages(9) }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    expect((container.querySelector('[data-testid="channel-post-image-attach-trigger"]') as HTMLButtonElement).disabled).toBe(true);
+
+    const items = container.querySelectorAll('[data-testid="channel-post-image-attachment-item"]');
+    await act(async () => {
+      (items[0]!.querySelector('[data-testid="channel-post-image-attachment-delete"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect((container.querySelector('[data-testid="channel-post-image-attach-trigger"]') as HTMLButtonElement).disabled).toBe(false);
+    expect(container.querySelector('[data-testid="channel-post-image-max-count-reached-reason"]')).toBeNull();
+  });
+});
+
 // story #3538(BE #3886, 유나 §17-16⑤ PO 確定) — 이미지 필수 채널 상신 전 선알림 + 422 문구.
 describe('ChannelPostEditPage — 이미지 필수 채널 선알림(story #3538)', () => {
   const REASON_TESTID = 'channel-post-image-required-reason';

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1991,7 +1991,7 @@ export default function ChannelPostEditPage() {
           />
           <Button
             type="button" variant="outline" size="sm"
-            disabled={imageUploadInProgress}
+            disabled={imageUploadInProgress || images.length >= imageSpec.maxCount}
             onClick={() => imageFileInputRef.current?.click()}
             data-testid="channel-post-image-attach-trigger"
           >
@@ -2004,6 +2004,15 @@ export default function ChannelPostEditPage() {
                 : imageUploadStatus.phase === 'uploading'
                   ? t('channelPostsImageUploading')
                   : t('channelPostsImageConfirming')}
+            </p>
+          ) : null}
+          {/* story #3564(유나 24회차 결함②·§5-2, 페드루 PO 確定 2026-09-06) — 캐러셀이
+              가득 차도(images.length>=maxCount) 트리거가 활성 상태였다(§5-2 "그려진
+              컨트롤은 할 수 있다는 단정" 위반 — 눌러도 서버 422로만 막힘). 업로드
+              진행 中엔 이 사유를 안 보인다(위 진행 문구가 이미 이유를 말한다). */}
+          {!imageUploadInProgress && images.length >= imageSpec.maxCount ? (
+            <p className="text-xs text-muted-foreground" data-testid="channel-post-image-max-count-reached-reason">
+              {t('channelPostsImageMaxCountReachedReason', { max: imageSpec.maxCount })}
             </p>
           ) : null}
           {imageUploadStatus.phase === 'error' ? (


### PR DESCRIPTION
## 배경
유나 24회차 결함②·§5-2(그려진 컨트롤은 「할 수 있다」는 단정) — 캐러셀이 `image_max_count`에 도달해도 「이미지 선택」 트리거가 계속 활성 상태라, 눌러도 서버 422(`CHANNEL_POST_IMAGE_COUNT_EXCEEDED`)로만 막혔다.

## 구현
- `images.length >= imageSpec.maxCount`면 트리거 비활성 + 버튼 밖 「최대 {max}장까지 첨부할 수 있습니다.」(값에서 조립, 하드코딩 0).
- 한 장 삭제하면 `images.length`가 줄어 같은 마운트에서 트리거가 자동 재활성(파생값이라 별도 배선 불요).
- 서버 422 방어선은 무변경(레이스 등 방어 목적 유지).

## 테스트
3건(9/10 활성·10/10 비활성+사유 문구·삭제 후 재활성) + 뮤테이션(maxCount 조건 제거 → RED 확인 후 복원).

## 검증
tsc 0·eslint 0·i18n 0·한자 0·focus-inset 가드 0·phrase-collision 가드 0·vitest 6467 전부 그린.