### PR TITLE
[SID:3585] feat: MCP sprintable_add_evidence에 payload additive — 검증 시트 갭 해소

### DIFF
--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -15,7 +15,9 @@ name = "sprintable"
 # 영구 고정이라 이 캡을 벗는 유일한 길. private 내부 결합 3곳(fn_metadata.arg_model 조작·
 # _tool_manager 재조회·list_tools 구성시점 바인딩) 전부 2.0.0 실 소스 대조로 등가 확認(스파이크,
 # 순수 rename+import경로 포팅 — 재설계 아님).
-version = "0.2.0"
+# 0.2.1 (2026-09-06, story #3585): sprintable_add_evidence에 payload additive — REST가 이미
+# 받는 구조화 페이로드(예: 검증 시트)가 MCP엔 없어 고객 에이전트가 못 만들던 갭 처방.
+version = "0.2.1"
 description = "Sprintable MCP server — BYO agent toolset over the Sprintable API (stdio). No repo clone required."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -696,7 +696,11 @@ _TOOL_DEFS: list[tuple] = [
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
      " 남김. 선택제(첨부 안 해도 무불이익). 아티팩트를 근거로 삼을 땐 artifact_id를 같이 주면"
      " 그 시각의 버전이 자동 고정된다(그 뒤 아티팩트가 새 버전으로 바뀌어도 이 evidence의"
-     " 근거는 안 흔들림).",
+     " 근거는 안 흔들림). 구조화 페이로드가 필요한 경우(예: 검증 시트) type=\"report\"와"
+     " payload를 같이 준다 — payload 예시: {\"kind\": \"verification_sheet\", \"items\":"
+     " [{\"name\": \"로그인 흐름\", \"verdict\": \"pass\"}, {\"name\": \"결제 흐름\","
+     " \"verdict\": \"fail\", \"note\": \"타임아웃\"}]} (verdict는 pass/fail/n_a 중 하나,"
+     " verified_by/verified_at은 서버가 호출자 정보로 자동 채운다).",
      AddEvidenceInput, add_evidence),
     # 판단 칸 (2) — story #2268(D단계, E-CONNECT)
     ("sprintable_add_judgment",

--- a/backend/sprintable_mcp/tools/evidence.py
+++ b/backend/sprintable_mcp/tools/evidence.py
@@ -20,11 +20,26 @@ class AddEvidenceInput(SprintableInput):
     # 조회해 고정한다(같은 아티팩트가 나중에 새 버전으로 바뀌어도 이 evidence의 근거는
     # 그대로 남는다).
     artifact_id: str | None = None
+    # story #3585(MCP·customer-zero, 페드루 PO 確定 2026-09-06) — REST `POST
+    # /api/v2/evidence`는 이미 받는 구조화 페이로드(예: type="report"+
+    # payload.kind="verification_sheet"+items[{name,verdict,note?}], 서버가
+    # verified_by/verified_at을 강제 — story #3561)가 MCP엔 아예 없어 고객
+    # 에이전트가 검증 시트를 MCP로 못 만들었다(3560/3561 계약의 에이전트 경로가
+    # MCP에선 닫혀 있던 갭, 3573 표본 evidence 0건의 원인). additive — 생략 시
+    # 기존 동작 완전 무변.
+    #
+    # verification_sheet 예시:
+    # {"kind": "verification_sheet", "items": [{"name": "로그인 흐름", "verdict": "pass"}, {"name": "결제 흐름", "verdict": "fail", "note": "타임아웃"}]}
+    payload: dict | None = None
 
 
 async def add_evidence(args: AddEvidenceInput) -> list[TextContent]:
     """done을 스스로 증명하는 자기 서명 첨부(검사지 아님) — story/task에 evidence(PR·배포·지표·
-    발행물 링크 등)를 남긴다. 강제 아닌 선택제(경고나 낙인은 없음, 없으면 현행과 동일)."""
+    발행물 링크 등)를 남긴다. 강제 아닌 선택제(경고나 낙인은 없음, 없으면 현행과 동일).
+
+    story #3585 — `payload`(예: 검증 시트)를 넘기면 REST와 동일하게 서버 검증
+    (`EVIDENCE_PAYLOAD_INVALID` 422 등)을 그대로 통과시킨다(이 함수는 그 검증
+    로직을 복제하지 않는다 — REST가 SSOT)."""
     try:
         payload = {
             "work_item_id": args.work_item_id,
@@ -38,6 +53,8 @@ async def add_evidence(args: AddEvidenceInput) -> list[TextContent]:
             payload["note"] = args.note
         if args.artifact_id is not None:
             payload["artifact_id"] = args.artifact_id
+        if args.payload is not None:
+            payload["payload"] = args.payload
         result = await client.post("/api/v2/evidence", json=payload)
         return ok(result)
     except Exception as exc:

--- a/backend/tests/test_3585_mcp_evidence_payload.py
+++ b/backend/tests/test_3585_mcp_evidence_payload.py
@@ -1,0 +1,101 @@
+"""story #3585(MCP·customer-zero, 페드루 PO 確定 2026-09-06) — MCP `sprintable_add_
+evidence`에 `payload` additive. REST `POST /api/v2/evidence`는 이미 받는 구조화
+페이로드(type="report"+payload.kind="verification_sheet"+items — story #3561)가
+MCP엔 아예 없어 고객 에이전트가 검증 시트를 MCP로 못 만들었다(3573 표본 evidence
+0건의 원인). 이 파일은 그 갭이 닫혔음을 고정한다 — REST 검증 로직은 여기서
+재구현하지 않는다(evidence.py 라우터가 SSOT, 이 MCP 도구는 순수 얇은 래핑).
+
+test_2668_mcp_submit_for_approval.py::test_submit_for_approval_* 패턴과 동형
+(client.post mock, additive 회귀 없음 확認)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_add_evidence_without_payload_sends_request_body_unchanged():
+    """additive 회귀 0 — payload 생략 시 기존 요청 body(payload 키 자체가 없음)가
+    한 글자도 안 바뀐다."""
+    from sprintable_mcp.tools.evidence import AddEvidenceInput, add_evidence
+
+    with patch("sprintable_mcp.tools.evidence.client") as mock_client:
+        mock_client.post = AsyncMock(return_value={"id": "ev-1"})
+        await add_evidence(AddEvidenceInput(
+            work_item_id="story-1", work_item_type="story", type="pr", ref="https://github.com/x/y/pull/1",
+        ))
+
+    mock_client.post.assert_awaited_once_with(
+        "/api/v2/evidence",
+        json={"work_item_id": "story-1", "work_item_type": "story", "type": "pr", "ref": "https://github.com/x/y/pull/1"},
+    )
+
+
+@pytest.mark.anyio
+async def test_add_evidence_with_verification_sheet_payload_forwards_to_rest():
+    """PO 確定 본체 — payload를 넘기면 REST body에 그대로 실린다(변형·재구현 0)."""
+    from sprintable_mcp.tools.evidence import AddEvidenceInput, add_evidence
+
+    sheet = {"kind": "verification_sheet", "items": [{"name": "로그인 흐름", "verdict": "pass"}]}
+    with patch("sprintable_mcp.tools.evidence.client") as mock_client:
+        mock_client.post = AsyncMock(return_value={"id": "ev-2", "payload": sheet})
+        out = await add_evidence(AddEvidenceInput(
+            work_item_id="story-1", work_item_type="story", type="report", ref="검증 시트", payload=sheet,
+        ))
+
+    mock_client.post.assert_awaited_once_with(
+        "/api/v2/evidence",
+        json={
+            "work_item_id": "story-1", "work_item_type": "story", "type": "report", "ref": "검증 시트",
+            "payload": sheet,
+        },
+    )
+    parsed = json.loads(out[0].text)
+    assert parsed["payload"] == sheet
+
+
+@pytest.mark.anyio
+async def test_add_evidence_payload_with_other_optional_fields_all_forwarded():
+    """payload가 source/note/artifact_id와 동시에 와도 전부 유지(상호배타 0)."""
+    from sprintable_mcp.tools.evidence import AddEvidenceInput, add_evidence
+
+    sheet = {"kind": "verification_sheet", "items": [{"name": "x", "verdict": "n_a"}]}
+    with patch("sprintable_mcp.tools.evidence.client") as mock_client:
+        mock_client.post = AsyncMock(return_value={"id": "ev-3"})
+        await add_evidence(AddEvidenceInput(
+            work_item_id="task-1", work_item_type="task", type="report", ref="검증",
+            source="agent", note="비고", artifact_id="artifact-1", payload=sheet,
+        ))
+
+    mock_client.post.assert_awaited_once_with(
+        "/api/v2/evidence",
+        json={
+            "work_item_id": "task-1", "work_item_type": "task", "type": "report", "ref": "검증",
+            "source": "agent", "note": "비고", "artifact_id": "artifact-1", "payload": sheet,
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_add_evidence_payload_validation_error_surfaces_as_err_not_crash():
+    """REST의 EVIDENCE_PAYLOAD_INVALID(422) 등 서버 검증 실패가 이 도구를
+    크래시시키지 않고 Error: 접두 텍스트로 정직하게 보고된다(REST가 SSOT —
+    이 함수가 검증을 재구현/선점하지 않는다는 증거)."""
+    from sprintable_mcp.tools.evidence import AddEvidenceInput, add_evidence
+
+    with patch("sprintable_mcp.tools.evidence.client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=RuntimeError("HTTP 422: EVIDENCE_PAYLOAD_INVALID"))
+        out = await add_evidence(AddEvidenceInput(
+            work_item_id="story-1", work_item_type="story", type="report", ref="x",
+            payload={"kind": "verification_sheet", "items": "not-a-list"},
+        ))
+
+    assert out[0].text.startswith("Error:")
+    assert "EVIDENCE_PAYLOAD_INVALID" in out[0].text


### PR DESCRIPTION
## 요약
REST `POST /api/v2/evidence`는 이미 받는 구조화 페이로드(type="report"+payload.kind="verification_sheet"+items — story #3561)가 MCP `sprintable_add_evidence`엔 아예 없어, MCP로 붙는 고객 에이전트(customer-zero fleet)가 검증 시트 evidence를 못 만들었다 — 3573 표본의 검증 시트 evidence 0건 원인.

## 처방
- `AddEvidenceInput`에 `payload: dict | None = None` additive(생략 시 기존 요청 body 완전 무변).
- 값이 있으면 REST body에 그대로 전달 — 이 함수는 검증을 재구현하지 않는다(evidence.py 라우터가 SSOT, 422 `EVIDENCE_PAYLOAD_INVALID` 등은 그대로 통과).
- 도구 설명(server.py)에 verification_sheet 예시 1개 추가.
- pyproject.toml 버전 0.2.0→0.2.1(hosted MCP·PyPI `sprintable` 패키지 동시 배포 대상).

## 검증
- 테스트 4건(payload 생략 시 body 무변·payload 전달·다른 선택필드와 동시 사용·서버 검증 실패가 크래시 아닌 `Error:` 텍스트로 보고) + 뮤테이션 1(payload 전달 라인 제거 → 2건 RED 확認 후 복원).
- 기존 MCP 도구 테스트 23건 회귀 통과.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>