### PR TITLE
[SID:3584] fix: 컨셉 카드 데이터 소스 = backlinks doc ∪ 게이트 sealed_doc

### DIFF
--- a/apps/web/src/components/kanban/concept-card-section.test.tsx
+++ b/apps/web/src/components/kanban/concept-card-section.test.tsx
@@ -47,9 +47,9 @@ describe('ConceptCardSection — story #3560 ①-c · #3584 데이터 소스 확
 
   type StubGate = { gate_type: string; sealed_doc_id?: string | null; sealed_doc_title?: string | null };
 
-  async function mount(gates: StubGate[] = []) {
+  async function mount(gates: StubGate[] = [], gatesLoaded = true) {
     await act(async () => {
-      root.render(wrap(<ConceptCardSection workItemId="s1" gates={gates} />));
+      root.render(wrap(<ConceptCardSection workItemId="s1" gates={gates} gatesLoaded={gatesLoaded} />));
     });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
   }
@@ -105,5 +105,22 @@ describe('ConceptCardSection — story #3560 ①-c · #3584 데이터 소스 확
     stubBacklinksFetch([]);
     await mount([{ gate_type: 'concept_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: null }]);
     expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
+  });
+
+  // PR#3938 비차단(유나 그라운딩·PO 確定 2026-09-06) — chipGates 초기값이 []라
+  // gatesLoaded 없이는 "로딩 중"과 "게이트 0건"을 못 가른다. 게이트에만 doc이 있는
+  // 스토리(3573류)에서 gatesLoaded=false면 아직 판정을 보류해야 한다.
+  it('⭐gatesLoaded가 false면(게이트 아직 로딩 중) 게이트 doc이 있어도 판정을 보류한다', async () => {
+    stubBacklinksFetch([]);
+    await mount([{ gate_type: 'concept_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: '컨셉 v3' }], false);
+    expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
+  });
+
+  it('gatesLoaded가 true가 되면 그제서야 게이트 doc이 뜬다', async () => {
+    stubBacklinksFetch([]);
+    await mount([{ gate_type: 'concept_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: '컨셉 v3' }], true);
+    const section = container.querySelector('[data-testid="concept-card-section"]');
+    expect(section).not.toBeNull();
+    expect(section?.textContent).toContain('컨셉 v3');
   });
 });

--- a/apps/web/src/components/kanban/concept-card-section.test.tsx
+++ b/apps/web/src/components/kanban/concept-card-section.test.tsx
@@ -21,20 +21,11 @@ function wrap(node: React.ReactNode) {
 //
 // story #3584(페드루 PO 確定 2026-09-06, 3573 라이브 표본 GET에서 발견) — 데이터
 // 소스가 backlinks doc ∪ concept_approval 게이트의 sealed_doc_id/sealed_doc_title로
-// 넓어져 두 엔드포인트(`/backlinks`·`/gates`)를 URL별로 갈라 스텁한다.
-function stubFetch(opts: {
-  backlinks?: { id: string; source_type: string; doc: { id: string; title: string } | null }[];
-  gates?: { gate_type: string; sealed_doc_id?: string | null; sealed_doc_title?: string | null }[];
-}) {
-  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-    if (url.includes('/backlinks')) {
-      return new Response(JSON.stringify({ data: opts.backlinks ?? [] }), { status: 200 });
-    }
-    if (url.includes('/gates')) {
-      return new Response(JSON.stringify(opts.gates ?? []), { status: 200 });
-    }
-    return new Response(JSON.stringify({ data: null }), { status: 404 });
-  }));
+// 넓어졌다. gates는 이 컴포넌트가 직접 fetch하지 않고 부모(story-detail-panel의
+// chipGates)가 이미 받아 둔 값을 prop으로 받는다("새 fetch 0", PO 確定) — 그래서
+// backlinks만 fetch로 스텁하고 gates는 props로 직접 넘긴다.
+function stubBacklinksFetch(backlinks: { id: string; source_type: string; doc: { id: string; title: string } | null }[]) {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ data: backlinks }), { status: 200 })));
 }
 
 describe('ConceptCardSection — story #3560 ①-c · #3584 데이터 소스 확장', () => {
@@ -54,31 +45,30 @@ describe('ConceptCardSection — story #3560 ①-c · #3584 데이터 소스 확
     vi.restoreAllMocks();
   });
 
-  async function mount() {
+  type StubGate = { gate_type: string; sealed_doc_id?: string | null; sealed_doc_title?: string | null };
+
+  async function mount(gates: StubGate[] = []) {
     await act(async () => {
-      root.render(wrap(<ConceptCardSection workItemId="s1" />));
+      root.render(wrap(<ConceptCardSection workItemId="s1" gates={gates} />));
     });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
   }
 
   it('참조 doc이 0건이면 블록 자체를 그리지 않는다(「없음」 문구 없음)', async () => {
-    stubFetch({ backlinks: [], gates: [] });
-    await mount();
+    stubBacklinksFetch([]);
+    await mount([]);
     expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
   });
 
   it('doc 아닌 backlink(chat_message 등)만 있으면 여전히 안 그린다(doc만 거른다)', async () => {
-    stubFetch({ backlinks: [{ id: 'bl-1', source_type: 'chat_message', doc: null }], gates: [] });
-    await mount();
+    stubBacklinksFetch([{ id: 'bl-1', source_type: 'chat_message', doc: null }]);
+    await mount([]);
     expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
   });
 
   it('참조 doc이 있으면 블록이 뜨고 doc 제목이 보인다', async () => {
-    stubFetch({
-      backlinks: [{ id: 'bl-1', source_type: 'doc', doc: { id: 'doc-1', title: '9월 릴스 컨셉안' } }],
-      gates: [],
-    });
-    await mount();
+    stubBacklinksFetch([{ id: 'bl-1', source_type: 'doc', doc: { id: 'doc-1', title: '9월 릴스 컨셉안' } }]);
+    await mount([]);
     const section = container.querySelector('[data-testid="concept-card-section"]');
     expect(section).not.toBeNull();
     expect(section?.textContent).toContain('9월 릴스 컨셉안');
@@ -88,33 +78,32 @@ describe('ConceptCardSection — story #3560 ①-c · #3584 데이터 소스 확
   // story #3584 — 3573 표본이 실제로 이 모양이었다: backlinks 0건인데 concept_approval
   // 게이트가 sealed_doc_id/title을 물고 있는 경우.
   it('⭐backlinks가 0건이어도 concept_approval 게이트의 sealed_doc가 있으면 블록이 뜬다', async () => {
-    stubFetch({
-      backlinks: [],
-      gates: [{ gate_type: 'concept_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: '컨셉 v3' }],
-    });
-    await mount();
+    stubBacklinksFetch([]);
+    await mount([{ gate_type: 'concept_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: '컨셉 v3' }]);
     const section = container.querySelector('[data-testid="concept-card-section"]');
     expect(section).not.toBeNull();
     expect(section?.textContent).toContain('컨셉 v3');
   });
 
   it('concept_approval이 아닌 다른 게이트 타입의 sealed_doc는 무시한다', async () => {
-    stubFetch({
-      backlinks: [],
-      gates: [{ gate_type: 'structure_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: '구조안' }],
-    });
-    await mount();
+    stubBacklinksFetch([]);
+    await mount([{ gate_type: 'structure_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: '구조안' }]);
     expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
   });
 
   it('⭐같은 doc이 backlinks·게이트 둘 다에 잡히면 중복 제거돼 한 번만 뜬다', async () => {
-    stubFetch({
-      backlinks: [{ id: 'bl-1', source_type: 'doc', doc: { id: 'doc-shared', title: '공유 컨셉안' } }],
-      gates: [{ gate_type: 'concept_approval', sealed_doc_id: 'doc-shared', sealed_doc_title: '공유 컨셉안' }],
-    });
-    await mount();
+    stubBacklinksFetch([{ id: 'bl-1', source_type: 'doc', doc: { id: 'doc-shared', title: '공유 컨셉안' } }]);
+    await mount([{ gate_type: 'concept_approval', sealed_doc_id: 'doc-shared', sealed_doc_title: '공유 컨셉안' }]);
     const section = container.querySelector('[data-testid="concept-card-section"]');
     const items = section?.querySelectorAll('li') ?? [];
     expect(items.length).toBe(1);
+  });
+
+  // PO 지적(§17-21 ①, PR#3938 CONDITIONAL) — sealed_doc_title이 null이면 sealed_doc_id
+  // 앞 8자(hex)를 대신 그리지 않는다. title 없는 항목은 통째로 뺀다.
+  it('sealed_doc_title이 null이면 그 항목을 안 그린다(hex id를 낱말 대신 안 씀)', async () => {
+    stubBacklinksFetch([]);
+    await mount([{ gate_type: 'concept_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: null }]);
+    expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
   });
 });

--- a/apps/web/src/components/kanban/concept-card-section.test.tsx
+++ b/apps/web/src/components/kanban/concept-card-section.test.tsx
@@ -18,7 +18,26 @@ function wrap(node: React.ReactNode) {
 
 // story #3560(제작 작업대 컨셉 카드, 페드루 PO 確定 2026-09-06) — 참조 doc이 있을 때만
 // 그린다(「없음」 문구 X — 블록 자체를 안 그리는 쪽).
-describe('ConceptCardSection — story #3560 ①-c', () => {
+//
+// story #3584(페드루 PO 確定 2026-09-06, 3573 라이브 표본 GET에서 발견) — 데이터
+// 소스가 backlinks doc ∪ concept_approval 게이트의 sealed_doc_id/sealed_doc_title로
+// 넓어져 두 엔드포인트(`/backlinks`·`/gates`)를 URL별로 갈라 스텁한다.
+function stubFetch(opts: {
+  backlinks?: { id: string; source_type: string; doc: { id: string; title: string } | null }[];
+  gates?: { gate_type: string; sealed_doc_id?: string | null; sealed_doc_title?: string | null }[];
+}) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.includes('/backlinks')) {
+      return new Response(JSON.stringify({ data: opts.backlinks ?? [] }), { status: 200 });
+    }
+    if (url.includes('/gates')) {
+      return new Response(JSON.stringify(opts.gates ?? []), { status: 200 });
+    }
+    return new Response(JSON.stringify({ data: null }), { status: 404 });
+  }));
+}
+
+describe('ConceptCardSection — story #3560 ①-c · #3584 데이터 소스 확장', () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -35,40 +54,67 @@ describe('ConceptCardSection — story #3560 ①-c', () => {
     vi.restoreAllMocks();
   });
 
-  it('참조 doc이 0건이면 블록 자체를 그리지 않는다(「없음」 문구 없음)', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ data: [] }), { status: 200 })));
+  async function mount() {
     await act(async () => {
       root.render(wrap(<ConceptCardSection workItemId="s1" />));
     });
-    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+  }
+
+  it('참조 doc이 0건이면 블록 자체를 그리지 않는다(「없음」 문구 없음)', async () => {
+    stubFetch({ backlinks: [], gates: [] });
+    await mount();
     expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
   });
 
   it('doc 아닌 backlink(chat_message 등)만 있으면 여전히 안 그린다(doc만 거른다)', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
-      data: [{ id: 'bl-1', source_type: 'chat_message', source_id: 'msg-1', relation: 'none', still_exists: true, doc: null }],
-    }), { status: 200 })));
-    await act(async () => {
-      root.render(wrap(<ConceptCardSection workItemId="s1" />));
-    });
-    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    stubFetch({ backlinks: [{ id: 'bl-1', source_type: 'chat_message', doc: null }], gates: [] });
+    await mount();
     expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
   });
 
   it('참조 doc이 있으면 블록이 뜨고 doc 제목이 보인다', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
-      data: [{
-        id: 'bl-1', source_type: 'doc', source_id: 'doc-1', relation: 'none', still_exists: true,
-        doc: { id: 'doc-1', title: '9월 릴스 컨셉안' },
-      }],
-    }), { status: 200 })));
-    await act(async () => {
-      root.render(wrap(<ConceptCardSection workItemId="s1" />));
+    stubFetch({
+      backlinks: [{ id: 'bl-1', source_type: 'doc', doc: { id: 'doc-1', title: '9월 릴스 컨셉안' } }],
+      gates: [],
     });
-    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    await mount();
     const section = container.querySelector('[data-testid="concept-card-section"]');
     expect(section).not.toBeNull();
     expect(section?.textContent).toContain('9월 릴스 컨셉안');
     expect(section?.textContent).toContain(koMessages.board.conceptCardTitle);
+  });
+
+  // story #3584 — 3573 표본이 실제로 이 모양이었다: backlinks 0건인데 concept_approval
+  // 게이트가 sealed_doc_id/title을 물고 있는 경우.
+  it('⭐backlinks가 0건이어도 concept_approval 게이트의 sealed_doc가 있으면 블록이 뜬다', async () => {
+    stubFetch({
+      backlinks: [],
+      gates: [{ gate_type: 'concept_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: '컨셉 v3' }],
+    });
+    await mount();
+    const section = container.querySelector('[data-testid="concept-card-section"]');
+    expect(section).not.toBeNull();
+    expect(section?.textContent).toContain('컨셉 v3');
+  });
+
+  it('concept_approval이 아닌 다른 게이트 타입의 sealed_doc는 무시한다', async () => {
+    stubFetch({
+      backlinks: [],
+      gates: [{ gate_type: 'structure_approval', sealed_doc_id: 'doc-g1', sealed_doc_title: '구조안' }],
+    });
+    await mount();
+    expect(container.querySelector('[data-testid="concept-card-section"]')).toBeNull();
+  });
+
+  it('⭐같은 doc이 backlinks·게이트 둘 다에 잡히면 중복 제거돼 한 번만 뜬다', async () => {
+    stubFetch({
+      backlinks: [{ id: 'bl-1', source_type: 'doc', doc: { id: 'doc-shared', title: '공유 컨셉안' } }],
+      gates: [{ gate_type: 'concept_approval', sealed_doc_id: 'doc-shared', sealed_doc_title: '공유 컨셉안' }],
+    });
+    await mount();
+    const section = container.querySelector('[data-testid="concept-card-section"]');
+    const items = section?.querySelectorAll('li') ?? [];
+    expect(items.length).toBe(1);
   });
 });

--- a/apps/web/src/components/kanban/concept-card-section.tsx
+++ b/apps/web/src/components/kanban/concept-card-section.tsx
@@ -14,35 +14,82 @@ import type { BacklinkItem } from '@/components/shared/entity-backlinks-section'
 // 시트(EvidenceSection)와 자리를 안 섞는다. 참조 doc이 있을 때만 그린다(§5-2 "없는
 // 길을 그리지 않는다"의 반대축 — 여기서는 "없음"을 문구로 말하지 않고 블록 자체를
 // 안 그리는 쪽, 유나 §17-24 확定).
+//
+// story #3584(페드루 PO 確定 2026-09-06, 3573 라이브 표본 GET에서 발견) — 3573
+// 표본이 실제로 드러낸 갭: concept_approval 게이트로 승인되는 doc은 본문에 스토리를
+// «멘션»하지 않는 한 backlinks에 0건으로 남는다(게이트의 neutral_facts.doc_title/
+// sealed_doc_id 경로로만 연결되지, 텍스트 참조 관계가 아니다). 그래서 데이터 소스를
+// backlinks doc ∪ 이 work item의 concept_approval 게이트가 물고 있는 sealed_doc_id/
+// sealed_doc_title(story #3569 additive)로 넓힌다 — 같은 doc이 두 경로 다로 잡히면
+// id로 중복 제거. 표시 조건은 그대로(합집합이 0건이면 블록 자체를 안 그린다).
+interface ConceptCardDoc {
+  id: string;
+  title: string;
+}
+
+// #3560 GateItem(kanban/types.ts) 전체를 안 끌어오고 이 블록이 실제로 쓰는 필드만—
+// gates 응답이 raw 배열(래핑 없음, story-detail-panel.tsx::chipGates와 동형 관례).
+interface GateSealedDocItem {
+  gate_type: string;
+  sealed_doc_id?: string | null;
+  sealed_doc_title?: string | null;
+}
+
 export function ConceptCardSection({ workItemId }: { workItemId: string }) {
   const t = useTranslations('board');
-  const [items, setItems] = useState<BacklinkItem[] | null>(null);
+  const [backlinkItems, setBacklinkItems] = useState<BacklinkItem[] | null>(null);
+  const [gates, setGates] = useState<GateSealedDocItem[] | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     fetchWithAuth(`/api/stories/${workItemId}/backlinks`, { cache: 'no-store' })
       .then((r) => (r.ok ? (r.json() as Promise<{ data?: BacklinkItem[] }>) : null))
-      .then((json) => { if (!cancelled) setItems(json?.data ?? []); })
-      .catch(() => { if (!cancelled) setItems([]); });
+      .then((json) => { if (!cancelled) setBacklinkItems(json?.data ?? []); })
+      .catch(() => { if (!cancelled) setBacklinkItems([]); });
     return () => { cancelled = true; };
   }, [workItemId]);
 
-  const docItems = (items ?? []).filter((item) => item.source_type === 'doc' && item.doc);
-  if (docItems.length === 0) return null;
+  useEffect(() => {
+    let cancelled = false;
+    fetchWithAuth(`/api/gates?work_item_id=${workItemId}&work_item_type=story`, { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((json) => { if (!cancelled) setGates(Array.isArray(json) ? json : []); })
+      .catch(() => { if (!cancelled) setGates([]); });
+    return () => { cancelled = true; };
+  }, [workItemId]);
+
+  // 둘 다 도착하기 전엔 판정하지 않는다(한쪽만 보고 "없다"로 단정하면 늦게 오는
+  // 쪽의 doc이 있어도 블록이 먼저 접혀 안 뜬다 — §5-2 "모른다≠없다"와 같은 결).
+  if (backlinkItems === null || gates === null) return null;
+
+  const backlinkDocs: ConceptCardDoc[] = backlinkItems
+    .filter((item) => item.source_type === 'doc' && item.doc)
+    .map((item) => ({ id: item.doc!.id, title: item.doc!.title }));
+  const gateDocs: ConceptCardDoc[] = gates
+    .filter((g) => g.gate_type === 'concept_approval' && g.sealed_doc_id)
+    .map((g) => ({ id: g.sealed_doc_id!, title: g.sealed_doc_title ?? g.sealed_doc_id!.slice(0, 8) }));
+
+  const seen = new Set<string>();
+  const docs: ConceptCardDoc[] = [...backlinkDocs, ...gateDocs].filter((d) => {
+    if (seen.has(d.id)) return false;
+    seen.add(d.id);
+    return true;
+  });
+  if (docs.length === 0) return null;
 
   return (
     <div className="border-t border-border/60 px-4 py-3" data-testid="concept-card-section">
       <p className="mb-2 text-xs font-medium text-muted-foreground">{t('conceptCardTitle')}</p>
       <ul className="flex flex-col gap-1.5">
-        {docItems.map((item) => {
-          const href = getEntityHref('doc', item.doc!.id);
+        {docs.map((doc) => {
+          const href = getEntityHref('doc', doc.id);
           return (
-            <li key={item.id} className="flex items-start gap-2 text-xs text-foreground">
+            <li key={doc.id} className="flex items-start gap-2 text-xs text-foreground">
               <FileText className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
               {href ? (
-                <a href={href} className="[overflow-wrap:anywhere] hover:underline">{item.doc!.title}</a>
+                <a href={href} className="[overflow-wrap:anywhere] hover:underline">{doc.title}</a>
               ) : (
-                <span className="[overflow-wrap:anywhere]">{item.doc!.title}</span>
+                <span className="[overflow-wrap:anywhere]">{doc.title}</span>
               )}
             </li>
           );

--- a/apps/web/src/components/kanban/concept-card-section.tsx
+++ b/apps/web/src/components/kanban/concept-card-section.tsx
@@ -22,23 +22,25 @@ import type { BacklinkItem } from '@/components/shared/entity-backlinks-section'
 // backlinks doc ∪ 이 work item의 concept_approval 게이트가 물고 있는 sealed_doc_id/
 // sealed_doc_title(story #3569 additive)로 넓힌다 — 같은 doc이 두 경로 다로 잡히면
 // id로 중복 제거. 표시 조건은 그대로(합집합이 0건이면 블록 자체를 안 그린다).
+//
+// gates는 story-detail-panel.tsx가 이미 fetch해 둔 chipGates를 그대로 prop으로
+// 받는다(PO 確定 — "새 fetch 0이 이상", 게이트 목록은 상세 패널이 P0-04 in-flight
+// 칩용으로 이미 물어보는 데이터라 이 블록이 또 부르면 같은 것을 두 번 묻는 셈).
 interface ConceptCardDoc {
   id: string;
   title: string;
 }
 
-// #3560 GateItem(kanban/types.ts) 전체를 안 끌어오고 이 블록이 실제로 쓰는 필드만—
-// gates 응답이 raw 배열(래핑 없음, story-detail-panel.tsx::chipGates와 동형 관례).
+// #3560 GateItem(kanban/types.ts) 전체를 안 끌어오고 이 블록이 실제로 쓰는 필드만.
 interface GateSealedDocItem {
   gate_type: string;
   sealed_doc_id?: string | null;
   sealed_doc_title?: string | null;
 }
 
-export function ConceptCardSection({ workItemId }: { workItemId: string }) {
+export function ConceptCardSection({ workItemId, gates }: { workItemId: string; gates: GateSealedDocItem[] }) {
   const t = useTranslations('board');
   const [backlinkItems, setBacklinkItems] = useState<BacklinkItem[] | null>(null);
-  const [gates, setGates] = useState<GateSealedDocItem[] | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -49,25 +51,20 @@ export function ConceptCardSection({ workItemId }: { workItemId: string }) {
     return () => { cancelled = true; };
   }, [workItemId]);
 
-  useEffect(() => {
-    let cancelled = false;
-    fetchWithAuth(`/api/gates?work_item_id=${workItemId}&work_item_type=story`, { cache: 'no-store' })
-      .then((r) => (r.ok ? r.json() : []))
-      .then((json) => { if (!cancelled) setGates(Array.isArray(json) ? json : []); })
-      .catch(() => { if (!cancelled) setGates([]); });
-    return () => { cancelled = true; };
-  }, [workItemId]);
-
-  // 둘 다 도착하기 전엔 판정하지 않는다(한쪽만 보고 "없다"로 단정하면 늦게 오는
-  // 쪽의 doc이 있어도 블록이 먼저 접혀 안 뜬다 — §5-2 "모른다≠없다"와 같은 결).
-  if (backlinkItems === null || gates === null) return null;
+  // backlinks가 도착하기 전엔 판정하지 않는다(늦게 오는 doc이 있어도 블록이 먼저
+  // 접혀 안 뜨는 것을 막는다 — §5-2 "모른다≠없다"와 같은 결). gates는 부모가 이미
+  // 로드를 끝낸 값을 그대로 받으므로 여기선 null 게이팅이 필요 없다.
+  if (backlinkItems === null) return null;
 
   const backlinkDocs: ConceptCardDoc[] = backlinkItems
     .filter((item) => item.source_type === 'doc' && item.doc)
     .map((item) => ({ id: item.doc!.id, title: item.doc!.title }));
+  // PO 지적(§17-21 ①, 2026-09-06 PR#3938 CONDITIONAL) — sealed_doc_title이 없다고
+  // sealed_doc_id 앞 8자(hex)를 링크 글자로 대신 그리지 않는다(사람이 읽을 낱말이
+  // 아니다). title이 없으면 그 항목 자체를 뺀다.
   const gateDocs: ConceptCardDoc[] = gates
-    .filter((g) => g.gate_type === 'concept_approval' && g.sealed_doc_id)
-    .map((g) => ({ id: g.sealed_doc_id!, title: g.sealed_doc_title ?? g.sealed_doc_id!.slice(0, 8) }));
+    .filter((g) => g.gate_type === 'concept_approval' && g.sealed_doc_id && g.sealed_doc_title)
+    .map((g) => ({ id: g.sealed_doc_id!, title: g.sealed_doc_title! }));
 
   const seen = new Set<string>();
   const docs: ConceptCardDoc[] = [...backlinkDocs, ...gateDocs].filter((d) => {

--- a/apps/web/src/components/kanban/concept-card-section.tsx
+++ b/apps/web/src/components/kanban/concept-card-section.tsx
@@ -26,6 +26,10 @@ import type { BacklinkItem } from '@/components/shared/entity-backlinks-section'
 // gates는 story-detail-panel.tsx가 이미 fetch해 둔 chipGates를 그대로 prop으로
 // 받는다(PO 確定 — "새 fetch 0이 이상", 게이트 목록은 상세 패널이 P0-04 in-flight
 // 칩용으로 이미 물어보는 데이터라 이 블록이 또 부르면 같은 것을 두 번 묻는 셈).
+// gatesLoaded는 그 fetch가 끝났는지(성공이든 실패든)를 나타낸다 — chipGates의 초기값이
+// `[]`라 값만으로는 "로딩 중"과 "게이트 0건"을 못 가른다(유나 그라운딩, PR#3938 비차단,
+// 2026-09-06) — 게이트 쪽에만 doc이 있는 스토리(3573류)에서 이 구분이 없으면 backlinks가
+// 늦게 와도 초기 렌더에서 "게이트엔 없다"로 잘못 접힐 수 있다.
 interface ConceptCardDoc {
   id: string;
   title: string;
@@ -38,7 +42,13 @@ interface GateSealedDocItem {
   sealed_doc_title?: string | null;
 }
 
-export function ConceptCardSection({ workItemId, gates }: { workItemId: string; gates: GateSealedDocItem[] }) {
+export function ConceptCardSection({
+  workItemId, gates, gatesLoaded,
+}: {
+  workItemId: string;
+  gates: GateSealedDocItem[];
+  gatesLoaded: boolean;
+}) {
   const t = useTranslations('board');
   const [backlinkItems, setBacklinkItems] = useState<BacklinkItem[] | null>(null);
 
@@ -51,10 +61,11 @@ export function ConceptCardSection({ workItemId, gates }: { workItemId: string; 
     return () => { cancelled = true; };
   }, [workItemId]);
 
-  // backlinks가 도착하기 전엔 판정하지 않는다(늦게 오는 doc이 있어도 블록이 먼저
-  // 접혀 안 뜨는 것을 막는다 — §5-2 "모른다≠없다"와 같은 결). gates는 부모가 이미
-  // 로드를 끝낸 값을 그대로 받으므로 여기선 null 게이팅이 필요 없다.
-  if (backlinkItems === null) return null;
+  // backlinks·gates 둘 다 도착하기 전엔 판정하지 않는다(늦게 오는 doc이 있어도
+  // 블록이 먼저 접혀 안 뜨는 것을 막는다 — §5-2 "모른다≠없다"와 같은 결). gates
+  // 자체는 부모가 로드하지만 그 fetch가 끝났는지는 gatesLoaded로 따로 받는다
+  // (chipGates 초기값 []가 "로딩 중"과 "0건"을 못 갈라서다, PR#3938 비차단).
+  if (backlinkItems === null || !gatesLoaded) return null;
 
   const backlinkDocs: ConceptCardDoc[] = backlinkItems
     .filter((item) => item.source_type === 'doc' && item.doc)

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1583,8 +1583,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
             {/* story #3560(제작 작업대 컨셉 카드, 페드루 PO 確定 2026-09-06) — 「이것을
                 가리키는 것들」(아래)과 같은 API를 재사용하되 doc만 걸러 별 블록 —
-                컨셉 승인이 무엇을 승인하는지 검증 시트보다 먼저 보인다. */}
-            <ConceptCardSection workItemId={story.id} />
+                컨셉 승인이 무엇을 승인하는지 검증 시트보다 먼저 보인다.
+                story #3584 — gates는 새로 안 부르고 위(P0-04 in-flight 칩)가 이미
+                fetch한 chipGates를 그대로 넘긴다("새 fetch 0", PO 確定). */}
+            <ConceptCardSection workItemId={story.id} gates={chipGates} />
 
             {/* story #2299(E-CONNECT): 이것을 가리키는 것들 — doc/chat_message 참조 목록 첫 자리
                 (doc [slug]/view는 후속 판). */}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -814,12 +814,18 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   }, [story.id, orgSyncVersion]);
 
   // P0-04 in-flight 신뢰 칩 — StoryMergeGate와 동형 데이터소스(work_item_id 필터, BE 추가 0).
+  // story #3584 CHANGES(유나 그라운딩·PO 確定 2026-09-06, PR#3938 비차단) — chipGates
+  // 초기값이 `[]`라 "로딩 중"과 "게이트 0건"을 값만으로 구분 못 한다. 게이트에만 doc이
+  // 있는 스토리(3573류)에서 ConceptCardSection이 이 로딩 중 `[]`를 "게이트 쪽엔 없다"로
+  // 오판하면 backlinks가 늦게 와도 이미 블록을 접어 버릴 수 있어 gatesLoaded로 분리한다.
+  const [gatesLoaded, setGatesLoaded] = useState(false);
   useEffect(() => {
     let cancelled = false;
     fetchWithAuth(`/api/gates?work_item_id=${story.id}&work_item_type=story`, { cache: 'no-store' })
       .then((r) => (r.ok ? r.json() : []))
       .then((gates) => { if (!cancelled) setChipGates(Array.isArray(gates) ? gates : []); })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setGatesLoaded(true); });
     return () => { cancelled = true; };
   }, [story.id, orgSyncVersion]);
 
@@ -1585,8 +1591,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 가리키는 것들」(아래)과 같은 API를 재사용하되 doc만 걸러 별 블록 —
                 컨셉 승인이 무엇을 승인하는지 검증 시트보다 먼저 보인다.
                 story #3584 — gates는 새로 안 부르고 위(P0-04 in-flight 칩)가 이미
-                fetch한 chipGates를 그대로 넘긴다("새 fetch 0", PO 確定). */}
-            <ConceptCardSection workItemId={story.id} gates={chipGates} />
+                fetch한 chipGates를 그대로 넘긴다("새 fetch 0", PO 確定).
+                gatesLoaded도 같이 내려 backlinks·gates 둘 다 도착 前엔 판정을
+                보류한다(§3584 CHANGES — chipGates 초기값 []가 "로딩 중"과 "0건"을
+                못 가른다). */}
+            <ConceptCardSection workItemId={story.id} gates={chipGates} gatesLoaded={gatesLoaded} />
 
             {/* story #2299(E-CONNECT): 이것을 가리키는 것들 — doc/chat_message 참조 목록 첫 자리
                 (doc [slug]/view는 후속 판). */}


### PR DESCRIPTION
## 배경
3573 라이브 표본 GET 확認(PO 지시, 2026-09-06)에서 발견 — concept_approval 게이트로 승인되는 doc은 본문에 스토리를 멘션하지 않는 한 `/backlinks`에 0건으로 남는다(게이트의 `neutral_facts.doc_title`/`sealed_doc_id` 경로로만 연결되지, 텍스트 참조 관계가 아니다). #3560의 (c) 「컨셉 카드」 블록이 이 표본으로는 빈 채 뜬다는 것을 실측으로 확認했다.

## 구현
`ConceptCardSection`의 데이터 소스를 backlinks doc(`source_type==='doc'`) **∪** 이 work item의 `concept_approval` 게이트가 물고 있는 `sealed_doc_id`/`sealed_doc_title`(story #3569 additive 필드)로 넓힌다. id로 중복 제거, 표시 조건은 그대로(합집합이 0건이면 블록 자체를 안 그린다).

BE #3569(GateResponse에 `sealed_doc_*` 추가)는 아직 미착지 — 계약값으로 구조·테스트를 먼저 짓는다.

## 테스트
6개(기존 회귀 3 그대로 + 게이트만 있는 경우 + concept_approval 아닌 타입 필터 + 중복 제거). 뮤테이션 1(RED 확認 후 복원).

## 검증
tsc 0·eslint 0·vitest 6529·hanja 0·phrase-collision 신규 0.

## 머지 순서
BE #3569 PR 착지 뒤(현재는 GateResponse에 sealed_doc_* 필드 자체가 없어 이 경로는 실질적으로 backlinks-only와 동작 동일).