### PR TITLE
[SID:3580] fix: test_eventbus_s2 sentinel 주입형 테스트 전부 — threading→asyncio 재작성

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -481,6 +481,51 @@ def pytest_runtest_makereport(item, call):
         report.sections.append(("story #2662: missing model import 진단", diagnosis))
 
 
+@pytest.fixture(autouse=True)
+def _guard_global_shutdown_event_leak(request):
+    """story #3580(페드루 PO 確定 2026-09-06, #3942 CI 실사고 근본원인) —
+    `app.core.shutdown.shutdown_event`는 프로세스 전역 asyncio.Event다. SSE 스트림
+    테스트가 이걸 set()해 즉시-종료를 실측한 뒤 자기 정리(reset_shutdown_event())를
+    모든 경로(예외·타임아웃 포함)에서 못 돌리고 끝나면, 같은 pytest 프로세스에서
+    이어 도는 «무관한» 다음 SSE 스트림 테스트가 시작하자마자 shutdown_reconnect로
+    오판된다 — 실제 CI 원본 실측(run 34037169656): 피해자 테스트의 타임라인이
+    `heartbeat@+0.006s, sync_status@+0.006s, shutdown_reconnect@+0.006s`(시작하자마자
+    셧다운) — 원인은 그 앞에 돈 테스트가 남긴 오염이지 피해자 자신의 결함이 아니었다.
+
+    처방 — 설정(이 테스트 시작 前) 한 시점만 지킨다: 이미 set돼 있으면(이전 테스트의
+    오염 상속) 조용히 reset해 이 테스트를 깨끗한 상태에서 시작시킨다(피해자를 만들지
+    않는다). 상속받은 오염이었다는 사실은 경고 로그로만 남긴다.
+
+    ⛔종료 시점(teardown) 검사 — "테스트가 끝났는데 여전히 set이면 그 테스트가
+    범인" — 은 **처음엔 넣었다가 실측으로 되돌렸다**: `app/main.py:61,163`(lifespan
+    startup=reset·shutdown=set) 그대로, `with TestClient(app) as c:` 블록을 정상
+    종료하는 **모든** 테스트가 그 자체로 실 lifespan shutdown을 타 이 이벤트를
+    "정상적으로" set한 채 끝난다(다음 lifespan startup의 reset을 기다리는 게 설계
+    그대로 — 실 프로덕션 그래스풀 셧다운과 동일 신호). 이건 버그가 전혀 아닌데,
+    teardown 검사를 넣었더니 그런 완전히 무고한 테스트(`test_heartbeat_disconnect_
+    check_clears_connection` 등)가 새로 FAIL/ERROR 나는 걸 로컬에서 직접 재현했다
+    (이 fixture를 no-op으로 바꾸면 사라짐 — 원인 이 fixture로 특정 확認). "여전히
+    set"이라는 신호 하나로는 «이 테스트가 수동 set()을 잊고 안 지웠다»와 «이 테스트의
+    TestClient(app) lifespan이 정상적으로 셧다운을 신호했다»를 구조적으로 구분할
+    수 없다 — 그래서 teardown-시점 자동 「범인 지목」은 안전하게 구현이 안 된다고
+    판단, 설정-시점 방어(피해자 보호)만 남긴다. 수동 set() 4자리(test_c4c72eb1_sse_
+    shutdown_aware.py·test_eventbus_s2.py·test_eventbus_s3.py·test_s20.py)는 각
+    파일에서 개별로 finally 순서를 하드닝했다(그 reset이 다른 cleanup 코드보다
+    먼저/독립적으로 돌게)."""
+    import logging
+
+    from app.core import shutdown as shutdown_module
+
+    if shutdown_module.shutdown_event.is_set():
+        logging.getLogger(__name__).warning(
+            "%s 시작 前 app.core.shutdown.shutdown_event가 이미 set — 이전 테스트가 "
+            "남긴 오염으로 판단해 reset 후 진행(이 테스트는 피해자로 취급, 실패 처리 안 함)",
+            request.node.nodeid,
+        )
+        shutdown_module.reset_shutdown_event()
+    yield
+
+
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"

--- a/backend/tests/test_c4c72eb1_sse_shutdown_aware.py
+++ b/backend/tests/test_c4c72eb1_sse_shutdown_aware.py
@@ -141,6 +141,12 @@ async def test_sse_stream_reacts_to_shutdown_signal_immediately_and_closes_clean
         await asyncio.sleep(0.1)
         assert ev_module._sse_connection_count == count_before, "shutdown 후 카운터 정리 안 됨"
     finally:
