### PR TITLE
[SID:3571] feat: Facebook Page 채널 동형 완성 — 댓글 조회·새로고침·승인 답변 + 인사이트 1일·7일 스냅샷 + facebook_sandbox 미러

### DIFF
--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -250,8 +250,11 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         authorize_url="https://www.facebook.com/v21.0/dialog/oauth",
         token_url="https://graph.facebook.com/v21.0/oauth/access_token",
         # pages_show_list=/me/accounts 목록 조회 · pages_manage_posts=피드 발행/삭제
-        # · pages_read_engagement=페이지 permalink류 읽기(⚠️미확認, 그라운딩 대상).
-        scope="pages_show_list,pages_manage_posts,pages_read_engagement",
+        # · pages_read_engagement=페이지 permalink류·인사이트 읽기(⚠️미확認, 그라운딩
+        # 대상) · pages_manage_engagement=댓글 답변(story #3571, 페드루 PO 確定
+        # 2026-09-06 — threads_manage_replies 선례와 동형: 기존 연결은 재인증 전까지
+        # 답변이 막힌다, 의도).
+        scope="pages_show_list,pages_manage_posts,pages_read_engagement,pages_manage_engagement",
         refresh_mode="reissue_from_access_token",
         credential_kind="oauth",
         display_name="Facebook Page",
@@ -260,6 +263,13 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         utm_medium="social",
         supports_unpublish=True,
         unpublish_required_scope="pages_manage_posts",
+        # story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06) — 댓글 조회/답변(Threads/
+        # Instagram 동형 축, facebook_publish.py::fetch_replies/reply). ⚠️미확認
+        # (그라운딩① — GET /{post-id}/comments·POST /{comment-id}/comments {message},
+        # Instagram의 전용 /replies 엔드포인트와 다른 형).
+        supports_fetch_replies=True,
+        supports_reply=True,
+        reply_required_scope="pages_manage_engagement",
         image_formats=("image/jpeg", "image/png"),
         image_max_bytes=10 * 1024 * 1024,
         image_width_min=320,
@@ -282,8 +292,6 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # 이미지가 아니라 자체 정책값이라는 점이 image_formats/max_bytes 등 다른
         # ⚠️미확認 필드들과 다르다).
         image_max_count=10,
-        # comments/insights는 declare-only 미지원(페드루 PO 明示 2026-09-06) — 빈
-        # insight_metrics·supports_fetch_replies 기본값(False) 그대로.
         image_required=False,  # Instagram과 달리 텍스트만으로도 피드 발행 가능.
         # story #3567(④) — Page 릴스. Meta 공식 규격을 그라운딩에서 확認 못 해
         # Instagram 값 그대로 동형 사용(⚠️미확認 — App Review로 실 Page 권한을
@@ -294,11 +302,21 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         video_aspect_target=9 / 16,
         video_aspect_tolerance=0.05,
         video_codecs=("avc1", "hvc1", "hev1"),
