### PR TITLE
[SID:3578] fix: 릴스 커버(9:16)가 구조적으로 못 올라가던 검증 순서 결함

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -57,6 +57,7 @@ from app.services.channel_posts import (
     unpublish_channel_post,
 )
 from app.services.channel_post_images import (
+    ChannelCoverAspectRatioRejectedError,
     ChannelImageAnimatedUnsupportedError,
     ChannelImageAspectRatioExceededError,
     ChannelImageAspectRatioTooNarrowError,
@@ -777,6 +778,14 @@ async def post_channel_post_image_confirm(
             detail={
                 "code": "CHANNEL_IMAGE_ASPECT_RATIO_TOO_NARROW", "message": str(exc),
                 "width_height_ratio": exc.width_height_ratio, "min_width_height_ratio": exc.min_width_height_ratio,
+            },
+        ) from exc
+    except ChannelCoverAspectRatioRejectedError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_COVER_ASPECT_RATIO_REJECTED", "message": str(exc),
+                "aspect_ratio": exc.aspect_ratio, "target": exc.target, "tolerance": exc.tolerance,
             },
         ) from exc
     except ChannelImageConversionFailedError as exc:

--- a/backend/app/services/channel_post_images.py
+++ b/backend/app/services/channel_post_images.py
@@ -147,6 +147,23 @@ class ChannelImageAspectRatioTooNarrowError(Exception):
         )
 
 
+class ChannelCoverAspectRatioRejectedError(Exception):
+    """story #3578(Phase2·BE·급·결함, 페드루 PO 確定 2026-09-06) — 캐러셀 이미지
+    규격(`image_aspect_min`/`image_aspect_max`)과 완전히 다른 축: 영상이 이미
+    붙어 있는 버전에 이미지 confirm이 오면 그건 캐러셀 첨부가 아니라 "커버
+    교체"라, 커버는 그 영상과 같은 비율(`video_aspect_target±video_aspect_
+    tolerance`, 어댑터 선언)이어야 한다는 완전히 다른 제약을 받는다. 유나
+    §17-16 ⑥과 짝 문구 형(현재값 노출)."""
+
+    def __init__(self, *, aspect_ratio: float, target: float, tolerance: float):
+        self.aspect_ratio = aspect_ratio
+        self.target = target
+        self.tolerance = tolerance
+        super().__init__(
+            f"커버는 영상과 같은 비율({target:.4f}±{tolerance:.2f})이어야 합니다 — 현재 {aspect_ratio:.4f}"
+        )
+
+
 class ChannelImageConversionFailedError(Exception):
     """재인코딩해도 어댑터 한도(image_max_bytes) 밑으로 못 낮춘 극히 드문 경우."""
 
