### PR TITLE
[SID:3596] feat: open_reply_draft·sent_replies_count additive + 2차 초안 409 방지(BE)

### DIFF
--- a/backend/app/routers/channel_post_comment_replies.py
+++ b/backend/app/routers/channel_post_comment_replies.py
@@ -13,6 +13,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.services.channel_post_comment_replies import (
     CommentNotFoundError,
+    CommentReplyDraftAlreadyOpenError,
     CommentReplyChannelUnsupportedError,
     CommentReplyNotFoundError,
     CommentReplyTargetDeletedError,
@@ -203,6 +204,15 @@ async def create_comment_reply_draft_endpoint(
         )
     except CommentNotFoundError as exc:
         raise HTTPException(status_code=404, detail=f"댓글을 찾을 수 없습니다: {comment_id}") from exc
+    except CommentReplyDraftAlreadyOpenError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "COMMENT_REPLY_DRAFT_ALREADY_OPEN",
+                "message": "안 보낸 초안이 이미 있습니다.",
+                "existing_reply_id": str(exc.existing_reply_id),
+            },
+        ) from exc
     return await _reply_view(db, reply, None)
 
 

--- a/backend/app/routers/channel_post_comments.py
+++ b/backend/app/routers/channel_post_comments.py
@@ -103,6 +103,15 @@ def _comment_reply_summary(reply, command_by_id: dict) -> CommentReplySummary:
     )
 
 
+class CommentOpenReplyDraft(BaseModel):
+    """story #3596(Phase2·BE, 페드루 PO 確定 2026-09-06) — 안 보낸(status draft/
+    pending) 최신 답변 1건. FE는 이 존재만으로 버튼을 「이어서 답변」으로 갈라
+    (답변 더하기 대신) 이 text로 다이얼로그를 채운다."""
+    id: uuid.UUID
+    status: str
+    text: str
+
+
 class CommentItem(BaseModel):
     id: uuid.UUID
     external_comment_id: str
@@ -119,6 +128,12 @@ class CommentItem(BaseModel):
     # {상태}" 형을 조립할 수 있게 한다. 답변 0건이면 0(reply가 null인 것과
     # 논리적으로 항상 같이 간다 — 0이면 reply도 반드시 null, 그 역도 성립).
     replies_count: int = 0
+    # story #3596(Phase2·BE, 페드루 PO 確定 2026-09-06) — 3593의 「답변 없음/이미
+    # 있음」 2갈래가 «보낸 답변»과 «안 보낸 초안»을 안 갈라 빈 다이얼로그로 2차
+    # 초안이 생기던 결함(#3947 카디르 비차단①)의 additive 처방. open_reply_draft
+    # null이면 안 보낸 초안 0건(replies_count>=sent_replies_count 항상 성립).
+    open_reply_draft: CommentOpenReplyDraft | None = None
+    sent_replies_count: int = 0
 
 
 class CommentListResponse(BaseModel):