+        # story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06②) — Page 게시물 insights
+        # → 정규화 7키 매핑(그라운딩②). impressions←post_impressions·reach←post_
+        # impressions_unique(Page 게시물의 «도달» 표준 메트릭·⚠️미확認)·engagements←
+        # post_engaged_users·clicks←post_clicks·views←post_video_views(영상
+        # 게시물만 — insight_snapshots.py::_fetch_facebook이 응답에 그 메트릭이
+        # 실제로 왔을 때만 채운다, 텍스트/이미지 게시물은 요청 metric 목록에 있어도
+        # 응답에 없어 자동으로 null="미제공"이 된다, _normalize의 «선언은 했지만
+        # 이번 fetch가 값을 못 줌» 경로 그대로 재사용 — 새 메커니즘 0). spend·
+        # conversions=광고 축(Phase 3) — 대응 후보 자체가 없어 아예 미선언.
+        insight_metrics=("impressions", "reach", "engagements", "clicks", "views"),
     ),
     "facebook_sandbox": ChannelAdapterConfig(
         authorize_url="https://www.facebook.com/v21.0/dialog/oauth",
         token_url="https://graph.facebook.com/v21.0/oauth/access_token",
-        scope="pages_show_list,pages_manage_posts,pages_read_engagement",
+        scope="pages_show_list,pages_manage_posts,pages_read_engagement,pages_manage_engagement",
         refresh_mode="reissue_from_access_token",
         # 페드루 PO 確定(2026-09-06) — instagram_sandbox와 달리 credential_kind=
         # "oauth"(=none이 아님). 페이지 수 마커(:pages-0/:pages-1)를 sandbox 앱
@@ -313,6 +331,11 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         utm_medium="test",
         supports_unpublish=True,
         unpublish_required_scope="pages_manage_posts",
+        # story #3571 — 실 facebook과 동형(댓글/답변, facebook_sandbox_publish.py::
+        # fetch_replies/reply).
+        supports_fetch_replies=True,
+        supports_reply=True,
+        reply_required_scope="pages_manage_engagement",
         image_formats=("image/jpeg", "image/png"),
         image_max_bytes=10 * 1024 * 1024,
         image_width_min=320,
@@ -333,6 +356,10 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         video_aspect_target=9 / 16,
         video_aspect_tolerance=0.05,
         video_codecs=("avc1", "hvc1", "hev1"),
+        # story #3571 — 실 facebook과 동일 5키 선언(sandbox가 실계정보다 관대하면
+        # 안 된다는 기존 관례 그대로, instagram_sandbox가 instagram과 동형 선언하는
+        # 것과 같은 원칙 — 일반 "sandbox"의 7키 전부와는 다르다).
+        insight_metrics=("impressions", "reach", "engagements", "clicks", "views"),
     ),
     # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각①) — Sprintable
     # 호스팅 블로그를 blog kind 어댑터 1호로 등재한다. **동작 무변경** — site_posts.py의

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -96,102 +96,72 @@ async def _fetch_replies_raw(
     (2026-09-05, PR#3865 리뷰) — 이번 fetch가 그 publication의 댓글 전체를 봤는지.
     False면 collect_comments_for_publication이 삭제 리컨실을 건너뛴다(첫 페이지만
     보고 "없다=삭제됐다"로 오판하면 다음 페이지 댓글이 매 수집마다 소프트 삭제되는
-    결함이 있었다 — sandbox=항상 2건 고정이라 테스트가 못 잡던 자리)."""
-    if channel == "sandbox":
-        from app.services import sandbox_publish
+    결함이 있었다 — sandbox=항상 2건 고정이라 테스트가 못 잡던 자리).
 
+    story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06④) — 채널별 if/elif(threads/
+    instagram이 연결 조회·토큰 복호화·에러 매핑을 그대로 중복 구현하던 것)를
+    해체하고, `publication_command.py:577`의 답변 발송 duck-typing과 같은 형으로
+    통일한다: `get_publish_client_module(channel)`이 돌려주는 모듈의 `fetch_replies`
+    를 그대로 호출 — 새 채널(facebook)은 그 모듈에 `fetch_replies`만 추가하면
+    되고, 이 함수 자체는 더는 안 늘어난다(Threads/Instagram 동작 불변, 회귀 0
+    은 테스트로 고정). sandbox/instagram_sandbox는 여전히 별도 분기 — 실 연결이
+    없는(access_token="sandbox" 고정) 별개 계약이라 아래 공용 블록(ChannelPublication/
+    ChannelConnection 조회)과 억지로 합치지 않는다(그 자체가 새 결합, PO 원칙 위반)."""
+    from app.services.channel_adapters import get_publish_client_module
+
+    if channel in ("sandbox", "instagram_sandbox"):
         if external_id is None:
             raise CommentFetchError(error_code="COMMENT_EXTERNAL_ID_MISSING", message="external_id가 없습니다")
+        _publish_client = get_publish_client_module(channel)
         import httpx
         async with httpx.AsyncClient() as client:
-            return await sandbox_publish.fetch_replies(client, access_token="sandbox", media_id=external_id)
+            return await _publish_client.fetch_replies(client, access_token="sandbox", media_id=external_id)
 
-    if channel == "threads":
-        from app.models.channel_connection import ChannelConnection
-        from app.models.channel_publication import ChannelPublication
-        from app.services.channel_connection import decrypt_for_use
-        from app.services.threads_publish import fetch_replies as threads_fetch_replies
+    from app.models.channel_connection import ChannelConnection
+    from app.models.channel_publication import ChannelPublication
+    from app.services.channel_adapters import ChannelPublishDispatchNotImplementedError
+    from app.services.channel_connection import decrypt_for_use
+    from app.services.threads_publish import ThreadsPublishError
 
-        pub = (await db.execute(
-            select(ChannelPublication).where(ChannelPublication.id == publication_id)
-        )).scalar_one_or_none()
-        if pub is None or pub.external_id is None:
-            raise CommentFetchError(
-                error_code="CHANNEL_CONNECTION_NOT_ACTIVE",
-                message=f"channel_publication을 찾을 수 없습니다: {publication_id}",
-            )
-        connection = await db.get(ChannelConnection, pub.connection_id)
-        if connection is None or connection.status != "active":
-            raise CommentFetchError(
-                error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"연결이 활성 상태가 아닙니다: {pub.connection_id}",
-            )
-        access_token = decrypt_for_use(connection)
-        if access_token is None:
-            raise CommentFetchError(error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message="연결에 자격이 없습니다")
+    pub = (await db.execute(
+        select(ChannelPublication).where(ChannelPublication.id == publication_id)
+    )).scalar_one_or_none()
+    if pub is None or pub.external_id is None:
+        raise CommentFetchError(
+            error_code="CHANNEL_CONNECTION_NOT_ACTIVE",
+            message=f"channel_publication을 찾을 수 없습니다: {publication_id}",
+        )
+    connection = await db.get(ChannelConnection, pub.connection_id)
+    if connection is None or connection.status != "active":
+        raise CommentFetchError(
+            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"연결이 활성 상태가 아닙니다: {pub.connection_id}",
+        )
+    access_token = decrypt_for_use(connection)
+    if access_token is None:
+        raise CommentFetchError(error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message="연결에 자격이 없습니다")
 
-        import httpx
-        try:
-            async with httpx.AsyncClient() as client:
-                return await threads_fetch_replies(client, access_token=access_token, media_id=pub.external_id)
-        except Exception as exc:  # noqa: BLE001 — ThreadsPublishError는 상태코드로 분류
-            from app.services.threads_publish import ThreadsPublishError
-            if isinstance(exc, ThreadsPublishError):
-                if exc.status_code in (401, 403):
-                    raise CommentFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message=str(exc)) from exc
-                if exc.status_code == 429:
-                    raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message=str(exc)) from exc
-                raise CommentFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
-            raise
+    try:
+        _publish_client = get_publish_client_module(channel)
+    except ChannelPublishDispatchNotImplementedError as exc:
+        # supports_fetch_replies=True인데 발행 클라이언트 모듈이 등록 안 된 설정
+        # 오류 방어(정상 경로면 collect_comments_for_publication의 어댑터 게이트가
+        # 이미 걸렀을 조합) — 옛 폴백 에러코드 그대로 유지(회귀 0).
+        raise CommentFetchError(
+            error_code="COMMENT_CHANNEL_NOT_IMPLEMENTED", message=f"fetch_replies dispatch가 없습니다: {channel}",
+        ) from exc
 
-    if channel == "instagram":
-        from app.models.channel_connection import ChannelConnection
-        from app.models.channel_publication import ChannelPublication
-        from app.services.channel_connection import decrypt_for_use
-        from app.services.instagram_publish import fetch_replies as instagram_fetch_replies
-
-        pub = (await db.execute(
-            select(ChannelPublication).where(ChannelPublication.id == publication_id)
-        )).scalar_one_or_none()
-        if pub is None or pub.external_id is None:
-            raise CommentFetchError(
-                error_code="CHANNEL_CONNECTION_NOT_ACTIVE",
-                message=f"channel_publication을 찾을 수 없습니다: {publication_id}",
-            )
-        connection = await db.get(ChannelConnection, pub.connection_id)
-        if connection is None or connection.status != "active":
-            raise CommentFetchError(
-                error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"연결이 활성 상태가 아닙니다: {pub.connection_id}",
-            )
-        access_token = decrypt_for_use(connection)
-        if access_token is None:
-            raise CommentFetchError(error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message="연결에 자격이 없습니다")
-
-        import httpx
-        try:
-            async with httpx.AsyncClient() as client:
-                return await instagram_fetch_replies(client, access_token=access_token, media_id=pub.external_id)
-        except Exception as exc:  # noqa: BLE001 — ThreadsPublishError는 상태코드로 분류(instagram도 재사용)
-            from app.services.threads_publish import ThreadsPublishError
-            if isinstance(exc, ThreadsPublishError):
-                if exc.status_code in (401, 403):
-                    raise CommentFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message=str(exc)) from exc
-                if exc.status_code == 429:
-                    raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message=str(exc)) from exc
-                raise CommentFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
-            raise
-
-    if channel == "instagram_sandbox":
-        from app.services import instagram_sandbox_publish
-
-        if external_id is None:
-            raise CommentFetchError(error_code="COMMENT_EXTERNAL_ID_MISSING", message="external_id가 없습니다")
-        import httpx
+    import httpx
+    try:
         async with httpx.AsyncClient() as client:
