### PR TITLE
[SID:3581] fix: 검증 시트 요약 — fail>0·na>0 동시 참일 때 새 갈래

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4882,6 +4882,7 @@
     "verificationSheetSummaryWithFail": "Failed {fail} · Total {total}",
     "verificationSheetSummaryAllPass": "All {total} passed",
     "verificationSheetSummaryWithNa": "Passed {pass} · {naLabel} {na}",
+    "verificationSheetSummaryWithFailAndNa": "",
     "verificationSheetColumnName": "Item",
     "verificationSheetColumnVerdict": "Verdict",
     "verificationSheetColumnNote": "Note",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4882,7 +4882,7 @@
     "verificationSheetSummaryWithFail": "Failed {fail} · Total {total}",
     "verificationSheetSummaryAllPass": "All {total} passed",
     "verificationSheetSummaryWithNa": "Passed {pass} · {naLabel} {na}",
-    "verificationSheetSummaryWithFailAndNa": "",
+    "verificationSheetSummaryWithFailAndNa": "Failed {fail} · {naLabel} {na} · Total {total}",
     "verificationSheetColumnName": "Item",
     "verificationSheetColumnVerdict": "Verdict",
     "verificationSheetColumnNote": "Note",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4882,7 +4882,7 @@
     "verificationSheetSummaryWithFail": "실패 {fail} · 전체 {total}",
     "verificationSheetSummaryAllPass": "{total}항목 모두 통과",
     "verificationSheetSummaryWithNa": "통과 {pass} · {naLabel} {na}",
-    "verificationSheetSummaryWithFailAndNa": "",
+    "verificationSheetSummaryWithFailAndNa": "실패 {fail} · {naLabel} {na} · 전체 {total}",
     "verificationSheetColumnName": "항목",
     "verificationSheetColumnVerdict": "판정",
     "verificationSheetColumnNote": "비고",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4882,6 +4882,7 @@
     "verificationSheetSummaryWithFail": "실패 {fail} · 전체 {total}",
     "verificationSheetSummaryAllPass": "{total}항목 모두 통과",
     "verificationSheetSummaryWithNa": "통과 {pass} · {naLabel} {na}",
+    "verificationSheetSummaryWithFailAndNa": "",
     "verificationSheetColumnName": "항목",
     "verificationSheetColumnVerdict": "판정",
     "verificationSheetColumnNote": "비고",

--- a/apps/web/src/components/verify/evidence-section.test.tsx
+++ b/apps/web/src/components/verify/evidence-section.test.tsx
@@ -367,6 +367,21 @@ describe('EvidenceSection — 검증 시트(story #3560, payload.kind=verificati
     expect(text).not.toContain('모두 통과');
   });
 
