### PR TITLE
[SID:3594] fix: test_3516_comment_scope_and_runbook.py 배치 순서 flake — 잔존 monkeypatch 정리

### DIFF
--- a/backend/tests/test_3516_comment_reply.py
+++ b/backend/tests/test_3516_comment_reply.py
@@ -578,7 +578,15 @@ async def test_api_create_draft_allows_agent_but_submit_rejects_agent():
 
 
 @pytest.mark.anyio
-async def test_insights_board_carries_three_comment_signal_fields():
+async def test_insights_board_carries_three_comment_signal_fields(monkeypatch):
+    """story #3594(테스트 위생, 페드루 PO 確定 2026-09-06) — 이 자리가 원래
+    `sandbox_publish.fetch_replies`를 pytest `monkeypatch` 없이 모듈 속성에
+    직접 대입했다(변수명만 `monkeypatch_target`, 실제 monkeypatch 기능은 0) —
+    이 프로세스에서 도는 «다음» 어떤 테스트든 실 sandbox_publish.fetch_replies
+    대신 이 고정 응답(댓글 1건 "c1")을 영구히 받게 됐다(자동 원복 0). #3945
+    회귀 실행 中 test_3516_comment_scope_and_runbook.py 3건이 이 잔존 때문에
+    엉뚱하게 실패하는 것을 실측(디디, 2026-09-06 14:57Z) — `monkeypatch.
+    setattr`로 바꾸면 pytest가 이 테스트 종료 즉시 원본으로 자동 복원한다."""
     from app.services.insights_board import list_insights_board
     from app.services.channel_post_comments import refresh_comments_now
     import app.services.sandbox_publish as sandbox_publish
@@ -606,8 +614,7 @@ async def test_insights_board_carries_three_comment_signal_fields():
             async def _fetch(client, *, access_token, media_id):
                 return [_fake_comment("c1")], True
 
-            monkeypatch_target = sandbox_publish
-            monkeypatch_target.fetch_replies = _fetch
+            monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
             await refresh_comments_now(s, org_id=org_id, publication_id=pub.id)
 
             result = await list_insights_board(


### PR DESCRIPTION
## 재현 조합(파일 이름째)
```
tests/test_3516_comment_reply.py::test_insights_board_carries_three_comment_signal_fields
→ tests/test_3516_comment_scope_and_runbook.py (전체, 3건 전부 RED)
```
`-p no:randomly`로 순서 고정, bisection(전체 → 절반 → 절반 → 1개)으로 정확히 이 테스트 하나까지 좁혔다. 이 2개 테스트만 그 순서로 돌려도 100% 재현.

## 원인 종류: 잔존(범인 정리)
`test_insights_board_carries_three_comment_signal_fields`가 `app.services.sandbox_publish.fetch_replies`를 pytest `monkeypatch` 없이 모듈 속성에 직접 대입했다(변수명만 `monkeypatch_target`, 실 monkeypatch 기능 0):
```python
monkeypatch_target = sandbox_publish
monkeypatch_target.fetch_replies = _fetch  # 원본
```
이 프로세스에서 도는 이후 어떤 테스트든 실 `sandbox_publish.fetch_replies` 대신 이 고정 응답(댓글 1건 `"c1"`)을 영구히 받는다(자동 원복 0). `test_3516_comment_scope_and_runbook.py` 3건은 sandbox_publish의 실제 시간 기반 로직(2건→delete_after 경과 후 1건, 소프트삭제 리컨실)에 의존하는데, 잔존한 `fetch_replies`가 항상 1건만 주니 `assert len(...) == 2`류가 전부 깨진다. 실패 메시지가 정확히 이를 보여준다: `AssertionError: assert 1 == 2` where `1 = len([{'id': 'c1', ...}])`.

## 수정
```python
monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
```
pytest가 이 테스트 종료 즉시 원본으로 자동 복원(테스트 함수에 `monkeypatch` fixture 파라미터 추가). 피해자 쪽(3516 3건) 코드는 무변경 — 가정 자체는 정상(실 sandbox_publish 로직과 일치), 범인만 정리. 우회(skip·xfail·retry·순서 강제) 0.

## 검증
- 재현 조합 10회 반복 green(수정 前 100% RED였던 조합).
- 뮤테이션 — `monkeypatch.setattr`을 원래 직접대입으로 되돌리면 같은 조합 3회 연속 다시 100% RED(3건 전부), 원복 후 다시 green.
- 격리 실행(`test_3516_comment_reply.py` 단독) 15건 그대로 green — 회귀 0.
- 원 6파일 광역 스윕(73건) green.
- 새 skip/xfail 0 · 새 destructive_schema 파일 0(shard-weights 변경 불요).

## AC 대조
1. 재현 조합을 파일 이름째 PR 본문에 기록, `-p no:randomly`로 RED 재현 ✓
2. 원인 종류 = 잔존, 그쪽(범인)에서 수정 · 피해자 우회 0 ✓
3. 같은 조합 10회 green · 격리 실행 green ✓
4. 뮤테이션 — 되돌리면 같은 조합 RED ✓

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>