-            return await instagram_sandbox_publish.fetch_replies(client, access_token="sandbox", media_id=external_id)
-
-    raise CommentFetchError(
-        error_code="COMMENT_CHANNEL_NOT_IMPLEMENTED", message=f"fetch_replies dispatch가 없습니다: {channel}",
-    )
+            return await _publish_client.fetch_replies(client, access_token=access_token, media_id=pub.external_id)
+    except Exception as exc:  # noqa: BLE001 — ThreadsPublishError는 상태코드로 분류(threads/instagram/facebook 공용)
+        if isinstance(exc, ThreadsPublishError):
+            if exc.status_code in (401, 403):
+                raise CommentFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message=str(exc)) from exc
+            if exc.status_code == 429:
+                raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message=str(exc)) from exc
+            raise CommentFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
+        raise
 
 
 async def collect_comments_for_publication(

--- a/backend/app/services/facebook_publish.py
+++ b/backend/app/services/facebook_publish.py
@@ -280,3 +280,81 @@ async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_i
     if resp.status_code != 200:
         return None
     return resp.json().get("permalink_url")
+
+
+# ─── story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06) — 댓글 조회+답변 ───────
+# ⚠️미확認(그라운딩①, 모듈 상단 딱지와 동형): `GET /{post-id}/comments`(fields·
+# paging.cursors)·답변 `POST /{comment-id}/comments {message}` — Instagram의
+# 전용 `/{ig-comment-id}/replies` 엔드포인트와 달리, Facebook은 같은 `/comments`
+# 엔드포인트가 대상이 post든 기존 댓글이든 그 밑에 새 댓글/답글을 단다(PO
+# 確定, Meta 문서 지식). threads_publish.py::fetch_replies와 동형 커서 상한
+# 방어(PR#3865 리뷰의 "첫 페이지만 보고 리컨실하면 뒷페이지가 오삭제되는"
+# 결함 클래스를 여기서도 막는다).
+_COMMENTS_URL_TMPL = _GRAPH_BASE + "/{post_id}/comments"
+_COMMENT_REPLY_URL_TMPL = _GRAPH_BASE + "/{comment_id}/comments"
+_COMMENTS_FIELDS = "id,message,from,created_time"
+_REPLIES_MAX_PAGES = 10
+
+
+async def fetch_replies(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> tuple[list[dict], bool]:
+    """이 post의 댓글 목록 + 완전 수집 여부. `channel_post_comments.py::
+    collect_comments_for_publication`은 각 항목의 top-level `raw.get("text")`/
+    `raw.get("username")`/`raw.get("timestamp")`를 읽는 계약(sandbox/threads raw
+    모양과 동일) — Facebook Page 댓글 원시 응답은 `message`/`from.name`/
+    `created_time`이라(instagram_publish.py::fetch_replies의 `from.username`
+    끌어올림과 동형 사상) 여기서 text/username/timestamp로 끌어올려 얹는다(원본
+    필드도 raw에 그대로 보존, 유실 없음)."""
+    from app.services.threads_publish import ThreadsPublishError
+
+    items: list[dict] = []
+    after_cursor: str | None = None
+    for _ in range(_REPLIES_MAX_PAGES):
+        params = {"fields": _COMMENTS_FIELDS, "access_token": access_token}
+        if after_cursor:
+            params["after"] = after_cursor
+        resp = await client.get(_COMMENTS_URL_TMPL.format(post_id=media_id), params=params)
+        if resp.status_code != 200:
+            raise ThreadsPublishError(
+                "FACEBOOK_FETCH_REPLIES_FAILED", resp.text[:500], status_code=resp.status_code,
+            )
+        body = resp.json()
+        for raw in body.get("data") or []:
+            frm = raw.get("from") or {}
+            item = dict(raw)
+            item["text"] = raw.get("message")
+            item["username"] = frm.get("name")
+            item["from_id"] = frm.get("id")
+            item["timestamp"] = raw.get("created_time")
+            items.append(item)
+        after_cursor = ((body.get("paging") or {}).get("cursors") or {}).get("after")
+        if not after_cursor:
+            return items, True
+    return items, False
+
+
+async def reply(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, reply_to_id: str, text: str,
+) -> tuple[str, str | None]:
+    """댓글에 답변 — `POST /{comment-id}/comments {message}`(모듈 상단 딱지 참고 —
+    Instagram의 전용 `/replies`와 다른 형). `reply_to_id`=대상 댓글의 external_
+    comment_id. `threads_user_id`는 이 호출엔 안 쓴다(대상이 댓글 id라 페이지/
+    유저 id가 URL에 안 들어감) — 시그니처는 dispatch 통일을 위해 그대로 유지
+    (sandbox_publish.py·threads_publish.py·instagram_publish.py와 동일 관례).
+    응답엔 permalink 개념이 없어(댓글은 post가 아님) 두 번째 반환값은 항상 None."""
+    from app.services.threads_publish import ThreadsPublishError
+
+    resp = await client.post(
+        _COMMENT_REPLY_URL_TMPL.format(comment_id=reply_to_id),
+        params={"message": text, "access_token": access_token},
+    )
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "FACEBOOK_REPLY_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    external_reply_id = body.get("id")
+    if not external_reply_id:
+        raise ThreadsPublishError(
+            "FACEBOOK_REPLY_MISSING_ID", "id missing in response", status_code=resp.status_code,
+        )
+    return str(external_reply_id), None

--- a/backend/app/services/facebook_sandbox_publish.py
+++ b/backend/app/services/facebook_sandbox_publish.py
@@ -1,8 +1,11 @@
 """story #3547(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06) — dev 전용 Facebook Page
 샌드박스 발행 클라이언트. `facebook_publish.py`와 정확히 같은 함수 시그니처(신규
 판정 로직 0) — 결정적·상태 없음(sandbox_publish.py·instagram_sandbox_publish.py와
-동형 설계 계약). comments/insights 함수는 아예 안 둔다(declare-only, supports_
-fetch_replies/insight_metrics를 어댑터에서 선언 안 함 — 페드루 PO 明示 2026-09-06)."""
+동형 설계 계약).
+
+story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06) — 댓글 조회/답변 추가(fetch_replies/
+reply, instagram_sandbox_publish.py와 동형 결정적 표본 — 실 provider 없이 정규화
+파이프라인 전체를 라이브로 실측)."""
 from __future__ import annotations
 
 import uuid
@@ -128,3 +131,32 @@ async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id
     # "삭제됨"을 시뮬레이션한다(sandbox_publish.py의 threads 계열과 동형 — 실
     # provider가 지원 확認된 능력은 sandbox도 성공으로 흉내낸다).
     return None
+
+
+# ─── story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06) — 댓글 수집+답변
+# (instagram_sandbox_publish.py와 동형 계약) ──────────────────────────────────
+
+
+def _deterministic_comment(*, media_id: str, index: int) -> dict:
+    seed = int(uuid.uuid5(uuid.NAMESPACE_URL, f"{media_id}:{index}").hex[:8], 16)
+    return {
+        "id": f"sandbox-fb-comment-{media_id}-{index}",
+        "text": f"샌드박스 FB 댓글 {index}(seed={seed % 1000})",
+        "username": f"sandbox_fb_user_{index}",
+        "timestamp": "2026-09-06T00:00:00+00:00",
+    }
+
+
+async def fetch_replies(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> tuple[list[dict], bool]:
+    """instagram_sandbox_publish.py::fetch_replies와 동형 — media_id 하나엔 항상
+    같은 2건(순서 고정), complete=True 고정(페이지네이션 개념 없음)."""
+    return [_deterministic_comment(media_id=media_id, index=i) for i in (1, 2)], True
+
+
+async def reply(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, reply_to_id: str, text: str,
+) -> tuple[str, str | None]:
+    """facebook_publish.py::reply와 동형 계약 — 댓글 답변엔 permalink 개념이
+    없어 두 번째 반환값은 항상 None(실 클라이언트와 동일하게, sandbox가 실제보다
+    관대한 값을 지어내지 않는다)."""
+    return f"sandbox-fb-reply-{uuid.uuid4().hex}", None

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -373,9 +373,13 @@ async def _fetch_facebook(client: "httpx.AsyncClient", *, access_token: str, med
         key = _FACEBOOK_METRIC_TO_KEY.get(item.get("name"))
         if key is None:
             continue
-        total = 0
-        for v in item.get("values", []) or []:
-            total += int(v.get("value", 0) or 0)
+        item_values = item.get("values") or []
+        # 페드루 PO 리뷰(2026-09-06) — 「값이 실제로 있을 때만 싣는다」 원칙: name은
+        # 왔지만 values가 빈 목록이면(예: 이 지표가 이번 응답에서 실제로 안 잡힘)
+        # total=0으로 지어내 싣지 않는다 — 항목이 1개 이상일 때만 합산해 싣는다.
+        if not item_values:
+            continue
+        total = sum(int(v.get("value", 0) or 0) for v in item_values)
         values[key] = values.get(key, 0) + total
     return {"raw": body, "values": values}
 

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -18,6 +18,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.insight_snapshot import InsightSnapshot
+from app.services.facebook_publish import _GRAPH_BASE as _FACEBOOK_GRAPH_BASE
 from app.services.instagram_publish import _GRAPH_BASE as _INSTAGRAM_GRAPH_BASE
 
 logger = logging.getLogger(__name__)
@@ -327,6 +328,85 @@ async def _fetch_instagram_via_connection(db: AsyncSession, snapshot: InsightSna
         return await _fetch_instagram(client, access_token=access_token, media_id=pub.external_id)
 
 
+# story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06②) — Meta 문서 지식(⚠️미확認,
+# threads/instagram 상단 딱지와 동형). Page 게시물 insights → §2(d) 7키 매핑:
+# post_impressions→impressions·post_impressions_unique→reach(Page 게시물의 «도달»
+# 표준 메트릭·⚠️미확認)·post_engaged_users→engagements·post_clicks→clicks·
+# post_video_views→views(영상 게시물만 — 텍스트/이미지 게시물은 이 메트릭이
+# 응답에 아예 안 실려, `values`에서 빠져 _normalize가 자동으로 null="미제공"
+# 처리한다. threads/instagram의 "선언 안 함=null"과 다른 축 — 이건 "선언은
+# 했지만 이번 fetch가 값을 못 줌"쪽, _normalize 독스트링의 두 번째 경우 그대로
+# 재사용, 새 메커니즘 0). spend/conversions은 아예 요청하지 않는다(광고 축·
+# Phase 3, 대응 후보 자체가 없음 — threads/instagram과 동일 사유).
+_FACEBOOK_INSIGHTS_URL_TMPL = _FACEBOOK_GRAPH_BASE + "/{post_id}/insights"
+_FACEBOOK_INSIGHTS_METRICS = "post_impressions,post_impressions_unique,post_engaged_users,post_clicks,post_video_views"
+_FACEBOOK_METRIC_TO_KEY = {
+    "post_impressions": "impressions",
+    "post_impressions_unique": "reach",
+    "post_engaged_users": "engagements",
+    "post_clicks": "clicks",
+    "post_video_views": "views",
+}
+
+
+async def _fetch_facebook(client: "httpx.AsyncClient", *, access_token: str, media_id: str) -> dict[str, Any]:  # noqa: F821
+    """_fetch_threads/_fetch_instagram과 동형 에러분류(같은 error_code 문자열
+    재사용, 새 매핑표 0)."""
+    import httpx
+
+    resp = await client.get(
+        _FACEBOOK_INSIGHTS_URL_TMPL.format(post_id=media_id),
+        params={"metric": _FACEBOOK_INSIGHTS_METRICS, "access_token": access_token},
+    )
+    if resp.status_code == 401:
+        raise InsightFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message="Facebook 액세스 토큰이 만료되었습니다")
+    if resp.status_code == 429:
+        raise InsightFetchError(error_code="CHANNEL_RATE_LIMITED", message="Facebook 인사이트 API 한도 초과")
+    if resp.status_code >= 500:
+        raise InsightFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=f"Facebook 서버 오류: {resp.status_code}")
+    if resp.status_code >= 400:
+        raise InsightFetchError(error_code="CHANNEL_PUBLISH_AUTH_REJECTED", message=f"Facebook 인사이트 요청 거부: {resp.status_code}")
+
+    body = resp.json()
+    values: dict[str, int] = {}
+    for item in body.get("data", []):
+        key = _FACEBOOK_METRIC_TO_KEY.get(item.get("name"))
+        if key is None:
+            continue
+        total = 0
+        for v in item.get("values", []) or []:
+            total += int(v.get("value", 0) or 0)
+        values[key] = values.get(key, 0) + total
+    return {"raw": body, "values": values}
+
+
+async def _fetch_facebook_via_connection(db: AsyncSession, snapshot: InsightSnapshot) -> dict[str, Any]:
+    from app.models.channel_connection import ChannelConnection
+    from app.models.channel_publication import ChannelPublication
+    from app.services.channel_connection import decrypt_for_use
+
+    pub = (await db.execute(
+        select(ChannelPublication).where(ChannelPublication.id == snapshot.publication_id)
+    )).scalar_one_or_none()
+    if pub is None or pub.external_id is None:
+        raise InsightFetchError(
+            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
+        )
+    connection = await db.get(ChannelConnection, pub.connection_id)
+    if connection is None or connection.status != "active":
+        raise InsightFetchError(
+            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"연결이 활성 상태가 아닙니다: {pub.connection_id}",
+        )
+    access_token = decrypt_for_use(connection)
+    if access_token is None:
+        raise InsightFetchError(error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message="연결에 자격이 없습니다")
+
+    import httpx
+
+    async with httpx.AsyncClient() as client:
+        return await _fetch_facebook(client, access_token=access_token, media_id=pub.external_id)
+
+
 async def _fetch_for_snapshot(db: AsyncSession, snapshot: InsightSnapshot) -> dict[str, Any]:
     """channel별 dispatch. 호출 前 `insight_metrics`가 빈 튜플이 아님을 이미 확인했다는
     전제(호출자 `process_due_insight_snapshots`가 그 판정을 한다 — 여기선 순수 dispatch
@@ -339,6 +419,14 @@ async def _fetch_for_snapshot(db: AsyncSession, snapshot: InsightSnapshot) -> di
         return await _fetch_threads_via_connection(db, snapshot)
     if snapshot.channel == "instagram":
         return await _fetch_instagram_via_connection(db, snapshot)
+    if snapshot.channel == "facebook":
+        return await _fetch_facebook_via_connection(db, snapshot)
+    # story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06③) — sandbox 결정값 재사용
+    # (instagram_sandbox와 달리 facebook_sandbox는 dispatch가 없으면 이 채널의
+    # insight_metrics 선언 자체가 무의미해진다 — 어댑터 선언과 dispatch를 짝으로
+    # 유지한다).
+    if snapshot.channel == "facebook_sandbox":
+        return _fetch_sandbox(publication_id=snapshot.publication_id)
     raise InsightFetchError(
         error_code="INSIGHT_CHANNEL_NOT_IMPLEMENTED",
         message=f"insight_metrics는 선언됐지만 fetch dispatch가 없습니다: {snapshot.channel}",

--- a/backend/tests/test_3571_facebook_comments_insights.py
+++ b/backend/tests/test_3571_facebook_comments_insights.py
@@ -428,6 +428,30 @@ async def test_facebook_insights_non_video_post_views_stays_none_not_zero():
 
 
 @pytest.mark.anyio
+async def test_facebook_insights_metric_name_present_but_values_empty_list_stays_absent_not_zero():
+    """페드루 PO 리뷰(2026-09-06) — name은 응답에 왔지만 그 values가 빈 목록인
+    경우(예: 그 회차에 실제로 안 잡힘)도 0으로 지어내면 안 된다 — "값이 실제로
+    있을 때만 싣는다" 원칙은 name 유무가 아니라 values 유무로 판정한다."""
+    from app.services.insight_snapshots import _fetch_facebook
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"data": [
+                {"name": "post_impressions", "values": [{"value": 100}]},
+                {"name": "post_clicks", "values": []},  # name은 있지만 값이 빈 목록.
+            ]}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    result = await _fetch_facebook(_FakeClient(), access_token="tok", media_id="post-1")
+    assert "clicks" not in result["values"], "values가 빈 목록이면 0을 지어내지 않고 키 자체가 없어야 한다"
+    assert result["values"]["impressions"] == 100
+
+
+@pytest.mark.anyio
 async def test_facebook_insights_metric_param_excludes_spend_and_conversions():
     from app.services.insight_snapshots import _FACEBOOK_INSIGHTS_METRICS
 

--- a/backend/tests/test_3571_facebook_comments_insights.py
+++ b/backend/tests/test_3571_facebook_comments_insights.py
@@ -1,0 +1,515 @@
+"""story #3571(Phase2·BE, 페드루 PO 確定 2026-09-06) — Facebook Page 채널 동형 완성:
+댓글 조회·새로고침·승인 답변(Threads/Instagram 동형) + 인사이트 1일·7일 스냅샷
+(insight_metrics 선언) + facebook_sandbox 미러. 그라운딩④의 본체 — `channel_post_
+comments.py::_fetch_replies_raw`의 채널별 if/elif(threads/instagram이 연결 조회·
+토큰 복호화·에러 매핑을 그대로 중복 구현하던 것)를 해체하고 `publication_command.py
+:577`의 답변 발송 duck-typing과 같은 형으로 통일한 뒤, facebook은 그 위에 `fetch_
+replies`/`reply`만 얹는다.
+
+세팅 헬퍼는 test_3497_insight_snapshots.py·test_e4fc29fa_site_post_orchestration.py
+재사용(중복 재발명 금지) — test_3320_instagram_piece3.py와 동형 관례."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+from tests.test_3497_insight_snapshots import _seed_channel_connection, _seed_channel_publication
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def _patch_transport(monkeypatch, handler) -> None:
+    """test_3497_insight_snapshots.py::_patch_threads_transport와 동형."""
+    import httpx
+
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    class _PatchedAsyncClient(real_async_client):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _PatchedAsyncClient)
+
+
+# ─── ChannelAdapterConfig: 댓글/인사이트 선언 ────────────────────────────────
+
+
+def test_facebook_adapter_declares_fetch_replies_reply_and_insight_metrics():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    fb = CHANNEL_ADAPTERS["facebook"]
+    assert fb.supports_fetch_replies is True
+    assert fb.supports_reply is True
+    assert fb.reply_required_scope == "pages_manage_engagement"
+    assert fb.insight_metrics == ("impressions", "reach", "engagements", "clicks", "views")
+    assert "pages_manage_engagement" in fb.scope
+
+
+def test_facebook_sandbox_adapter_declares_same_capabilities_as_facebook():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    fb, fb_sandbox = CHANNEL_ADAPTERS["facebook"], CHANNEL_ADAPTERS["facebook_sandbox"]
+    assert fb_sandbox.supports_fetch_replies is True
+    assert fb_sandbox.supports_reply is True
+    assert fb_sandbox.insight_metrics == fb.insight_metrics
+
+
+# ─── facebook_publish.py::fetch_replies ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_facebook_fetch_replies_normalizes_message_from_created_time_to_top_level():
+    """channel_post_comments.py::collect_comments_for_publication이 raw.get("text")/
+    raw.get("username")/raw.get("timestamp")를 top-level에서 읽는 계약(sandbox/threads
+    raw 모양과 동일) — Facebook Page 댓글 원시 응답은 message/from.name/created_time
+    이라 fetch_replies가 이걸 끌어올려야 한다."""
+    from app.services.facebook_publish import fetch_replies
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {
+                "data": [
+                    {"id": "c1", "message": "댓글1", "created_time": "2026-09-06T00:00:00+0000",
+                     "from": {"id": "u1", "name": "스프린터블 데모"}},
+                ],
+                "paging": {},
+            }
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    items, complete = await fetch_replies(_FakeClient(), access_token="tok", media_id="post-1")
+    assert complete is True
+    assert items[0]["text"] == "댓글1"
+    assert items[0]["username"] == "스프린터블 데모"
+    assert items[0]["from_id"] == "u1"
+    assert items[0]["timestamp"] == "2026-09-06T00:00:00+0000"
+    assert items[0]["from"] == {"id": "u1", "name": "스프린터블 데모"}  # 원본 보존.
+    assert items[0]["message"] == "댓글1"  # 원본 필드도 유실 없음.
+
+
+@pytest.mark.anyio
+async def test_facebook_fetch_replies_follows_cursor_until_exhausted():
+    from app.services.facebook_publish import fetch_replies
+
+    pages = [
+        {"data": [{"id": "c1", "message": "a", "from": {"name": "u1"}}], "paging": {"cursors": {"after": "cursor2"}}},
+        {"data": [{"id": "c2", "message": "b", "from": {"name": "u2"}}], "paging": {}},
+    ]
+    call_count = {"n": 0}
+
+    class _FakeResponse:
+        def __init__(self, body):
+            self.status_code = 200
+            self._body = body
+        def json(self):
+            return self._body
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            resp = _FakeResponse(pages[call_count["n"]])
+            call_count["n"] += 1
+            return resp
+
+    items, complete = await fetch_replies(_FakeClient(), access_token="tok", media_id="post-1")
+    assert [i["id"] for i in items] == ["c1", "c2"]
+    assert complete is True
+    assert call_count["n"] == 2
+
+
+@pytest.mark.anyio
+async def test_facebook_fetch_replies_failure_raises_threads_publish_error():
+    from app.services.facebook_publish import fetch_replies
+    from app.services.threads_publish import ThreadsPublishError
+
+    class _FakeResponse:
+        status_code = 400
+        text = "bad request"
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await fetch_replies(_FakeClient(), access_token="tok", media_id="post-1")
+    assert exc_info.value.code == "FACEBOOK_FETCH_REPLIES_FAILED"
+
+
+# ─── facebook_publish.py::reply ──────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_facebook_reply_posts_to_comment_comments_endpoint_not_replies():
+    """PO 確定 — Facebook은 Instagram의 전용 /replies와 달리 같은 /comments
+    엔드포인트가 대상이 post든 댓글이든 그 밑에 새 댓글을 단다."""
+    from app.services.facebook_publish import reply
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"id": "reply-1"}
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            captured["url"], captured["params"] = url, params
+            return _FakeResponse()
+
+    external_reply_id, permalink = await reply(
+        _FakeClient(), access_token="tok", threads_user_id="page-1", reply_to_id="c1", text="답변합니다",
+    )
+    assert external_reply_id == "reply-1"
+    assert permalink is None  # FB 댓글엔 permalink 개념이 없음.
+    assert captured["url"].endswith("/c1/comments")
+    assert not captured["url"].endswith("/c1/replies")
+    assert captured["params"]["message"] == "답변합니다"
+
+
+@pytest.mark.anyio
+async def test_facebook_reply_failure_raises():
+    from app.services.facebook_publish import reply
+    from app.services.threads_publish import ThreadsPublishError
+
+    class _FakeResponse:
+        status_code = 403
+        text = "forbidden"
+
+    class _FakeClient:
+        async def post(self, url, *, params):
+            return _FakeResponse()
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await reply(_FakeClient(), access_token="tok", threads_user_id="page-1", reply_to_id="c1", text="x")
+    assert exc_info.value.code == "FACEBOOK_REPLY_FAILED"
+
+
+# ─── facebook_sandbox_publish.py: 결정적 댓글+답변 ───────────────────────────
+
+
+@pytest.mark.anyio
+async def test_facebook_sandbox_fetch_replies_deterministic_two_comments():
+    from app.services.facebook_sandbox_publish import fetch_replies
+
+    items, complete = await fetch_replies(None, access_token="x", media_id="post-1")
+    assert complete is True
+    assert [i["id"] for i in items] == ["sandbox-fb-comment-post-1-1", "sandbox-fb-comment-post-1-2"]
+
+    items2, _ = await fetch_replies(None, access_token="x", media_id="post-1")
+    assert items == items2, "결정적이어야 함(같은 media_id는 매번 같은 값)"
+
+
+@pytest.mark.anyio
+async def test_facebook_sandbox_reply_returns_id_without_permalink():
+    from app.services.facebook_sandbox_publish import reply
+
+    external_reply_id, permalink = await reply(
+        None, access_token="x", threads_user_id="page-1", reply_to_id="c1", text="답변",
+    )
+    assert external_reply_id.startswith("sandbox-fb-reply-")
+    assert permalink is None
+
+
+# ─── channel_post_comments.py::_fetch_replies_raw dispatch(facebook/facebook_sandbox) ─
+
+
+@pytest.mark.anyio
+async def test_collect_comments_for_publication_dispatches_facebook(monkeypatch):
+    from app.models.channel_post_comment import ChannelPostComment
+    from app.services.channel_post_comments import collect_comments_for_publication
+    import app.services.facebook_publish as facebook_publish
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="fb-post-1",
+            )
+
+            async def _fake_fetch(client, *, access_token, media_id):
+                return [{"id": "c1", "text": "댓글", "username": "u1", "timestamp": datetime.now(timezone.utc).isoformat()}], True
+
+            monkeypatch.setattr(facebook_publish, "fetch_replies", _fake_fetch)
+            await collect_comments_for_publication(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook", external_id="fb-post-1",
+            )
+            await s.commit()
+
+            rows = (await s.execute(
+                select(ChannelPostComment).where(ChannelPostComment.publication_id == pub.id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].external_comment_id == "c1"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_collect_comments_for_publication_dispatches_facebook_sandbox():
+    """facebook_sandbox는 instagram_sandbox/sandbox와 달리 credential_kind="oauth"
+    (channel_adapters.py::facebook_sandbox 주석 — 페이지 수 마커를 진짜 authorize→
+    callback 라우터로 나른다)라, 이 dispatch는 여전히 실 ChannelConnection/
+    ChannelPublication 조회 경로(공용 블록)를 탄다 — facebook_sandbox_publish.py
+    ::fetch_replies 자체가 결정적 값을 낼 뿐, "연결 불요" 축은 sandbox/
+    instagram_sandbox 전용이다."""
+    from app.models.channel_post_comment import ChannelPostComment
+    from app.services.channel_post_comments import collect_comments_for_publication
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook_sandbox")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook_sandbox", external_id="fb-sandbox-post-1",
+            )
+
+            await collect_comments_for_publication(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                external_id="fb-sandbox-post-1",
+            )
+            await s.commit()
+
+            rows = (await s.execute(
+                select(ChannelPostComment).where(ChannelPostComment.publication_id == pub.id)
+            )).scalars().all()
+            assert len(rows) == 2, "sandbox는 결정적 2건을 upsert해야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_collect_comments_facebook_token_expired_maps_to_channel_token_expired(monkeypatch):
+    from app.services.channel_post_comments import CommentFetchError, collect_comments_for_publication
+    import app.services.facebook_publish as facebook_publish
+    from app.services.threads_publish import ThreadsPublishError
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="fb-post-1",
+            )
+
+            async def _fake_fetch_401(client, *, access_token, media_id):
+                raise ThreadsPublishError("FACEBOOK_FETCH_REPLIES_FAILED", "expired", status_code=401)
+
+            monkeypatch.setattr(facebook_publish, "fetch_replies", _fake_fetch_401)
+            with pytest.raises(CommentFetchError) as exc_info:
+                await collect_comments_for_publication(
+                    s, org_id=org_id, publication_id=pub.id, channel="facebook", external_id="fb-post-1",
+                )
+            assert exc_info.value.error_code == "CHANNEL_TOKEN_EXPIRED"
+    finally:
+        await engine.dispose()
+
+
+# ─── insight_snapshots.py::_fetch_facebook(MockTransport) ────────────────────
+
+
+@pytest.mark.anyio
+async def test_facebook_insights_maps_5_keys_spend_conversions_stay_none(monkeypatch):
+    import httpx
+
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="facebook")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="facebook")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="facebook", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            # 영상 게시물 표본 — post_video_views가 응답에 실제로 온다(views 채워짐).
+            _patch_transport(monkeypatch, lambda request: httpx.Response(200, json={"data": [
+                {"name": "post_impressions", "values": [{"value": 1000}]},
+                {"name": "post_impressions_unique", "values": [{"value": 700}]},
+                {"name": "post_engaged_users", "values": [{"value": 50}]},
+                {"name": "post_clicks", "values": [{"value": 20}]},
+                {"name": "post_video_views", "values": [{"value": 300}]},
+            ]}))
+            counts = await process_due_insight_snapshots(s)
+
+            assert counts["captured"] == 2, counts
+            snap = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == pub.id)
+            )).scalars().first()
+            assert snap.normalized["impressions"] == 1000
+            assert snap.normalized["reach"] == 700
+            assert snap.normalized["engagements"] == 50
+            assert snap.normalized["clicks"] == 20
+            assert snap.normalized["views"] == 300
+            # 광고 축(Phase 3) — 대응 후보 자체가 없어 요청도 안 함, 항상 미제공.
+            assert snap.normalized["spend"] is None
+            assert snap.normalized["conversions"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_facebook_insights_non_video_post_views_stays_none_not_zero():
+    """비영상(텍스트/이미지) 게시물은 post_video_views가 응답에 아예 안 실린다 —
+    0으로 지어내지 않고 null="미제공"이어야 한다(이 스토리의 척추, _normalize의
+    "선언은 했지만 이번 fetch가 값을 못 줌" 경로)."""
+    from app.services.insight_snapshots import _fetch_facebook
+
+    class _FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"data": [
+                {"name": "post_impressions", "values": [{"value": 100}]},
+                {"name": "post_impressions_unique", "values": [{"value": 80}]},
+                {"name": "post_engaged_users", "values": [{"value": 5}]},
+                {"name": "post_clicks", "values": [{"value": 1}]},
+                # post_video_views 없음(비영상 게시물).
+            ]}
+
+    class _FakeClient:
+        async def get(self, url, *, params):
+            return _FakeResponse()
+
+    result = await _fetch_facebook(_FakeClient(), access_token="tok", media_id="post-1")
+    assert "views" not in result["values"], "응답에 없으면 values에도 없어야 _normalize가 null로 채운다"
+
+
+@pytest.mark.anyio
+async def test_facebook_insights_metric_param_excludes_spend_and_conversions():
+    from app.services.insight_snapshots import _FACEBOOK_INSIGHTS_METRICS
+
+    requested = _FACEBOOK_INSIGHTS_METRICS.split(",")
+    assert "spend" not in requested
+    assert "conversions" not in requested
+    assert "post_video_views" in requested  # 조건부(영상만)라도 요청 목록엔 포함.
+
+
+@pytest.mark.anyio
+async def test_facebook_insights_token_expired_maps_correctly(monkeypatch):
+    import httpx
+
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from app.models.insight_snapshot import InsightSnapshot
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="facebook")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="facebook")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="facebook", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            _patch_transport(monkeypatch, lambda request: httpx.Response(401, text="expired"))
+            await process_due_insight_snapshots(s)
+
+            snap = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == pub.id)
+            )).scalars().first()
+            assert snap.status == "failed"
+            assert snap.error_code == "CHANNEL_TOKEN_EXPIRED"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_facebook_sandbox_insights_dispatch_reuses_sandbox_decisive_values_filtered_to_5_keys():
+    """PO 確定③ — facebook_sandbox는 _fetch_sandbox()의 기존 결정값을 재사용하되,
+    facebook_sandbox의 insight_metrics(5키, facebook과 동형) 밖인 spend/conversions
+    는 sandbox 원시값에 있어도 null이어야 한다(어댑터 선언이 안전망 역할)."""
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="facebook_sandbox")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=connection.id, channel="facebook_sandbox", external_id="fb-sandbox-post-1",
+            )
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="facebook_sandbox", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            counts = await process_due_insight_snapshots(s)
+            assert counts["captured"] == 2, counts
+
+            snap = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == pub.id)
+            )).scalars().first()
+            assert snap.normalized["impressions"] is not None
+            assert snap.normalized["reach"] is not None
+            assert snap.normalized["engagements"] is not None
+            assert snap.normalized["clicks"] is not None
+            assert snap.normalized["views"] is not None
+            assert snap.normalized["spend"] is None, "선언 밖 키는 sandbox 원시값에 있어도 null"
+            assert snap.normalized["conversions"] is None
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1396,6 +1396,11 @@
       "file": "tests/test_3578_cover_aspect_validation_order.py",
       "sec": 30.0,
       "source": "story-3578-cover-aspect-validation-order(PR 개설 前 선제 등재 — 로컬 raw pytest 5건 실측 CPU 4.3s(동시 부하로 벽시계는 변동 큼) 기준 CI 배율(~6x, story #3383) 보수적으로 반영한 30s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3571_facebook_comments_insights.py",
+      "sec": 20.0,
+      "source": "story-3571-facebook-comments-insights(PR 개설 前 선제 등재 — 로컬 raw pytest 17건 3.26s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
블루프린트 §7 Phase 2 AC 「댓글 답변을 승인하며 … 1일·7일 성과」의 Facebook 몫. 그라운딩①~④(디디, PO 確定 2026-09-06) 반영.

## ④ 본체 — 채널별 if/elif 해체(회귀 0)
`channel_post_comments.py::_fetch_replies_raw`가 threads/instagram 각각 연결 조회·토큰 복호화·에러 매핑을 그대로 중복 구현하던 것을 해체 — `publication_command.py:577`의 답변 발송 duck-typing(`get_publish_client_module`)과 같은 형으로 통일했다. sandbox/instagram_sandbox는 여전히 별도 분기(실 연결이 없는 access_token="sandbox" 고정 계약이라 억지로 안 합침). facebook은 이 통일된 경로 위에 `fetch_replies`/`reply`만 얹으면 끝 — 이 리팩터 자체의 회귀 0은 threads/instagram 기존 테스트(178건) 전체 그린으로 고정.

## ① 댓글 조회+답변
`facebook_publish.py`에 `fetch_replies`/`reply` 신설 — Threads/Instagram과 동일 시그니처. Page 댓글은 `GET /{post-id}/comments`(message/from/created_time을 text/username/timestamp로 끌어올림)·답변은 Instagram의 전용 `/replies`와 달리 같은 `/comments` 엔드포인트(⚠️미확認, PO 確定). 어댑터에 `supports_fetch_replies`/`supports_reply`/`reply_required_scope="pages_manage_engagement"` 추가.

## ② 인사이트 1일·7일 → 7키 매핑
`insight_snapshots.py`에 `_fetch_facebook`/`_fetch_facebook_via_connection` 신설. impressions←post_impressions·reach←post_impressions_unique(⚠️미확認)·engagements←post_engaged_users·clicks←post_clicks·views←post_video_views(영상 게시물만 — 응답에 없으면 `_normalize`가 자동으로 null="미제공", 0으로 지어내지 않음). spend/conversions은 대응 후보 자체가 없어 요청도 안 함.

## facebook_sandbox 미러
`facebook_sandbox_publish.py::fetch_replies`/`reply` — instagram_sandbox_publish.py와 동형 결정적 2건. insight는 기존 `_fetch_sandbox()`를 채널-무관 재사용하되, facebook_sandbox의 insight_metrics 선언을 facebook과 동형 5키로 좁혀 spend/conversions는 null.

## 검증
- 테스트 17건 + 뮤테이션 2(① supports_fetch_replies=False → dispatch 우회 재현 RED ② 미제공 metric을 0으로 지어냄 → RED) 확認 후 복원.
- 회귀 178건(comments/instagram/insight/authz 전체) 통과.
- collect-only 에러 0(2131건). shard-weights 등재·lint 3종 통과.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>