### PR TITLE
[SID:3568] fix: 발행 성공 뒤 비활성 사유가 「승인된 최신 버전」으로 오뜨던 결함

### DIFF
--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -851,6 +851,26 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     expect(container.querySelector('[data-testid="channel-post-external-id"]')?.textContent).toBe('media-1');
   });
 
+  // story #3568(유나 24회차 실측·§17-15, 페드루 PO 確定 2026-09-06) — 발행 성공 뒤
+  // 비활성 발행 버튼 사유가 "승인된 최신 버전에서만…"(publishDisabledReason)으로
+  // 떨어지던 결함. site-posts(content/[draftId]/page.test.tsx:773)와 동형 pin —
+  // published면 publishDisabledReasonAlreadyPublished, 옛 문장은 음성 대조.
+  it('⭐발행됨(published) — 비활성 사유가 「이미 발행됐습니다」이지 「승인된 최신 버전」이 아니다', async () => {
+    stubFetch({
+      draftDetail: {
+        gate_status: 'approved', sealed_content_sha256: 'h1', body_sha256: 'h1',
+        publication_status: 'published', permalink: 'https://threads.net/@x/1', external_id: 'media-1',
+        published_at: '2026-09-04T00:00:00Z', publication_id: 'pub-1',
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const reason = container.querySelector('[data-testid="channel-post-publish-disabled-reason"]')?.textContent;
+    expect(reason).toBe('이미 발행됐습니다 — 다시 발행할 새 내용이 없습니다.');
+    expect(reason).not.toContain('승인된 최신 버전');
+  });
+
   it('⭐T9 — publication_status=container_created(부분 성공) — "이어서 발행" 안내가 보인다(발행됨 카드는 안 보임)', async () => {
     stubFetch({
       draftDetail: { gate_status: 'approved', sealed_content_sha256: 'h1', publication_status: 'container_created' },

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1554,8 +1554,6 @@ export default function ChannelPostEditPage() {
   // 만 site와 동일하게 role===owner|admin으로 좁힌다(발행 취소는 더 무거운 되돌릴 수
   // 없는 행동 — settings/page.tsx·org-members-section.tsx와 같은 role 소스 재사용,
   // 새 조회 안 만듦). 이 화면 자체가 사람 전용(에이전트에게 화면 없음, AC14)이라
-  // 없는 행동 — settings/page.tsx·org-members-section.tsx와 같은 role 소스 재사용,
-  // 새 조회 안 만듦). 이 화면 자체가 사람 전용(에이전트에게 화면 없음, AC14)이라
   // "휴먼 게이팅"의 실체는 이 owner/admin 세분화다.
   const canPublish = view.publishable;
   const canUnpublish = role === 'owner' || role === 'admin';

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1547,8 +1547,13 @@ export default function ChannelPostEditPage() {
   // story #3402 PR2 ②-a(doc §5·AC5) — 발행/발행 취소 버튼 게이팅(API 배선은 ②-b).
   // canPublish는 site-posts(content/[draftId]/page.tsx::canPublish)와 동형으로 role
   // 제약이 아니라 view.publishable(업무 상태) 그대로다 — "승인된 최신 버전에서만
-  // 발행할 수 있다"는 판단은 게이트/봉인 일치 여부이지 누구인지가 아니다. canUnpublish
+  // 발행할 수 있다"는 판단은 게이트/봉인 일치 여부이지 누구인지가 아니다. 사유 렌더도
+  // site-posts와 동형(story #3568 정정 — 이전엔 canPublish만 동형이고 사유 렌더가
+  // SEAL_MISSING→기본 두 갈래뿐이라 안 따라갔다: 발행 성공 뒤 "승인된 최신 버전에서만…"
+  // 오문구가 뜨는 결함이었다). canUnpublish
   // 만 site와 동일하게 role===owner|admin으로 좁힌다(발행 취소는 더 무거운 되돌릴 수
+  // 없는 행동 — settings/page.tsx·org-members-section.tsx와 같은 role 소스 재사용,
+  // 새 조회 안 만듦). 이 화면 자체가 사람 전용(에이전트에게 화면 없음, AC14)이라
   // 없는 행동 — settings/page.tsx·org-members-section.tsx와 같은 role 소스 재사용,
   // 새 조회 안 만듦). 이 화면 자체가 사람 전용(에이전트에게 화면 없음, AC14)이라
   // "휴먼 게이팅"의 실체는 이 owner/admin 세분화다.
@@ -1943,7 +1948,11 @@ export default function ChannelPostEditPage() {
         </div>
         {!canPublish ? (
           <p className="text-xs text-muted-foreground" data-testid="channel-post-publish-disabled-reason">
-            {view.blockedReason === 'SEAL_MISSING' ? t('publishDisabledReasonSealMissing') : t('publishDisabledReason')}
+            {view.blockedReason === 'SEAL_MISSING'
+              ? t('publishDisabledReasonSealMissing')
+              : view.status === 'published'
+                ? t('publishDisabledReasonAlreadyPublished')
+                : t('publishDisabledReason')}
           </p>
         ) : null}
         {/* B4(페드루 PO) — canPublish는 참인데 command_status가 pending/blocked라 막힌


### PR DESCRIPTION
## 배경
유나 24회차 실측(2026-09-06, 배포 41·뭉클랩 초안 62a58b31) — 발행 성공 뒤 같은 화면에 발행됨 카드와 "승인된 최신 버전에서만 발행할 수 있습니다."가 동시에 뜬다. §17-15 "같은 화면 두 문장이 다른 세계" 클래스.

## 원인
`canPublish`(게이팅)는 site-posts와 동형이었지만 사유 렌더가 `SEAL_MISSING→기본` 두 갈래뿐이라 site-posts의 `status==='published'` 갈래를 안 따라갔다.

## 구현(유나 처방 그대로)
site-posts(`content/[draftId]/page.tsx:1559`)와 동형 3갈래:
```
SEAL_MISSING → publishDisabledReasonSealMissing
status==='published' → publishDisabledReasonAlreadyPublished(기존 키, 새 카피 0)
그 외 → publishDisabledReason
```
1548행 주석도 "canPublish만 동형" → "사유 렌더도 동형"으로 정정.

## 테스트
site-posts `page.test.tsx:773` 형 그대로 1건(published 상태 → 사유가 "이미 발행됐습니다"·"승인된 최신 버전" 부재 음성 대조) + 뮤테이션(3갈래→2갈래 원복 → 옛 오문구 재출현 RED 확인 후 복원).

## 검증
tsc 0·eslint 0·vitest 6487 전부 그린.