### PR TITLE
[SID:3582] fix: phrase-collision 가드 — 글자·숫자 0개 값은 비교 쌍에서 제외

### DIFF
--- a/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
@@ -356,11 +356,13 @@ describe('scanRepository — 글자·숫자 0개 값 사전 제외(story #3582)'
     expect(symbolOnlyExcluded.has('content.originAuthorUnknown')).toBe(true);
   });
 
-  it('원래 EXEMPT였던 두 쌍은 이제 EXEMPT_PAIRS 등재 없이도 새 충돌로 안 걸린다(규칙이 대신 안다)', () => {
+  it('원래 EXEMPT였던 세 쌍(3402 2·3575 1)은 이제 EXEMPT_PAIRS 등재 없이도 새 충돌로 안 걸린다(규칙이 대신 안다)', () => {
     expect(EXEMPT_PAIRS.has('content.channelPostsTextTooLong <-> content.originAuthorUnknown')).toBe(false);
     expect(EXEMPT_PAIRS.has('content.channelPostsRateLimitedUntil <-> content.originAuthorUnknown')).toBe(false);
+    expect(EXEMPT_PAIRS.has('content.errorChannelVideoUploadFailedWithStatus <-> content.originAuthorUnknown')).toBe(false);
     const { newFindings } = scanRepository();
     expect(newFindings.has('content.channelPostsTextTooLong <-> content.originAuthorUnknown')).toBe(false);
     expect(newFindings.has('content.channelPostsRateLimitedUntil <-> content.originAuthorUnknown')).toBe(false);
+    expect(newFindings.has('content.errorChannelVideoUploadFailedWithStatus <-> content.originAuthorUnknown')).toBe(false);
   });
 });

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
@@ -365,4 +365,21 @@ describe('scanRepository — 글자·숫자 0개 값 사전 제외(story #3582)'
     expect(newFindings.has('content.channelPostsRateLimitedUntil <-> content.originAuthorUnknown')).toBe(false);
     expect(newFindings.has('content.errorChannelVideoUploadFailedWithStatus <-> content.originAuthorUnknown')).toBe(false);
   });
