### PR TITLE
[SID:3588] StoryDetailPanel key={story.id} 리마운트로 카드전환 잔존 state 닫기

### DIFF
--- a/apps/web/src/components/epics/epic-swimlane-board.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.tsx
@@ -635,6 +635,7 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
 
             {selectedStory && (
               <StoryDetailPanel
+                key={selectedStory.id}
                 story={selectedStory}
                 tasks={storyTasks}
                 getStatusLabel={domainLabels.statusLabel}

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -647,6 +647,44 @@ describe('KanbanBoard — 실시간(SSE) 상세 패널 동기화(#2137)', () => 
   });
 });
 
+// story #3588 — StoryDetailPanel이 selectedStory prop만 바뀌고 리마운트 안 되면(kanban-board.tsx/
+// epic-swimlane-board.tsx 둘 다 <StoryDetailPanel key 없이> 소비) editingTitle 등 로컬 state가
+// A→B 카드 전환 뒤에도 살아남는다. key={story.id}로 통짜 리마운트해 전부 초기화되는지 고정한다.
+describe('KanbanBoard — 상세 패널 story 전환 시 로컬 state 리셋(#3588)', () => {
+  async function openPanel(title: string) {
+    const card = container.querySelector(`[title="${title}"]`) as HTMLElement | null;
+    expect(card).not.toBeNull();
+    await act(async () => {
+      card!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('A에서 제목 편집모드 진입 후 B로 전환하면 편집모드가 자동으로 닫힌다', async () => {
+    stubFetch([
+      { id: 's1', title: 'S1', status: 'backlog', priority: 'medium' },
+      { id: 's2', title: 'S2', status: 'backlog', priority: 'medium' },
+    ]);
+    await mount();
+    await openPanel('S1');
+    const dialog = () => container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog()).not.toBeNull();
+
+    const titleButton = dialog().querySelector('h2')!.closest('button') as HTMLElement;
+    await act(async () => {
+      titleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(dialog().querySelector('[data-testid="story-title-input"]')).not.toBeNull();
+
+    await openPanel('S2');
+
+    expect(dialog().querySelector('[data-testid="story-title-input"]')).toBeNull();
+    expect(dialog().textContent).toContain('S2');
+  });
+});
+
 // story #2104 — BE stories.py:1056(human-only 영구삭제 403)를 FE가 미리 안 보고 에이전트
 // 계정에도 삭제 트리거를 무조건 열었다(#2091/#2103과 같은 결함). 양방향 고정 — human까지
 // 잠그면 정당한 삭제가 봉쇄되는 더 큰 사고다(승격 위험목록의 잔여 미검증 칸 해소).

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1803,6 +1803,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
 
       {selectedStory && (
         <StoryDetailPanel
+          key={selectedStory.id}
           story={selectedStory}
           tasks={storyTasks}
           memberMap={memberMap}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1340,6 +1340,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               <div className="space-y-2">
                 <input
                   ref={titleInputRef}
+                  data-testid="story-title-input"
                   type="text"
                   value={titleDraft}
                   onChange={(e) => setTitleDraft(e.target.value)}
@@ -1634,6 +1635,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                       <EntityAwareTextarea>로 바꾸고 projectId만 넘기면 `#` 피커가 붙는다.
                       참조 코어(chat-input-entity-tokens.ts/use-entity-picker.ts) diff 0. */}
                   <EntityAwareTextarea
+                    data-testid="story-description-input"
                     value={descriptionDraft}
                     onChange={setDescriptionDraft}
                     onPaste={handlePasteAttach}

--- a/apps/web/src/components/shared/entity-aware-textarea.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.tsx
@@ -22,6 +22,7 @@ interface EntityAwareTextareaProps {
    * chat-input-entity-tokens.ts의 canonical entityTypeLabel() 그대로(회귀 0). 참조 코어
    * 파일(chat-input-entity-tokens.ts) 자체는 diff 0 규율(#2264 AC3)이라 여기 소비처에서만 얹는다. */
   getEntityTypeLabel?: (canonicalSlug: string) => string | undefined;
+  'data-testid'?: string;
 }
 
 /**
@@ -30,7 +31,7 @@ interface EntityAwareTextareaProps {
  * use-entity-picker.ts, 이 파일은 그 위의 얇은 렌더 래퍼 — chat-input.tsx의 entity dropdown
  * JSX를 그대로 재사용). story description/AC(story-detail-panel.tsx)가 첫 소비자.
  */
-export function EntityAwareTextarea({ value, onChange, projectId, placeholder, className, autoFocus, onPaste, getEntityTypeLabel }: EntityAwareTextareaProps) {
+export function EntityAwareTextarea({ value, onChange, projectId, placeholder, className, autoFocus, onPaste, getEntityTypeLabel, 'data-testid': dataTestId }: EntityAwareTextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const entityPicker = useEntityPicker(projectId);
 
@@ -71,6 +72,7 @@ export function EntityAwareTextarea({ value, onChange, projectId, placeholder, c
     <div className="relative">
       <textarea
         ref={textareaRef}
+        data-testid={dataTestId}
         value={value}
         onChange={handleChange}
         onKeyDown={handleKeyDown}


### PR DESCRIPTION
## 변경 사항
- `kanban-board.tsx`·`epic-swimlane-board.tsx` 두 `<StoryDetailPanel>` 소비처에 `key={selectedStory.id}` 추가 — story A→B 카드 전환 시 컴포넌트가 완전히 리마운트되도록.
- 텍스트 잔존(제목/설명/AC draft)은 기존 story.id-deps effect로 이미 닫혀 있었고, 이 PR이 닫는 것은 편집 모드(editingTitle)·backlinkItems·gatesLoaded — #3938 비차단 2건 같이 닫힘.
  - `editingTitle`/`editingDescription`/`editingAC`: story.id 변경을 리셋하는 effect가 없어 전환 후에도 편집모드가 유지됨.
  - `concept-card-section.tsx`의 `backlinkItems`(story-detail-panel.tsx의 `gatesLoaded`와 짝): `gatesLoaded`가 story.id 변경 시 `false`로 리셋되지 않아 전환 직후 이전 스토리의 backlink 카드가 잠깐 노출될 수 있었음.
- 제목·설명 편집 칸에 `data-testid="story-title-input"`/`data-testid="story-description-input"` 추가(EntityAwareTextarea에 `data-testid` passthrough 신설).

## 테스트
- `kanban-board.test.tsx`에 회귀 테스트 추가: A 카드에서 제목 편집모드 진입 → B 카드로 전환 → 편집모드 자동 종료 검증.
- 뮤테이션 검증: `key={selectedStory.id}` 제거 시 해당 테스트가 RED로 떨어짐을 확인(복구 후 재검증 완료).
- `pnpm vitest run` 관련 4개 테스트 파일 125개 전부 PASS.
- `pnpm exec tsc --noEmit` 클린.
- `pnpm exec eslint` 변경 파일 5개 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA