### PR TITLE
[SID:3591] 영상 있는 초안의 커버 규격 태그 비율을 videoSpec 이름표로

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2581,6 +2581,7 @@
     "channelPostsImageAttachLabel": "Attach image",
     "channelPostsImageSpecTag": "{formats} · up to {maxBytes} · max aspect {aspectMax}:1 · width {widthMin}–{widthMax}px · color space {colorSpace}",
     "channelPostsImageSpecTagWithMin": "{formats} · up to {maxBytes} · aspect {aspectMinDisplay} ~ {aspectMaxDisplay} · width {widthMin}–{widthMax}px · color space {colorSpace}",
+    "channelPostsCoverSpecTag": "{formats} · up to {maxBytes} · aspect {aspectTarget} · width {widthMin}–{widthMax}px · color space {colorSpace}",
     "channelPostsImageAttachTriggerCta": "Choose image",
     "channelPostsImageAttachAlt": "Attached image",
     "channelPostsImageUploadRequestingUrl": "Preparing upload…",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2581,6 +2581,7 @@
     "channelPostsImageAttachLabel": "이미지 첨부",
     "channelPostsImageSpecTag": "{formats} · 최대 {maxBytes} · 비율 최대 {aspectMax}:1 · 너비 {widthMin}–{widthMax}px · 색상공간 {colorSpace}",
     "channelPostsImageSpecTagWithMin": "{formats} · 최대 {maxBytes} · 비율 {aspectMinDisplay} ~ {aspectMaxDisplay} · 너비 {widthMin}–{widthMax}px · 색상공간 {colorSpace}",
+    "channelPostsCoverSpecTag": "{formats} · 최대 {maxBytes} · 비율 {aspectTarget} · 너비 {widthMin}–{widthMax}px · 색상공간 {colorSpace}",
     "channelPostsImageAttachTriggerCta": "이미지 선택",
     "channelPostsImageAttachAlt": "첨부 이미지",
     "channelPostsImageUploadRequestingUrl": "업로드 준비 중…",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -4049,6 +4049,49 @@ describe('ChannelPostEditPage — 릴스 영상 슬롯(story #3556)', () => {
     expect(container.querySelector('[data-testid="channel-post-video-attach-trigger"]')?.textContent).toBe('영상 교체');
   });
 