+
+  // 유나 비차단(2026-09-06, #3931 Design review) — 위 두 테스트는 "제외가 일했다"와
+  // "애초에 그 쌍이 안 겹쳤다"를 못 가른다. 주석의 약속("제외 로직을 끄면 다시 RED")을
+  // 코드로 직접 증명한다 — scanRepository의 사전 제외를 «건너뛰고» findSubstringCollisions에
+  // 실 값 그대로(originAuthorUnknown="—" · channelPostsTextTooLong="{max}자 한도인데
+  // {current}자입니다 — 줄여서 재상신해 주세요.") 넘기면 여전히 겹친다(순수 판정 로직
+  // 자체는 살아있다는 양성대조).
+  it('제외 없이 findSubstringCollisions에 직접 넘기면 여전히 겹친다(제외가 "일한다"는 증명, 애초에 안 겹친 게 아니다)', () => {
+    const phrases = new Map([
+      ['content.originAuthorUnknown', { value: '—', numberAdjacent: false }],
+      [
+        'content.channelPostsTextTooLong',
+        { value: '{max}자 한도인데 {current}자입니다 — 줄여서 재상신해 주세요.', numberAdjacent: true },
+      ],
+    ]);
+    expect(findSubstringCollisions(phrases)).toHaveLength(1);
+  });
 });

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
@@ -7,6 +7,7 @@ import {
   findSubstringCollisions,
   flattenMessages,
   GRANDFATHER_BASELINE,
+  hasLetterOrNumber,
   isNumberAdjacent,
   pairKey,
   parseKeyUsages,
@@ -325,5 +326,41 @@ describe('GRANDFATHER_LIVE_COUNT_TEST — 「선언된 수」와 「지금 실�
     expect(GRANDFATHER_BASELINE.size).toBeGreaterThan(0); // sanity: baseline은 안 비었다
     const { exemptHit } = scanRepository();
     expect(exemptHit.size).toBe(EXEMPT_PAIRS.size);
+  });
+});
+
+// story #3582(유나 관측 · PO 確定 2026-09-06) — 값에 유니코드 글자(L)·숫자(N)가 0개면
+// «구»(phrase)를 담지 않으므로 이 가드가 잡으려는 병(두 셈이 헷갈림)의 대상이 아니다.
+describe('hasLetterOrNumber — story #3582', () => {
+  it('제외 — 순수 구두점/기호 값(글자·숫자 0개)', () => {
+    expect(hasLetterOrNumber('—')).toBe(false);
+    expect(hasLetterOrNumber('...')).toBe(false);
+    expect(hasLetterOrNumber('↳')).toBe(false);
+    expect(hasLetterOrNumber('≥')).toBe(false);
+    expect(hasLetterOrNumber('≤')).toBe(false);
+  });
+
+  it('비제외 — 글자나 숫자가 하나라도 있으면 그대로 비교 대상(짧은 값도)', () => {
+    expect(hasLetterOrNumber('막힘')).toBe(true);
+    expect(hasLetterOrNumber('나')).toBe(true);
+    expect(hasLetterOrNumber('{n}')).toBe(true); // 보간 자리 자체가 글자를 포함
+    expect(hasLetterOrNumber('1')).toBe(true);
+  });
+});
+
+// story #3582 — 비교 쌍을 만들기 «전»에 제외되므로, 글자·숫자 0개 값과 다른 값의 짝은
+// exempt/grandfather/new 어디로도 안 잡히고(=이미 빠진 것) symbolOnlyExcluded에만 잡힌다.
+describe('scanRepository — 글자·숫자 0개 값 사전 제외(story #3582)', () => {
+  it('content.originAuthorUnknown("—")이 symbolOnlyExcluded에 잡힌다(인스턴스별 EXEMPT 없이도 비교 자체를 안 한다)', () => {
+    const { symbolOnlyExcluded } = scanRepository();
+    expect(symbolOnlyExcluded.has('content.originAuthorUnknown')).toBe(true);
+  });
+
+  it('원래 EXEMPT였던 두 쌍은 이제 EXEMPT_PAIRS 등재 없이도 새 충돌로 안 걸린다(규칙이 대신 안다)', () => {
+    expect(EXEMPT_PAIRS.has('content.channelPostsTextTooLong <-> content.originAuthorUnknown')).toBe(false);
+    expect(EXEMPT_PAIRS.has('content.channelPostsRateLimitedUntil <-> content.originAuthorUnknown')).toBe(false);
+    const { newFindings } = scanRepository();
+    expect(newFindings.has('content.channelPostsTextTooLong <-> content.originAuthorUnknown')).toBe(false);
+    expect(newFindings.has('content.channelPostsRateLimitedUntil <-> content.originAuthorUnknown')).toBe(false);
   });
 });

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -189,6 +189,18 @@ export function isNumberAdjacent(value: string): boolean {
   return false;
 }
 