+  // story #3581(유나 #3927 비차단 발견, 페드루 PO 確定 2026-09-06) — fail>0·na>0 동시
+  // 참이면 예전엔 fail 갈래(「실패 N · 전체 M」)로 떨어져 na가 조용히 사라졌다. 새
+  // 갈래(verificationSheetSummaryWithFailAndNa)로 분리됐는지만 검증한다 — 낱말은
+  // 유나 §17-24 확定 대기라 지금 키 값은 빈 문자열(임의 문장 커밋 금지, 페드루 지시).
+  it('실패 있음 + 해당없음 있음 — 새 갈래로 분리된다(예전 fail-only 문구로 떨어지지 않는다)', async () => {
+    await renderWithSheet([
+      { name: 'A', verdict: 'fail' },
+      { name: 'B', verdict: 'n_a' },
+      { name: 'C', verdict: 'pass' },
+    ]);
+    const text = findRowSummary().textContent ?? '';
+    // 낱말 확定 전 placeholder(빈 문자열)라 지금은 이 값 — 유나 §17-24 도착 뒤 실 문구로 교체.
+    expect(text).toBe('검증 시트');
+  });
+
   it('펼침 표 — 비고가 하나도 없으면 비고 열 자체가 없다', async () => {
     await renderWithSheet([{ name: '자막 표시', verdict: 'pass' }, { name: '길이 15초 이내', verdict: 'fail' }]);
     await act(async () => { findRowSummary().click(); });

--- a/apps/web/src/components/verify/evidence-section.test.tsx
+++ b/apps/web/src/components/verify/evidence-section.test.tsx
@@ -367,19 +367,17 @@ describe('EvidenceSection — 검증 시트(story #3560, payload.kind=verificati
     expect(text).not.toContain('모두 통과');
   });
 
-  // story #3581(유나 #3927 비차단 발견, 페드루 PO 確定 2026-09-06) — fail>0·na>0 동시
-  // 참이면 예전엔 fail 갈래(「실패 N · 전체 M」)로 떨어져 na가 조용히 사라졌다. 새
-  // 갈래(verificationSheetSummaryWithFailAndNa)로 분리됐는지만 검증한다 — 낱말은
-  // 유나 §17-24 확定 대기라 지금 키 값은 빈 문자열(임의 문장 커밋 금지, 페드루 지시).
-  it('실패 있음 + 해당없음 있음 — 새 갈래로 분리된다(예전 fail-only 문구로 떨어지지 않는다)', async () => {
+  // story #3581(유나 #3927 비차단 발견 → §17-24 낱말 확定 2026-09-06) — fail>0·na>0
+  // 동시 참이면 예전엔 fail 갈래(「실패 N · 전체 M」)로 떨어져 na가 조용히 사라졌다.
+  // 새 갈래로 분리 — 「실패 · 해당 없음 · 전체」 셋 다 한 줄에.
+  it('실패 있음 + 해당없음 있음 — 「실패 N · 해당 없음 M · 전체 K」(예전 fail-only 문구로 안 떨어진다)', async () => {
     await renderWithSheet([
       { name: 'A', verdict: 'fail' },
       { name: 'B', verdict: 'n_a' },
       { name: 'C', verdict: 'pass' },
     ]);
     const text = findRowSummary().textContent ?? '';
-    // 낱말 확定 전 placeholder(빈 문자열)라 지금은 이 값 — 유나 §17-24 도착 뒤 실 문구로 교체.
-    expect(text).toBe('검증 시트');
+    expect(text).toContain('실패 1 · 해당 없음 1 · 전체 3');
   });
 
   it('펼침 표 — 비고가 하나도 없으면 비고 열 자체가 없다', async () => {

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -61,10 +61,10 @@ function verificationSheetSummary(
   const fail = items.filter((i) => i.verdict === 'fail').length;
   const na = items.filter((i) => i.verdict === 'n_a').length;
   const pass = items.filter((i) => i.verdict === 'pass').length;
-  // story #3581(유나 #3927 비차단 발견, 페드루 PO 確定 2026-09-06) — fail>0·na>0가
+  // story #3581(유나 #3927 비차단 발견 → §17-24 낱말 확定 2026-09-06) — fail>0·na>0가
   // 동시에 참이면 예전엔 fail 갈래로 떨어져 na가 조용히 사라졌다(§3-2 "모른다≠0"과
   // 같은 결 — 해당 없음 항목이 있었다는 사실이 통째로 안 보였다). 4갈래로: 이 조합만
-  // 새 갈래(낱말은 유나 §17-24 확定 대기 — 지금은 i18n 키만, 값은 빈 문자열).
+  // 새 갈래(「실패 N · 해당 없음 M · 전체 K」).
   if (fail > 0 && na > 0) return t('verificationSheetSummaryWithFailAndNa', { fail, na, total, naLabel });
   if (fail > 0) return t('verificationSheetSummaryWithFail', { fail, total });
   if (na > 0) return t('verificationSheetSummaryWithNa', { pass, na, naLabel });

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -61,6 +61,11 @@ function verificationSheetSummary(
   const fail = items.filter((i) => i.verdict === 'fail').length;
   const na = items.filter((i) => i.verdict === 'n_a').length;
   const pass = items.filter((i) => i.verdict === 'pass').length;
+  // story #3581(유나 #3927 비차단 발견, 페드루 PO 確定 2026-09-06) — fail>0·na>0가
+  // 동시에 참이면 예전엔 fail 갈래로 떨어져 na가 조용히 사라졌다(§3-2 "모른다≠0"과
+  // 같은 결 — 해당 없음 항목이 있었다는 사실이 통째로 안 보였다). 4갈래로: 이 조합만
+  // 새 갈래(낱말은 유나 §17-24 확定 대기 — 지금은 i18n 키만, 값은 빈 문자열).
+  if (fail > 0 && na > 0) return t('verificationSheetSummaryWithFailAndNa', { fail, na, total, naLabel });
   if (fail > 0) return t('verificationSheetSummaryWithFail', { fail, total });
   if (na > 0) return t('verificationSheetSummaryWithNa', { pass, na, naLabel });
   return t('verificationSheetSummaryAllPass', { total });


### PR DESCRIPTION
## 배경
유나 발견(#3927 비차단, 2026-09-06) — 검증 시트 요약 3갈래 중 fail>0·na>0가 동시에 참이면 fail 갈래(「실패 N · 전체 M」)로 떨어져 na(해당 없음) 항목의 존재가 조용히 사라졌다.

## 처방
4갈래로 분리 — 이 조합만 새 키 `verificationSheetSummaryWithFailAndNa`로: 「실패 {fail} · 해당 없음 {na} · 전체 {total}」(유나 §17-24 확定). 분기 순서: `fail>0&&na>0` → 새 갈래 / `fail>0` → 기존 / `na>0` → 기존 / 그 외 → 모두 통과.

## 테스트
새 갈래 분리 확認(예전 fail-only 문구로 안 떨어짐) + 기존 3갈래 회귀 0. 뮤테이션(새 갈래 제거 → 예전 문구 재출현 RED 확認 후 복원).

## 검증
tsc 0·eslint 0·vitest 6510·hanja 0·phrase-collision 신규 0.