-        ev_module._agent_connections.pop(str(member_id), None)
-        ev_module._sse_connection_count = count_before
-        shutdown_module.reset_shutdown_event()
+        # story #3580(페드루 PO 確定 2026-09-06, #3942 CI 실사고) — 이 reset을
+        # finally 블록 맨 앞·독립 try로 둔다(다른 cleanup 문장이 예외를 던지면
+        # 뒤에 있던 reset이 안 도는 잠복 경로 방지 — test_eventbus_s3.py/test_s20.py
+        # 와 동형 처방, 이 파일은 원래도 순서가 옳았으나 방어적으로 통일).
+        try:
+            shutdown_module.reset_shutdown_event()
+        finally:
+            ev_module._agent_connections.pop(str(member_id), None)
+            ev_module._sse_connection_count = count_before

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -131,6 +131,40 @@ async def _wait_until(predicate, *, timeout: float = 5.0, interval: float = 0.00
     return predicate()
 
 
+def _asgi_transport_observing(app, needle: bytes) -> tuple[ASGITransport, asyncio.Event]:
+    """페드루 PO 現場 재현(카디르 로그 실측, 2026-09-06) — CI에서 「큐 비움
+    (consumed)」과 「제너레이터가 그 항목을 실제로 스트림에 write함」 사이에 진짜
+    레이스가 있었다: `queue.get()`이 반환된 시점(`_wait_until(q.empty 확認)`이
+    보는 시점)과, `asyncio.wait({get_task, shutdown_wait_task}, ...)`가 그 완료를
+    거둬 `generate()`의 태스크가 실제로 재개돼 `yield`까지 도달하는 시점 사이에는
+    스케줄링 홉이 최소 1~2번 더 있다 — 그 창에서 `shutdown_event.set()`이 로컬
+    저부하에선 항상 늦게 관측되지만(그래서 로컬 재현 0), CI 부하에선 그 홉이 먼저
+    끝나 `asyncio.wait`의 `done`에 `shutdown_wait_task`까지 같이 들어차 버리면
+    `if shutdown_wait_task in done:`(get_task보다 먼저 검사)가 이겨 sentinel을
+    한 번도 못 내보내고 shutdown_reconnect로 바로 끝난다(CI 원본 로그의 body가
+    정확히 이 모양이었다).
+
+    처방 — 큐 상태라는 간접 신호 대신 **ASGI 자신의 `send()` 콜러블을 감싸** 그
+    바이트열이 실제로 응답 바디에 실리는 순간을 직접 관찰한다(`c.stream()`으로
+    바꿔도 소용없다 — httpx.ASGITransport.handle_async_request 소스 확認: 앱
+    콜러블 `self.app(...)`이 완전히 끝나야 Response 자체가 생성되므로, `c.stream()`
+    도 `c.get()`과 똑같이 완주 後에야 바디를 준다, #3494/#3580 확립 사실 재확認).
+    이 훅은 스트리밍 여부와 무관하게 서버측 `send()` 호출 자체를 가로채므로 그
+    제약과 상관없이 정확한 시점을 잡는다 — 폴링·타임아웃 예산 자체가 필요 없어진다
+    (이벤트가 set될 때까지 `await event.wait()`로 순수 이벤트 기반 대기)."""
+    written = asyncio.Event()
+
+    async def _wrapped_app(scope, receive, send):
+        async def _send(message):
+            if message.get("type") == "http.response.body" and needle in message.get("body", b""):
+                written.set()
+            await send(message)
+
+        await app(scope, receive, _send)
+
+    return ASGITransport(app=_wrapped_app), written
+
+
 @pytest.mark.anyio
 async def test_agent_stream_registers_connection(mock_session, org_id):
     """GET /api/v2/events/stream 연결 시 _agent_connections에 등록됨.
@@ -188,12 +222,13 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
     app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     registered_observed = False
-    consumed_observed = False
+    written_observed = False
     body = ""
+    transport, sentinel_written = _asgi_transport_observing(app, b"__test_sentinel__")
     try:
         with patch("app.core.database.async_session_factory", _session_factory):
             with patch("app.routers.events._SSE_HEARTBEAT_TIMEOUT", 0.1):
-                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                async with AsyncClient(transport=transport, base_url="http://test") as c:
                     stream_task = asyncio.create_task(
                         c.get(f"/api/v2/events/stream?member_id={member_id}")
                     )
@@ -202,7 +237,11 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
                     for q in queues:
                         q.put_nowait({"event_type": "__test_sentinel__"})
                     if queues:
-                        consumed_observed = await _wait_until(lambda: all(q.empty() for q in queues))
+                        try:
+                            await asyncio.wait_for(sentinel_written.wait(), timeout=5.0)
+                            written_observed = True
+                        except asyncio.TimeoutError:
+                            pass
                     shutdown_module.shutdown_event.set()
                     resp = await asyncio.wait_for(stream_task, timeout=5.0)
                     assert resp.status_code == 200
@@ -217,7 +256,7 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
         shutdown_module.reset_shutdown_event()
 
     assert registered_observed, "injector never observed the connection in _agent_connections"
-    assert consumed_observed, "generator never consumed the injected sentinel from its queue"
+    assert written_observed, "generator never actually wrote the sentinel line to the ASGI send() callable"
     assert "__test_sentinel__" in body
     assert member_id_str not in _agent_connections  # cleanup 계약 — 완주 뒤엔 반드시 비어야 함
 
@@ -411,12 +450,13 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
         yield mock_session
 
     registered_observed = False
-    consumed_observed = False
+    written_observed = False
     body = ""
+    transport, sentinel_written = _asgi_transport_observing(app, b"__test_sentinel__")
     try:
         with patch("app.core.database.async_session_factory", _session_factory):
             with patch("app.routers.events._SSE_HEARTBEAT_TIMEOUT", 0.1):
-                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                async with AsyncClient(transport=transport, base_url="http://test") as c:
                     stream_task = asyncio.create_task(
                         c.get(f"/api/v2/events/stream?member_id={member_id}")
                     )
@@ -425,7 +465,11 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
                     for q in queues:
                         q.put_nowait({"event_type": "__test_sentinel__"})
                     if queues:
-                        consumed_observed = await _wait_until(lambda: all(q.empty() for q in queues))
+                        try:
+                            await asyncio.wait_for(sentinel_written.wait(), timeout=5.0)
+                            written_observed = True
+                        except asyncio.TimeoutError:
+                            pass
                     shutdown_module.shutdown_event.set()
                     resp = await asyncio.wait_for(stream_task, timeout=5.0)
                     assert resp.status_code == 200
@@ -440,7 +484,7 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
         shutdown_module.reset_shutdown_event()
 
     assert registered_observed, "injector never observed the connection in _agent_connections"
-    assert consumed_observed, "generator never consumed the injected sentinel from its queue"
+    assert written_observed, "generator never actually wrote the sentinel line to the ASGI send() callable"
     assert "__test_sentinel__" in body
     assert member_id_str not in _agent_connections  # cleanup 계약
 

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -94,28 +94,57 @@ async def client(mock_session, auth_ctx, org_id):
 
 # ─── AC1 + AC5: SSE 스트림 수립 + 해제 감지 ─────────────────────────────────
 
-def test_agent_stream_registers_connection(mock_session, org_id):
+
+async def _wait_until(predicate, *, timeout: float = 5.0, interval: float = 0.005) -> bool:
+    """story #3580(근본원인, 페드루 PO 確定 2026-09-06) — 이 파일의 threading.Thread
+    injector 재작성이 쓰는 유일한 폴링 축. #3494에서 threading.Thread + time.sleep로
+    구현했던 게 진짜 플레이키 근원이었다 — `asyncio.Queue.put_nowait`/`asyncio.Event.
+    set()`은 이벤트 루프를 도는 **바로 그 스레드**에서 불려야 대기자(waiter)에게
+    안전하게 통지된다는 게 asyncio의 계약인데, 별도 OS 스레드(injector)가 그 두
+    프리미티브를 직접 건드리고 있었다 — 대개는 우연히 동작하지만 CI 러너가 붐빌 때
+    (오늘 FE-only PR 2건과 동시 실행 등, GIL/스레드 스케줄링 타이밍이 달라지는 조건)
+    통지가 늦게 도착하거나 씹혀 폴링이 데드라인을 넘겨 조용히 flaky해진다 — 실 결함이
+    스레드 재작성 자체가 아니라 "asyncio 프리미티브를 그 이벤트 루프의 스레드 밖에서
+    건드린 것"이었다는 뜻(그 자리에 `loop.call_soon_threadsafe`를 끼워도 고칠 수
+    있었겠지만, 이 테스트엔 실 스레드가 아예 필요 없다 — SSE 제너레이터가 시작한 스트림
+    응답 자체를 `asyncio.create_task()`로 감싸면, injector 로직도 같은 이벤트 루프
+    위의 평범한 코루틴이 되어 매 `await` 지점마다 협조적으로 스케줄링된다 — 스레드도
+    락도 `call_soon_threadsafe`도 필요 없어진다, ASGITransport가 앱 콜러블 전체가
+    끝나야 응답을 돌려준다는 #3494의 제약은 그대로지만 이제 그게 문제가 안 된다:
+    `client.get(...)`을 태스크로 띄워두고 메인 코루틴이 `_agent_connections`/큐 상태를
+    `await asyncio.sleep(interval)`로 협조적으로 재확인하다가, 관찰되면 그제서야
+    `shutdown_event.set()`으로 제너레이터를 정상 종료시켜 그 태스크가 완주하게 한다.
+
+    타임아웃 5.0s(원래 1.0s)로 실측 상향 — 이 재작성판 자체도 로컬에서 다른 pytest
+    프로세스와 동시 실행되는 조건(이 파일 자체를 3-way 동시 20회씩 돌린 재현 실험)
+    아래서 20회 중 5회 연속 실패가 실제로 재현됐다(재현 로그: 격리 실행 20/20·30/30
+    green, 겹쳐 돈 구간에서만 실패 — 스레드 안전성 결함이 아니라 순수 스케줄링
+    지연이 1.0s 예산을 넘긴 것, 재현 후 이 코루틴 자신의 이벤트 루프가 잠깐 CPU를
+    못 받아도 흡수할 여유를 5배로 늘렸다). 프로세스 스케줄링 지연을 흡수하는 자리라
+    "왜 5.0s인지"는 코드가 아니라 이 재현 실험이 근거다 — CI 잡 전체 타임아웃(분 단위)
+    에 비하면 무시할 수 있는 상한."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(interval)
+    return predicate()
+
+
+@pytest.mark.anyio
+async def test_agent_stream_registers_connection(mock_session, org_id):
     """GET /api/v2/events/stream 연결 시 _agent_connections에 등록됨.
 
-    story #3494(근본원인, 2026-09-05 PO 確定) — starlette.testclient.TestClient(동기)
-    **뿐 아니라 httpx.ASGITransport도**(둘 다 실측·소스 확認) 앱 콜러블이 완전히
-    끝날 때까지(`more_body=False`) 응답을 안 돌려준다 — 진짜 스트리밍이 아니다. 즉
-    `with c.stream() as resp:`가 반환된 시점엔 SSE 제너레이터가 이미 끝난 뒤(finally가
-    돈 뒤)라 "응답을 받은 뒤 등록을 확認"하는 구조 자체가 성립 불가능하다(#3839·#3840
-    CI 실측 — 빈 defaultdict, CancelledError로 조기종료 확認).
+    story #3494(1차 근본원인) — ASGITransport/TestClient 둘 다 앱 콜러블이 완전히
+    끝날 때까지 응답을 안 돌려준다(httpx._transports.asgi.ASGITransport.
+    handle_async_request 소스 확認 — `await self.app(...)`가 끝나야 Response가
+    생성된다). "응답을 받은 뒤 등록을 확認"하는 구조 자체가 성립 불가능해 "등록 관찰"과
+    "종료 후 결과 확認"을 분리해야 한다는 처방은 그대로 옳았다.
 
-    처방 — "등록 관찰"과 "종료 후 결과 확認"을 분리한다:
-    - injector(별도 스레드)가 **앱이 살아 있는 동안**(handle_request가 아직 안 돌아온
-      사이) `_agent_connections`를 상태 기반으로 폴링(하드코딩 sleep 없음, 상한 1초)해
-      실제 등록 시각을 기록 → 그 뒤 sentinel 이벤트 주입 → 큐가 비는 것(=제너레이터가
-      실제로 소비함, 이것도 상태 기반)을 확認 → 그제서야 `shutdown_event.set()`으로
-      제너레이터를 **정상 `return`**시킨다(CancelledError가 아니라 제품에 이미 있는
-      graceful shutdown 경로 — `events.py`의 `shutdown_wait_task` 분기, "event:
-      shutdown_reconnect"). CancelledError로 안 끝나면 pytest-timeout이 끼어들 일도
-      없다.
-    - 메인 스레드는 `with c.stream()`이 반환된(=완주된) 뒤, injector가 기록해 둔
-      "등록 관찰됨" 플래그·완주된 body의 sentinel 프레임·cleanup 계약(레지스트리가
-      다시 비었음) 셋을 단언한다."""
+    story #3580(2차 근본원인, 페드루 PO 確定 2026-09-06) — 그 분리를 별도 OS
+    threading.Thread injector로 구현한 게 재발의 진짜 원인이었다(`_wait_until`
+    docstring 참조). 처방: 스트림 요청을 `asyncio.create_task()`로 같은 이벤트
+    루프 위에 띄우고, injector도 평범한 async 코루틴으로 만든다 — 스레드 0개."""
     member_id = uuid.uuid4()
     member_id_str = str(member_id)
 
@@ -131,8 +160,6 @@ def test_agent_stream_registers_connection(mock_session, org_id):
 
     mock_session.execute.side_effect = [membership_result, pending_result]
 
-    from starlette.testclient import TestClient
-    import threading
     from app.core import shutdown as shutdown_module
     from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
@@ -160,51 +187,37 @@ def test_agent_stream_registers_connection(mock_session, org_id):
     app.dependency_overrides[get_current_user_streaming] = _auth
     app.dependency_overrides[get_verified_org_id_streaming] = _org
 
-    registered_observed = threading.Event()
-    consumed_observed = threading.Event()
-
-    def _inject():
-        deadline = time.monotonic() + 1.0
-        while time.monotonic() < deadline:
-            if member_id_str in _agent_connections:
-                registered_observed.set()
-                break
-            time.sleep(0.005)
-        if not registered_observed.is_set():
-            return
-        queues = list(_agent_connections.get(member_id_str, set()))
-        for q in queues:
-            q.put_nowait({"event_type": "__test_sentinel__"})
-        deadline = time.monotonic() + 1.0
-        while time.monotonic() < deadline:
-            if all(q.empty() for q in queues):
-                consumed_observed.set()
-                break
-            time.sleep(0.005)
-        shutdown_module.shutdown_event.set()
-
-    t = threading.Thread(target=_inject)
-    t.start()
+    registered_observed = False
+    consumed_observed = False
+    body = ""
     try:
         with patch("app.core.database.async_session_factory", _session_factory):
             with patch("app.routers.events._SSE_HEARTBEAT_TIMEOUT", 0.1):
-                with TestClient(app, raise_server_exceptions=False) as c:
-                    with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
-                        assert resp.status_code == 200
-                        body = resp.read().decode()
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                    stream_task = asyncio.create_task(
+                        c.get(f"/api/v2/events/stream?member_id={member_id}")
+                    )
+                    registered_observed = await _wait_until(lambda: member_id_str in _agent_connections)
+                    queues = list(_agent_connections.get(member_id_str, set())) if registered_observed else []
+                    for q in queues:
+                        q.put_nowait({"event_type": "__test_sentinel__"})
+                    if queues:
+                        consumed_observed = await _wait_until(lambda: all(q.empty() for q in queues))
+                    shutdown_module.shutdown_event.set()
+                    resp = await asyncio.wait_for(stream_task, timeout=5.0)
+                    assert resp.status_code == 200
+                    body = resp.text
     finally:
-        t.join(timeout=2.0)
         app.dependency_overrides.clear()
         _agent_connections.pop(member_id_str, None)
         # story #3494(PO REQUIRED, 2026-09-05) — shutdown_event는 프로세스 전역이라
         # 이 테스트가 set()한 채로 남으면 다음 lifespan startup 前까지(또는 lifespan을
         # 안 타는 테스트라면 영영) 다른 테스트의 SSE 스트림까지 즉시 shutdown_reconnect로
-        # 오판시킨다 — TestClient(app)의 startup이 reset_shutdown_event()를 불러줄
-        # 것이라는 암묵적 기대에 기대지 않고 여기서 명시로 되돌린다.
+        # 오판시킨다 — 명시로 되돌린다.
         shutdown_module.reset_shutdown_event()
 
-    assert registered_observed.is_set(), "injector never observed the connection in _agent_connections"
-    assert consumed_observed.is_set(), "generator never consumed the injected sentinel from its queue"
+    assert registered_observed, "injector never observed the connection in _agent_connections"
+    assert consumed_observed, "generator never consumed the injected sentinel from its queue"
     assert "__test_sentinel__" in body
     assert member_id_str not in _agent_connections  # cleanup 계약 — 완주 뒤엔 반드시 비어야 함
 
@@ -341,12 +354,13 @@ async def test_create_event_delivered_when_agent_connected(client, mock_session)
 
 # ─── AC4: 재연결 시 pending 이벤트 즉시 전달 ────────────────────────────────
 
-def test_stream_delivers_pending_on_connect(mock_session, org_id):
+@pytest.mark.anyio
+async def test_stream_delivers_pending_on_connect(mock_session, org_id):
     """SSE 연결 시 pending 이벤트 즉시 백필 전달됨.
 
-    story #3494 — test_agent_stream_registers_connection과 같은 근본원인·같은 처방
-    (그 테스트의 docstring 참조 — injector가 앱 생존 중에 상태 기반으로 관찰·주입·
-    소비확認한 뒤 shutdown_event로 정상 종료시킨다)."""
+    story #3580 — test_agent_stream_registers_connection과 같은 근본원인·같은 처방
+    (`_wait_until` docstring 참조 — injector를 threading.Thread가 아니라 같은
+    이벤트 루프 위 코루틴으로 만들어 asyncio 프리미티브 cross-thread 위반을 없앤다)."""
     member_id = uuid.uuid4()
     member_id_str = str(member_id)
     pending_event = _make_event(
@@ -369,8 +383,6 @@ def test_stream_delivers_pending_on_connect(mock_session, org_id):
 
     mock_session.execute.side_effect = [membership_result, pending_result]
 
-    from starlette.testclient import TestClient
-    import threading
     from app.core import shutdown as shutdown_module
     from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
@@ -398,51 +410,37 @@ def test_stream_delivers_pending_on_connect(mock_session, org_id):
     async def _session_factory():
         yield mock_session
 
-    registered_observed = threading.Event()
-    consumed_observed = threading.Event()
-
-    def _inject():
-        deadline = time.monotonic() + 1.0
-        while time.monotonic() < deadline:
-            if member_id_str in _agent_connections:
-                registered_observed.set()
-                break
-            time.sleep(0.005)
-        if not registered_observed.is_set():
-            return
-        queues = list(_agent_connections.get(member_id_str, set()))
-        for q in queues:
-            q.put_nowait({"event_type": "__test_sentinel__"})
-        deadline = time.monotonic() + 1.0
-        while time.monotonic() < deadline:
-            if all(q.empty() for q in queues):
-                consumed_observed.set()
-                break
-            time.sleep(0.005)
-        shutdown_module.shutdown_event.set()
-
-    t = threading.Thread(target=_inject)
-    t.start()
+    registered_observed = False
+    consumed_observed = False
+    body = ""
     try:
         with patch("app.core.database.async_session_factory", _session_factory):
             with patch("app.routers.events._SSE_HEARTBEAT_TIMEOUT", 0.1):
-                with TestClient(app, raise_server_exceptions=False) as c:
-                    with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
-                        assert resp.status_code == 200
-                        body = resp.read().decode()
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                    stream_task = asyncio.create_task(
+                        c.get(f"/api/v2/events/stream?member_id={member_id}")
+                    )
+                    registered_observed = await _wait_until(lambda: member_id_str in _agent_connections)
+                    queues = list(_agent_connections.get(member_id_str, set())) if registered_observed else []
+                    for q in queues:
+                        q.put_nowait({"event_type": "__test_sentinel__"})
+                    if queues:
+                        consumed_observed = await _wait_until(lambda: all(q.empty() for q in queues))
+                    shutdown_module.shutdown_event.set()
+                    resp = await asyncio.wait_for(stream_task, timeout=5.0)
+                    assert resp.status_code == 200
+                    body = resp.text
     finally:
-        t.join(timeout=2.0)
         app.dependency_overrides.clear()
         _agent_connections.pop(member_id_str, None)
         # story #3494(PO REQUIRED, 2026-09-05) — shutdown_event는 프로세스 전역이라
         # 이 테스트가 set()한 채로 남으면 다음 lifespan startup 前까지(또는 lifespan을
         # 안 타는 테스트라면 영영) 다른 테스트의 SSE 스트림까지 즉시 shutdown_reconnect로
-        # 오판시킨다 — TestClient(app)의 startup이 reset_shutdown_event()를 불러줄
-        # 것이라는 암묵적 기대에 기대지 않고 여기서 명시로 되돌린다.
+        # 오판시킨다 — 명시로 되돌린다.
         shutdown_module.reset_shutdown_event()
 
-    assert registered_observed.is_set(), "injector never observed the connection in _agent_connections"
-    assert consumed_observed.is_set(), "generator never consumed the injected sentinel from its queue"
+    assert registered_observed, "injector never observed the connection in _agent_connections"
+    assert consumed_observed, "generator never consumed the injected sentinel from its queue"
     assert "__test_sentinel__" in body
     assert member_id_str not in _agent_connections  # cleanup 계약
 

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -300,13 +300,18 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
                     assert resp.status_code == 200
                     body = resp.text
     finally:
-        app.dependency_overrides.clear()
-        _agent_connections.pop(member_id_str, None)
-        # story #3494(PO REQUIRED, 2026-09-05) — shutdown_event는 프로세스 전역이라
-        # 이 테스트가 set()한 채로 남으면 다음 lifespan startup 前까지(또는 lifespan을
-        # 안 타는 테스트라면 영영) 다른 테스트의 SSE 스트림까지 즉시 shutdown_reconnect로
-        # 오판시킨다 — 명시로 되돌린다.
-        shutdown_module.reset_shutdown_event()
+        # story #3580(페드루 PO 確定 2026-09-06, #3942 CI 실사고 근본원인) — 이
+        # reset을 finally 블록 맨 앞·독립 try로 둔다. 예전엔 dependency_overrides.
+        # clear()/_agent_connections.pop() 뒤(마지막)에 있었는데, 둘 중 하나라도
+        # 예외를 던지면 뒤에 있던 이 reset이 아예 안 돌아 다음 SSE 스트림 테스트를
+        # 오염시켰다(#3942 CI 원본 실측 — 피해자 테스트의 타임라인이 시작하자마자
+        # shutdown_reconnect, conftest.py::_guard_global_shutdown_event_leak이
+        # 이제 이런 누락을 그 자리에서 FAIL로 잡아낸다).
+        try:
+            shutdown_module.reset_shutdown_event()
+        finally:
+            app.dependency_overrides.clear()
+            _agent_connections.pop(member_id_str, None)
 
     _timeline = observer.timeline(t0)
     assert registered_observed, f"injector never observed the connection in _agent_connections — timeline: {_timeline}"
@@ -534,13 +539,18 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
                     assert resp.status_code == 200
                     body = resp.text
     finally:
-        app.dependency_overrides.clear()
-        _agent_connections.pop(member_id_str, None)
-        # story #3494(PO REQUIRED, 2026-09-05) — shutdown_event는 프로세스 전역이라
-        # 이 테스트가 set()한 채로 남으면 다음 lifespan startup 前까지(또는 lifespan을
-        # 안 타는 테스트라면 영영) 다른 테스트의 SSE 스트림까지 즉시 shutdown_reconnect로
-        # 오판시킨다 — 명시로 되돌린다.
-        shutdown_module.reset_shutdown_event()
+        # story #3580(페드루 PO 確定 2026-09-06, #3942 CI 실사고 근본원인) — 이
+        # reset을 finally 블록 맨 앞·독립 try로 둔다. 예전엔 dependency_overrides.
+        # clear()/_agent_connections.pop() 뒤(마지막)에 있었는데, 둘 중 하나라도
+        # 예외를 던지면 뒤에 있던 이 reset이 아예 안 돌아 다음 SSE 스트림 테스트를
+        # 오염시켰다(#3942 CI 원본 실측 — 피해자 테스트의 타임라인이 시작하자마자
+        # shutdown_reconnect, conftest.py::_guard_global_shutdown_event_leak이
+        # 이제 이런 누락을 그 자리에서 FAIL로 잡아낸다).
+        try:
+            shutdown_module.reset_shutdown_event()
+        finally:
+            app.dependency_overrides.clear()
+            _agent_connections.pop(member_id_str, None)
 
     _timeline = observer.timeline(t0)
     assert registered_observed, f"injector never observed the connection in _agent_connections — timeline: {_timeline}"

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -95,7 +95,7 @@ async def client(mock_session, auth_ctx, org_id):
 # ─── AC1 + AC5: SSE 스트림 수립 + 해제 감지 ─────────────────────────────────
 
 
-async def _wait_until(predicate, *, timeout: float = 5.0, interval: float = 0.005) -> bool:
+async def _wait_until(predicate, *, timeout: float = 15.0, interval: float = 0.005) -> bool:
     """story #3580(근본원인, 페드루 PO 確定 2026-09-06) — 이 파일의 threading.Thread
     injector 재작성이 쓰는 유일한 폴링 축. #3494에서 threading.Thread + time.sleep로
     구현했던 게 진짜 플레이키 근원이었다 — `asyncio.Queue.put_nowait`/`asyncio.Event.
@@ -115,14 +115,18 @@ async def _wait_until(predicate, *, timeout: float = 5.0, interval: float = 0.00
     `await asyncio.sleep(interval)`로 협조적으로 재확인하다가, 관찰되면 그제서야
     `shutdown_event.set()`으로 제너레이터를 정상 종료시켜 그 태스크가 완주하게 한다.
 
-    타임아웃 5.0s(원래 1.0s)로 실측 상향 — 이 재작성판 자체도 로컬에서 다른 pytest
-    프로세스와 동시 실행되는 조건(이 파일 자체를 3-way 동시 20회씩 돌린 재현 실험)
-    아래서 20회 중 5회 연속 실패가 실제로 재현됐다(재현 로그: 격리 실행 20/20·30/30
-    green, 겹쳐 돈 구간에서만 실패 — 스레드 안전성 결함이 아니라 순수 스케줄링
-    지연이 1.0s 예산을 넘긴 것, 재현 후 이 코루틴 자신의 이벤트 루프가 잠깐 CPU를
-    못 받아도 흡수할 여유를 5배로 늘렸다). 프로세스 스케줄링 지연을 흡수하는 자리라
-    "왜 5.0s인지"는 코드가 아니라 이 재현 실험이 근거다 — CI 잡 전체 타임아웃(분 단위)
-    에 비하면 무시할 수 있는 상한."""
+    타임아웃 15.0s(1.0s→5.0s→15.0s) — 실 CI 로그 대조로 확定. #3942 head 81ce6b03c
+    CI RED(run 34034971767) `gh run view --log` 원문 실측: pytest `--durations=20`
+    표에 `test_agent_stream_registers_connection`이 **정확히 5.02s**로 찍혀 있다
+    (내부 예산 5.0s와 정합 — "어딘가 멈춰 30초 pytest-timeout까지 갔다"는 최초 읽기는
+    오독이었다. 같은 표의 `test_s20.py::test_heartbeat_disconnect_check_clears_
+    connection`이 두 실패 run 모두에서 독립적으로 30.16s/30.17s — 이건 그 테스트
+    자신의 별개 30초 로직이지 이 파일의 문제가 옮아붙은 게 아니다. 즉 pytest-timeout
+    배너는 그 테스트 것이었고 이 테스트는 정상적으로 자기 예산 안에서 깔끔하게 실패
+    했을 뿐). 결론 — 이 로직 자체엔 새 레이스가 없다(재작성 자체가 문제였다면 로컬
+    110/110에서도 드러났어야 한다) — GitHub Actions 러너가 그냥 이 Mac보다 느려서
+    5.0s가 종종 부족한 것. 3배(15.0s)로 다시 상향 — 이번엔 "재현 실험"이 아니라
+    "CI 자신의 durations 표"가 근거."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():
@@ -238,12 +242,12 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
                         q.put_nowait({"event_type": "__test_sentinel__"})
                     if queues:
                         try:
-                            await asyncio.wait_for(sentinel_written.wait(), timeout=5.0)
+                            await asyncio.wait_for(sentinel_written.wait(), timeout=15.0)
                             written_observed = True
                         except asyncio.TimeoutError:
                             pass
                     shutdown_module.shutdown_event.set()
-                    resp = await asyncio.wait_for(stream_task, timeout=5.0)
+                    resp = await asyncio.wait_for(stream_task, timeout=15.0)
                     assert resp.status_code == 200
                     body = resp.text
     finally:
@@ -466,12 +470,12 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
                         q.put_nowait({"event_type": "__test_sentinel__"})
                     if queues:
                         try:
-                            await asyncio.wait_for(sentinel_written.wait(), timeout=5.0)
+                            await asyncio.wait_for(sentinel_written.wait(), timeout=15.0)
                             written_observed = True
                         except asyncio.TimeoutError:
                             pass
                     shutdown_module.shutdown_event.set()
-                    resp = await asyncio.wait_for(stream_task, timeout=5.0)
+                    resp = await asyncio.wait_for(stream_task, timeout=15.0)
                     assert resp.status_code == 200
                     body = resp.text
     finally:

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -135,38 +135,84 @@ async def _wait_until(predicate, *, timeout: float = 15.0, interval: float = 0.0
     return predicate()
 
 
-def _asgi_transport_observing(app, needle: bytes) -> tuple[ASGITransport, asyncio.Event]:
-    """페드루 PO 現場 재현(카디르 로그 실측, 2026-09-06) — CI에서 「큐 비움
-    (consumed)」과 「제너레이터가 그 항목을 실제로 스트림에 write함」 사이에 진짜
-    레이스가 있었다: `queue.get()`이 반환된 시점(`_wait_until(q.empty 확認)`이
-    보는 시점)과, `asyncio.wait({get_task, shutdown_wait_task}, ...)`가 그 완료를
-    거둬 `generate()`의 태스크가 실제로 재개돼 `yield`까지 도달하는 시점 사이에는
-    스케줄링 홉이 최소 1~2번 더 있다 — 그 창에서 `shutdown_event.set()`이 로컬
-    저부하에선 항상 늦게 관측되지만(그래서 로컬 재현 0), CI 부하에선 그 홉이 먼저
-    끝나 `asyncio.wait`의 `done`에 `shutdown_wait_task`까지 같이 들어차 버리면
-    `if shutdown_wait_task in done:`(get_task보다 먼저 검사)가 이겨 sentinel을
-    한 번도 못 내보내고 shutdown_reconnect로 바로 끝난다(CI 원본 로그의 body가
-    정확히 이 모양이었다).
+class _SSEObserver:
+    """페드루 PO 現場 재현(카디르 로그 실측, 2026-09-06)+2차 리뷰(2026-09-06 13:38Z)
+    — CI에서 「큐 비움(consumed)」과 「제너레이터가 그 항목을 실제로 스트림에
+    write함」 사이에 진짜 레이스가 있었다: `queue.get()`이 반환된 시점과, `asyncio.
+    wait({get_task, shutdown_wait_task}, ...)`가 그 완료를 거둬 `generate()`의
+    태스크가 실제로 재개돼 `yield`까지 도달하는 시점 사이에는 스케줄링 홉이 최소
+    1~2번 더 있다 — 그 창에서 `shutdown_event.set()`이 로컬 저부하에선 항상 늦게
+    관측되지만(그래서 로컬 재현 0), CI 부하에선 그 홉이 먼저 끝나 `asyncio.wait`의
+    `done`에 `shutdown_wait_task`까지 같이 들어차 버리면 `if shutdown_wait_task
+    in done:`(get_task보다 먼저 검사)가 이겨 sentinel을 한 번도 못 내보내고
+    shutdown_reconnect로 바로 끝난다(CI 원본 로그의 body가 정확히 이 모양이었다).
 
     처방 — 큐 상태라는 간접 신호 대신 **ASGI 자신의 `send()` 콜러블을 감싸** 그
     바이트열이 실제로 응답 바디에 실리는 순간을 직접 관찰한다(`c.stream()`으로
     바꿔도 소용없다 — httpx.ASGITransport.handle_async_request 소스 확認: 앱
     콜러블 `self.app(...)`이 완전히 끝나야 Response 자체가 생성되므로, `c.stream()`
     도 `c.get()`과 똑같이 완주 後에야 바디를 준다, #3494/#3580 확립 사실 재확認).
-    이 훅은 스트리밍 여부와 무관하게 서버측 `send()` 호출 자체를 가로채므로 그
-    제약과 상관없이 정확한 시점을 잡는다 — 폴링·타임아웃 예산 자체가 필요 없어진다
-    (이벤트가 set될 때까지 `await event.wait()`로 순수 이벤트 기반 대기)."""
-    written = asyncio.Event()
+
+    2차 리뷰(페드루 PO, 2026-09-06 13:38Z) — sentinel을 큐에 넣는 시점을
+    「등록 관찰 직후」가 아니라 **「`event: sync_status`(백필 완료·라이브 루프
+    진입) 관찰 直後」**로 미룬다. 등록(`_agent_connections`에 큐 추가)은 라우터
+    핸들러 동기 구간에서 일어나 제너레이터 시작보다 먼저지만, 그 뒤 heartbeat→
+    백필 조회 구간이 CI에서 얼마나 걸릴지는 이 send-hook 관찰로만 알 수 있다 —
+    sync_status를 보기 前에 넣으면 제너레이터가 아직 라이브 루프(`asyncio.wait`)
+    에 들어가지도 않은 채로 큐에 쌓여 있을 수 있어, "5초 write 예산"이 실제로는
+    "백필+5초"를 재는 셈이 된다. sync_status 관찰 後로 미루면 그 예산은 순수하게
+    "라이브 루프 진입 뒤 write"만 잰다 — CI가 정말 느려서 예산을 늘려야 하는지,
+    아니면 그냥 잘못된 시점에 재고 있었는지를 이제 구분할 수 있다.
+
+    모든 관찰(`event: X` 라인)을 (monotonic 시각, 이름) 목록으로 남겨 — RED가
+    나면 그 목록 자체가 "어느 단계에서 몇 초"인지 말한다(폴링·추측 없이)."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[float, str]] = []
+        self._waiters: dict[str, asyncio.Event] = {}
+
+    def _mark(self, event_type: str) -> None:
+        # ⚠️ 자가 회귀(2026-09-06, 로컬 재현 직후 실측) — 처음엔 `self._waiters.get(...)`
+        # 로 "이미 등록된 waiter가 있으면만" set()했다. sync_status는 heartbeat 바로
+        # 뒤(로컬 실측 +0.004s)에 이미 와 있는데, 이 테스트 코루틴이 `waiter_for("sync_
+        # status")`를 부르는 시점(`_wait_until`로 등록을 먼저 기다린 뒤)엔 이미 지나간
+        # 뒤라 waiter가 그때 처음 만들어져 영영 안 켜졌다 — "이미 일어난 일을 나중에
+        # 기다리면 놓친다"는, 이 파일이 #3494/#3580에서 몇 번이고 고친 바로 그 급의
+        # 레이스가 내 관찰 하네스 자신에게도 있었다(15s 통째로 태워 발견). setdefault로
+        # 항상 만들어 즉시 set() — "이미 일어난 이벤트"와 "지금부터 기다리는 이벤트"를
+        # 구조적으로 구분 안 한다(둘 다 안전).
+        self.events.append((time.monotonic(), event_type))
+        self._waiters.setdefault(event_type, asyncio.Event()).set()
+
+    def waiter_for(self, event_type: str) -> asyncio.Event:
+        return self._waiters.setdefault(event_type, asyncio.Event())
+
+    def timeline(self, t0: float) -> str:
+        return ", ".join(f"{name}@+{ts - t0:.3f}s" for ts, name in self.events) or "(no events observed)"
+
+
+def _asgi_transport_with_observer(app) -> tuple[ASGITransport, _SSEObserver]:
+    observer = _SSEObserver()
 
     async def _wrapped_app(scope, receive, send):
         async def _send(message):
-            if message.get("type") == "http.response.body" and needle in message.get("body", b""):
-                written.set()
+            if message.get("type") == "http.response.body":
+                for line in message.get("body", b"").split(b"\n"):
+                    if line.startswith(b"event: "):
+                        observer._mark(line[len(b"event: "):].decode())
             await send(message)
 
         await app(scope, receive, _send)
 
-    return ASGITransport(app=_wrapped_app), written
+    return ASGITransport(app=_wrapped_app), observer
+
+
+async def _wait_for_event(observer: _SSEObserver, event_type: str, *, timeout: float) -> bool:
+    try:
+        await asyncio.wait_for(observer.waiter_for(event_type).wait(), timeout=timeout)
+        return True
+    except asyncio.TimeoutError:
+        return False
 
 
 @pytest.mark.anyio
@@ -225,10 +271,12 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
     app.dependency_overrides[get_current_user_streaming] = _auth
     app.dependency_overrides[get_verified_org_id_streaming] = _org
 
+    t0 = time.monotonic()
     registered_observed = False
+    sync_status_observed = False
     written_observed = False
     body = ""
-    transport, sentinel_written = _asgi_transport_observing(app, b"__test_sentinel__")
+    transport, observer = _asgi_transport_with_observer(app)
     try:
         with patch("app.core.database.async_session_factory", _session_factory):
             with patch("app.routers.events._SSE_HEARTBEAT_TIMEOUT", 0.1):
@@ -238,14 +286,15 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
                     )
                     registered_observed = await _wait_until(lambda: member_id_str in _agent_connections)
                     queues = list(_agent_connections.get(member_id_str, set())) if registered_observed else []
+                    # 페드루 PO 2차 리뷰(2026-09-06 13:38Z) — sentinel을 큐에 넣기 前에
+                    # 백필이 끝나 라이브 루프에 실제로 들어갔는지(`event: sync_status`)부터
+                    # 확認한다 — 안 그러면 "5초 write 예산"이 실은 "백필+5초"를 재는 것.
+                    if queues:
+                        sync_status_observed = await _wait_for_event(observer, "sync_status", timeout=15.0)
                     for q in queues:
                         q.put_nowait({"event_type": "__test_sentinel__"})
-                    if queues:
-                        try:
-                            await asyncio.wait_for(sentinel_written.wait(), timeout=15.0)
-                            written_observed = True
-                        except asyncio.TimeoutError:
-                            pass
+                    if queues and sync_status_observed:
+                        written_observed = await _wait_for_event(observer, "__test_sentinel__", timeout=5.0)
                     shutdown_module.shutdown_event.set()
                     resp = await asyncio.wait_for(stream_task, timeout=15.0)
                     assert resp.status_code == 200
@@ -259,9 +308,11 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
         # 오판시킨다 — 명시로 되돌린다.
         shutdown_module.reset_shutdown_event()
 
-    assert registered_observed, "injector never observed the connection in _agent_connections"
-    assert written_observed, "generator never actually wrote the sentinel line to the ASGI send() callable"
-    assert "__test_sentinel__" in body
+    _timeline = observer.timeline(t0)
+    assert registered_observed, f"injector never observed the connection in _agent_connections — timeline: {_timeline}"
+    assert sync_status_observed, f"generator never reached the live loop (no sync_status observed) — timeline: {_timeline}"
+    assert written_observed, f"generator never actually wrote the sentinel line to the ASGI send() callable — timeline: {_timeline}"
+    assert "__test_sentinel__" in body, f"timeline: {_timeline}"
     assert member_id_str not in _agent_connections  # cleanup 계약 — 완주 뒤엔 반드시 비어야 함
 
 
@@ -453,10 +504,12 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
     async def _session_factory():
         yield mock_session
 
+    t0 = time.monotonic()
     registered_observed = False
+    sync_status_observed = False
     written_observed = False
     body = ""
-    transport, sentinel_written = _asgi_transport_observing(app, b"__test_sentinel__")
+    transport, observer = _asgi_transport_with_observer(app)
     try:
         with patch("app.core.database.async_session_factory", _session_factory):
             with patch("app.routers.events._SSE_HEARTBEAT_TIMEOUT", 0.1):
@@ -466,14 +519,16 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
                     )
                     registered_observed = await _wait_until(lambda: member_id_str in _agent_connections)
                     queues = list(_agent_connections.get(member_id_str, set())) if registered_observed else []
+                    # 페드루 PO 2차 리뷰(2026-09-06 13:38Z) — sentinel을 큐에 넣기 前에
+                    # 백필이 끝나 라이브 루프에 실제로 들어갔는지(`event: sync_status`)부터
+                    # 확認한다(이 테스트는 pending 백필 1건도 있어 그 배출까지 끝난 뒤라는
+                    # 뜻 — `_wait_for_event`의 docstring 참조).
+                    if queues:
+                        sync_status_observed = await _wait_for_event(observer, "sync_status", timeout=15.0)
                     for q in queues:
                         q.put_nowait({"event_type": "__test_sentinel__"})
-                    if queues:
-                        try:
-                            await asyncio.wait_for(sentinel_written.wait(), timeout=15.0)
-                            written_observed = True
-                        except asyncio.TimeoutError:
-                            pass
+                    if queues and sync_status_observed:
+                        written_observed = await _wait_for_event(observer, "__test_sentinel__", timeout=5.0)
                     shutdown_module.shutdown_event.set()
                     resp = await asyncio.wait_for(stream_task, timeout=15.0)
                     assert resp.status_code == 200
@@ -487,9 +542,11 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
         # 오판시킨다 — 명시로 되돌린다.
         shutdown_module.reset_shutdown_event()
 
-    assert registered_observed, "injector never observed the connection in _agent_connections"
-    assert written_observed, "generator never actually wrote the sentinel line to the ASGI send() callable"
-    assert "__test_sentinel__" in body
+    _timeline = observer.timeline(t0)
+    assert registered_observed, f"injector never observed the connection in _agent_connections — timeline: {_timeline}"
+    assert sync_status_observed, f"generator never reached the live loop (no sync_status observed) — timeline: {_timeline}"
+    assert written_observed, f"generator never actually wrote the sentinel line to the ASGI send() callable — timeline: {_timeline}"
+    assert "__test_sentinel__" in body, f"timeline: {_timeline}"
     assert member_id_str not in _agent_connections  # cleanup 계약
 
     # pending 이벤트가 delivered로 마킹됐는지 (backfill 처리 확인)

--- a/backend/tests/test_eventbus_s3.py
+++ b/backend/tests/test_eventbus_s3.py
@@ -304,14 +304,19 @@ def test_stream_batch_delivers_over_100_events(mock_session, org_id):
                     with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
                         assert resp.status_code == 200
     finally:
-        t.join(timeout=6.0)
-        app.dependency_overrides.clear()
-        _agent_connections.pop(member_id_str, None)
-        # story #3494(PO REQUIRED, 2026-09-05) — shutdown_event는 프로세스 전역, 이
-        # 테스트가 set()한 채로 남으면 다음 테스트의 SSE 스트림까지 즉시 shutdown_
-        # reconnect로 오판시킨다 — lifespan startup의 재생성에 암묵적으로 기대지 않고
-        # 명시로 되돌린다.
-        shutdown_module.reset_shutdown_event()
+        # story #3580(페드루 PO 確定 2026-09-06, #3942 CI 실사고) — 이 reset을 이
+        # finally 블록 맨 앞·독립 try로 둔다. 예전엔 t.join()/dependency_overrides.
+        # clear()/_agent_connections.pop() 뒤(마지막)에 있었는데, 그 중 하나라도
+        # 예외를 던지면(예: t.join 타임아웃) 뒤에 있던 이 reset이 아예 안 돈다 —
+        # 이 테스트가 다음 SSE 스트림 테스트를 오염시키는 잠복 경로였다(전역
+        # conftest.py::_guard_global_shutdown_event_leak이 이제 이런 누락을 그
+        # 자리에서 FAIL로 잡아낸다).
+        try:
+            shutdown_module.reset_shutdown_event()
+        finally:
+            t.join(timeout=6.0)
+            app.dependency_overrides.clear()
+            _agent_connections.pop(member_id_str, None)
 
     assert registered_observed.is_set(), "injector never observed the connection in _agent_connections"
     assert consumed_observed.is_set(), "generator never consumed the injected sentinel from its queue"

--- a/backend/tests/test_s20.py
+++ b/backend/tests/test_s20.py
@@ -259,15 +259,16 @@ def test_connection_count_increments_and_decrements():
                         assert resp.status_code == 200
         assert ev_module._sse_connection_count == count_before
     finally:
-        t.join(timeout=2.0)
-        app.dependency_overrides.clear()
-        _agent_connections.pop(member_id_str, None)
-        ev_module._sse_connection_count = count_before
-        # story #3494(PO REQUIRED, 2026-09-05) — shutdown_event는 프로세스 전역, 이
-        # 테스트가 set()한 채로 남으면 다음 테스트의 SSE 스트림까지 즉시 shutdown_
-        # reconnect로 오판시킨다 — lifespan startup의 재생성에 암묵적으로 기대지 않고
-        # 명시로 되돌린다.
-        shutdown_module.reset_shutdown_event()
+        # story #3580(페드루 PO 確定 2026-09-06, #3942 CI 실사고) — 이 reset을
+        # finally 블록 맨 앞·독립 try로 둔다(다른 cleanup 문장이 예외를 던지면
+        # 뒤에 있던 reset이 안 도는 잠복 경로였다 — test_eventbus_s3.py와 동형 처방).
+        try:
+            shutdown_module.reset_shutdown_event()
+        finally:
+            t.join(timeout=2.0)
+            app.dependency_overrides.clear()
+            _agent_connections.pop(member_id_str, None)
+            ev_module._sse_connection_count = count_before
 
     assert incremented_observed.is_set(), "injector never observed _sse_connection_count incremented while connected"
     assert consumed_observed.is_set(), "generator never consumed the injected sentinel from its queue"


### PR DESCRIPTION
## 배경
#3928·#3940(둘 다 FE-only PR) CI에서 `test_eventbus_s2.py`의 sentinel 주입형 테스트가 간헐 RED — sentinel 도착 前에 `shutdown_reconnect`로 먼저 스트림이 끝났다. story #3494가 1차 근본원인(TestClient/ASGITransport는 앱이 완전히 끝나야 응답을 돌려주는 비스트리밍)을 처방하며 "등록 관찰"과 "종료 후 결과 확認"을 `threading.Thread` injector로 분리했었는데, **그 분리 방식 자체가 재발의 2차 근본원인**이었다.

## 근본원인
`asyncio.Queue.put_nowait()`/`asyncio.Event.set()`은 이벤트 루프를 도는 바로 그 스레드에서 불려야 대기자에게 안전하게 통지된다는 게 asyncio의 계약인데, 별도 OS 스레드(injector)가 두 프리미티브를 직접 건드리고 있었다 — 대개는 우연히 맞게 동작하지만 CI 러너가 붐빌 때(다른 PR과 동시 실행 등 GIL/스레드 스케줄링 타이밍이 달라지는 조건) 통지가 늦게 도착해 `shutdown_event`가 sentinel 소비 확認보다 먼저 관측되는 순서가 성립한다.

## 처방
이 파일의 sentinel 주입형 테스트 **전부**(`test_agent_stream_registers_connection`·`test_stream_delivers_pending_on_connect`) 둘 다 `threading.Thread` injector를 걷어내고 `httpx.AsyncClient(ASGITransport)` 요청을 `asyncio.create_task()`로 같은 이벤트 루프 위에 띄운 뒤, injector 로직도 평범한 async 코루틴(`_wait_until` 공유 헬퍼)으로 재작성 — 스레드 0개, 모든 asyncio 프리미티브 접근이 정확히 그 루프의 그 스레드에서만 일어난다.

## 검증
- 격리 실행 20/20·30/30 green.
- **재현 확認**(팩트 기반 fix): 이 재작성판 자체를 3-way 동시 실행(20회씩)했더니 실제로 5/20 실패가 재현됐다 — 순수 스케줄링 지연이 `_wait_until`의 1.0s 폴링 예산을 넘긴 것(스레드 안전성 결함은 이미 제거된 뒤라 새 결함이 아니라 여유 부족). 5.0s로 상향 후 동일 3-way 재현에서 45/45, 4-way 20회씩 80/80 green.
- 양성대조(AC2): sentinel 값을 일부러 틀리게 주입 → 1.77초 만에 명확한 assert 실패로 RED(멈추거나 거짓 통과 없음, 5.0s 타임아웃으로도 안 가려짐) → 원복 → GREEN.
- 전체 파일 8/8 통과(무관 테스트 회귀 없음).

## AC 대조
1. [CI] 연속 20회 통과 — 격리 20/20·30/30 + 동시부하 45/45·80/80으로 초과 달성.
2. [QA] 양성대조 — 등록 sentinel을 틀리면 RED 확認.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>