+// story #3582(유나 관측 · #3929 Design review 2026-09-06 09:39Z 비차단 · PO 確定) —
+// 카탈로그에 글자·숫자가 하나도 없는 값(「—」·「...」·「↳」·「≥」·「≤」류)이 9건 있다. 이
+// 가드가 잡으려는 병은 "«같은 뜻을 다르게»가 아니라 «다른 두 셈이 같은 말로 헷갈린다»"
+// 인데, 값이 순수 구두점/기호면 «구»(phrase)를 담지 않으니 애초에 이 축의 대상이 아니다
+// (3402·3575가 정확히 이 모양으로 3번 EXEMPT를 늘렸다 — 매 사유 문장마다 "—" 하나가
+// originAuthorUnknown과 겹쳐 걸렸다). 비교 쌍을 만들기 «전»에 제외한다 — 인스턴스별
+// EXEMPT 승인 대신 규칙이 이 축 자체를 안다.
+const LETTER_OR_NUMBER_RE = /\p{L}|\p{N}/u;
+export function hasLetterOrNumber(value: string): boolean {
+  return LETTER_OR_NUMBER_RE.test(value);
+}
+
 // ── 충돌 판정 ────────────────────────────────────────────────────────────
 
 /** 서로 다른 키의 값이 부분문자열 관계(포함하거나 포함되는)면서 «최소 한쪽이 수와 함께
@@ -274,15 +286,15 @@ export function findSubstringCollisions(
 // 부분문자열은 겹치지만 하나는 애초에 안 보이는 값이라 혼동 여지가 실질 0.
 // story #3402(2026-09-04, 유나 design review·페드루 PO 판정) — content.channelPostsTextTooLong/
 // channelPostsRateLimitedUntil(둘 다 {max}/{current}/{time} 보간이 있어 numberAdjacent=true)
-// <-> content.originAuthorUnknown("—" 한 글자, 보간 없음). 겹치는 건 오직 문장 중간의 「—」
-// 구두점 하나뿐이다 — originAuthorUnknown이 "—"를 값으로 쓰는 건 «값을 모른다»는 자리표시
-// 기호(이 화면 전역에서 「키 부재→—」 관례)이지 이 두 문장이 말하는 "한도"·"reset 시각"과
-// 같은 개념을 가리키는 게 전혀 아니다. #2352/#2365가 잡으려는 "같은 화면의 두 «수»가
-// 헷갈리는" 병이 아니다 — 애초에 originAuthorUnknown 쪽엔 수 자체가 없다(단독 자리표시
-// 기호일 뿐). 유나 design review가 이 두 문구의 "—" 구두점 자체를 정본으로 지정했다(쉼표로
-// 바꾸면 en 쪽이 comma splice가 되는 문법 문제까지 겹쳐 구두점을 굽히지 않는 쪽으로 판정,
-// 페드루 PO 확定 2026-09-04 06:13Z). 다시 볼 때 — 이 가드가 "구두점 자체"를 문제 삼는
-// 방식으로 정교해지면(값 안의 특정 기호 하나만 따로 취급) 재검토.
+// <-> content.originAuthorUnknown("—" 한 글자, 보간 없음)가 겪던 오탐. 겹치는 건 오직 문장
+// 중간의 「—」 구두점 하나뿐 — originAuthorUnknown이 "—"를 값으로 쓰는 건 «값을 모른다»는
+// 자리표시 기호(이 화면 전역에서 「키 부재→—」 관례)이지 이 두 문장이 말하는 "한도"·"reset
+// 시각"과 같은 개념을 가리키는 게 전혀 아니다. ⚠️story #3582(PO 確定 2026-09-06) — 이런
+// "값에 글자·숫자가 0개"인 오탐이 매 사유 문장마다 EXEMPT를 한 줄씩 늘리는 패턴이라(3575가
+// errorChannelVideoUploadFailedWithStatus 짝으로 세 번째를 늘렸다), 인스턴스별 승인 대신
+// hasLetterOrNumber() 사전 제외로 규칙 자체에 이 축을 흡수했다 — originAuthorUnknown이
+// 낀 세 쌍(3402 2·3575 1) 전부 그래서 삭제(양성대조: 제외 로직을 끄면 다시 RED가 되어야
+// 한다).
 export const EXEMPT_PAIRS = new Set<string>([
   'goals.indexCountActive <-> goals.statusActive',
   'goals.indexCountDone <-> goals.statusDone',
@@ -291,12 +303,6 @@ export const EXEMPT_PAIRS = new Set<string>([
   'sprints.days <-> sprints.overdueBadge',
   'onboarding.projectLimitExceededError <-> settings.tabProjects',
   'settings.memberLimitExceededError <-> settings.roleMember',
-  'content.channelPostsTextTooLong <-> content.originAuthorUnknown',
-  'content.channelPostsRateLimitedUntil <-> content.originAuthorUnknown',
-  // 3575 ⑤ 추가(페드루 PO 승인 2026-09-06) — errorChannelVideoUploadFailedWithStatus
-  // ("…서버가 {status}로 응답했습니다.")도 위와 같은 클래스: 문장 속 "—" 구두점 하나가
-  // originAuthorUnknown 단독 자리표시와 겹칠 뿐, 수({status})는 한쪽에만 있다.
-  'content.errorChannelVideoUploadFailedWithStatus <-> content.originAuthorUnknown',
   // story #3422(2026-09-04, ②-c FailureActionBadge) — channelPostsFailureAutoRetryAt
   // ({time} 보간 있음) <-> channelPostsFailureRetryCta("다시 시도", 보간 없음). 겹치는
   // 건 "다시 시도"라는 흔한 동사구 하나뿐 — auto_retry(자동, 버튼 없음)와 dead_letter
@@ -459,6 +465,8 @@ export interface RepositoryScanResult {
   grandfathered: Map<string, CollisionPair>;
   exemptHit: Set<string>;
   grandfatherHit: Set<string>;
+  // story #3582 — 글자·숫자 0개라 비교 쌍 자체를 안 만든 (namespace.key) 집합.
+  symbolOnlyExcluded: Set<string>;
 }
 
 /** main()에서 뽑아낸 전 저장소 스캔 — story #2410, GRANDFATHER_LIVE_COUNT_TEST가 이걸 불러
@@ -474,6 +482,7 @@ export function scanRepository(): RepositoryScanResult {
   const grandfathered = new Map<string, CollisionPair>();
   const exemptHit = new Set<string>();
   const grandfatherHit = new Set<string>();
+  const symbolOnlyExcluded = new Set<string>();
 
   for (const abs of files) {
     const content = readFileSync(abs, 'utf8');
@@ -486,6 +495,8 @@ export function scanRepository(): RepositoryScanResult {
     for (const qualifiedKey of usages) {
       const value = messages.get(qualifiedKey);
       if (value === undefined) continue;
+      // story #3582 — 비교 쌍을 만들기 전에 제외(글자·숫자 0개 값).
+      if (!hasLetterOrNumber(value)) { symbolOnlyExcluded.add(qualifiedKey); continue; }
       phrases.set(qualifiedKey, { value, numberAdjacent: isNumberAdjacent(value) });
     }
 
@@ -504,11 +515,11 @@ export function scanRepository(): RepositoryScanResult {
     }
   }
 
-  return { files, totalDynamicCalls, newFindings, grandfathered, exemptHit, grandfatherHit };
+  return { files, totalDynamicCalls, newFindings, grandfathered, exemptHit, grandfatherHit, symbolOnlyExcluded };
 }
 
 function main(): void {
-  const { files, totalDynamicCalls, newFindings, grandfathered, exemptHit, grandfatherHit } = scanRepository();
+  const { files, totalDynamicCalls, newFindings, grandfathered, exemptHit, grandfatherHit, symbolOnlyExcluded } = scanRepository();
 
   const staleExempt = [...EXEMPT_PAIRS].filter((pk) => !exemptHit.has(pk));
   const staleGrandfather = [...GRANDFATHER_BASELINE].filter((pk) => !grandfatherHit.has(pk));
@@ -517,6 +528,11 @@ function main(): void {
     `[AC7] i18n 문구 충돌 스캔(같은 파일·수와 함께 서는 쌍만) — 파일 ${files.length}개 · ` +
       `동적 키 호출(정적 미포착) ${totalDynamicCalls}건(AC4㉡) · grandfather(미triage 채무, 안 막음) ${grandfatherHit.size}건 · ` +
       `exempt ${EXEMPT_PAIRS.size}건 · en.json 미검사(AC4㉢)`,
+  );
+  // story #3582 — 이 가드가 «못 잡는 것»(AC4 관례와 같은 결) 선언: 글자·숫자 0개 값은
+  // «구»를 담지 않으므로 비교 쌍 자체를 안 만든다.
+  console.log(
+    `  ℹ️ 글자·숫자 없는 값이라 비교 제외(이 가드가 못 잡는 축) ${symbolOnlyExcluded.size}건: ${[...symbolOnlyExcluded].sort().join(', ')}`,
   );
   if (staleExempt.length > 0) {
     console.log(`  ⚠️ exempt로 등재됐으나 이번 스캔에서 안 걸린(죽은 문서 후보): ${staleExempt.join(', ')}`);


### PR DESCRIPTION
## 배경
유나 관측(#3929 Design review, 비차단) — EXEMPT_PAIRS 45건 중 3건이 전부 같은 이유(문장 속 "—" 하나가 `content.originAuthorUnknown`="—" 단독 자리표시와 겹침). 카탈로그에 글자·숫자가 하나도 없는 값이 9건 — 이 가드가 잡으려는 병("다른 두 셈이 헷갈림")의 대상이 아니다.

## 처방
`hasLetterOrNumber()` 신설 — 값에 유니코드 글자(L)·숫자(N)가 0개면 비교 쌍을 만들기 **전에** 제외. 제외 목록을 실행 로그 1줄로 출력(이 가드가 못 잡는 축 선언). `originAuthorUnknown` 관련 EXEMPT_PAIRS 2건 삭제(develop에 아직 없는 #3929분 1건은 그 PR 머지 후 별도 정리) — 삭제 뒤에도 가드 그린(양성대조).

## 테스트
`hasLetterOrNumber` 제외/비제외 9 + `scanRepository` 통합 2 + 뮤테이션(제외 로직 제거 → RED 확認 후 복원).

## 검증
tsc 0·eslint 0·vitest 6513 전부 그린.

## 후속
#3929(3575) 머지 후 그쪽이 추가한 3번째 `originAuthorUnknown` EXEMPT 항목도 같은 이유로 삭제 필요(별도 커밋).