@@ -170,6 +185,8 @@ async def list_publication_comments_endpoint(
     reply_by_comment_id = result["reply_by_comment_id"]
     command_by_id = result["command_by_id"]
     reply_counts_by_comment_id = result["reply_counts_by_comment_id"]
+    open_reply_draft_by_comment_id = result["open_reply_draft_by_comment_id"]
+    sent_reply_counts_by_comment_id = result["sent_reply_counts_by_comment_id"]
     return CommentListResponse(
         last_collected_at=result["last_collected_at"].isoformat() if result["last_collected_at"] else None,
         comments=[
@@ -182,6 +199,15 @@ async def list_publication_comments_endpoint(
                     if c.id in reply_by_comment_id else None
                 ),
                 replies_count=reply_counts_by_comment_id.get(c.id, 0),
+                open_reply_draft=(
+                    CommentOpenReplyDraft(
+                        id=open_reply_draft_by_comment_id[c.id].id,
+                        status=open_reply_draft_by_comment_id[c.id].status,
+                        text=open_reply_draft_by_comment_id[c.id].text,
+                    )
+                    if c.id in open_reply_draft_by_comment_id else None
+                ),
+                sent_replies_count=sent_reply_counts_by_comment_id.get(c.id, 0),
             )
             for c in result["comments"]
         ],

--- a/backend/app/services/channel_post_comment_replies.py
+++ b/backend/app/services/channel_post_comment_replies.py
@@ -53,6 +53,17 @@ class CommentReplyApproverRoleMissingError(Exception):
         super().__init__(f"기본 승인 role이 없습니다: {org_id}")
 
 
+class CommentReplyDraftAlreadyOpenError(Exception):
+    """story #3596(Phase2·BE, 페드루 PO 確定 2026-09-06) — 안 보낸 초안(status
+    draft/pending)이 이미 있는 댓글에 새 초안 생성 요청(409). 「빈 다이얼로그로
+    2차 초안이 생기는」 결함(#3947 카디르 비차단①)의 서버 쪽 봉함 — FE는 이
+    existing_reply_id로 «이어서 답변» 다이얼로그를 채운다."""
+
+    def __init__(self, *, existing_reply_id: uuid.UUID):
+        self.existing_reply_id = existing_reply_id
+        super().__init__(f"안 보낸 초안이 이미 있습니다: {existing_reply_id}")
+
+
 def compute_target_comment_state(
     *, comment: ChannelPostComment, sealed_target_text_sha256: str | None,
 ) -> TargetCommentState:
@@ -147,8 +158,23 @@ async def create_comment_reply_draft(
     created_by_member_id: uuid.UUID, created_by_kind: str,
 ) -> ChannelPostCommentReply:
     """AC3 초안 — is_agent_caller 허용(승인·발행은 human-only, submit부터). gate_id는
-    아직 없다(0339가 nullable로 정정한 이유)."""
+    아직 없다(0339가 nullable로 정정한 이유).
+
+    story #3596 — 이 댓글에 안 보낸 초안(status draft/pending)이 이미 있으면 409
+    (fail-closed, 새 초안 0건). «빈 다이얼로그로 2차 초안» 결함의 서버 쪽 봉함."""
     await _get_owned_comment(db, org_id=org_id, comment_id=comment_id)
+
+    existing_open = (await db.execute(
+        select(ChannelPostCommentReply)
+        .where(
+            ChannelPostCommentReply.comment_id == comment_id,
+            ChannelPostCommentReply.status.in_(("draft", "pending")),
+        )
+        .order_by(ChannelPostCommentReply.created_at.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    if existing_open is not None:
+        raise CommentReplyDraftAlreadyOpenError(existing_reply_id=existing_open.id)
 
     reply = ChannelPostCommentReply(
         id=uuid.uuid4(), org_id=org_id, comment_id=comment_id, gate_id=None, command_id=None,

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -675,6 +675,13 @@ async def list_comments_for_publication(
     reply_counts_by_comment_id = await _reply_counts_by_comment_ids(
         db, comment_ids=[c.id for c in rows],
     )
+    # story #3596 — 안 보낸 초안(있으면 «이어서 답변» 버튼)·보낸 답변 수(배지 N).
+    open_reply_draft_by_comment_id = await _open_reply_draft_by_comment_ids(
+        db, comment_ids=[c.id for c in rows],
+    )
+    sent_reply_counts_by_comment_id = await _sent_reply_counts_by_comment_ids(
+        db, comment_ids=[c.id for c in rows],
+    )
 
     # story #3529(additive, 유나 §22-15 채택) — 댓글 목록 reply{} 요약에 발송 명령
     # 상태 4필드(command_status·failure_kind·next_attempt_at·reason_code)를 얹기
@@ -700,6 +707,8 @@ async def list_comments_for_publication(
         "comments_next_allowed_at": comments_next_allowed_at,
         "command_by_id": command_by_id,
         "reply_counts_by_comment_id": reply_counts_by_comment_id,
+        "open_reply_draft_by_comment_id": open_reply_draft_by_comment_id,
+        "sent_reply_counts_by_comment_id": sent_reply_counts_by_comment_id,
     }
 
 
@@ -737,6 +746,51 @@ async def _latest_reply_by_comment_ids(
     reply_alias = aliased(ChannelPostCommentReply, subq)
     rows = (await db.execute(select(reply_alias).where(subq.c.rn == 1))).scalars().all()
     return {reply.comment_id: reply for reply in rows}
+
+
+async def _open_reply_draft_by_comment_ids(
+    db: AsyncSession, *, comment_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, ChannelPostCommentReply]:
+    """story #3596(Phase2·BE, 페드루 PO 確定 2026-09-06) — 댓글당 «안 보낸» 최신
+    답변(status draft/pending) 1건. `_latest_reply_by_comment_ids`와 동형 ROW_NUMBER
+    윈도우, WHERE절만 status 필터 추가(sent/failed는 여기 안 잡힌다 — 이미 나갔거나
+    이미 실패 흐름이 따로 있다)."""
+    if not comment_ids:
+        return {}
+    from sqlalchemy.orm import aliased
+
+    rn = func.row_number().over(
+        partition_by=ChannelPostCommentReply.comment_id, order_by=ChannelPostCommentReply.created_at.desc(),
+    ).label("rn")
+    subq = (
+        select(ChannelPostCommentReply, rn)
+        .where(
+            ChannelPostCommentReply.comment_id.in_(comment_ids),
+            ChannelPostCommentReply.status.in_(("draft", "pending")),
+        )
+        .subquery()
+    )
+    reply_alias = aliased(ChannelPostCommentReply, subq)
+    rows = (await db.execute(select(reply_alias).where(subq.c.rn == 1))).scalars().all()
+    return {reply.comment_id: reply for reply in rows}
+
+
+async def _sent_reply_counts_by_comment_ids(
+    db: AsyncSession, *, comment_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    """story #3596 — 댓글당 «실제로 나간» 답변 개수(status=sent만). 배지 「답변 N」
+    의 N은 이제 이 값(초안은 배지가 아니라 버튼 낱말로만 드러난다, 유나 §확定8)."""
+    if not comment_ids:
+        return {}
+    rows = (await db.execute(
+        select(ChannelPostCommentReply.comment_id, func.count())
+        .where(
+            ChannelPostCommentReply.comment_id.in_(comment_ids),
+            ChannelPostCommentReply.status == "sent",
+        )
+        .group_by(ChannelPostCommentReply.comment_id)
+    )).all()
+    return {comment_id: count for comment_id, count in rows}
 
 
 async def _reply_counts_by_comment_ids(

--- a/backend/tests/test_3516_comment_reply_piece2b.py
+++ b/backend/tests/test_3516_comment_reply_piece2b.py
@@ -269,6 +269,11 @@ async def test_comment_list_reply_summary_picks_latest_of_multiple_drafts():
                 s, org_id=org_id, comment_id=comment.id, text="진짜 최신(먼저 삽입)",
                 created_by_member_id=human_id, created_by_kind="human",
             )
+            # story #3596 — 안 보낸 초안(draft/pending)이 있는 댓글엔 새 초안 생성이
+            # 409(CommentReplyDraftAlreadyOpenError). 이 테스트의 의도(최신 선택
+            # 검증)와 무관한 축이라 먼저 만든 초안을 sent로 닫은 뒤 다음 초안을 만든다.
+            newer_by_time.status = "sent"
+            await s.commit()
             older_by_time = await create_comment_reply_draft(
                 s, org_id=org_id, comment_id=comment.id, text="진짜 과거(나중 삽입)",
                 created_by_member_id=human_id, created_by_kind="human",

--- a/backend/tests/test_3516_comment_scope_and_runbook.py
+++ b/backend/tests/test_3516_comment_scope_and_runbook.py
@@ -130,6 +130,11 @@ async def test_agent_scope_matrix():
             )
             human_reply = await submit_comment_reply(s, org_id=org_id, reply_id=human_draft.id, requester_member_id=human_id)
             gate_id = human_reply.gate_id
+            # story #3596 — 안 보낸 초안(draft/pending)이 있는 댓글엔 새 초안 생성이
+            # 409(CommentReplyDraftAlreadyOpenError). 아래 에이전트 초안 POST가 같은
+            # 댓글을 쓰므로, gate_id 확보에 쓴 이 답변을 sent로 닫아 그 축과 분리한다.
+            human_reply.status = "sent"
+            await s.commit()
 
         _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
         try:

--- a/backend/tests/test_3593_comment_reply_additive.py
+++ b/backend/tests/test_3593_comment_reply_additive.py
@@ -113,7 +113,13 @@ async def test_comment_with_two_replies_exposes_count_and_latest_text():
                 s, org_id=org_id, project_id=project_id,
             )
             comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
-            await _submit_and_approve_reply_with_text(s, org_id=org_id, human_id=human_id, comment=comment, text="첫 답변")
+            # story #3596(PO 確定 2026-09-06) — 안 보낸 초안이 있는 댓글엔 새 초안
+            # 생성이 409로 막힌다(2차 초안 방지). 이 테스트가 원래 검증하려는 것은
+            # "2건째 답변"이지, "첫 답변이 안 보낸 채 방치"가 아니므로 첫 답변을
+            # sent로 마감한 뒤 두 번째를 만든다(원 의도 불변, 새 가드와 정합).
+            first_reply = await _submit_and_approve_reply_with_text(s, org_id=org_id, human_id=human_id, comment=comment, text="첫 답변")
+            first_reply.status = "sent"
+            await s.commit()
             second_reply = await _submit_and_approve_reply_with_text(
                 s, org_id=org_id, human_id=human_id, comment=comment, text="두 번째 답변",
             )

--- a/backend/tests/test_3596_open_reply_draft_additive.py
+++ b/backend/tests/test_3596_open_reply_draft_additive.py
@@ -1,0 +1,184 @@
+"""story #3596(Phase2·BE, 페드루 PO 確定 2026-09-06, #3947 카디르 비차단① 근거) —
+목록 API에 댓글마다 open_reply_draft(안 보낸 최신 답변)·sent_replies_count(보낸
+답변 수)를 additive로 얹는다. create_comment_reply_draft는 안 보낸 초안이 이미
+있으면 409(2차 초안 방지).
+
+세팅 헬퍼는 test_3593_comment_reply_additive.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_default_role, _seed_human, _seed_org, _session_factory
+from app.main import app
+from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+from tests.test_3516_comment_reply import _seed_comment, _seed_full_publication_chain, _submit_and_approve_reply
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+        insight_metrics=("impressions", "reach", "views", "engagements", "clicks", "spend", "conversions"),
+        supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+async def _create_reply(db, *, org_id, comment, text, human_id):
+    from app.services.channel_post_comment_replies import create_comment_reply_draft
+
+    return await create_comment_reply_draft(
+        db, org_id=org_id, comment_id=comment.id, text=text,
+        created_by_member_id=human_id, created_by_kind="human",
+    )
+
+
+@pytest.mark.anyio
+async def test_draft_only_exposes_open_reply_draft_and_zero_sent_count():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            draft = await _create_reply(s, org_id=org_id, comment=comment, text="작성 중인 답변", human_id=human_id)
+
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+            async with _client_for(app) as client:
+                resp = await client.get(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments")
+            item = resp.json()["comments"][0]
+            assert item["open_reply_draft"]["id"] == str(draft.id)
+            assert item["open_reply_draft"]["status"] == "draft"
+            assert item["open_reply_draft"]["text"] == "작성 중인 답변"
+            assert item["sent_replies_count"] == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sent_only_exposes_null_open_draft_and_sent_count_one():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+            reply.status = "sent"
+            await s.commit()
+
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+            async with _client_for(app) as client:
+                resp = await client.get(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments")
+            item = resp.json()["comments"][0]
+            assert item["open_reply_draft"] is None
+            assert item["sent_replies_count"] == 1
+            assert item["replies_count"] == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sent_reply_plus_new_draft_shows_both_derived_fields_consistently():
+    """#3947 카디르 비차단⑥ — repliesCount·sent_replies_count·open_reply_draft
+    3필드 정합을 전용 테스트로 고정(보낸 1+안 보낸 초안 1 = replies_count 2·
+    sent_replies_count 1·open_reply_draft != null)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            sent_reply = await _submit_and_approve_reply(s, org_id=org_id, human_id=human_id, comment=comment)
+            sent_reply.status = "sent"
+            await s.commit()
+
+            open_draft = await _create_reply(s, org_id=org_id, comment=comment, text="이어서 쓰는 중", human_id=human_id)
+
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+            async with _client_for(app) as client:
+                resp = await client.get(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments")
+            item = resp.json()["comments"][0]
+            assert item["replies_count"] == 2
+            assert item["sent_replies_count"] == 1
+            assert item["open_reply_draft"]["id"] == str(open_draft.id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_draft_rejects_second_draft_with_409_and_existing_id():
+    """AC3 — open_reply_draft가 있는 댓글에 새 초안 요청 → 409 + 기존 초안 id."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            first_draft = await _create_reply(s, org_id=org_id, comment=comment, text="첫 초안", human_id=human_id)
+
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+            async with _client_for(app) as client:
+                resp = await client.post(
+                    f"/api/v2/organizations/{org_id}/comments/{comment.id}/replies", json={"text": "두 번째 시도"},
+                )
+            assert resp.status_code == 409, resp.text
+            body = resp.json()
+            assert body["error"]["existing_reply_id"] == str(first_draft.id), body
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1431,6 +1431,11 @@
       "file": "tests/test_3593_comment_reply_additive.py",
       "sec": 20.0,
       "source": "story-3593-comment-reply-additive(PR 개설 前 선제 등재 — 로컬 raw pytest 3건 3.31s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3596_open_reply_draft_additive.py",
+      "sec": 18.0,
+      "source": "story-3596-open-reply-draft-additive(PR 개설 前 선제 등재 — 로컬 raw pytest 4건 3.88s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 18s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 근거
#3947 카디르 비차단①(2026-09-06 15:25Z) — `_reply_counts_by_comment_ids`가 status 필터 없이 초안 포함 전부를 세어, 초안 하나뿐인 댓글도 「답변 더하기」가 되고 `onReply`는 빈 칸에서 새로 시작한다 → 두 번째 초안이 생기고 첫 초안엔 닿을 길이 없는 결함. 이 PR은 BE additive만(FE는 별도 PR, #3945/#3947 형).

## BE additive
- `CommentItem.open_reply_draft{id,status,text}|null` — 안 보낸(status draft/pending) 최신 답변 1건. `_open_reply_draft_by_comment_ids`(`_latest_reply_by_comment_ids`와 동형 ROW_NUMBER, status 필터만 추가).
- `CommentItem.sent_replies_count` — status=sent만 카운트(배지 N의 새 주어). `_sent_reply_counts_by_comment_ids`(GROUP BY 동형 패턴).
- 기존 `reply`·`replies_count` 불변.

## 서버 거부(AC3)
`create_comment_reply_draft` — 안 보낸 초안이 이미 있으면 `CommentReplyDraftAlreadyOpenError(existing_reply_id)`→409(2차 초안 0건, fail-closed).

## 검증
- 신규 4건 — 초안만(open!=null·sent 0) · 보낸만(open null·sent 1) · 보낸1+초안1(3필드 정합, #3947 카디르 비차단⑥) · 409+기존 id.
- 회귀 수정 1 — `test_3593`의 「2건 다 안 보낸 채」 시나리오가 새 409 가드와 충돌해(그 자체가 이 스토리의 원 결함 재현) 첫 답변을 sent로 마감하도록 갱신(원 검증 의도 불변).
- 회귀 7건(3593 계열) green.
- shard-weights 등재(로컬 3.88s×6=18s)·lint 통과.

## AC 대조
1. `open_reply_draft`·`sent_replies_count` additive, 기존 필드 불변 ✓
3. 새 초안 요청 → 409 + 기존 초안 id ✓
6. 3필드(replies_count·sent_replies_count·open_reply_draft) 정합 전용 테스트 ✓
11. 단건 `GET .../replies/{replyId}`는 기존 라우트 그대로 재사용 가능(신규 엔드포인트 0) — FE PR에서 prefill에 그대로 씀.

FE(버튼 3갈래·prefill·i18n 키 2)는 별도 PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>