### PR TITLE
[SID:3593] feat: 댓글 답변 표시 FE — 행 한 줄·버튼 이름 갈래·배지 개수 표기

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2249,6 +2249,8 @@
     "commentsCapturedAtLabel": "As of {time}",
     "commentsConvertToTaskCta": "Convert to task",
     "commentsReplyCta": "Reply",
+    "commentsReplyAgainCta": "Add another reply",
+    "commentsReplyCountStatusLabel": "{count} replies · latest {status}",
     "commentsSectionTitleWithCount": "Comments {count}",
     "commentsDeletedCountLabel": "{count} deleted comments",
     "commentsDeletedNote": "The original was deleted.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2249,6 +2249,8 @@
     "commentsCapturedAtLabel": "{time} 기준",
     "commentsConvertToTaskCta": "작업으로 전환",
     "commentsReplyCta": "답변",
+    "commentsReplyAgainCta": "답변 더하기",
+    "commentsReplyCountStatusLabel": "답변 {count} · 최신 {status}",
     "commentsSectionTitleWithCount": "댓글 {count}",
     "commentsDeletedCountLabel": "지워진 댓글 {count}건",
     "commentsDeletedNote": "원본이 지워졌습니다.",

--- a/apps/web/src/components/content/comment-convert-to-task-dialog.test.tsx
+++ b/apps/web/src/components/content/comment-convert-to-task-dialog.test.tsx
@@ -45,6 +45,8 @@ const COMMENT: CommentItem = {
   replyFailureAction: undefined,
   replyCommandId: null,
   replyId: null,
+  latestReplyText: null,
+  repliesCount: 0,
 };
 
 describe('CommentConvertToTaskDialog', () => {

--- a/apps/web/src/components/content/comment-reply-dialog.test.tsx
+++ b/apps/web/src/components/content/comment-reply-dialog.test.tsx
@@ -35,6 +35,7 @@ const COMMENT: CommentItem = {
   id: 'c1', authorDisplayName: '홍길동', bodyText: '언제 재입고되나요?',
   externalCreatedAt: '2026-09-05T10:00:00Z', capturedAt: '2026-09-05T10:00:00Z', deletedAt: null, replyStatus: 'none',
   replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null, replyId: null,
+  latestReplyText: null, repliesCount: 0,
 };
 
 const DRAFT_REPLY: ReplyView = {

--- a/apps/web/src/components/content/comment-reply-status-chip.tsx
+++ b/apps/web/src/components/content/comment-reply-status-chip.tsx
@@ -10,17 +10,27 @@ import {
 /**
  * story #3517(유나 §22-④) — status-chip.tsx(원문/변형 상태)와 같은 마크업·data attribute
  * 관례(measureChip 대비 헬퍼가 이 자리 하나만 보면 되게) — 댓글 답변 상태 6종 전용.
+ * story #3593(Phase2·FE, 페드루 PO 確定 2026-09-06) — `repliesCount`는 additive
+ * optional. 2건 이상(재상신 이력)이면 배지 낱말이 "답변 N · 최신 {status}"로
+ * 바뀐다(1건이면 기존 그대로) — {status} 자리는 여전히 commentReplyStatusLabelKey
+ * 그대로 넣어(유나 확定: 「발행됨」 등 상태 낱말 자체는 불변, 조합 문구만 새로).
  */
-export function CommentReplyStatusChip({ status }: { status: CommentReplyStatus }) {
+export function CommentReplyStatusChip({
+  status, repliesCount,
+}: { status: CommentReplyStatus; repliesCount?: number }) {
   const t = useTranslations('content');
   const tone = COMMENT_REPLY_STATUS_TONE[status];
+  const statusLabel = t(commentReplyStatusLabelKey(status));
+  const label = repliesCount != null && repliesCount >= 2
+    ? t('commentsReplyCountStatusLabel', { count: repliesCount, status: statusLabel })
+    : statusLabel;
   return (
     <span
       data-comment-reply-status-chip={status}
       className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${tone.bg} ${tone.text}`}
     >
       <span data-chip-dot className={`h-1.5 w-1.5 shrink-0 rounded-full ${tone.dot}`} aria-hidden="true" />
-      {t(commentReplyStatusLabelKey(status))}
+      {label}
     </span>
   );
 }

--- a/apps/web/src/components/content/comments-section.test.tsx
+++ b/apps/web/src/components/content/comments-section.test.tsx
@@ -35,6 +35,8 @@ function baseComment(overrides: Partial<CommentItem>): CommentItem {
     replyFailureAction: undefined,
     replyCommandId: null,
     replyId: null,
+    latestReplyText: null,
+    repliesCount: 0,
     ...overrides,
   };
 }
@@ -283,6 +285,54 @@ describe('CommentsSection — 행 액션(story #3517 조각②)', () => {
     await act(async () => { btn.click(); });
     expect(onReply).toHaveBeenCalledWith(comment);
   });
+
+  // story #3593(Phase2·FE, 페드루 PO 確定 2026-09-06) — AC2: 답변이 있으면 행에
+  // 최신 답변 텍스트 한 줄이 보인다. submitted·awaiting_send(발송 前)에도 보인다
+  // (유나 실측 — "내가 무엇을 답했는지"를 발송 전에 확認할 수 있어야 한다).
+  it.each(['submitted', 'awaiting_send', 'published'] as const)(
+    '답변 상태=%s여도 latestReplyText가 있으면 행에 한 줄로 보인다',
+    async (replyStatus) => {
+      const face = loadedFace([baseComment({ replyStatus, latestReplyText: '최신 답변 본문', repliesCount: 1 })]);
+      const { container, root } = mount();
+      await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
+      expect(container.querySelector('[data-testid="comments-item-reply-text"]')?.textContent).toBe('최신 답변 본문');
+    },
+  );
+
+  it('답변 자체가 없으면(latestReplyText=null) 답변 텍스트 줄 자체가 안 뜬다', async () => {
+    const face = loadedFace([baseComment({ replyStatus: 'none', latestReplyText: null, repliesCount: 0 })]);
+    const { container, root } = mount();
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
+    expect(container.querySelector('[data-testid="comments-item-reply-text"]')).toBeNull();
+  });
+
+  // story #3593 AC3 — 버튼 이름이 상태로 갈린다.
+  it('repliesCount=0이면 버튼 「답변」, repliesCount>0이면 「답변 더하기」', async () => {
+    const face = loadedFace([
+      baseComment({ id: 'c1', repliesCount: 0 }),
+      baseComment({ id: 'c2', repliesCount: 1, replyStatus: 'published' }),
+    ]);
+    const { container, root } = mount();
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
+    const buttons = container.querySelectorAll('[data-testid="comments-item-reply"]');
+    expect(buttons[0]?.textContent).toBe('답변');
+    expect(buttons[1]?.textContent).toBe('답변 더하기');
+  });
+
+  // story #3593 AC4·AC5 — 답변 2건 이상이면 배지가 「답변 N · 최신 {상태}」로
+  // 바뀌고, 1건이면 기존 배지("발행됨" 낱말 그대로) 그대로다.
+  it('repliesCount>=2면 배지가 「답변 N · 최신 {상태}」, 1건이면 기존 배지 그대로', async () => {
+    const face = loadedFace([
+      baseComment({ id: 'c1', replyStatus: 'published', repliesCount: 1 }),
+      baseComment({ id: 'c2', replyStatus: 'published', repliesCount: 2 }),
+    ]);
+    const { container, root } = mount();
+    await act(async () => { root.render(wrap(<CommentsSection face={face} displayTimezone={TZ} onRefresh={async () => ({ ok: true })} onConvertToTask={() => {}} onReply={() => {}} onRetryReply={async () => ({ ok: true })} onResubmitReply={() => {}} />)); });
+    const chips = container.querySelectorAll('[data-comment-reply-status-chip]');
+    expect(chips[0]?.textContent).toContain('발행됨');
+    expect(chips[0]?.textContent).not.toContain('·');
+    expect(chips[1]?.textContent).toBe('답변 2 · 최신 발행됨');
+  });
 });
 
 // story #3517(BE #3865 조각①, PO 確定 2026-09-05) — 원 응답(snake_case)→CommentsFace
@@ -321,7 +371,7 @@ describe('deriveCommentsFace(story #3517, BE #3865/#3876 응답 매핑)', () => 
       comments: [{
         id: 'c1', authorDisplayName: '홍길동', bodyText: '본문',
         externalCreatedAt: '2026-09-05T09:00:00Z', capturedAt: '2026-09-05T10:00:00Z', deletedAt: null,
-        replyStatus: 'none', replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null, replyId: null,
+        replyStatus: 'none', replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null, replyId: null, latestReplyText: null, repliesCount: 0,
       }],
     });
   });
@@ -375,6 +425,42 @@ describe('deriveCommentsFace(story #3517, BE #3865/#3876 응답 매핑)', () => 
     expect((face as Extract<CommentsFace, { kind: 'empty' }>).nextAllowedAt).toBe('2026-09-05T10:05:00Z');
   });
 
+  // story #3593(Phase2·FE, 페드루 PO 確定 2026-09-06, BE #3945 additive) —
+  // reply.text·replies_count가 각각 latestReplyText·repliesCount로 옮겨진다.
+  it('reply.text·replies_count가 latestReplyText·repliesCount로 옮겨진다', () => {
+    const face = deriveCommentsFace(rawResponse({
+      active_count: 1,
+      comments: [rawComment({
+        replies_count: 2,
+        reply: {
+          id: 'r1', status: 'sent', external_reply_url: null, command_id: null,
+          command_status: null, failure_kind: null, next_attempt_at: null, reason_code: null,
+          text: '두 번째 답변',
+        },
+      })],
+    }));
+    const comment = (face as Extract<CommentsFace, { kind: 'loaded' }>).comments[0]!;
+    expect(comment.latestReplyText).toBe('두 번째 답변');
+    expect(comment.repliesCount).toBe(2);
+  });
+
+  // 회귀가드 — reply.text·replies_count 둘 다 응답에서 생략되면(구버전 픽스처)
+  // 죽지 않고 안전 기본값(null·0)으로 폴백한다(§17 "신호 없으면 지어내지 않는다").
+  it('reply.text·replies_count가 생략되면 latestReplyText=null·repliesCount=0으로 안전 폴백', () => {
+    const face = deriveCommentsFace(rawResponse({
+      active_count: 1,
+      comments: [rawComment({
+        reply: {
+          id: 'r1', status: 'sent', external_reply_url: null, command_id: null,
+          command_status: null, failure_kind: null, next_attempt_at: null, reason_code: null,
+        },
+      })],
+    }));
+    const comment = (face as Extract<CommentsFace, { kind: 'loaded' }>).comments[0]!;
+    expect(comment.latestReplyText).toBeNull();
+    expect(comment.repliesCount).toBe(0);
+  });
+
   // story #3517(유나 §22-10①·⑨, PO 確定 2026-09-05 정정) — "댓글 없음" 판정은
   // active_count 하나만 본다. deleted_count>0(전부 지워짐)이어도 active_count=0이면
   // "댓글 없음" 얼굴이다 — deletedCount는 그 empty 얼굴 자체가 들고 있어(SectionHeader
@@ -389,7 +475,7 @@ describe('deriveCommentsFace(story #3517, BE #3865/#3876 응답 매핑)', () => 
       comments: [{
         id: 'c1', authorDisplayName: null, bodyText: 'x',
         externalCreatedAt: null, capturedAt: 't', deletedAt: '2026-09-05T11:00:00Z',
-        replyStatus: 'none', replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null, replyId: null,
+        replyStatus: 'none', replyExternalUrl: null, replyFailureAction: undefined, replyCommandId: null, replyId: null, latestReplyText: null, repliesCount: 0,
       }],
     });
   });

--- a/apps/web/src/components/content/comments-section.tsx
+++ b/apps/web/src/components/content/comments-section.tsx
@@ -46,6 +46,16 @@ export interface CommentItem {
    * 「다시 상신」이 여는 다이얼로그에 «지금 답변»을 prefill하는 데 쓴다(단건 GET
    * .../replies/{replyId}로 원문을 가져온다). null=이 댓글에 답변 자체가 없다. */
   replyId: string | null;
+  /** story #3593(Phase2·FE, 페드루 PO 確定 2026-09-06, BE #3945 additive) — 최신
+   * 답변의 실제 본문. null=이 댓글에 답변 자체가 없다(replyId===null과 항상 같이
+   * 간다). 발송 前(submitted·awaiting_send)에도 "내가 무엇을 답했는지"를 화면이
+   * 말해야 한다는 유나 실측 처방 — 행에 한 줄(truncate)로 보인다. */
+  latestReplyText: string | null;
+  /** story #3593 — 이 댓글의 전체 답변 개수(초안 포함, BE replies_count 그대로).
+   * 0이면 latestReplyText도 반드시 null(그 역도 성립). 2건 이상이면 배지가
+   * "답변 N · 최신 {상태}"로 바뀐다(1건이면 기존 배지 그대로 — 상태 낱말 자체는
+   * 불변). */
+  repliesCount: number;
 }
 
 // story #3517(유나 §22-②) — 세 얼굴. "미수집"(null)·"댓글 없음"([])·"불러오지 못함"(fetch
@@ -84,7 +94,15 @@ export interface RawCommentsResponse {
       id: string; status: string; external_reply_url: string | null; command_id: string | null;
       command_status: string | null; failure_kind: string | null;
       next_attempt_at: string | null; reason_code: string | null;
+      /** story #3593(BE #3945 additive) — 옵셔널로 둔다(기존 픽스처·구버전 소비처가
+       * 이 키 없이 reply 객체를 만들어도 안 죽는다, §17 "신호 없으면 지어내지
+       * 않는다" — 아래 deriveCommentsFace에서 `?? null`로만 안전 폴백). */
+      text?: string;
     } | null;
+    /** story #3593(BE #3945 additive, 유나 §22-16) — 이 댓글 전체 답변 개수. 옵셔널
+     * (기존 픽스처 무변경, 없으면 0으로 안전 폴백 — comments_next_allowed_at과
+     * 같은 관례). */
+    replies_count?: number;
   }[];
   active_count: number;
   deleted_count: number;
@@ -146,6 +164,8 @@ export function deriveCommentsFace(data: RawCommentsResponse): CommentsFace {
     }),
     replyCommandId: c.reply?.command_id ?? null,
     replyId: c.reply?.id ?? null,
+    latestReplyText: c.reply?.text ?? null,
+    repliesCount: c.replies_count ?? 0,
   }));
   // story #3517(유나 §22-10, PO 確定 2026-09-05) — "댓글 없음" 판정은 active_count
   // 하나만 본다(comments.length 아님 — 페이지 잘림·지워진 행이 섞이면 틀린다).
@@ -275,7 +295,7 @@ function CommentsList({
                 자리 자체를 안 그린다 — 지어내지 않는다. */}
             {comment.replyStatus !== null ? (
             <div className="flex items-center gap-2" data-testid="comments-item-reply-status">
-              <CommentReplyStatusChip status={comment.replyStatus} />
+              <CommentReplyStatusChip status={comment.replyStatus} repliesCount={comment.repliesCount} />
               {comment.replyStatus === 'published' && comment.replyExternalUrl ? (
                 <a
                   href={comment.replyExternalUrl}
@@ -288,6 +308,15 @@ function CommentsList({
                 </a>
               ) : null}
             </div>
+            ) : null}
+            {/* story #3593(Phase2·FE, 페드루 PO 確定 2026-09-06) — 최신 답변 본문
+                한 줄(truncate). 발송 前(submitted·awaiting_send)에도 보인다 —
+                CommentBodyText의 길이 기반 접기/펼치기와 다른 축(여기는 목록
+                리듬 안의 짧은 미리보기일 뿐, 전문은 답변 다이얼로그에서 본다). */}
+            {comment.latestReplyText ? (
+              <p className="truncate text-xs text-muted-foreground" data-testid="comments-item-reply-text">
+                {comment.latestReplyText}
+              </p>
             ) : null}
             {/* story #3544(3517 조각③, 유나 §22-15③, PO 確定 2026-09-06) — 「왜
                 멈췄고 다음에 뭘 하나」는 칩과 다른 축이라 칩 옆이 아니라 그 아래
@@ -322,7 +351,11 @@ function CommentsList({
                   onClick={() => onReply(comment)}
                   data-testid="comments-item-reply"
                 >
-                  {t('commentsReplyCta')}
+                  {/* story #3593(Phase2·FE, 페드루 PO 確定 2026-09-06) — 이미 답변이
+                      있으면(재상신 이력) 버튼 이름이 "답변 더하기"로 갈린다(3592
+                      처방과 합쳐 접근 이름도 같은 낱말 — 이 버튼은 visible text가
+                      곧 accessible name이라 별도 aria-label 불필요). */}
+                  {comment.repliesCount > 0 ? t('commentsReplyAgainCta') : t('commentsReplyCta')}
                 </Button>
               </div>
             ) : null}


### PR DESCRIPTION
## 스택 PR — base = #3945(BE, feat/3593-be-comment-reply-additive)
#3945가 develop에 머지되면 이 PR의 base가 develop으로 자동 재조정됩니다(GitHub 관례). 그 전까지는 #3945의 diff가 이 PR에도 함께 보입니다 — 리뷰는 이 PR 고유 커밋(9b3c76419)만 봐 주세요.

## FE additive(AC2·3·4, AC5는 제약)
- 답변이 있으면(`latestReplyText`) 행에 최신 답변 텍스트 한 줄(truncate) — submitted·awaiting_send(발송 前)에도 보인다(발송 전 확認 가능, 유나 실측 처방 그대로).
- 답변 버튼 이름 — 답변 0건 「답변」 / 1건 이상 「답변 더하기」(ko/en 키, 버튼 visible text가 곧 accessible name).
- 답변 상태 칩 — `repliesCount>=2`면 「답변 N · 최신 {상태}」로, 1건이면 기존 배지 그대로(「발행됨」 등 상태 낱말 자체는 불변 — `CommentReplyStatusChip`에 `repliesCount` optional prop 추가·조합 라벨만 신설).

## 계약
- `RawCommentsResponse`: `reply.text`·`comments[].replies_count` 둘 다 옵셔널(`comments_next_allowed_at`과 같은 관례) — 기존 픽스처 무변경으로 컴파일. 없으면 `latestReplyText=null`·`repliesCount=0` 안전 폴백.
- `CommentItem`: `latestReplyText`·`repliesCount` 신규 필드(둘 다 required — 0이면 `latestReplyText`도 반드시 null, 그 역도 성립).

## 검증
- 신규 8건(`deriveCommentsFace` 매핑 2 + 렌더 6) 전부 green.
- 뮤테이션 3 — 버튼 라벨 갈래 제거·칩 조합 라벨 제거·답변 텍스트 줄 제거, 각각 RED 확認 후 원복 GREEN.
- 기존 회귀 — `comments-section`(58)·`comment-reply-status-chip`·`comment-reply-dialog`·`comment-convert-to-task-dialog`(4파일 74건)·`[draftId]/page.test.tsx`(209건) 전부 green.
- `type-check`·`lint`(0 error)·i18n 중복/한자/문구충돌 가드 전부 통과.

## AC 대조
2. 답변 있는 행에 최신 답변 텍스트 한 줄(truncate), submitted·awaiting_send에도 보임 ✓
3. 버튼 이름 갈래(답변/답변 더하기), 접근 이름도 같은 낱말 ✓
4. 답변 2건 이상 배지 「답변 N · 최신 {상태}」, 1건이면 기존 배지 ✓
5. 배지 「발행됨」 낱말 불변(조합 라벨 안에서도 동일 키 재사용) ✓

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>