### PR TITLE
[SID:3579] fix: test_3574가 #3579 리네임 이전 모듈명을 여전히 import(develop 컬렉션 블로커)

### DIFF
--- a/backend/tests/test_3574_video_requires_single_cover.py
+++ b/backend/tests/test_3574_video_requires_single_cover.py
@@ -7,7 +7,7 @@ image_for_version`, position=0만 대표)가 그대로 커버 캐리에 쓰여 N
 (새 버전 생성) 시작 前 422 `CHANNEL_VIDEO_REQUIRES_SINGLE_COVER`. 0·1장은 현행
 그대로(단수 getter 의미가 정확히 일치하는 구간이라 무변경).
 
-세팅 헬퍼는 test_620beefc_channel_post_image.py(base)·test_3567_facebook_page_
+세팅 헬퍼는 test_620beefc_channel_post_image_upload.py(base)·test_3567_facebook_page_
 final.py(facebook_sandbox 영상 픽스처) 재사용(중복 재발명 금지)."""
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ import uuid
 
 import pytest
 
-from tests.test_620beefc_channel_post_image import (
+from tests.test_620beefc_channel_post_image_upload import (
     _client_for,
     _create_draft,
     _jpeg_bytes,
@@ -85,7 +85,7 @@ def _local_channel_media_storage(monkeypatch, tmp_path):
 
 @pytest.fixture(autouse=True)
 def _local_channel_media_storage_object_path_fix(monkeypatch):
-    import tests.test_620beefc_channel_post_image as base_test_module
+    import tests.test_620beefc_channel_post_image_upload as base_test_module
 
     monkeypatch.setattr(base_test_module, "_CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
     yield


### PR DESCRIPTION
## 요약
develop 자체가 `-m destructive_schema --collect-only`에서 1 error로 즉시 중단되는 상태였다.

## 원인
#3579(60초 가드 2파일 3-way 분할, `a1e8322e2`)가 `test_620beefc_channel_post_image.py`를 `test_620beefc_channel_post_image_upload.py`로 리네임하며 그 시점 의존 파일 전부를 스윕했으나, `#3574`(PR#3932)가 그 사이 별도로 develop에 머지되며 같은 옛 모듈명을 참조하는 `test_3574_video_requires_single_cover.py`가 스윕 대상 밖에 있었다 — develop `e1eaabf06`(#3579의 rebase base) 시점엔 #3574가 아직 없었기 때문(머지 순서 경합, #3579 자체의 리네임 스윕 실수가 아니라 그 뒤 별도 머지와의 경합).

## 처방
`from tests.test_620beefc_channel_post_image import`·`import tests.test_620beefc_channel_post_image as base_test_module` 2곳을 실제 위치(`test_620beefc_channel_post_image_upload`)로 정정.

## 검증
- `git grep`으로 develop 전체(옛 두 모듈명 `test_620beefc_channel_post_image`·`test_3373_channel_connections`, `.py` 확장자 없는 순수 import 형까지) 잔존 참조 **0건** 확認.
- `-m destructive_schema --collect-only` 에러 0(2114건 정상 수집).
- `test_3574_video_requires_single_cover.py` 6건 통과·shard-weights lint 통과.

급 — develop 자체 CI 컬렉션 블로커(뒤이은 모든 PR의 CI가 이 에러에 함께 막힘).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>