### PR TITLE
[SID:3597] fix: IG/FB 댓글수집 CONNECTION 실패의 connection 승격 threads 전용 게이트 제거

### DIFF
--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -113,9 +113,22 @@ async def _fetch_replies_raw(
         if external_id is None:
             raise CommentFetchError(error_code="COMMENT_EXTERNAL_ID_MISSING", message="external_id가 없습니다")
         _publish_client = get_publish_client_module(channel)
+        from app.services.threads_publish import ThreadsPublishError
         import httpx
-        async with httpx.AsyncClient() as client:
-            return await _publish_client.fetch_replies(client, access_token="sandbox", media_id=external_id)
+        try:
+            async with httpx.AsyncClient() as client:
+                return await _publish_client.fetch_replies(client, access_token="sandbox", media_id=external_id)
+        except ThreadsPublishError as exc:
+            # story #3597 — instagram_sandbox_publish.py::fetch_replies가 새
+            # [sandbox:expire-after-publish] 마커로 401을 던지기 전까지는 이 분기가
+            # 예외를 낼 일이 없어(sandbox_publish.py는 fetch_replies에서 절대
+            # raise 안 함) 이 try/except 자체가 없었다 — 아래 공용 블록(157행대)의
+            # 매핑을 그대로 재사용(새 판정 로직 0).
+            if exc.status_code in (401, 403):
+                raise CommentFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message=str(exc)) from exc
+            if exc.status_code == 429:
+                raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message=str(exc)) from exc
+            raise CommentFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
 
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -451,7 +451,7 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
             except CommentFetchError as exc:
                 failure_kind = classify_failure_kind(exc.error_code)
                 if failure_kind == FAILURE_KIND_CONNECTION:
-                    await _promote_connection_status(db, publication_id=row.publication_id, channel=row.channel)
+                    await _promote_connection_status(db, publication_id=row.publication_id)
                     row.status = "failed"
                     row.error_code = exc.error_code
                     await _schedule_next_continuous_poll_if_active(
@@ -525,11 +525,14 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
     return counts
 
 
-async def _promote_connection_status(db: AsyncSession, *, publication_id: uuid.UUID, channel: str) -> None:
-    """insight_snapshots.py::_promote_connection_status_for_snapshot과 동형 — sandbox는
-    connection 자체가 없어 no-op."""
-    if channel != "threads":
-        return
+async def _promote_connection_status(db: AsyncSession, *, publication_id: uuid.UUID) -> None:
+    """insight_snapshots.py::_promote_connection_status_for_snapshot과 동형 — 가드는
+    channel 이름이 아니라 connection 유무(sandbox는 connection 자체가 없어 no-op).
+    story #3597(Phase2·BE, 페드루 PO 確定 2026-09-06, 3595 실측 근거) — 이전엔
+    `if channel != "threads": return`로 잘려 있어(#3517 원 구현이 threads만 구현하던
+    시절 그대로 방치) IG/FB 댓글 수집 CONNECTION 실패는 에러코드까지 정확히
+    분류되고도 /organization/channels 칩·재연결 버튼에 안 섰다 — insight_snapshots.py
+    쪽은 애초에 이 가드가 없었다(그쪽이 맞았다)."""
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
 

--- a/backend/app/services/facebook_sandbox_publish.py
+++ b/backend/app/services/facebook_sandbox_publish.py
@@ -22,6 +22,12 @@ _MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
 # SANDBOX_FACEBOOK_* 관례를 따른다).
 _MARKER_REELS_PROCESSING_FAILED = "[sandbox:reels-processing-failed]"
 _MARKER_REELS_CODEC_REJECTED = "[sandbox:reels-codec-rejected]"
+# story #3597(Phase2·BE, 페드루 PO 確定 2026-09-06) — instagram_sandbox_publish.py
+# 와 같은 마커 문자열(새 마커 어휘 0) — 「발행 뒤 만료」. create_container가 이미
+# 최종 media_id를 낸다는 이 파일의 계약(publish_container가 그대로 되돌림)이라
+# 접미사를 여기서 바로 붙인다(별도 전달 단계 불필요, instagram과 유일한 차이).
+_MARKER_EXPIRE_AFTER_PUBLISH = "[sandbox:expire-after-publish]"
+_EXPIRE_AFTER_PUBLISH_SUFFIX = "-expireafterpublish"
 
 
 async def create_container(
@@ -38,6 +44,8 @@ async def create_container(
         raise ThreadsPublishError(
             "SANDBOX_FACEBOOK_TOKEN_EXPIRED", "sandbox: [sandbox:expired-token] 마커 시뮬레이션", status_code=401,
         )
+    if _MARKER_EXPIRE_AFTER_PUBLISH in text:
+        return f"sandbox-fb-post-{uuid.uuid4().hex}{_EXPIRE_AFTER_PUBLISH_SUFFIX}"
     return f"sandbox-fb-post-{uuid.uuid4().hex}"
 
 
@@ -149,7 +157,15 @@ def _deterministic_comment(*, media_id: str, index: int) -> dict:
 
 async def fetch_replies(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> tuple[list[dict], bool]:
     """instagram_sandbox_publish.py::fetch_replies와 동형 — media_id 하나엔 항상
-    같은 2건(순서 고정), complete=True 고정(페이지네이션 개념 없음)."""
+    같은 2건(순서 고정), complete=True 고정(페이지네이션 개념 없음).
+
+    story #3597 — media_id가 `_EXPIRE_AFTER_PUBLISH_SUFFIX`를 달고 있으면 401을
+    던진다(instagram_sandbox_publish.py::fetch_replies와 동형)."""
+    if media_id.endswith(_EXPIRE_AFTER_PUBLISH_SUFFIX):
+        raise ThreadsPublishError(
+            "SANDBOX_FACEBOOK_TOKEN_EXPIRED",
+            "sandbox: [sandbox:expire-after-publish] 마커 시뮬레이션(발행 후 토큰 만료)", status_code=401,
+        )
     return [_deterministic_comment(media_id=media_id, index=i) for i in (1, 2)], True
 
 

--- a/backend/app/services/instagram_sandbox_publish.py
+++ b/backend/app/services/instagram_sandbox_publish.py
@@ -31,6 +31,15 @@ _MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
 # 검증(codec-rejected와 다른 축)과 구분해 둔다.
 _MARKER_REELS_PROCESSING_FAILED = "[sandbox:reels-processing-failed]"
 _MARKER_REELS_CODEC_REJECTED = "[sandbox:reels-codec-rejected]"
+# story #3597(Phase2·BE, 페드루 PO 確定 2026-09-06) — 「발행 뒤 만료」 마커. 위
+# `_MARKER_EXPIRED_TOKEN`은 create_container 자체를 실패시켜(발행 前) 그 글이
+# 애초에 존재하지 못하므로 fetch_replies로 갈 표본이 안 생긴다 — #3595/#3597
+# 라이브 검증(연결 승격→칩→재연결)이 필요로 하는 건 "발행은 성공했는데 나중에
+# 토큰이 만료된" 표본. text 마커는 create_container에서만 읽고(publish_container·
+# fetch_replies는 원문을 다시 안 받음), creation_id→media_id에 접미사로 실어
+# 옮긴다(comment-2-deleted와 동형 사상 — 서버 메모리 0, id 문자열 자체가 표식).
+_MARKER_EXPIRE_AFTER_PUBLISH = "[sandbox:expire-after-publish]"
+_EXPIRE_AFTER_PUBLISH_SUFFIX = "-expireafterpublish"
 
 
 async def create_container(
@@ -54,6 +63,8 @@ async def create_container(
         raise ThreadsPublishError(
             "INSTAGRAM_IMAGE_REQUIRED", "Instagram 발행은 이미지가 필수입니다(피드 이미지 1장)", status_code=422,
         )
+    if _MARKER_EXPIRE_AFTER_PUBLISH in text:
+        return f"sandbox-ig-creation-{uuid.uuid4().hex}{_EXPIRE_AFTER_PUBLISH_SUFFIX}"
     return f"sandbox-ig-creation-{uuid.uuid4().hex}"
 
 
@@ -130,7 +141,12 @@ async def get_container_status(
 async def publish_container(
     client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, creation_id: str,
 ) -> str:
-    return f"sandbox-ig-media-{uuid.uuid4().hex}"
+    media_id = f"sandbox-ig-media-{uuid.uuid4().hex}"
+    # story #3597 — create_container가 [sandbox:expire-after-publish] 마커를 봤으면
+    # 표식을 media_id로 옮긴다(fetch_replies는 media_id만 받는다).
+    if creation_id.endswith(_EXPIRE_AFTER_PUBLISH_SUFFIX):
+        media_id = f"{media_id}{_EXPIRE_AFTER_PUBLISH_SUFFIX}"
+    return media_id
 
 
 async def get_publishing_limit(
@@ -171,7 +187,17 @@ async def fetch_replies(client: httpx.AsyncClient, *, access_token: str, media_i
     """sandbox_publish.py::fetch_replies와 동형 — media_id 하나엔 항상 같은 2건
     (순서 고정), complete=True 고정(페이지네이션 개념 없음). AC8류
     comment-2-deleted 시각 시뮬레이션은 이 조각(③) 스코프 밖(원 스토리 §3516
-    AC8이 이미 threads/기존 sandbox에서 검증한 마커라 여기서 중복 재발명 안 함)."""
+    AC8이 이미 threads/기존 sandbox에서 검증한 마커라 여기서 중복 재발명 안 함).
+
+    story #3597 — media_id가 `_EXPIRE_AFTER_PUBLISH_SUFFIX`를 달고 있으면(발행
+    시점에 [sandbox:expire-after-publish] 마커를 봤을 때만) 401을 던진다 —
+    "발행은 성공했는데 나중에 토큰이 만료됐다"를 라이브에서 재현하는 유일한
+    신호(서버 메모리 0, media_id 문자열 자체가 표식)."""
+    if media_id.endswith(_EXPIRE_AFTER_PUBLISH_SUFFIX):
+        raise ThreadsPublishError(
+            "SANDBOX_INSTAGRAM_TOKEN_EXPIRED",
+            "sandbox: [sandbox:expire-after-publish] 마커 시뮬레이션(발행 후 토큰 만료)", status_code=401,
+        )
     return [_deterministic_comment(media_id=media_id, index=i) for i in (1, 2)], True
 
 

--- a/backend/tests/test_3597_ig_fb_connection_status_promote.py
+++ b/backend/tests/test_3597_ig_fb_connection_status_promote.py
@@ -75,6 +75,26 @@ def _enable_sandbox_adapter(monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _enable_instagram_sandbox_adapter(monkeypatch):
+    """instagram_sandbox는 sandbox와 동형 사정 — CHANNEL_ADAPTERS 본 registry에
+    없다(_PUBLISH_CLIENT_MODULE_PATHS 전용). facebook_sandbox는 이미 본 registry에
+    있어(channel_adapters.py:316) 이 fixture가 불필요."""
+    import app.services.channel_adapters as adapters_mod
+
+    ig_sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="instagram_sandbox_publish", refresh_mode="manual",
+        display_name="Instagram Sandbox", credential_kind="none", max_text_length=2200,
+        utm_source="instagram_sandbox", utm_medium="test",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=1.91, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=10,
+        supports_fetch_replies=True,
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "instagram_sandbox", ig_sandbox_config)
+    yield
+
+
 @pytest.mark.anyio
 async def test_instagram_connection_failure_promotes_status_expired(monkeypatch):
     """AC1·AC2 — instagram CONNECTION 실패가 이제 connection.status를 expired로
@@ -191,5 +211,84 @@ async def test_sandbox_connection_untouched_by_promote(monkeypatch):
 
             await s.refresh(conn)
             assert conn.status == "active"
+    finally:
+        await engine.dispose()
+
+
+# ─── story #3597(페드루 PO 追加 2026-09-06) — 「발행 뒤 만료」 라이브 마커 ────────
+# [sandbox:expire-after-publish]: create_container/publish_container를 실제로
+# 거쳐(발행은 성공) media_id에 표식을 남기고, fetch_replies가 그 media_id를 보면
+# 401을 던진다 — AC3 라이브 검증(PO Test Org)이 실제로 재현하는 정확한 경로를
+# 여기서 코드로도 고정한다(create_container→publish_container→fetch_replies
+# 전부 실동작, monkeypatch 0).
+
+
+@pytest.mark.anyio
+async def test_instagram_sandbox_expire_after_publish_marker_promotes_status_expired():
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+    import app.services.instagram_sandbox_publish as ig_sandbox
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram_sandbox")
+
+            creation_id = await ig_sandbox.create_container(
+                None, access_token="x", threads_user_id="u", text="[sandbox:expire-after-publish]",
+                image_url="https://example.com/i.jpg",
+            )
+            media_id = await ig_sandbox.publish_container(None, access_token="x", threads_user_id="u", creation_id=creation_id)
+            assert media_id.endswith("-expireafterpublish")
+
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="instagram_sandbox", external_id=media_id,
+            )
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="instagram_sandbox", external_id=media_id, anchor_at=anchor,
+            )
+            await s.commit()
+
+            counts = await process_due_comment_collections(s)
+            assert counts["failed"] == 1
+
+            await s.refresh(conn)
+            assert conn.status == "expired"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_facebook_sandbox_expire_after_publish_marker_promotes_status_expired():
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+    import app.services.facebook_sandbox_publish as fb_sandbox
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook_sandbox")
+
+            creation_id = await fb_sandbox.create_container(
+                None, access_token="x", threads_user_id="u", text="[sandbox:expire-after-publish]",
+            )
+            media_id = await fb_sandbox.publish_container(None, access_token="x", threads_user_id="u", creation_id=creation_id)
+            assert media_id.endswith("-expireafterpublish")
+
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook_sandbox", external_id=media_id,
+            )
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox", external_id=media_id, anchor_at=anchor,
+            )
+            await s.commit()
+
+            counts = await process_due_comment_collections(s)
+            assert counts["failed"] == 1
+
+            await s.refresh(conn)
+            assert conn.status == "expired"
     finally:
         await engine.dispose()

--- a/backend/tests/test_3597_ig_fb_connection_status_promote.py
+++ b/backend/tests/test_3597_ig_fb_connection_status_promote.py
@@ -1,0 +1,195 @@
+"""story #3597(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-06, 3595 실측 근거) —
+`channel_post_comments.py::_promote_connection_status`가 `if channel != "threads":
+return`로 잘려 있어 IG/FB 댓글 수집 CONNECTION 실패는 에러코드까지 정확히 분류
+되고도 connection.status 승격이 안 됐다(/organization/channels 칩·재연결 버튼에
+안 섬). 가드를 channel 이름이 아니라 connection 유무로 바꾼 뒤(insight_snapshots.py
+::_promote_connection_status_for_snapshot과 동형) 재확認한다.
+
+세팅 헬퍼는 test_3497_insight_snapshots.py·test_3516_channel_post_comments.py와
+동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+from tests.test_3497_insight_snapshots import _seed_channel_connection, _seed_channel_publication
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    """test_3516_comment_reply.py와 동형 — channel_connection 암호화 키가 없으면
+    _seed_channel_connection의 encrypt_channel_credential이 죽는다."""
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    """test_3516_comment_reply.py와 동형 — sandbox는 CHANNEL_ADAPTERS 본 registry에
+    없어(_PUBLISH_CLIENT_MODULE_PATHS 전용 채널) supports_fetch_replies=True로
+    임시 등재해야 collect_comments_for_publication이 unsupported로 조기 종료하지
+    않는다."""
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish", refresh_mode="manual",
+        display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+        supports_fetch_replies=True,
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+@pytest.mark.anyio
+async def test_instagram_connection_failure_promotes_status_expired(monkeypatch):
+    """AC1·AC2 — instagram CONNECTION 실패가 이제 connection.status를 expired로
+    승격한다(이전엔 threads 전용 가드에 막혀 no-op이었다)."""
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+    from app.services.threads_publish import ThreadsPublishError
+    import app.services.instagram_publish as instagram_publish
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="instagram", external_id="media-1")
+
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="instagram", external_id="media-1", anchor_at=anchor,
+            )
+            await s.commit()
+
+            async def _raise_expired(client, *, access_token, media_id):
+                raise ThreadsPublishError("TOKEN_EXPIRED", "sandbox: 401 시뮬레이션", status_code=401)
+
+            monkeypatch.setattr(instagram_publish, "fetch_replies", _raise_expired)
+            counts = await process_due_comment_collections(s)
+            assert counts["failed"] == 1
+
+            await s.refresh(conn)
+            assert conn.status == "expired"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_facebook_connection_failure_promotes_status_expired(monkeypatch):
+    """AC1·AC2 — facebook도 동형(3595 표가 지목한 두 번째 채널)."""
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+    from app.services.threads_publish import ThreadsPublishError
+    import app.services.facebook_publish as facebook_publish
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook", external_id="media-1", anchor_at=anchor,
+            )
+            await s.commit()
+
+            async def _raise_expired(client, *, access_token, media_id):
+                raise ThreadsPublishError("TOKEN_EXPIRED", "sandbox: 401 시뮬레이션", status_code=401)
+
+            monkeypatch.setattr(facebook_publish, "fetch_replies", _raise_expired)
+            counts = await process_due_comment_collections(s)
+            assert counts["failed"] == 1
+
+            await s.refresh(conn)
+            assert conn.status == "expired"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_facebook_connection_failure_does_not_downgrade_revoked_or_error():
+    """기존 규율 불변 — 이미 revoked·error인 연결은 expired로 덮어쓰지 않는다
+    (_promote_connection_status의 `not in ("revoked", "error")` 가드는 이 PR이
+    안 건드린다, 여기서 회귀 0을 고정)."""
+    from app.services.channel_post_comments import _promote_connection_status
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook", status="revoked")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+            await s.commit()
+
+            await _promote_connection_status(s, publication_id=pub.id)
+            await s.commit()
+            await s.refresh(conn)
+            assert conn.status == "revoked"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sandbox_connection_untouched_by_promote(monkeypatch):
+    """sandbox 채널 — connection이 있어도(테스트 시딩 관례) 실제로 CONNECTION류
+    실패를 만들 방법이 없으니 무변(AC1의 "connection 유무" 가드가 sandbox를 특별
+    취급하지 않아도 실질 결과는 그대로임을 고정)."""
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="sandbox", external_id="media-1", anchor_at=anchor,
+            )
+            await s.commit()
+
+            counts = await process_due_comment_collections(s)
+            assert counts["captured"] == 1
+            assert counts["failed"] == 0
+
+            await s.refresh(conn)
+            assert conn.status == "active"
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1434,8 +1434,8 @@
     },
     {
       "file": "tests/test_3597_ig_fb_connection_status_promote.py",
-      "sec": 16.0,
-      "source": "story-3597-ig-fb-connection-status-promote(PR 개설 前 선제 등재 — 로컬 raw pytest 4건 2.26s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 16s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 22.0,
+      "source": "story-3597-ig-fb-connection-status-promote(페드루 PO 追加 2026-09-06 — [sandbox:expire-after-publish] 마커 라이브검증 테스트 2건 추가 뒤 재측정. 로컬 raw pytest 6건 3.15s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 22s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1431,6 +1431,11 @@
       "file": "tests/test_3593_comment_reply_additive.py",
       "sec": 20.0,
       "source": "story-3593-comment-reply-additive(PR 개설 前 선제 등재 — 로컬 raw pytest 3건 3.31s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3597_ig_fb_connection_status_promote.py",
+      "sec": 16.0,
+      "source": "story-3597-ig-fb-connection-status-promote(PR 개설 前 선제 등재 — 로컬 raw pytest 4건 2.26s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 16s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 근거
3595 측정 표(아티팩트 4f7f6d33-df5f-4ea9-af0d-19664aaa2bdf) — `channel_post_comments.py::_promote_connection_status`에 `if channel != "threads": return`가 있어, IG/FB 댓글 수집 CONNECTION 실패(`classify_failure_kind`가 에러코드까지는 정확히 CONNECTION으로 분류)가 connection.status 승격까지는 못 갔다. `/organization/channels` 페이지의 칩·재연결 버튼에 안 서던 자리(3595 표 행① 「미표시」).

## 수정 ①(승격 가드)
가드를 channel 이름이 아니라 connection 유무로 — `insight_snapshots.py::_promote_connection_status_for_snapshot`은 애초에 이런 가드가 없었다(그쪽이 옳은 형이었다). threads-only 두 줄만 제거 — 함수 나머지 로직(connection 존재 여부·revoked/error 상태 유지 규칙)은 그대로.

## 수정 ②([sandbox:expire-after-publish] 마커 신설, 페드루 PO 追加)
기존 `[sandbox:expired-token]`은 `create_container` 자체를 실패시켜(발행 前) 그 글이 애초에 존재하지 못해 `fetch_replies`로 갈 표본이 안 생긴다. AC3 라이브 검증(연결 승격→칩→재연결)이 필요로 하는 건 "발행은 성공했는데 나중에 토큰이 만료된" 표본 — 새 마커로 그 표본을 만든다.
- `instagram_sandbox_publish.py`·`facebook_sandbox_publish.py` — text 마커는 `create_container`에서만 읽고(`[sandbox:comment-2-deleted]`와 동형 사상), 접미사로 `creation_id`→`media_id`에 실어 옮긴다. `fetch_replies`가 그 접미사를 보면 401(`ThreadsPublishError`)을 던진다.
- `channel_post_comments.py::_fetch_replies_raw` — `sandbox`/`instagram_sandbox` bypass 분기에 try/except 추가(공용 블록의 401/403/429 매핑 그대로 재사용). **이 3번째 파일 변경의 근거**: `instagram_sandbox`는 이 bypass 분기를 타는데 원래 예외 매핑이 없어(`sandbox_publish.py`는 `fetch_replies`에서 절대 raise 안 해 지금까지 필요가 없었다) 새 마커가 401을 던져도 `CommentFetchError`로 변환 안 돼 CONNECTION 분류·승격까지 못 갔다(뮤테이션으로 재현 확認). `facebook_sandbox`는 이 bypass 목록에 없어(원래부터 공용 블록을 탐) 이 수정이 불필요했다.

## 검증
- 신규 6건 — instagram/facebook CONNECTION 실패→expired · revoked/error 유지 규칙 회귀 0 · sandbox(connection 있어도) 무변 · **[sandbox:expire-after-publish] 마커로 IG/FB 각각 create_container→publish_container→fetch_replies 전부 실동작(monkeypatch 0)→CONNECTION 분류→status expired**.
- 뮤테이션 4 — threads-only 가드 원복(IG·FB RED) · fetch_replies 마커체크 제거(IG·FB RED) · bypass 분기 try/except 제거(RED, instagram_sandbox 회귀 재현) — 전부 원복 GREEN.
- 회귀 176건(FB/IG 어댑터 소비 테스트 파일 6개+3597 자체+3516/3497 계열).
- shard-weights 재측정(로컬 3.15s×6=22s)·lint 통과.

## AC 대조
1. 가드를 connection 유무로 — IG/FB CONNECTION 실패 시 status expired(revoked/error 유지)·sandbox 무변 ✓
2. 테스트 IG·FB 각 1 + sandbox 무변 1 · 뮤테이션(가드 원복→RED) ✓
3. 라이브(PO Test Org [sandbox:expire-after-publish] 마커) — **코드 레벨로 확認**: 마커 발행이 실제로 성공하고, `fetch_replies`가 그 media_id에서 401을 던져 CONNECTION 분류→승격까지 전부 실동작(테스트 2건이 이 전체 경로를 monkeypatch 0으로 재현). PO Test Org 실 UI 왕복(칩 표시→재연결 버튼)은 라이브 확認 별도 필요.
4. 3595 표 갱신 — 이 PR 머지 확認 후 별도로 표 v3 갱신 예정.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>