### PR TITLE
[SID:3569] feat: GateResponse에 sealed_doc_id/sealed_doc_body_sha256/sealed_doc_title additive

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -223,6 +223,17 @@ class GateResponse(BaseModel):
     sealed_content_version: int | None = None
     sealed_content_sha256: str | None = None
     sealed_content_body: str | None = None
+    # story #3569(Phase2·BE·소형, 페드루 PO 確定 2026-09-06) — concept_approval 전용
+    # sealing(story #3561/#3922). sealed_content_*와 동일 선례 — Gate ORM 컬럼명과
+    # 일치라 from_attributes로 자동 채워짐(다른 gate_type은 전부 None).
+    sealed_doc_id: uuid.UUID | None = None
+    sealed_doc_body_sha256: str | None = None
+    # story #3569 — sealed_doc_id 하나로는 FE가 «봉인 doc 링크(글자=doc 제목)»를 못
+    # 그린다(3560 FE (b), 미르코 그라운딩). Gate ORM엔 이 컬럼이 없다 — **봉인 시점이
+    # 아니라 「지금」 doc 제목**(제목은 봉인 대상이 아니다, 본문 sha만 봉인 — PO 明示)을
+    # list_gates/get_gate_endpoint가 각자 배치/단건 조회해 채운다. 삭제된 doc·
+    # sealed_doc_id 자체가 없으면 null(지어내지 않는다).
+    sealed_doc_title: str | None = None
     reapproval_required: bool = False
     created_at: datetime
     updated_at: datetime
@@ -747,6 +758,30 @@ async def list_gates(
         for resp, g in zip(responses, gates):
             resp.risk_grade = derive_risk_grade(_posture, g.gate_type)
 
+    # story #3569(Phase2·BE·소형, 페드루 PO 確定 2026-09-06) — concept_approval 게이트의
+    # sealed_doc_id가 가리키는 doc의 **지금** 제목(봉인 시점 값이 아니다 — 제목은 봉인
+    # 대상이 아니다, 본문 sha만 봉인). work_item_summary/doc_proj(위 doc_approval용
+    # 배치)와는 키 축이 다르다(work_item_id가 아니라 sealed_doc_id) — 별도의 독립
+    # 1회 배치(N+1 0). 삭제된 doc·sealed_doc_id 자체가 없으면 None(지어내지 않는다).
+    # ⚠️getattr(..., None) — 이 파일의 여러 test_1970/1972류 테스트가 gate를 SimpleNamespace
+    # 로 목(mock)해 새 Gate ORM 컬럼을 안 갖고 있다(sealed_content_* 등 다른 필드는 GateResponse.
+    # model_validate()의 from_attributes 관용(속성 없으면 pydantic 기본값)으로만 접근돼 이 함정을
+    # 안 밟았는데, 이 블록은 g.sealed_doc_id를 Python 코드에서 직접 읽어 AttributeError로 터졌다
+    # — 실측 확認(7건 회귀).
+    sealed_doc_ids = {sid for g in gates if (sid := getattr(g, "sealed_doc_id", None)) is not None}
+    if sealed_doc_ids:
+        from app.models.doc import Doc as _SealedDoc
+        title_rows = (await session.execute(
+            select(_SealedDoc.id, _SealedDoc.title).where(
+                _SealedDoc.id.in_(sealed_doc_ids), _SealedDoc.org_id == org_id, _SealedDoc.deleted_at.is_(None),
+            )
+        )).all()
+        sealed_doc_title_by_id = {did: title for did, title in title_rows}
+        for resp, g in zip(responses, gates):
+            sid = getattr(g, "sealed_doc_id", None)
+            if sid is not None:
+                resp.sealed_doc_title = sealed_doc_title_by_id.get(sid)
+
     # doc-side enrich 2종 Doc 조회를 **한 배치**로(org-scope·soft-delete 가드·N+1 0):
     #  ⓐ work_item_summary(24f5ae18): work_item_type=='doc' gate → title/slug.
     #  ⓑ can_approve(89484c8c): gate_type=='doc_approval' gate → project_id.
@@ -1247,6 +1282,17 @@ async def get_gate_endpoint(
     # 미경유) + 이 gate의 gate_type을 derive_risk_grade()로 파생(doc §2 SSOT).
     _posture = await get_org_posture(session, org_id)
     resp.risk_grade = derive_risk_grade(_posture, gate.gate_type)
+    # story #3569 — list_gates와 동일 축(sealed_doc_id, work_item_id 아님)·동일 규칙
+    # (지금 제목·삭제/미존재 doc은 None). getattr(...) 방어 — list_gates 쪽 주석 참고
+    # (SimpleNamespace mock gate 회귀와 동일 원인).
+    _sealed_doc_id = getattr(gate, "sealed_doc_id", None)
+    if _sealed_doc_id is not None:
+        from app.models.doc import Doc as _SealedDoc
+        resp.sealed_doc_title = (await session.execute(
+            select(_SealedDoc.title).where(
+                _SealedDoc.id == _sealed_doc_id, _SealedDoc.org_id == org_id, _SealedDoc.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
     # story #2815(§5-④): merge 게이트만 의미 있음(다른 gate_type은 PR/repo 개념 자체가 없음).
     if gate.gate_type == MERGE_GATE_TYPE:
         _link = await resolve_pr_link(session, org_id, gate.work_item_id)

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -763,12 +763,7 @@ async def list_gates(
     # 대상이 아니다, 본문 sha만 봉인). work_item_summary/doc_proj(위 doc_approval용
     # 배치)와는 키 축이 다르다(work_item_id가 아니라 sealed_doc_id) — 별도의 독립
     # 1회 배치(N+1 0). 삭제된 doc·sealed_doc_id 자체가 없으면 None(지어내지 않는다).
-    # ⚠️getattr(..., None) — 이 파일의 여러 test_1970/1972류 테스트가 gate를 SimpleNamespace
-    # 로 목(mock)해 새 Gate ORM 컬럼을 안 갖고 있다(sealed_content_* 등 다른 필드는 GateResponse.
-    # model_validate()의 from_attributes 관용(속성 없으면 pydantic 기본값)으로만 접근돼 이 함정을
-    # 안 밟았는데, 이 블록은 g.sealed_doc_id를 Python 코드에서 직접 읽어 AttributeError로 터졌다
-    # — 실측 확認(7건 회귀).
-    sealed_doc_ids = {sid for g in gates if (sid := getattr(g, "sealed_doc_id", None)) is not None}
+    sealed_doc_ids = {g.sealed_doc_id for g in gates if g.sealed_doc_id is not None}
     if sealed_doc_ids:
         from app.models.doc import Doc as _SealedDoc
         title_rows = (await session.execute(
@@ -778,9 +773,8 @@ async def list_gates(
         )).all()
         sealed_doc_title_by_id = {did: title for did, title in title_rows}
         for resp, g in zip(responses, gates):
-            sid = getattr(g, "sealed_doc_id", None)
-            if sid is not None:
-                resp.sealed_doc_title = sealed_doc_title_by_id.get(sid)
+            if g.sealed_doc_id is not None:
+                resp.sealed_doc_title = sealed_doc_title_by_id.get(g.sealed_doc_id)
 
     # doc-side enrich 2종 Doc 조회를 **한 배치**로(org-scope·soft-delete 가드·N+1 0):
     #  ⓐ work_item_summary(24f5ae18): work_item_type=='doc' gate → title/slug.
@@ -1283,14 +1277,12 @@ async def get_gate_endpoint(
     _posture = await get_org_posture(session, org_id)
     resp.risk_grade = derive_risk_grade(_posture, gate.gate_type)
     # story #3569 — list_gates와 동일 축(sealed_doc_id, work_item_id 아님)·동일 규칙
-    # (지금 제목·삭제/미존재 doc은 None). getattr(...) 방어 — list_gates 쪽 주석 참고
-    # (SimpleNamespace mock gate 회귀와 동일 원인).
-    _sealed_doc_id = getattr(gate, "sealed_doc_id", None)
-    if _sealed_doc_id is not None:
+    # (지금 제목·삭제/미존재 doc은 None).
+    if gate.sealed_doc_id is not None:
         from app.models.doc import Doc as _SealedDoc
         resp.sealed_doc_title = (await session.execute(
             select(_SealedDoc.title).where(
-                _SealedDoc.id == _sealed_doc_id, _SealedDoc.org_id == org_id, _SealedDoc.deleted_at.is_(None),
+                _SealedDoc.id == gate.sealed_doc_id, _SealedDoc.org_id == org_id, _SealedDoc.deleted_at.is_(None),
             )
         )).scalar_one_or_none()
     # story #2815(§5-④): merge 게이트만 의미 있음(다른 gate_type은 PR/repo 개념 자체가 없음).

--- a/backend/tests/test_1970_gate_single_get.py
+++ b/backend/tests/test_1970_gate_single_get.py
@@ -137,11 +137,13 @@ async def test_summary_story_missing_returns_none():
 
 
 def _gate(org, work_item_id, wtype, gate_id=None):
-    return SimpleNamespace(
+    # story #3569(페드루 PO 리뷰) — SimpleNamespace 대신 gate_mock_factory.make_gate()
+    # (story #2837 "건드릴 때 이관" 관례 — 실 Gate ORM 인스턴스라 sealed_doc_id 등 새 컬럼이
+    # 늘어도 AttributeError로 재발하지 않는다, mock을 실물 스키마에 맞춰 올리는 쪽).
+    from tests.gate_mock_factory import make_gate
+    return make_gate(
         id=gate_id or uuid.uuid4(), org_id=org, work_item_id=work_item_id, work_item_type=wtype,
-        gate_type="merge", status="pending", resolver_id=None, resolved_at=None,
-        resolution_note=None, held_until=None, neutral_facts=None, requires_human=False,
-        evidence_status=None, decision_basis=None, auto_decision_reason=None,
+        gate_type="merge",
         created_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
         updated_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
     )

--- a/backend/tests/test_1972_gate_risk_grade.py
+++ b/backend/tests/test_1972_gate_risk_grade.py
@@ -203,11 +203,13 @@ def test_derive_risk_grade_is_pure_no_session_param():
 
 
 def _gate(org, work_item_id, wtype, gate_type="merge", gate_id=None):
-    return SimpleNamespace(
+    # story #3569(페드루 PO 리뷰) — SimpleNamespace 대신 gate_mock_factory.make_gate()
+    # (story #2837 "건드릴 때 이관" 관례 — 실 Gate ORM 인스턴스라 sealed_doc_id 등 새 컬럼이
+    # 늘어도 AttributeError로 재발하지 않는다, mock을 실물 스키마에 맞춰 올리는 쪽).
+    from tests.gate_mock_factory import make_gate
+    return make_gate(
         id=gate_id or uuid.uuid4(), org_id=org, work_item_id=work_item_id, work_item_type=wtype,
-        gate_type=gate_type, status="pending", resolver_id=None, resolved_at=None,
-        resolution_note=None, held_until=None, neutral_facts=None, requires_human=False,
-        evidence_status=None, decision_basis=None, auto_decision_reason=None,
+        gate_type=gate_type,
         created_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
         updated_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
     )

--- a/backend/tests/test_1973_gate_urgency_sort.py
+++ b/backend/tests/test_1973_gate_urgency_sort.py
@@ -80,11 +80,13 @@ def test_apply_gate_urgency_sort_no_python_level_sort():
 
 
 def _gate(org, work_item_id, wtype, gate_type="merge", gate_id=None):
-    return SimpleNamespace(
+    # story #3569(페드루 PO 리뷰) — SimpleNamespace 대신 gate_mock_factory.make_gate()
+    # (story #2837 "건드릴 때 이관" 관례 — 실 Gate ORM 인스턴스라 sealed_doc_id 등 새 컬럼이
+    # 늘어도 AttributeError로 재발하지 않는다, mock을 실물 스키마에 맞춰 올리는 쪽).
+    from tests.gate_mock_factory import make_gate
+    return make_gate(
         id=gate_id or uuid.uuid4(), org_id=org, work_item_id=work_item_id, work_item_type=wtype,
-        gate_type=gate_type, status="pending", resolver_id=None, resolved_at=None,
-        resolution_note=None, held_until=None, neutral_facts=None, requires_human=False,
-        evidence_status=None, decision_basis=None, auto_decision_reason=None,
+        gate_type=gate_type,
         created_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
         updated_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
     )

--- a/backend/tests/test_3569_gate_sealed_doc_fields.py
+++ b/backend/tests/test_3569_gate_sealed_doc_fields.py
@@ -1,0 +1,201 @@
+"""story #3569(Phase2·BE·소형, 페드루 PO 確定 2026-09-06) — 3561 후속. `GateResponse`
+(list/detail 공용)에 `sealed_doc_id`·`sealed_doc_body_sha256`·`sealed_doc_title`
+additive — #3922(3561)는 두 필드를 `Gate` 모델과 상신 1회성 응답에만 실어, FE(3560)
+가 봉인 doc을 못 읽는 갭(미르코 그라운딩(b)).
+
+確定 매핑:
+1. `sealed_doc_id`/`sealed_doc_body_sha256`는 Gate ORM 컬럼명과 일치해
+   `from_attributes`로 자동 채워짐(신규 코드 0). `sealed_doc_title`은 **봉인 시점이
+   아니라 「지금」 doc 제목**(제목은 봉인 대상이 아니다 — 본문 sha만 봉인) — 신규
+   배치 조회.
+2. list_gates·get_gate_endpoint 각각 독립 N+1-금지 조회(work_item_summary/doc_proj
+   와 다른 축 — sealed_doc_id로 키잉, work_item_id 아님).
+3. concept_approval이 아닌 게이트는 셋 다 null(sealed_estimated_cost_minor 관례
+   동형).
+
+세팅 헬퍼는 test_3561_concept_approval_gate.py 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_3561_concept_approval_gate import (
+    _client_for,
+    _seed_default_role,
+    _seed_doc,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+    _submit_concept_approval,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_and_detail_expose_sealed_doc_fields_for_concept_approval():
+    from app.main import app
+    from app.services.doc import compute_doc_body_sha256
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            doc_id = await _seed_doc(s, org_id, project_id, content="본문", title="컨셉 문서 제목")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_submit = await _submit_concept_approval(client, org_id, doc_id, work_item_id=story_id)
+            assert r_submit.status_code == 201, r_submit.text
+            gate_id = r_submit.json()["gate_id"]
+
+            r_list = await client.get(f"/api/v2/gates", params={"work_item_id": str(story_id), "work_item_type": "story"})
+            assert r_list.status_code == 200, r_list.text
+            list_row = next(g for g in r_list.json() if g["id"] == gate_id)
+
+            r_detail = await client.get(f"/api/v2/gates/{gate_id}")
+            assert r_detail.status_code == 200, r_detail.text
+            detail_row = r_detail.json()
+
+        expected_sha = compute_doc_body_sha256("본문")
+        for row in (list_row, detail_row):
+            assert row["sealed_doc_id"] == str(doc_id)
+            assert row["sealed_doc_body_sha256"] == expected_sha
+            assert row["sealed_doc_title"] == "컨셉 문서 제목"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_other_gate_types_have_null_sealed_doc_fields():
+    from app.main import app
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", status="pending", neutral_facts={},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_detail = await client.get(f"/api/v2/gates/{gate_id}")
+        assert r_detail.status_code == 200, r_detail.text
+        body = r_detail.json()
+        assert body["sealed_doc_id"] is None
+        assert body["sealed_doc_body_sha256"] is None
+        assert body["sealed_doc_title"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sealed_doc_title_null_when_doc_deleted_but_ids_and_sha_preserved():
+    """제목=null이어도 sealed_doc_id·sealed_doc_body_sha256(봉인 그 자체)은 그대로
+    남는다 — 제목만 「지금 doc 조회 결과」라 doc이 사라지면 그 축만 null이 된다."""
+    from app.main import app
+    from sqlalchemy import select
+    from app.models.doc import Doc
+    from datetime import datetime, timezone
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            doc_id = await _seed_doc(s, org_id, project_id, content="본문", title="곧 삭제될 문서")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_submit = await _submit_concept_approval(client, org_id, doc_id, work_item_id=story_id)
+            assert r_submit.status_code == 201, r_submit.text
+            gate_id = r_submit.json()["gate_id"]
+
+        async with Session() as s:
+            doc = (await s.execute(select(Doc).where(Doc.id == doc_id))).scalar_one()
+            doc.deleted_at = datetime.now(timezone.utc)
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r_detail = await client.get(f"/api/v2/gates/{gate_id}")
+        assert r_detail.status_code == 200, r_detail.text
+        body = r_detail.json()
+        assert body["sealed_doc_id"] == str(doc_id)
+        assert body["sealed_doc_body_sha256"] is not None
+        assert body["sealed_doc_title"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_gates_batches_sealed_doc_title_lookup_no_n_plus_1():
+    """뮤테이션 대상 — list_gates의 sealed_doc_title 배치 enrich 블록을 제거하면
+    (sealed_doc_id는 그대로지만 title이 안 채워짐) 이 테스트가 RED여야 한다.
+    N+1 방지 확認도 겸함(여러 게이트가 서로 다른 doc을 참조해도 정확히 매칭)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id)
+            story_a = await _seed_story(s, org_id, project_id, title="스토리 A")
+            story_b = await _seed_story(s, org_id, project_id, title="스토리 B")
+            doc_a = await _seed_doc(s, org_id, project_id, content="본문 A", title="문서 A")
+            doc_b = await _seed_doc(s, org_id, project_id, content="본문 B", title="문서 B")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r1 = await _submit_concept_approval(client, org_id, doc_a, work_item_id=story_a)
+            assert r1.status_code == 201, r1.text
+            r2 = await _submit_concept_approval(client, org_id, doc_b, work_item_id=story_b)
+            assert r2.status_code == 201, r2.text
+
+            r_list = await client.get(
+                f"/api/v2/gates", params={"ids": f"{r1.json()['gate_id']},{r2.json()['gate_id']}"},
+            )
+        assert r_list.status_code == 200, r_list.text
+        rows = {row["id"]: row for row in r_list.json()}
+        assert rows[r1.json()["gate_id"]]["sealed_doc_title"] == "문서 A"
+        assert rows[r2.json()["gate_id"]]["sealed_doc_title"] == "문서 B"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_gate_decider_can_approve_89484c8c.py
+++ b/backend/tests/test_gate_decider_can_approve_89484c8c.py
@@ -35,7 +35,11 @@ def _agent(mid: uuid.UUID) -> ResolvedMember:
 
 
 def _gate(requester_id, *, work_item_id=None, status="pending", gate_id=None):
-    return SimpleNamespace(
+    # story #3569(페드루 PO 리뷰) — SimpleNamespace 대신 gate_mock_factory.make_gate()
+    # (story #2837 "건드릴 때 이관" 관례 — 실 Gate ORM 인스턴스라 sealed_doc_id 등 새 컬럼이
+    # 늘어도 AttributeError로 재발하지 않는다, mock을 실물 스키마에 맞춰 올리는 쪽).
+    from tests.gate_mock_factory import make_gate
+    return make_gate(
         id=gate_id or uuid.uuid4(),
         gate_type="doc_approval",
         neutral_facts={"requested_by_member_id": str(requester_id)} if requester_id else {},
@@ -200,8 +204,10 @@ async def test_list_gates_can_approve_false_for_agent():
 
 
 async def _run_non_doc_can_approve(project_role):
+    from tests.gate_mock_factory import make_gate
+
     org = uuid.uuid4()
-    merge = SimpleNamespace(
+    merge = make_gate(
         id=uuid.uuid4(), gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(),
         neutral_facts={}, status="pending", designated_approver_id=None,
     )

--- a/backend/tests/test_gate_decider_can_approve_89484c8c.py
+++ b/backend/tests/test_gate_decider_can_approve_89484c8c.py
@@ -259,8 +259,13 @@ async def test_list_gates_can_approve_uses_doc_approval_predicate_not_work_item_
     """② DRY: doc_approval 인데 work_item_type≠doc 인 이상 게이트도 project_id 를 doc_approval predicate
     (work_item_id→Doc·transition 과 동일)로 조회 → can_approve 가 transition 강제와 정합. work_item_type 으로
     키잉하면 project_id=None→can_approve False 로 갈림(이 테스트가 그 회귀를 잠금)."""
+    # story #3569(페드루 PO 리뷰) — SimpleNamespace 대신 gate_mock_factory.make_gate()
+    # (story #2837 "건드릴 때 이관" 관례 — 실 Gate ORM 인스턴스라 sealed_doc_id 등 새 컬럼이
+    # 늘어도 AttributeError로 재발하지 않는다).
+    from tests.gate_mock_factory import make_gate
+
     org, doc_id, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
-    g = SimpleNamespace(  # 이상: gate_type=doc_approval 이나 work_item_type≠doc
+    g = make_gate(  # 이상: gate_type=doc_approval 이나 work_item_type≠doc
         id=uuid.uuid4(), gate_type="doc_approval", work_item_type="story", work_item_id=doc_id,
         neutral_facts={"requested_by_member_id": str(uuid.uuid4())}, status="pending",
     )

--- a/backend/tests/test_gate_inbox_doc_enrich.py
+++ b/backend/tests/test_gate_inbox_doc_enrich.py
@@ -19,12 +19,15 @@ def anyio_backend():
 
 
 def _gate(org, work_item_id, wtype):
-    return SimpleNamespace(
+    # story #3569(페드루 PO 리뷰) — SimpleNamespace 대신 gate_mock_factory.make_gate()
+    # (story #2837 "건드릴 때 이관" 관례 — 실 Gate ORM 인스턴스라 sealed_doc_id 등 새 컬럼이
+    # 늘어도 AttributeError로 재발하지 않는다). work_item_summary는 Gate 모델 컬럼이 아니라
+    # GateResponse 쪽 enrich 산출물이라 여기서 세팅하지 않는다(make_gate 기본값과 무관).
+    from tests.gate_mock_factory import make_gate
+
+    return make_gate(
         id=uuid.uuid4(), org_id=org, work_item_id=work_item_id, work_item_type=wtype,
-        gate_type="doc_approval" if wtype == "doc" else "merge", status="pending",
-        resolver_id=None, resolved_at=None, resolution_note=None, held_until=None,
-        neutral_facts=None, requires_human=False, evidence_status=None,
-        decision_basis=None, auto_decision_reason=None, work_item_summary=None,
+        gate_type="doc_approval" if wtype == "doc" else "merge",
         created_at=datetime(2026, 6, 26, tzinfo=timezone.utc),
         updated_at=datetime(2026, 6, 26, tzinfo=timezone.utc),
     )

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1386,6 +1386,11 @@
       "file": "tests/test_3574_video_requires_single_cover.py",
       "sec": 36.0,
       "source": "story-3574-video-requires-single-cover(PR 개설 前 선제 등재 — 로컬 raw pytest 6건 5.98s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 36s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3569_gate_sealed_doc_fields.py",
+      "sec": 27.0,
+      "source": "story-3569-gate-sealed-doc-fields(PR 개설 前 선제 등재 — 로컬 raw pytest 4건 4.43s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 27s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 배경
3561 후속 — #3922가 `sealed_doc_id`/`sealed_doc_body_sha256`를 `Gate` 모델과 상신 1회성 응답(`DocConceptApprovalSubmitResponse`)에만 실어, FE(3560) `GateItem`이 봉인 doc을 못 읽는 갭(미르코 그라운딩(b), PO 귀책 — 3560 PO 確定이 게이트 응답 계약을 안 적어둔 채 FE에 링크를 요구).

## 구현(PO 確定 1pt·additive만)
- `sealed_doc_id`/`sealed_doc_body_sha256` — Gate ORM 컬럼명과 일치해 `GateResponse.model_validate()`의 `from_attributes`로 **자동** 채워집니다(신규 코드 0).
- `sealed_doc_title` — **봉인 시점이 아니라 「지금」 doc 제목**(제목은 봉인 대상이 아니다, 본문 sha만 봉인) — `list_gates`·`get_gate_endpoint` 각각 독립 N+1-금지 배치 조회. `work_item_summary`/`doc_proj`(기존 doc_approval용 배치)와는 키 축이 다릅니다(`work_item_id`가 아니라 `sealed_doc_id`). 삭제된 doc·`sealed_doc_id` 자체가 없으면 null.
- `concept_approval`이 아닌 게이트는 셋 다 null(`sealed_estimated_cost_minor` 관례 동형).

## PO 리뷰 반영
`getattr(g, "sealed_doc_id", None)` 방어 코드는 「테스트 mock이 제품 코드를 굽힌 것」이라는 지적을 받아 제거했습니다 — 대신 회귀를 낸 4개 파일(`test_1970_gate_single_get.py`·`test_1972_gate_risk_grade.py`·`test_1973_gate_urgency_sort.py`·`test_gate_decider_can_approve_89484c8c.py`)의 `SimpleNamespace`(Gate형) mock을 `gate_mock_factory.make_gate()`로 이관했습니다 — story #2837이 이미 확立한 "건드릴 때 이관" 관례 그대로(실 `Gate` ORM 인스턴스라 새 컬럼이 늘어도 구조적으로 `AttributeError` 재발 불가). `test_1974_gate_assigned_to_me.py`는 이미 이 팩토리를 쓰고 있어 애초에 회귀가 없었습니다.

## 테스트
4건(list/detail 3필드 노출·타 유형 null·doc 삭제 뒤 title만 null(id·sha는 보존)·N+1 없는 배치 확認) + 뮤테이션 1(list_gates title enrich 제거→RED). 회귀 131건(3569/3561/2198/1970/1972/1973/1974/gate_decider_89484c8c/2054/5ace2e84/2864/2042/gate_can_approve_48f064e5/gate_transition_human_only/rc1_body_trust_actor) 전체 통과. shard-weights 등재·lint 통과. base develop(#3922 head 5212448ca 포함, 스쿼시 머지 뒤 재-rebase — PR diff엔 이 스토리 변경분만).