+  // story #3591(§17-23④ 짝, PO 確定 2026-09-06) — 영상 붙은 초안의 커버 규격 태그가
+  // 캐러셀 비율(image_aspect_min/max)을 그대로 말해 3586 거부 문장("9:16이어야")과
+  // 한 화면에서 다른 세계였다. 비율 조각만 videoSpec 이름표로 바뀌고 나머지(형식·
+  // 용량·너비·색상공간)는 이미지 규격 그대로인지 고정.
+  it('⭐#3591 — 영상 첨부 後 커버 규격 태그는 videoSpec 이름표(9:16)를 쓰고 캐러셀 범위(1:1.25)는 안 보인다', async () => {
+    stubXhrForVideoUpload();
+    stubFetch({
+      videoMaxBytes: 100 * 1024 * 1024, videoMaxSeconds: 90, videoMinSeconds: 3,
+      videoAspectTarget: 0.5625, videoCodecs: ['avc1'],
+      imageMaxCount: 1, imageAspectMin: 0.8, imageAspectMax: 1.91,
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const input = container.querySelector('[data-testid="channel-post-video-file-input"]') as HTMLInputElement;
+    const file = new File(['x'], 'a.mp4', { type: 'video/mp4' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    await act(async () => { input.dispatchEvent(new Event('change', { bubbles: true })); });
+    await flush();
+
+    const specTag = container.querySelector('[data-testid="channel-post-image-spec-tag"]')?.textContent ?? '';
+    expect(specTag).toContain('9:16');
+    expect(specTag).not.toContain('1:1.25');
+    expect(specTag).not.toContain('~');
+    // 나머지 조각은 이미지 규격 그대로(형식·용량·너비·색상공간 무변).
+    expect(specTag).toContain('320');
+    expect(specTag).toContain('1440');
+    expect(specTag).toContain('sRGB');
+  });
+
+  it('⭐#3591 — 영상 없으면 커버 분기가 안 타고 캐러셀 범위(1:1.25 ~ 1.91:1)가 그대로 뜬다(회귀)', async () => {
+    stubFetch({
+      videoMaxBytes: 100 * 1024 * 1024,
+      imageMaxCount: 1, imageAspectMin: 0.8, imageAspectMax: 1.91,
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const specTag = container.querySelector('[data-testid="channel-post-image-spec-tag"]')?.textContent ?? '';
+    expect(specTag).toContain('1:1.25 ~ 1.91:1');
+    expect(specTag).not.toContain('9:16');
+  });
+
   // story #3577(유나 헤더 실측·페드루 PO 지적 2026-09-06) — putVideoWithProgress
   // 내부(구 :1133)와 호출부(:1173)가 둘 다 Content-Type을 세팅해 XHR이
   // setRequestHeader를 같은 헤더 이름으로 두 번 불러 "video/mp4, video/mp4"로

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -2335,10 +2335,24 @@ export default function ChannelPostEditPage() {
             </span>
           </div>
           <p className="text-xs text-muted-foreground" data-testid="channel-post-image-spec-tag">
-            {/* story #3530(유나 §17-16④, PO 確定 2026-09-06) — aspectMin>0(선언
+            {/* story #3591(유나 §17-23④ 짝, PO 確定 2026-09-06) — 영상이 있으면
+                이 구역은 커버(BE가 video_aspect_target으로 잰다, 3578) — 비율
+                조각만 videoSpec 이름표(formatVideoAspectRatio, 3586 거부 문장과
+                같은 헬퍼)로 바꾸고 나머지 조각(형식·용량·너비·색상공간)은 이미지
+                규격 그대로. 영상 없으면 아래 캐러셀 분기 무변. */}
+            {video && videoSpec
+              ? t('channelPostsCoverSpecTag', {
+                  formats: imageSpec.formats.map((f) => f.replace('image/', '').toUpperCase()).join(', '),
+                  maxBytes: formatFileSize(imageSpec.maxBytes),
+                  aspectTarget: formatVideoAspectRatio(videoSpec.aspectTarget),
+                  widthMin: imageSpec.widthMin,
+                  widthMax: imageSpec.widthMax,
+                  colorSpace: imageSpec.colorSpace,
+                })
+              : /* story #3530(유나 §17-16④, PO 確定 2026-09-06) — aspectMin>0(선언
                 있음)일 때만 두 경계를 보인다. 0(미선언)이면 지금처럼 최대만 —
-                0을 1:∞로 뒤집지 않는다. */}
-            {imageSpec.aspectMin > 0
+                0을 1:∞로 뒤집지 않는다. */
+              imageSpec.aspectMin > 0
               ? t('channelPostsImageSpecTagWithMin', {
                   formats: imageSpec.formats.map((f) => f.replace('image/', '').toUpperCase()).join(', '),
                   maxBytes: formatFileSize(imageSpec.maxBytes),


### PR DESCRIPTION
## 변경 사항
- 영상 1(9:16)+커버 1 붙은 초안에서 커버 구역 규격 태그가 캐러셀 이미지 비율(`image_aspect_min`/`image_aspect_max`, 예: 「비율 1:1.25 ~ 1.91:1」)을 그대로 말해 3578(BE) 422 거부 문장(3586, 「릴스 커버는 9:16 비율이어야 합니다.」)과 같은 화면에서 다른 값을 가리키던 결함 fix.
- `video && videoSpec`(영상 첨부 中)일 때만 비율 조각을 `videoSpec.aspectTarget`의 이름표(`formatVideoAspectRatio` — 3586 거부 문장·영상 규격 태그와 같은 헬퍼)로 교체. 나머지 조각(형식·용량·너비·색상공간)은 `imageSpec` 그대로.
- 새 i18n 키 `channelPostsCoverSpecTag`(ko/en) — 유나 §17-23④ 確定 낱말 그대로.
- 영상 없는 버전은 기존 캐러셀 범위 분기 무변.

## 테스트
- 신규 2: 영상 有 → 태그가 「9:16」을 담고 「1:1.25」 부재 / 영상 無 → 기존 범위(「1:1.25 ~ 1.91:1」) 그대로(회귀).
- 뮤테이션 1: `video && videoSpec` 분기 제거 시 영상 有 테스트가 RED로 떨어짐을 확인(복구 후 재검증).
- `pnpm vitest run` 대상 테스트 파일 211개 전부 PASS.
- `pnpm exec tsc --noEmit` 클린.
- `pnpm exec eslint` 변경 파일 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA