### PR TITLE
[SID:3574] fix: 이미지 2장 이상 초안 영상 첨부 시 N-1장 소실 방지

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -87,6 +87,7 @@ from app.services.channel_post_videos import (
     ChannelVideoDurationTooShortError,
     ChannelVideoObjectNotFoundError,
     ChannelVideoPathNotScopedError,
+    ChannelVideoRequiresSingleCoverError,
     ChannelVideoTooLargeError,
     ChannelVideoUnparsableError,
     ChannelVideoUnsupportedError,
@@ -687,6 +688,10 @@ async def post_channel_post_video_confirm(
         ) from exc
     except ChannelVideoUploadFailedError as exc:
         raise HTTPException(status_code=502, detail={"code": "CHANNEL_VIDEO_UPLOAD_FAILED", "message": str(exc)}) from exc
+    except ChannelVideoRequiresSingleCoverError as exc:
+        raise HTTPException(
+            status_code=422, detail={"code": "CHANNEL_VIDEO_REQUIRES_SINGLE_COVER", "message": str(exc)},
+        ) from exc
     return _video_response(version, video_row)
 
 

--- a/backend/app/services/channel_post_videos.py
+++ b/backend/app/services/channel_post_videos.py
@@ -41,6 +41,7 @@ from app.services.channel_post_images import (
     _require_bucket,
     compute_image_seal_hash,
     get_channel_post_image_for_version,
+    list_channel_post_images_for_version,
 )
 from app.services.channel_posts import (
     ChannelPostDraftNotFoundError,
@@ -130,6 +131,19 @@ class ChannelVideoUploadFailedError(Exception):
     def __init__(self, *, object_path: str):
         self.object_path = object_path
         super().__init__(f"영상 업로드 실패: {object_path}")
+
+
+class ChannelVideoRequiresSingleCoverError(Exception):
+    """story #3574(Phase2·BE·결함, 페드루 PO 確定 2026-09-06) — 이 함수 아래의
+    「단수 getter로 커버 1장만 캐리」가 이미지 N장(N≥2, 캐러셀) 버전에 그대로
+    도달하면 나머지 N-1장이 사용자 행동 하나(영상 첨부)로 조용히 사라진다
+    (유나 §17-23 ④ 규격 구멍 실측 — `get_channel_post_image_for_version`이
+    position=0만 대표로 돌려주는 기존 계약 자체는 옳다, 문제는 그 계약을
+    캐러셀 버전에도 무비판 적용한 이 호출부였다). 금지 AC — 트랜잭션(새 버전
+    생성) 시작 前에 명시 거부."""
+
+    def __init__(self):
+        super().__init__("영상은 커버 이미지 1장과만 함께 갈 수 있습니다 — 이미지를 1장으로 줄인 뒤 첨부하세요.")
 
 
 @dataclass(frozen=True)
@@ -373,6 +387,13 @@ async def confirm_channel_post_video_upload(
     )).scalar_one_or_none()
     if latest is None:
         raise ChannelPostDraftNotFoundError(draft_id)
+
+    # story #3574(Phase2·BE·결함, 페드루 PO 確定 2026-09-06) — 트랜잭션(새 버전 생성)
+    # 시작 前 명시 거부. 이미지 0·1장일 때만 아래 단수 캐리 로직에 도달한다(그 경우
+    # 의미가 정확히 일치 — position=0 대표 1장=전체 1장).
+    existing_images = await list_channel_post_images_for_version(db, version_id=latest.id)
+    if len(existing_images) >= 2:
+        raise ChannelVideoRequiresSingleCoverError()
 
     existing_cover = await get_channel_post_image_for_version(db, version_id=latest.id)
     cover_sha256 = existing_cover.final_sha256 if existing_cover is not None else ""

--- a/backend/tests/test_3574_video_requires_single_cover.py
+++ b/backend/tests/test_3574_video_requires_single_cover.py
@@ -1,0 +1,224 @@
+"""story #3574(Phase2·BE·결함, 페드루 PO 確定 2026-09-06) — 이미지 2장 이상(캐러셀)
+초안에 영상을 첨부하면 `channel_post_videos.py`의 단수 getter(`get_channel_post_
+image_for_version`, position=0만 대표)가 그대로 커버 캐리에 쓰여 N-1장이 사용자
+행동 하나로 조용히 사라지던 결함(유나 §17-23 ④ 실측).
+
+確定(금지 AC) — 영상 confirm 시 최신 버전의 이미지 수가 **2 이상이면** 트랜잭션
+(새 버전 생성) 시작 前 422 `CHANNEL_VIDEO_REQUIRES_SINGLE_COVER`. 0·1장은 현행
+그대로(단수 getter 의미가 정확히 일치하는 구간이라 무변경).
+
+세팅 헬퍼는 test_620beefc_channel_post_image.py(base)·test_3567_facebook_page_
+final.py(facebook_sandbox 영상 픽스처) 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_620beefc_channel_post_image import (
+    _client_for,
+    _create_draft,
+    _jpeg_bytes,
+    _seed_connection,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+    _upload_and_confirm,
+)
+from tests.test_3567_facebook_page_final import (
+    _VALID_9_16,
+    _build_mp4,
+    _upload_and_confirm_video,
+    _seed_default_role,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+_CHANNEL_MEDIA_BUCKET = "test-channel-media-3574"
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage(monkeypatch, tmp_path):
+    import app.services.channel_post_images as cpi_module
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage_object_path_fix(monkeypatch):
+    import tests.test_620beefc_channel_post_image as base_test_module
+
+    monkeypatch.setattr(base_test_module, "_CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _instagram_sandbox_video_config(monkeypatch):
+    """test_3554_instagram_reels.py::_instagram_sandbox_video_config와 동형 —
+    SANDBOX_CHANNEL_ENABLED 조건부 블록(모듈 import 시점 1회 평가)에 기대지 않고
+    이 테스트 파일이 필요로 하는 정확한 값(image_max_count=10+video_*)을 직접
+    주입한다(import 순서 무관하게 결정적)."""
+    import app.services.channel_adapters as adapters_mod
+
+    ig_sandbox_cfg = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual", credential_kind="none", display_name="Instagram Sandbox",
+        max_text_length=2200, utm_source="instagram_sandbox", utm_medium="test",
+        image_formats=("image/jpeg",), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91, image_aspect_min=0.8,
+        image_width_min=320, image_width_max=1440, image_color_space="sRGB",
+        image_max_count=10,
+        video_max_bytes=100 * 1024 * 1024, video_max_seconds=90.0, video_min_seconds=3.0,
+        video_aspect_target=9 / 16, video_aspect_tolerance=0.05,
+        video_codecs=("avc1", "hvc1", "hev1"),
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "instagram_sandbox", ig_sandbox_cfg)
+    yield
+
+
+async def _upload_n_images(client, org_id, draft_id, n: int, *, size=(800, 1000)):
+    responses = []
+    for i in range(n):
+        raw = _jpeg_bytes(*size, color=(10 * i, 50, 80))
+        r = await _upload_and_confirm(client, org_id, draft_id, raw, content_type="image/jpeg")
+        responses.append(r)
+    return responses
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("channel", ["facebook_sandbox", "instagram_sandbox"])
+async def test_video_confirm_rejected_when_two_images(channel):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel=channel)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            responses = await _upload_n_images(client, org_id, draft_id, 2)
+            for r in responses:
+                assert r.status_code == 201, r.text
+
+            raw_video = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, raw_video)
+        assert r_video.status_code == 422, r_video.text
+        assert r_video.json()["error"]["code"] == "CHANNEL_VIDEO_REQUIRES_SINGLE_COVER"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("channel", ["facebook_sandbox", "instagram_sandbox"])
+async def test_video_confirm_carries_single_cover_when_one_image(channel):
+    from app.main import app
+    from sqlalchemy import select
+    from app.models.channel_post_image import ChannelPostImage
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel=channel)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r_image = await _upload_and_confirm(
+                client, org_id, draft_id, _jpeg_bytes(800, 1000), content_type="image/jpeg",
+            )
+            assert r_image.status_code == 201, r_image.text
+
+            raw_video = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, raw_video)
+        assert r_video.status_code == 201, r_video.text
+        new_version_id = uuid.UUID(r_video.json()["version_id"])
+
+        async with Session() as s:
+            covers = (await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == new_version_id)
+            )).scalars().all()
+        assert len(covers) == 1
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("channel", ["facebook_sandbox", "instagram_sandbox"])
+async def test_video_confirm_carries_zero_cover_when_no_image(channel):
+    from app.main import app
+    from sqlalchemy import select
+    from app.models.channel_post_image import ChannelPostImage
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel=channel)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw_video = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, raw_video)
+        assert r_video.status_code == 201, r_video.text
+        new_version_id = uuid.UUID(r_video.json()["version_id"])
+
+        async with Session() as s:
+            covers = (await s.execute(
+                select(ChannelPostImage).where(ChannelPostImage.version_id == new_version_id)
+            )).scalars().all()
+        assert len(covers) == 0
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1360,7 +1360,12 @@
     {
       "file": "tests/test_3567_facebook_page_final.py",
       "sec": 40.0,
-      "source": "story-3567-facebook-page-final(PO 리뷰 조건 반영 후 로컬 raw pytest 19건 6.73s 재실측 — 조건 반영 커밋이 테스트 3건 추가했는데 등재 갱신을 누락했던 것을 story #3574 작업 중 발견·즉시 수정. CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "source": "story-3567-facebook-page-final(PO 리뷰 조건 반영 후 로컬 raw pytest 19건 6.73s 재실측 — story #3574 작업 중 발견한 등재 갱신 누락 보정. CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3574_video_requires_single_cover.py",
+      "sec": 36.0,
+      "source": "story-3574-video-requires-single-cover(PR 개설 前 선제 등재 — 로컬 raw pytest 6건 5.98s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 36s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
- 영상 첨부(video-confirm)가 latest 버전의 단일-이미지 캐리포워드 로직만 상정하고 있어, 이미지가 2장 이상 붙은 버전에 영상을 첨부하면 기존 단일-getter가 1장만 골라 캐리하고 나머지 N-1장이 조용히 소실됐다(원 결함).
- 처방 — 영상 confirm 트랜잭션 진입 前에 `list_channel_post_images_for_version()`으로 기존 이미지 수를 세어 2장 이상이면 422 `CHANNEL_VIDEO_REQUIRES_SINGLE_COVER`로 즉시 거부(트랜잭션/버전 생성 이전 — 부분 상태 없음). 0/1장 경로는 완전 무변경(기존 캐리포워드 그대로 정상).

## 근거
- `channel_post_videos.py`: `ChannelVideoRequiresSingleCoverError` 신규 + 사전 거부 체크.
- `channel_posts.py`: 라우터 예외→422 매핑.
- 테스트 6건(facebook_sandbox/instagram_sandbox × {2장 거부·1장 캐리·0장 캐리}) + 뮤테이션 1(거부 블록 제거 → 원 소실 버그 정확 재현 확認 후 RED, 복원).

## rebase 노트
이 브랜치는 원래 미착지 상태였던 `feat/3567-facebook-page-final`(PR #3925, facebook_sandbox 영상/캐러셀 지원 자체가 그 PR 산출물이라 그 브랜치 위에서 구현) 위에서 작업했다. #3925가 develop에 스쿼시 머지된 뒤(`f44dae1eb`) `git rebase --onto origin/develop feat/3567-facebook-page-final feat/3574-video-requires-single-cover`로 재배치 — PR diff에는 이 스토리 자체 커밋(`141b4b45c`) 하나만 남는다.

## 검증
- 회귀 6건 통과·shard-weights 등재·lint 통과·develop 최신 반영 확인.
- FE(#3575, 이미 develop 병합)가 이 422 코드/메시지를 서버 방어선으로 참조 — BE 계약 변경 없음.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>