### PR TITLE
[SID:3590] draft.video_meta seed로 재로드에서도 릴스 메타 줄 유지(FE)

### DIFF
--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -4092,6 +4092,36 @@ describe('ChannelPostEditPage — 릴스 영상 슬롯(story #3556)', () => {
     expect(specTag).not.toContain('9:16');
   });
 
+  // story #3590(유나 §17-23⑤-1 정정, 페드루 PO 確定 2026-09-06, BE #3944 additive) —
+  // 업로드 직후엔 메타 줄이 섰지만 재진입(단건 재조회)에서는 draft.video_url만
+  // 실어 사라졌다. draft.video_meta seed로 재로드에서도 confirm 응답과 같은
+  // 필드명·같은 문장이 서는지 고정(새 문구 조립 0).
+  it('⭐#3590 — 재로드에서도 draft.video_meta로 메타 줄이 confirm 응답과 같은 문장으로 선다', async () => {
+    stubFetch({
+      videoMaxBytes: 100 * 1024 * 1024, imageMaxCount: 1,
+      draftDetail: {
+        video_url: 'https://storage.googleapis.com/bucket/channel-media/o/d1/x.mp4',
+        video_meta: { duration_seconds: 12.5, width: 1080, height: 1920, codec: 'avc1', original_bytes: 20000000 },
+      } as never,
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="channel-post-video-meta"]')?.textContent)
+      .toBe('12.5초 · 1080×1920 · H.264 · 19.1 MB');
+  });
+
+  it('⭐#3590 — video_meta가 없으면(BE 미착지·video_row 없음) 재로드는 여전히 메타 줄을 안 그린다(회귀)', async () => {
+    stubFetch({
+      videoMaxBytes: 100 * 1024 * 1024, imageMaxCount: 1,
+      draftDetail: { video_url: 'https://storage.googleapis.com/bucket/channel-media/o/d1/x.mp4' } as never,
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="channel-post-video-meta"]')).toBeNull();
+  });
+
   // story #3577(유나 헤더 실측·페드루 PO 지적 2026-09-06) — putVideoWithProgress
   // 내부(구 :1133)와 호출부(:1173)가 둘 다 Content-Type을 세팅해 XHR이
   // setRequestHeader를 같은 헤더 이름으로 두 번 불러 "video/mp4, video/mp4"로

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -104,6 +104,11 @@ interface ChannelPostDraftDetail {
   // poster={thumbnail_url}>, 없으면 기존처럼 썸네일만 그린다. 없으면 null(영상
   // 미첨부 또는 BE 미착지 — 둘 다 화면 동작 동일, fail-closed).
   video_url?: string | null;
+  // story #3590(Phase2·BE→FE·소형, 페드루 PO 確定 2026-09-06, BE #3944 additive) —
+  // video_url과 동형 관례(단건 전용). ChannelPostVideoResponse(confirm 응답)와
+  // 정확히 같은 필드명·타입 — formatVideoMetaLine이 재로드에서도 같은 문장을
+  // 낸다. video_row 없으면 null.
+  video_meta?: { duration_seconds: number; width: number; height: number; codec: string; original_bytes: number } | null;
   // story #3422 B3(페드루 PO, 2026-09-04 13:14Z) — 실패 배지(FailureActionBadge)가 이
   // 화면에 mount 안 된 채로 남아 있던 갭. 단건 GET(ChannelPostDraftListItem과 동형
   // shape, backend/app/routers/channel_posts.py)이 이미 내는 필드.
@@ -738,11 +743,25 @@ export default function ChannelPostEditPage() {
         const d = draftJson?.data;
         const list = versionsJson?.data ?? [];
         setDraft(d ?? null);
-        // story #3556(확定 갭②, 페드루 PO 2026-09-06) — 별도 영상 GET이 없어 초기
-        // 로드는 draft.video_url(재생 URL만)로만 seed한다 — 길이·해상도·코덱은
-        // "모른다"(undefined)로 남긴다(지어내지 않는다). 이 세션에서 새로 업로드하면
-        // handleVideoFileSelected가 confirm 응답의 풍부한 메타로 통째로 교체한다.
-        setVideo(d?.video_url ? { videoUrl: d.video_url } : null);
+        // story #3590(유나 §17-23⑤-1 정정, 페드루 PO 確定 2026-09-06) — BE #3944가
+        // video_meta(additive)를 실어 준 뒤로는 재로드에서도 confirm 응답과 같은
+        // 필드명으로 seed한다(formatVideoMetaLine이 같은 코드로 같은 문장을 낸다
+        // — 새 문구 조립 0). video_meta가 없으면(BE 미착지·video_row 없음) 종전대로
+        // videoUrl만 seed하고 메타는 "모른다"(undefined)로 남긴다.
+        setVideo(d?.video_url
+          ? {
+              videoUrl: d.video_url,
+              ...(d.video_meta
+                ? {
+                    durationSeconds: d.video_meta.duration_seconds,
+                    width: d.video_meta.width,
+                    height: d.video_meta.height,
+                    codec: d.video_meta.codec,
+                    originalBytes: d.video_meta.original_bytes,
+                  }
+                : {}),
+            }
+          : null);
         // story #3514(doc a0da40c9, PO 確定 2026-09-05) — lint-on-read. 저장/상신
         // 응답에서만 갱신되던 위반 목록을 로드 시점에도 채운다 — "저장 없이" 위반
         // 목록·상신 비활성이 선다(§16-7을 읽기까지 넓힘). 계약 없으면(BE 미착지)


### PR DESCRIPTION
## 변경 사항
- BE #3944(already merged in develop)가 additive로 얹은 `ChannelPostDraftListItem.video_meta{duration_seconds,width,height,codec,original_bytes}`(confirm 응답 `ChannelPostVideoResponse`와 정확히 같은 필드명·타입)를 draft 로드 seed에 반영.
- 업로드 직후엔 `formatVideoMetaLine`이 메타 줄(길이·해상도·코덱·용량)을 그렸지만, 재진입(단건 재조회)에서는 `draft.video_url`만 seed해 메타가 사라지던 결함 fix.
- `video_meta`가 없으면(BE 미착지·video_row 없음) 종전대로 `videoUrl`만 seed(회귀 0).
- 새 문구 조립 0 — confirm 경로와 같은 `formatVideoMetaLine` 그대로 재사용.

## 테스트
- 신규 1: 재로드 → 메타 줄이 confirm 응답과 정확히 같은 문장(`12.5초 · 1080×1920 · H.264 · 19.1 MB`).
- 회귀 1: `video_meta` 없으면 메타 줄 자체가 안 뜸(종전 동작 유지).
- 뮤테이션 1: seed 스프레드 제거 시 재로드 테스트가 RED로 떨어짐을 확인(복구 후 재검증).
- `pnpm vitest run` 대상 테스트 파일 211개 전부 PASS.
- `pnpm exec tsc --noEmit` 클린.
- `pnpm exec eslint` 변경 파일 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA