### PR TITLE
[SID:3586] feat: 릴스 커버 비율 422 CHANNEL_COVER_ASPECT_RATIO_REJECTED FE 매핑

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2596,6 +2596,7 @@
     "channelPostsImageAspectRatioTooNarrow": "This image is too tall. The minimum aspect ratio is {minAspectRatio}, but this is {aspectRatio}",
     "channelPostsImageConversionFailed": "Even after automatic conversion, this still exceeds the {maxBytes} limit ({finalBytes})",
     "channelPostsImageAnimatedUnsupported": "Animated images aren't supported ({frameCount} frames)",
+    "channelPostsVideoCoverAspectRatioRejected": "The cover ratio is {actual}. A Reels cover must be {target}.",
     "channelPostsImageConvertedBadgeBase": "Automatically converted to fit this channel's specs",
     "channelPostsImageConvertedBadgeWidthFragment": "width {from}px → {to}px",
     "channelPostsImageConvertedBadgeBytesFragment": "size {from} → {to}",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2596,6 +2596,7 @@
     "channelPostsImageAspectRatioTooNarrow": "세로가 너무 깁니다. 비율 하한은 {minAspectRatio}인데 {aspectRatio}입니다",
     "channelPostsImageConversionFailed": "자동 변환 후에도 한도 {maxBytes}를 넘습니다({finalBytes})",
     "channelPostsImageAnimatedUnsupported": "애니메이션 이미지는 지원하지 않습니다({frameCount}프레임)",
+    "channelPostsVideoCoverAspectRatioRejected": "커버 비율이 {actual}입니다. 릴스 커버는 {target} 비율이어야 합니다.",
     "channelPostsImageConvertedBadgeBase": "이 채널 규격에 맞춰 자동 변환됐습니다",
     "channelPostsImageConvertedBadgeWidthFragment": "너비 {from}px → {to}px",
     "channelPostsImageConvertedBadgeBytesFragment": "용량 {from} → {to}",

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -371,6 +371,14 @@ export const EXEMPT_PAIRS = new Set<string>([
   // docs.indexDocCount류)이지 #2352/#2365가 잡으려는 "다른 두 셈이 헷갈리는" 병이
   // 아니다. 유나 §17-24 원문 확定값 — 재작명 대상 아님.
   'verify.verificationSheetColumnName <-> verify.verificationSheetSummaryAllPass',
+  // story #3586(BE #3933, 유나 §17-23 확定 2026-09-06 · PO 승인 2026-09-06) —
+  // content.channelPostsVideoCoverAspectRatioRejected(완결 오류 문장, actual/target
+  // 값 보간) <-> content.channelPostsCoverAttachLabel("커버", 첨부 버튼 라벨). 완결
+  // 오류 문장 vs 첨부 버튼 라벨 — 같은 대상("커버")을 다른 레지스터로 부르는 것이지
+  // #2352/#2365가 잡으려는 "다른 것을 세는 두 수가 헷갈리는" 병이 아니다(가드 표적
+  // 클래스 밖). actual/target을 NON_NUMBER_PLACEHOLDER_NAMES에 넣지 않는다(PO 지적
+  // — 그 이름들은 다른 자리에서 진짜 수를 실을 수 있어 자를 무디게 만든다).
+  'content.channelPostsCoverAttachLabel <-> content.channelPostsVideoCoverAspectRatioRejected',
 ]);
 
 // ⛔⭐오르테가군 지적(2026-07-31) — 이 목록에 «새로» 넣는 것은 PO 승인을 거친다. 이유 없이

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -2328,6 +2328,66 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     expect(errorText).not.toContain('0.56');
   });
 
