### PR TITLE
[SID:3593] feat: 댓글 답변 목록 API additive — reply.text·replies_count(BE 몫)

### DIFF
--- a/backend/app/routers/channel_post_comments.py
+++ b/backend/app/routers/channel_post_comments.py
@@ -45,6 +45,12 @@ class CommentReplySummary(BaseModel):
     status: str
     external_reply_url: str | None
     command_id: uuid.UUID | None
+    # story #3593(Phase2·BE, 페드루 PO 確定 2026-09-06) — 유나 실측: 답변 sent
+    # 뒤에도 행에 답변 텍스트가 어디에도 없어(comments-section.tsx grep 0건)
+    # 「내가 무엇을 답했는지」가 화면에서 안 보였다. DB엔 이미 저장돼 있던
+    # 값(ChannelPostCommentReply.text)의 투영만 빠진 자리 — 이 요약이 이미
+    # 「최신 답변」이므로 그 답변의 실제 본문을 그대로 싣는다.
+    text: str
     # story #3529(additive, 유나 §22-15 채택) — PublicationCommand 4필드 그대로
     # (새 이름/새 값 0). command_id가 null이면 넷 다 null.
     command_status: str | None = Field(
@@ -87,7 +93,7 @@ def _comment_reply_summary(reply, command_by_id: dict) -> CommentReplySummary:
     command = command_by_id.get(reply.command_id) if reply.command_id is not None else None
     return CommentReplySummary(
         id=reply.id, status=reply.status, external_reply_url=reply.external_reply_url,
-        command_id=reply.command_id,
+        command_id=reply.command_id, text=reply.text,
         command_status=command.status if command is not None else None,
         failure_kind=command.failure_kind if command is not None else None,
         next_attempt_at=(
@@ -106,6 +112,13 @@ class CommentItem(BaseModel):
     captured_at: str
     deleted_at: str | None
     reply: CommentReplySummary | None = None
+    # story #3593(Phase2·BE, 페드루 PO 確定 2026-09-06) — `reply`는 이미 「최신
+    # 답변」이지만(_latest_reply_by_comment_ids), 답변이 2건 이상(재상신 이력)
+    # 이면 배지 하나(=이 최신 status)만으로는 "이 발행됨이 어느 답변의 상태인가"
+    # 가 안 선다(유나 실측). 전체 개수를 additive로 얹어 FE가 "답변 N · 최신
+    # {상태}" 형을 조립할 수 있게 한다. 답변 0건이면 0(reply가 null인 것과
+    # 논리적으로 항상 같이 간다 — 0이면 reply도 반드시 null, 그 역도 성립).
+    replies_count: int = 0
 
 
 class CommentListResponse(BaseModel):
@@ -156,6 +169,7 @@ async def list_publication_comments_endpoint(
 
     reply_by_comment_id = result["reply_by_comment_id"]
     command_by_id = result["command_by_id"]
+    reply_counts_by_comment_id = result["reply_counts_by_comment_id"]
     return CommentListResponse(
         last_collected_at=result["last_collected_at"].isoformat() if result["last_collected_at"] else None,
         comments=[
@@ -167,6 +181,7 @@ async def list_publication_comments_endpoint(
                     _comment_reply_summary(reply_by_comment_id[c.id], command_by_id)
                     if c.id in reply_by_comment_id else None
                 ),
+                replies_count=reply_counts_by_comment_id.get(c.id, 0),
             )
             for c in result["comments"]
         ],

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -667,6 +667,15 @@ async def list_comments_for_publication(
         db, comment_ids=[c.id for c in rows],
     )
 
+    # story #3593(Phase2·BE, 페드루 PO 確定 2026-09-06) — 유나 실측: 답변이 2건
+    # 이상이면(재상신 이력) 화면의 배지 하나(=최신 답변 status)가 「이 발행됨이
+    # 어느 답변의 상태인가」를 말 못 한다. 최신 답변 요약(위)과 별개로 댓글당
+    # 전체 답변 개수를 배치 조회(N+1 X) — FE가 "답변 N · 최신 {상태}" 형을
+    # 조립할 수 있게. count_comments_by_publication_ids와 동형 GROUP BY 패턴.
+    reply_counts_by_comment_id = await _reply_counts_by_comment_ids(
+        db, comment_ids=[c.id for c in rows],
+    )
+
     # story #3529(additive, 유나 §22-15 채택) — 댓글 목록 reply{} 요약에 발송 명령
     # 상태 4필드(command_status·failure_kind·next_attempt_at·reason_code)를 얹기
     # 위한 배치 조회(N+1 X) — PublicationCommand 그대로, 새 컬럼/새 이름 0.
@@ -690,6 +699,7 @@ async def list_comments_for_publication(
         "reply_by_comment_id": latest_reply_by_comment_id,
         "comments_next_allowed_at": comments_next_allowed_at,
         "command_by_id": command_by_id,
+        "reply_counts_by_comment_id": reply_counts_by_comment_id,
     }
 
 
@@ -727,6 +737,22 @@ async def _latest_reply_by_comment_ids(
     reply_alias = aliased(ChannelPostCommentReply, subq)
     rows = (await db.execute(select(reply_alias).where(subq.c.rn == 1))).scalars().all()
     return {reply.comment_id: reply for reply in rows}
+
+
+async def _reply_counts_by_comment_ids(
+    db: AsyncSession, *, comment_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    """story #3593 — 댓글당 전체 답변 개수(초안 포함 모든 status) 배치 조회
+    (N+1 X). count_comments_by_publication_ids와 동형 GROUP BY 패턴.
+    comment_ids 없으면 빈 dict(호출부가 `.get(comment_id, 0)`)."""
+    if not comment_ids:
+        return {}
+    rows = (await db.execute(
+        select(ChannelPostCommentReply.comment_id, func.count())
+        .where(ChannelPostCommentReply.comment_id.in_(comment_ids))
+        .group_by(ChannelPostCommentReply.comment_id)
+    )).all()
+    return {comment_id: count for comment_id, count in rows}
 
 
 async def count_comments_by_publication_ids(

--- a/backend/tests/test_3593_comment_reply_additive.py
+++ b/backend/tests/test_3593_comment_reply_additive.py
@@ -1,0 +1,187 @@
+"""story #3593(Phase2·BE, 페드루 PO 確定 2026-09-06) — 유나 배포 44 FB 답변 경로
+실측(publication c547fa6d·댓글 9d255bd9): 답변 sent 뒤에도 행에 답변 텍스트가
+어디에도 없었다(comments-section.tsx에 reply.text류를 그리는 코드 0건). DB엔
+이미 저장된 값(ChannelPostCommentReply.text)의 투영만 빠진 자리 — 이 스토리의
+BE 몫만(FE는 3592 뒤 별도 PR, 페드루 PO 明示).
+
+또한 `create_comment_reply_draft`는 기존 답변을 확認하지 않고 새 행을 만든다
+(2차 답변 허용·중복 가드 0) — 그런데 목록 응답은 배지 하나(=최신 답변 status)
+뿐이라, 답변이 2건 이상이면 「이 상태가 어느 답변의 것인가」가 안 선다. 이
+스토리는 `reply`(이미 최신 답변 — `_latest_reply_by_comment_ids`)에 `text`를
+additive로 얹고, `CommentItem`에 `replies_count`를 additive로 얹는다.
+
+세팅 헬퍼는 test_3529_comment_reply_command_status.py·test_3516_comment_
+reply.py(조각②) 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import (
+    _seed_default_role, _seed_human, _seed_org, _session_factory,
+)
+from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+from tests.test_3516_comment_reply import _seed_comment, _seed_full_publication_chain
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    """test_3529_comment_reply_command_status.py와 동형 — supports_reply/
+    fetch_replies=True로 등재."""
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+        insight_metrics=("impressions", "reach", "views", "engagements", "clicks", "spend", "conversions"),
+        supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+async def _submit_and_approve_reply_with_text(s, *, org_id, human_id, comment, text: str):
+    """test_3516_comment_reply.py::_submit_and_approve_reply와 동형이나 text를
+    파라미터로 받는다 — 이 스토리는 2건의 답변을 «다른 본문»으로 구분해야 한다
+    (그 헬퍼는 "답변 본문" 고정이라 이 스토리 전용으로 옆에 둔다, 공용 헬퍼 수정
+    없음 — 다른 소비처 회귀 0)."""
+    from app.services.channel_post_comment_replies import create_comment_reply_draft, submit_comment_reply
+    from app.services.gate_service import transition_gate
+
+    draft = await create_comment_reply_draft(
+        s, org_id=org_id, comment_id=comment.id, text=text, created_by_member_id=human_id,
+        created_by_kind="human",
+    )
+    reply = await submit_comment_reply(s, org_id=org_id, reply_id=draft.id, requester_member_id=human_id)
+    await transition_gate(s, org_id, reply.gate_id, "approved", human_id, "승인")
+    await s.commit()
+    return reply
+
+
+@pytest.mark.anyio
+async def test_comment_with_two_replies_exposes_count_and_latest_text():
+    """AC1 — 답변 2건인 댓글에서 replies_count==2·reply(=latest)가 더 최근에
+    만든 답변의 text·status를 실어야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            await _seed_default_role(s, org_id)
+            _work_item_id, _gate, _conn, pub = await _seed_full_publication_chain(
+                s, org_id=org_id, project_id=project_id,
+            )
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+            await _submit_and_approve_reply_with_text(s, org_id=org_id, human_id=human_id, comment=comment, text="첫 답변")
+            second_reply = await _submit_and_approve_reply_with_text(
+                s, org_id=org_id, human_id=human_id, comment=comment, text="두 번째 답변",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments")
+        assert r.status_code == 200, r.text
+        item = next(c for c in r.json()["comments"] if c["id"] == str(comment.id))
+        assert item["replies_count"] == 2, item
+        assert item["reply"]["text"] == "두 번째 답변", item
+        assert item["reply"]["id"] == str(second_reply.id), item
+        assert item["reply"]["status"] == "pending", item
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comment_with_single_reply_exposes_text_and_count_one():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            await _seed_default_role(s, org_id)
+            _work_item_id, _gate, _conn, pub = await _seed_full_publication_chain(
+                s, org_id=org_id, project_id=project_id,
+            )
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+            await _submit_and_approve_reply_with_text(s, org_id=org_id, human_id=human_id, comment=comment, text="유일한 답변")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments")
+        assert r.status_code == 200, r.text
+        item = next(c for c in r.json()["comments"] if c["id"] == str(comment.id))
+        assert item["replies_count"] == 1, item
+        assert item["reply"]["text"] == "유일한 답변", item
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comment_without_reply_exposes_zero_count_and_null_reply():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            await _seed_default_role(s, org_id)
+            _work_item_id, _gate, _conn, pub = await _seed_full_publication_chain(
+                s, org_id=org_id, project_id=project_id,
+            )
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments")
+        assert r.status_code == 200, r.text
+        item = next(c for c in r.json()["comments"] if c["id"] == str(comment.id))
+        assert item["replies_count"] == 0, item
+        assert item["reply"] is None, item
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1421,6 +1421,11 @@
       "file": "tests/test_3589_image_upload_cleanup_on_reject.py",
       "sec": 26.0,
       "source": "story-3589-upload-cleanup-on-reject(2-way 분할 — 이미지 5건 로컬 4.26s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 26s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3593_comment_reply_additive.py",
+      "sec": 20.0,
+      "source": "story-3593-comment-reply-additive(PR 개설 前 선제 등재 — 로컬 raw pytest 3건 3.31s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 배경
유나 배포 44 FB 답변 경로 실측(2026-09-06 14:13Z, publication c547fa6d·댓글 9d255bd9) — 답변 sent 뒤에도 행 어디에도 답변 텍스트가 없었다(`comments-section.tsx`에 `reply.text`류를 그리는 코드 0건). DB엔 이미 저장된 값(`ChannelPostCommentReply.text`)의 투영만 빠진 자리였다.

또한 `create_comment_reply_draft`는 기존 답변을 확認하지 않고 새 행을 만든다(2차 답변 허용·중복 가드 0) — 그런데 목록 응답은 배지 하나(=최신 답변 status)뿐이라, 답변이 2건 이상이면 「이 상태가 어느 답변의 것인가」가 안 선다.

## BE additive(이 PR — 스토리 確定 「BE 몫부터」, FE는 3592 뒤 별도 PR)
- `CommentReplySummary.text` — `reply`는 이미 `_latest_reply_by_comment_ids`로 «최신 답변»이므로, 새 필드 없이 그 요약에 실제 본문만 얹는다(같은 배치 조회 재사용, 추가 쿼리 0).
- `CommentItem.replies_count` — 댓글당 전체 답변 개수(초안 포함) 배치 조회 신설(`_reply_counts_by_comment_ids`, `count_comments_by_publication_ids`와 동형 GROUP BY 패턴, N+1 X).
- 기존 필드(`reply` 자체·`command_status`류 4필드) 불변 — `comments-section.tsx`가 이미 `c.reply?.xxx`로 소비 중인 필드명이라 리네임 없이 순수 추가만.

## 검증
- 신규 3건 — 답변 2건(count==2·reply가 최신 것의 text/id/status) · 답변 1건(count==1) · 무응답(count==0·reply=null).
- 뮤테이션 2 — replies_count 강제 0(count 관련 2건 RED) · text 강제 빈 문자열(text 관련 2건 RED) → 둘 다 원복 GREEN.
- 회귀 73건(3516/3529/3571 계열) 통과. 무관 3건(`test_3516_comment_scope_and_runbook.py`) 배치 순서 의존 사전 존재 flake 확認(git stash로 develop 베이스라인 대조 — 내 변경 없이도 재현, 이 PR과 무관, 별도 이슈로 남김).
- shard-weights 등재(로컬 3.31s×6=20s)·lint 통과.

## AC 대조
1. [BE] 답변마다 text·댓글마다 replies_count·latest_reply.status(=기존 reply.status 그대로) additive·기존 필드 불변 ✓ — 확認.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>