@@ -392,7 +409,34 @@ async def confirm_channel_post_image_upload(
 
     probe = ImageOps.exif_transpose(probe)
     width, height = probe.size
-    if adapter.image_aspect_min > 0 and height > 0:
+
+    # story #3578(Phase2·BE·급·결함, 페드루 PO 確定 2026-09-06) — 분기(영상 유무)를
+    # 비율 검증보다 먼저 결정한다. 지연 import는 channel_post_videos.py가 이
+    # 모듈을 모듈 레벨에서 import하는 순환을 피하기 위함(story #3554 기존 관례,
+    # 아래 캐리 로직이 쓰던 것을 여기로 당김 — 신규 순환 0). 이전엔 이 검증이
+    # "이게 캐러셀 이미지인지 커버인지" 조차 모른 채 image_aspect_min(0.80)
+    # 하나로 먼저 돌아, 릴스 커버(9:16=0.5625)가 그 하한을 구조적으로 못 넘어
+    # 어떤 실제 커버도 통과 못 하던 결함(유나 §17-23 ④ 실측)의 근본원인이었다.
+    from app.services.channel_post_videos import _copy_video_row, get_channel_post_video_for_version
+
+    latest_for_cover_check = latest_for_count
+    if latest_for_cover_check is None:
+        raise ChannelPostDraftNotFoundError(draft_id)
+    existing_video = await get_channel_post_video_for_version(db, version_id=latest_for_cover_check.id)
+
+    if existing_video is not None:
+        # story #3578 — 커버 규격(video_aspect_target±video_aspect_tolerance,
+        # 어댑터 선언 — 하드코딩 0). 캐러셀 image_aspect_min/max와 완전히 다른
+        # 축(캐러셀=정지 이미지 앨범 규격·커버=그 영상과 같은 비율이어야 하는
+        # 제약)이라 아래 캐러셀 분기와 절대 안 섞는다.
+        if width > 0 and height > 0 and adapter.video_aspect_target > 0:
+            cover_ratio = width / height
+            if abs(cover_ratio - adapter.video_aspect_target) > adapter.video_aspect_tolerance:
+                raise ChannelCoverAspectRatioRejectedError(
+                    aspect_ratio=cover_ratio, target=adapter.video_aspect_target,
+                    tolerance=adapter.video_aspect_tolerance,
+                )
+    elif adapter.image_aspect_min > 0 and height > 0:
         # story #3320 — Instagram류(orientation-aware, 방향별 한도가 다름: 가로
         # 최대 1.91:1·세로 최대 4:5=0.8). 아래(Threads 등) 정규화(long/short, 항상
         # ≥1) 검사를 그대로 쓰면 image_aspect_max(1.91)가 방향 구분 없이 양쪽에
@@ -432,21 +476,16 @@ async def confirm_channel_post_image_upload(
 
     final_sha256 = derived_sha256 or original_sha256
 
-    latest = latest_for_count
-    if latest is None:
-        raise ChannelPostDraftNotFoundError(draft_id)
+    latest = latest_for_cover_check
 
     # story #3554(Phase2, 페드루 PO 確定 2026-09-06③) — 이 draft에 영상이 이미
     # 붙어 있으면 이 호출은 캐러셀 첨부가 아니라 "커버 교체"다(PO 明示 "커버=별개
     # 이미지 에셋·기존 이미지 파이프" — 새 업로드 경로를 안 만드는 대신, 여기서
     # 영상 유무로 두 모드를 가른다). 커버는 항상 position=0 슬롯 하나뿐 — 옛
     # 커버를 캐리포워드하지 않고 이번 것으로 완전히 대체한다(캐러셀의 "추가"와
-    # 다른 의미 축). 봉인은 `[video_sha256, cover_sha256]`(순서 고정) — 지연
-    # import는 channel_post_videos.py가 이 모듈을 모듈 레벨에서 import하는
-    # 순환을 피하기 위함(channel_posts.py의 기존 관례와 동형).
-    from app.services.channel_post_videos import _copy_video_row, get_channel_post_video_for_version
-
-    existing_video = await get_channel_post_video_for_version(db, version_id=latest.id)
+    # 다른 의미 축). 봉인은 `[video_sha256, cover_sha256]`(순서 고정). `existing_
+    # video`는 story #3578에서 비율 검증 분기 결정을 위해 위로 옮긴 조회를 그대로
+    # 재사용(중복 쿼리 0).
     if existing_video is not None:
         new_position = 0
         composite_sha256 = compute_image_seal_hash([existing_video.original_sha256, final_sha256])

--- a/backend/tests/test_3554_instagram_reels.py
+++ b/backend/tests/test_3554_instagram_reels.py
@@ -451,7 +451,7 @@ async def test_cover_attach_after_video_computes_composite_and_replaces_not_appe
             assert r_video.status_code == 201, r_video.text
             video_sha256 = __import__("hashlib").sha256(video_raw).hexdigest()
 
-            cover1_raw = _jpeg_bytes(800, 1000, color=(10, 20, 30))
+            cover1_raw = _jpeg_bytes(720, 1280, color=(10, 20, 30))
             r_cover1 = await _upload_and_confirm(client, org_id, draft_id, cover1_raw, content_type="image/jpeg")
             assert r_cover1.status_code == 201, r_cover1.text
             version1_id = r_cover1.json()["version_id"]
@@ -468,7 +468,7 @@ async def test_cover_attach_after_video_computes_composite_and_replaces_not_appe
         assert version1.image_sha256 == compute_image_seal_hash([video_sha256, images_v1[0].final_sha256])
 
         async with _client_for(app) as client:
-            cover2_raw = _jpeg_bytes(800, 1000, color=(200, 210, 220))
+            cover2_raw = _jpeg_bytes(720, 1280, color=(200, 210, 220))
             r_cover2 = await _upload_and_confirm(client, org_id, draft_id, cover2_raw, content_type="image/jpeg")
             assert r_cover2.status_code == 201, r_cover2.text
             version2_id = r_cover2.json()["version_id"]
@@ -510,7 +510,7 @@ async def test_text_only_edit_after_video_and_cover_carries_forward_both():
             draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
             video_raw = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
             await _upload_and_confirm_video(client, org_id, draft_id, video_raw)
-            cover_raw = _jpeg_bytes(800, 1000)
+            cover_raw = _jpeg_bytes(720, 1280)
             r_cover = await _upload_and_confirm(client, org_id, draft_id, cover_raw, content_type="image/jpeg")
             assert r_cover.status_code == 201, r_cover.text
             version_before_id = r_cover.json()["version_id"]

--- a/backend/tests/test_3567_facebook_page_final.py
+++ b/backend/tests/test_3567_facebook_page_final.py
@@ -656,7 +656,7 @@ async def test_facebook_reels_composite_seal_includes_cover_hash():
     from sqlalchemy import select
     from app.models.channel_post_version import ChannelPostVersion
 
-    same_cover = _jpeg_bytes(800, 1000, color=(77, 77, 77))
+    same_cover = _jpeg_bytes(720, 1280, color=(77, 77, 77))
 
     engine, Session = await _session_factory()
     try:

--- a/backend/tests/test_3578_cover_aspect_validation_order.py
+++ b/backend/tests/test_3578_cover_aspect_validation_order.py
@@ -1,0 +1,207 @@
+"""story #3578(Phase2·BE·급·결함, 페드루 PO 確定 2026-09-06) — 릴스 커버(9:16)가
+구조적으로 못 올라가던 결함. `channel_post_images.py`의 이미지 비율 검증
+(image_aspect_min=0.80)이 커버/캐러셀 분기(영상 유무)보다 먼저 돌아 커버도
+캐러셀 규격(하한 0.80)으로 재졌다 — 릴스 커버는 본디 9:16(0.5625)이라 그 하한을
+영원히 못 넘는다(유나 §17-23 ④ 실측).
+
+確定 — 분기(영상 유무)를 먼저 결정하고, 영상이 있으면 **커버 규격**
+(video_aspect_target±video_aspect_tolerance, 어댑터 선언)으로 검증. 영상이
+없으면(캐러셀) 기존 image_aspect_min/max 그대로(회귀 0).
+
+세팅 헬퍼는 test_620beefc_channel_post_image_upload.py(base)·test_3567_facebook_page_
+final.py(facebook_sandbox 영상 픽스처)·test_3574_video_requires_single_cover.py
+(instagram_sandbox 영상 설정 monkeypatch) 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_620beefc_channel_post_image_upload import (
+    _client_for,
+    _create_draft,
+    _jpeg_bytes,
+    _seed_connection,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+    _upload_and_confirm,
+)
+from tests.test_3567_facebook_page_final import (
+    _VALID_9_16,
+    _build_mp4,
+    _upload_and_confirm_video,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+_CHANNEL_MEDIA_BUCKET = "test-channel-media-3578"
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage(monkeypatch, tmp_path):
+    import app.services.channel_post_images as cpi_module
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage_object_path_fix(monkeypatch):
+    import tests.test_620beefc_channel_post_image_upload as base_test_module
+
+    monkeypatch.setattr(base_test_module, "_CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _instagram_sandbox_video_config(monkeypatch):
+    """test_3554_instagram_reels.py::_instagram_sandbox_video_config와 동형 —
+    SANDBOX_CHANNEL_ENABLED 조건부 블록(모듈 import 시점 1회 평가)에 기대지 않고
+    이 테스트 파일이 필요로 하는 정확한 값(image_max_count=10+video_*)을 직접
+    주입한다(import 순서 무관하게 결정적)."""
+    import app.services.channel_adapters as adapters_mod
+
+    ig_sandbox_cfg = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual", credential_kind="none", display_name="Instagram Sandbox",
+        max_text_length=2200, utm_source="instagram_sandbox", utm_medium="test",
+        image_formats=("image/jpeg",), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91, image_aspect_min=0.8,
+        image_width_min=320, image_width_max=1440, image_color_space="sRGB",
+        image_max_count=10,
+        video_max_bytes=100 * 1024 * 1024, video_max_seconds=90.0, video_min_seconds=3.0,
+        video_aspect_target=9 / 16, video_aspect_tolerance=0.05,
+        video_codecs=("avc1", "hvc1", "hev1"),
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "instagram_sandbox", ig_sandbox_cfg)
+    yield
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("channel", ["facebook_sandbox", "instagram_sandbox"])
+async def test_cover_9_16_accepted_after_video_attached(channel):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel=channel)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw_video = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, raw_video)
+            assert r_video.status_code == 201, r_video.text
+
+            r_cover = await _upload_and_confirm(
+                client, org_id, draft_id, _jpeg_bytes(720, 1280), content_type="image/jpeg",
+            )
+        assert r_cover.status_code == 201, r_cover.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("channel", ["facebook_sandbox", "instagram_sandbox"])
+async def test_cover_square_rejected_with_cover_specific_code(channel):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel=channel)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw_video = _build_mp4(duration_seconds=6.0, **_VALID_9_16)
+            r_video = await _upload_and_confirm_video(client, org_id, draft_id, raw_video)
+            assert r_video.status_code == 201, r_video.text
+
+            r_cover = await _upload_and_confirm(
+                client, org_id, draft_id, _jpeg_bytes(1000, 1000), content_type="image/jpeg",
+            )
+        assert r_cover.status_code == 422, r_cover.text
+        detail = r_cover.json()["error"]
+        assert detail["code"] == "CHANNEL_COVER_ASPECT_RATIO_REJECTED"
+        assert detail["target"] == pytest.approx(9 / 16)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("channel", ["instagram_sandbox"])
+async def test_carousel_image_without_video_uses_carousel_spec_regression_zero(channel):
+    """영상 없는 버전(캐러셀)은 기존 image_aspect_min/max 그대로 — 9:16(0.5625)
+    이미지는 여전히 캐러셀 하한(0.80) 미달로 기존 422 코드가 나야 한다(회귀 0).
+    facebook은 image_aspect_min 자체를 선언 안 해(하한 없음, Threads류 상한-only
+    관례) 이 축의 회귀 대상이 아니다 — instagram(_sandbox)만 해당."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel=channel)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r_image = await _upload_and_confirm(
+                client, org_id, draft_id, _jpeg_bytes(720, 1280), content_type="image/jpeg",
+            )
+        assert r_image.status_code == 422, r_image.text
+        assert r_image.json()["error"]["code"] == "CHANNEL_IMAGE_ASPECT_RATIO_TOO_NARROW"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1391,6 +1391,11 @@
       "file": "tests/test_3569_gate_sealed_doc_fields.py",
       "sec": 27.0,
       "source": "story-3569-gate-sealed-doc-fields(PR 개설 前 선제 등재 — 로컬 raw pytest 4건 4.43s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 27s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3578_cover_aspect_validation_order.py",
+      "sec": 30.0,
+      "source": "story-3578-cover-aspect-validation-order(PR 개설 前 선제 등재 — 로컬 raw pytest 5건 실측 CPU 4.3s(동시 부하로 벽시계는 변동 큼) 기준 CI 배율(~6x, story #3383) 보수적으로 반영한 30s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
- `channel_post_images.py`의 이미지 비율 검증(image_aspect_min=0.80)이 커버/캐러셀 분기(영상 유무)보다 먼저 돌아, 릴스 커버(9:16=0.5625)도 캐러셀 하한(0.80)으로 재져 **어떤 값으로도 커버를 못 올리는** 구조적 결함이었다.
- 처방 — 분기(영상 유무)를 비율 검증보다 먼저 결정한다. 영상이 있으면(=커버 경로) `video_aspect_target±video_aspect_tolerance`(어댑터 선언, 하드코딩 0)로 검증 — 벗어나면 422 `CHANNEL_COVER_ASPECT_RATIO_REJECTED`. 영상이 없으면(캐러셀) 기존 `image_aspect_min`/`max` 그대로(회귀 0).

## 발견 즉시 수정(부수)
이 순서 수정으로 기존 `test_3554_instagram_reels.py` 2건·`test_3567_facebook_page_final.py` 1건이 800×1000(비율 0.8, 캐러셀 하한을 간신히 통과하던 임의값 — 실제로는 유효한 9:16 커버가 아니었음)을 "커버" 픽스처로 쓰고 있었음이 드러났다. 720×1280(정확히 9:16)로 교체 — 이 테스트들의 실제 관심사(교체-not-추가·합성 해시 계산)는 무변.

## 검증
- 테스트 5건(9:16 커버 승인·1:1 커버 거부·캐러셀 무영상 회귀 0, 각 facebook_sandbox/instagram_sandbox) + 뮤테이션 1(분기 순서 원복 → 9:16 커버 거부 재현 확認 후 RED, 복원).
- 회귀 114건(3578/3550/3554/620beefc/3320/3567/authz_coverage) 전체 통과.
- shard-weights 등재·lint 통과.

## rebase 노트
`feat/3567-facebook-page-final`(PR #3925, facebook_sandbox 영상/커버 지원 자체가 그 PR 산출물) 위에서 작업 — #3925가 develop에 스쿼시 머지된 뒤(`f44dae1eb`) `git rebase --onto origin/develop feat/3567-facebook-page-final feat/3578-cover-aspect-validation-order`로 재배치. 충돌 0.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>