+  // story #3586(BE #3933, 유나 §17-23 확定 2026-09-06) — 릴스 커버 비율 거부.
+  // actual·target 둘 다 formatVideoAspectRatio(규격 태그 헬퍼)로 조립 — 날 소수
+  // 금지, tolerance는 절대오차라 문장에 안 싣는다(PO 정정).
+  it('⭐#3586 — CHANNEL_COVER_ASPECT_RATIO_REJECTED(422) — actual·target이 규격 태그 형(「9:16」)으로 조립된다', async () => {
+    stubFetch({
+      imageMaxCount: 1,
+      onImageConfirm: () => ({
+        status: 422,
+        body: { detail: { code: 'CHANNEL_COVER_ASPECT_RATIO_REJECTED', message: '…', aspect_ratio: 1.0, target: 0.5625, tolerance: 0.05 } },
+      }),
+    });
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    const input = container.querySelector('[data-testid="channel-post-image-file-input"]') as HTMLInputElement;
+    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    const errorText = container.querySelector('[data-testid="channel-post-image-upload-error"]')?.textContent ?? '';
+    expect(errorText).toContain('1:1');
+    expect(errorText).toContain('9:16');
+    expect(errorText).not.toContain('0.5625');
+    expect(errorText).not.toContain('0.05');
+    expect(errorText).not.toContain('%');
+  });
+
+  // ⭐뮤테이션 방향 — detail target이 바뀌면 문구의 {target}도 바뀐다(하드코딩
+  // "9:16" 문자열이 아니라 실제로 detail 값을 읽는다는 증거).
+  it('⭐#3586 — detail target이 다른 값(4:5)이면 문구도 그 값으로 바뀐다', async () => {
+    stubFetch({
+      imageMaxCount: 1,
+      onImageConfirm: () => ({
+        status: 422,
+        body: { detail: { code: 'CHANNEL_COVER_ASPECT_RATIO_REJECTED', message: '…', aspect_ratio: 1.0, target: 0.8, tolerance: 0.05 } },
+      }),
+    });
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    const input = container.querySelector('[data-testid="channel-post-image-file-input"]') as HTMLInputElement;
+    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    const errorText = container.querySelector('[data-testid="channel-post-image-upload-error"]')?.textContent ?? '';
+    expect(errorText).toContain('4:5');
+    expect(errorText).not.toContain('9:16');
+  });
+
   // story #3530 REQUIRED 2(유나 Design 변경요청, PO 채택 2026-09-06) — exceeded
   // 갈래도 formatAspectBound로(전엔 toFixed(1)라 IG 1.91이 「1.9」로 태그와 다른
   // 수였다) + 방향 없는 문구("이미지가 너무 길쭉합니다" — "가로가 너무 깁니다"류

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -2360,6 +2360,26 @@ describe('ChannelPostEditPage — 이미지 첨부(T3-M, story #3428)', () => {
     expect(errorText).not.toContain('%');
   });
 
+  it('⭐#3586 CHANGES — target/actual 중 하나라도 없으면 구멍 문장 대신 일반 경로(서버 message)', async () => {
+    stubFetch({
+      imageMaxCount: 1,
+      onImageConfirm: () => ({
+        status: 422,
+        body: { detail: { code: 'CHANNEL_COVER_ASPECT_RATIO_REJECTED', message: '서버 메시지 그대로' } },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    const input = container.querySelector('[data-testid="channel-post-image-file-input"]') as HTMLInputElement;
+    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    await act(async () => { input.dispatchEvent(new Event('change', { bubbles: true })); });
+    await flush();
+    const errorText = container.querySelector('[data-testid="channel-post-image-upload-error"]')?.textContent ?? '';
+    expect(errorText).toContain('서버 메시지 그대로');
+    expect(errorText).not.toContain('비율이');
+  });
+
   // ⭐뮤테이션 방향 — detail target이 바뀌면 문구의 {target}도 바뀐다(하드코딩
   // "9:16" 문자열이 아니라 실제로 detail 값을 읽는다는 증거).
   it('⭐#3586 — detail target이 다른 값(4:5)이면 문구도 그 값으로 바뀐다', async () => {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -344,6 +344,15 @@ function describeChannelImageError(info: SitePostApiErrorInfo, t: (key: string, 
       });
     case 'image_animated_unsupported':
       return t('channelPostsImageAnimatedUnsupported', { frameCount: info.imageFrameCount ?? '' });
+    // story #3586(BE #3933, 유나 §17-23 확定 2026-09-06 · PO 정정 — tolerance는
+    // 절대오차지 퍼센트가 아니라 문장에 안 싣는다) — 방향(세로/가로) 문장 없음
+    // (BE가 abs 한 갈래라 어느 쪽으로 벗어났는지 모른다). actual·target 둘 다
+    // formatVideoAspectRatio(규격 태그 헬퍼, §17-23②)로 — 날 소수 금지.
+    case 'cover_aspect_ratio_rejected':
+      return t('channelPostsVideoCoverAspectRatioRejected', {
+        actual: typeof info.imageAspectRatio === 'number' ? formatVideoAspectRatio(info.imageAspectRatio) : '',
+        target: typeof info.coverAspectTarget === 'number' ? formatVideoAspectRatio(info.coverAspectTarget) : '',
+      });
     default:
       return info.humanMessageKey ? t(info.humanMessageKey) : (info.humanMessageFallback || t('errorChannelImageUploadFailed'));
   }

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -349,10 +349,16 @@ function describeChannelImageError(info: SitePostApiErrorInfo, t: (key: string, 
     // (BE가 abs 한 갈래라 어느 쪽으로 벗어났는지 모른다). actual·target 둘 다
     // formatVideoAspectRatio(규격 태그 헬퍼, §17-23②)로 — 날 소수 금지.
     case 'cover_aspect_ratio_rejected':
-      return t('channelPostsVideoCoverAspectRatioRejected', {
-        actual: typeof info.imageAspectRatio === 'number' ? formatVideoAspectRatio(info.imageAspectRatio) : '',
-        target: typeof info.coverAspectTarget === 'number' ? formatVideoAspectRatio(info.coverAspectTarget) : '',
-      });
+      // 유나 CHANGES(PR#3940, §17-23 ⑤-1) — actual/target 둘 다 있을 때만 이
+      // 문장. 하나라도 없으면 구멍 난 문장(「…입니다. …이어야 합니다.」) 대신
+      // 아래 default(서버 message 일반 경로)로 떨어진다.
+      if (typeof info.imageAspectRatio === 'number' && typeof info.coverAspectTarget === 'number') {
+        return t('channelPostsVideoCoverAspectRatioRejected', {
+          actual: formatVideoAspectRatio(info.imageAspectRatio),
+          target: formatVideoAspectRatio(info.coverAspectTarget),
+        });
+      }
+      return info.humanMessageKey ? t(info.humanMessageKey) : (info.humanMessageFallback || t('errorChannelImageUploadFailed'));
     default:
       return info.humanMessageKey ? t(info.humanMessageKey) : (info.humanMessageFallback || t('errorChannelImageUploadFailed'));
   }

--- a/apps/web/src/components/content/api-error.ts
+++ b/apps/web/src/components/content/api-error.ts
@@ -71,6 +71,9 @@ export type SitePostApiErrorKind =
   | 'concept_not_approved'
   // story #3575(BE #3574, 페드루 PO 確定 2026-09-06) — 영상 초안 커버 2장째 서버 거부.
   | 'video_requires_single_cover'
+  // story #3586(BE #3933, 페드루 PO 確定 2026-09-06) — 릴스 커버 비율이 어댑터 선언
+  // target±tolerance를 벗어남(캐러셀 image_aspect_min/max와 다른 축 — 커버 전용).
+  | 'cover_aspect_ratio_rejected'
   | 'unknown';
 
 export interface SitePostApiErrorInfo {
@@ -122,6 +125,10 @@ export interface SitePostApiErrorInfo {
   spentMinor?: number;
   estimatedCostMinor?: number;
   remainingMinor?: number;
+  // story #3586 — CHANNEL_COVER_ASPECT_RATIO_REJECTED 전용(BE aspect_ratio는 기존
+  // imageAspectRatio 필드를 그대로 재사용 — 같은 JSON 키, kind로만 뜻이 갈린다).
+  coverAspectTarget?: number;
+  coverAspectTolerance?: number;
 }
 
 interface KnownError {
@@ -182,6 +189,10 @@ const KNOWN_ERRORS: Record<string, KnownError> = {
   // 2장째 올리려 할 때의 서버 방어선(화면 상한 1이 정상 경로를 이미 막지만, 레이스
   // 등으로 도달 시 회귀 0). labelKey 빈칸 — 서버 message 그대로(3471 동형).
   CHANNEL_VIDEO_REQUIRES_SINGLE_COVER: { labelKey: '', kind: 'video_requires_single_cover' },
+  // story #3586(BE #3933 21ac3dc3a, 유나 §17-23 확定 2026-09-06) — 릴스 커버 비율이
+  // 어댑터 target±tolerance를 벗어남. labelKey 비움 — page.tsx가 actual/target을
+  // formatVideoAspectRatio로 조립한다(image_aspect_ratio_* 동형 관례).
+  CHANNEL_COVER_ASPECT_RATIO_REJECTED: { labelKey: '', kind: 'cover_aspect_ratio_rejected' },
   // EXTERNAL_PUBLISH_APPROVAL_REQUIRED·SITE_POST_SEAL_MISSING·SITE_POST_REAPPROVAL_REQUIRED
   // 는 위 site 항목을 그대로 재사용한다(같은 external_publish 게이트 개념 공유, doc §9-4).
   // story #3402·PR#3764 — 채널 포스트 전용 GATE_ALREADY_HELD. site와 kind는 같지만
@@ -240,6 +251,7 @@ function extractCodeAndMessage(detail: unknown): {
   imageAspectRatio?: number; imageMaxAspectRatio?: number; imageFinalBytes?: number;
   imageWidthHeightRatio?: number; imageMinWidthHeightRatio?: number;
   limitMinor?: number; spentMinor?: number; estimatedCostMinor?: number; remainingMinor?: number;
+  coverAspectTarget?: number; coverAspectTolerance?: number;
 } {
   if (typeof detail === 'string') return { message: detail };
   if (detail && typeof detail === 'object') {
@@ -281,6 +293,11 @@ function extractCodeAndMessage(detail: unknown): {
       spentMinor: typeof d.spent_minor === 'number' ? d.spent_minor : undefined,
       estimatedCostMinor: typeof d.estimated_cost_minor === 'number' ? d.estimated_cost_minor : undefined,
       remainingMinor: typeof d.remaining_minor === 'number' ? d.remaining_minor : undefined,
+      // story #3586 — CHANNEL_COVER_ASPECT_RATIO_REJECTED 전용(channel_posts.py
+      // 21ac3dc3a 그대로: aspect_ratio·target·tolerance). aspect_ratio는 위
+      // imageAspectRatio가 이미 같은 JSON 키를 읽는다(재사용, 새 필드 0).
+      coverAspectTarget: typeof d.target === 'number' ? d.target : undefined,
+      coverAspectTolerance: typeof d.tolerance === 'number' ? d.tolerance : undefined,
     };
   }
   return {};
@@ -324,6 +341,8 @@ export function parseSitePostApiError(
   const spentMinor = fromDetail.spentMinor ?? fromError.spentMinor;
   const estimatedCostMinor = fromDetail.estimatedCostMinor ?? fromError.estimatedCostMinor;
   const remainingMinor = fromDetail.remainingMinor ?? fromError.remainingMinor;
+  const coverAspectTarget = fromDetail.coverAspectTarget ?? fromError.coverAspectTarget;
+  const coverAspectTolerance = fromDetail.coverAspectTolerance ?? fromError.coverAspectTolerance;
   const raw = JSON.stringify({ code: code ?? null, message: message ?? null });
 
   const known = code ? KNOWN_ERRORS[code] : undefined;
@@ -356,5 +375,7 @@ export function parseSitePostApiError(
     spentMinor,
     estimatedCostMinor,
     remainingMinor,
+    coverAspectTarget,
+    coverAspectTolerance,
   };
 }


### PR DESCRIPTION
## 배경
3578(BE #3933, 21ac3dc3a)가 릴스 커버 비율 검증 순서 결함을 고치며 새 422 코드 `CHANNEL_COVER_ASPECT_RATIO_REJECTED`(detail: `aspect_ratio`/`target`/`tolerance`)를 낸다. FE `api-error.ts` KNOWN_ERRORS엔 이 코드가 0건이라 사용자는 「알 수 없는 오류」 일반 문구를 본다.

## 구현
- `SitePostApiErrorKind`에 `cover_aspect_ratio_rejected` 추가, `coverAspectTarget`/`coverAspectTolerance` 필드 신설(`aspect_ratio`는 기존 `imageAspectRatio` 재사용 — 같은 JSON 키).
- `KNOWN_ERRORS`에 등재(labelKey 비움, image_aspect_ratio_* 동형 관례).
- `describeChannelImageError`에 분기 추가 — 기존 §17-23② `formatVideoAspectRatio` 헬퍼로 actual/target 둘 다 규격 태그 형(예: "9:16")으로 조립. 날 소수 노출 금지, tolerance/방향 문장 없음(유나 §17-23 확定 + PO 정정).

## 부수
phrase-collision guard `EXEMPT_PAIRS`에 1건 등재(PO 승인) — 신규 문장 문구가 기존 "커버" 라벨과 부분문자열로 겹치는 것을 등재(같은 대상·다른 레지스터, 실 혼동 없음).

## 테스트
2개(태그 형 조립·target 값에 따라 문구가 바뀜) + 뮤테이션 1(RED 확認 후 복원).

## 검증
tsc 0·eslint 0·vitest 6528·hanja 0·phrase-collision 신규 0.

## 머지 순서
BE #3933(21ac3dc3a) — base가 develop이 아니라 feat/3567-facebook-page-final(#3925 미착지)이라던 커밋 노트대로, #3933 자체가 develop에 착지한 뒤 병합.