### PR TITLE
[SID:3599] fix: 댓글 답변 게이트 재개방·덮어쓰기 봉함 — reply 단위 scope_key + 결재 이력

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4719,6 +4719,8 @@
     "recipeApprovalSummaryCollapse": "Hide draft summary",
     "recipeApprovalVersionLabel": "Version",
     "recipeApprovalSealedHashLabel": "Sealed hash",
+    "recipeApprovalSealedVersionMissing": "We can't confirm which body this approval sealed — below is the last sealed body",
+    "commentReplyAlreadySentCount": "{count} replies already sent to this comment",
     "commentReplyTargetLabel": "Target comment",
     "commentReplyTargetTextLabel": "Target comment body",
     "commentReplyTargetTextNotSealed": "The target comment body isn't in this card yet — check the original before approving",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4719,6 +4719,8 @@
     "recipeApprovalSummaryCollapse": "산출물 요약 접기",
     "recipeApprovalVersionLabel": "버전",
     "recipeApprovalSealedHashLabel": "봉인 해시",
+    "recipeApprovalSealedVersionMissing": "이 승인이 어느 본문을 봉인했는지 확인할 수 없습니다 — 아래는 마지막으로 봉인된 본문입니다",
+    "commentReplyAlreadySentCount": "이 댓글에 이미 보낸 답변 {count}건",
     "commentReplyTargetLabel": "대상 댓글",
     "commentReplyTargetTextLabel": "대상 댓글 본문",
     "commentReplyTargetTextNotSealed": "대상 댓글 본문은 아직 카드에 실리지 않습니다 — 원문에서 확인하고 승인해 주세요",

--- a/apps/web/src/components/cage/gate-evidence-render.test.tsx
+++ b/apps/web/src/components/cage/gate-evidence-render.test.tsx
@@ -570,8 +570,12 @@ describe('GateEvidence — 댓글 답변 게이트 봉인 축(story #3517)', () 
   // 하지 않고 「확인할 수 없습니다」만 말한다 — 자리는 버전·해시 줄이 서던
   // 그 자리(줄을 새로 만들지 않는다). 뮤테이션(이 분기 제거 → "v" 텍스트가
   // 다시 보여 RED).
-  it('⑥-4 sealed_content_version이 null이면 「확인할 수 없습니다」만 서고 v숫자는 안 뜬다', async () => {
-    const gate = commentReplyGate({ target_external_comment_id: 'ext-comment-1' });
+  it('⑥-4 결정 난(rejected) 행에서 sealed_content_version이 null이면 「확인할 수 없습니다」만 서고 v숫자는 안 뜬다', async () => {
+    const gate = realApiShapedGate({
+      gate_type: 'external_publish', work_item_type: 'story', status: 'rejected', github_check_run_id: null,
+      neutral_facts: { kind: 'comment_reply', target_external_comment_id: 'ext-comment-1' },
+      sealed_content_body: '안녕하세요, 다음 주 월요일에 재입고됩니다.',
+    });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -579,6 +583,20 @@ describe('GateEvidence — 댓글 답변 게이트 봉인 축(story #3517)', () 
 
     expect(container.textContent).toContain(koMessages.cage.recipeApprovalSealedVersionMissing);
     expect(container.textContent).not.toMatch(/\bv\d/);
+  });
+
+  // story #3599(유나 §22-17 ⑥-4 조건 갱신, 페드루 PO 정정 2026-09-07) — pending
+  // 옛 게이트(아직 아무도 승인/반려한 적 없음)는 "무엇을 승인했나" 물음 자체가
+  // 안 서므로 캡션이 뜨면 안 된다(지어내지 않는다). 뮤테이션(isResolved 조건
+  // 제거 → 이 pending 표본에도 캡션이 떠 RED).
+  it('⑥-4 pending인데 sealed_content_version이 null이면 캡션이 안 뜬다(결정 前)', async () => {
+    const gate = commentReplyGate({ target_external_comment_id: 'ext-comment-1' });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).not.toContain(koMessages.cage.recipeApprovalSealedVersionMissing);
   });
 
   it('⑥-4 sealed_content_version이 있으면(신규 3599 게이트) 기존 버전·해시 줄이 그대로 뜨고 확인불가 문구는 없다', async () => {

--- a/apps/web/src/components/cage/gate-evidence-render.test.tsx
+++ b/apps/web/src/components/cage/gate-evidence-render.test.tsx
@@ -599,6 +599,42 @@ describe('GateEvidence — 댓글 답변 게이트 봉인 축(story #3517)', () 
     expect(container.textContent).not.toContain(koMessages.cage.recipeApprovalSealedVersionMissing);
   });
 
+  // story #3599(페드루 PO 정정 2026-09-07, 그라운딩) — held(일시정지·가역)는
+  // gate.status!=='pending'이지만 판단이 난 게 아니다. void_gate가 resolved_at
+  // 도 채우는 것과 달리(그라운딩 확認, gate_service.py:1592) held는 resolver_id
+  // 만 채우고 판단 자체는 없다 — 어느 조건으로 재도 캡션이 뜨면 안 된다.
+  it('⑥-4 held(일시정지)인데 sealed_content_version이 null이면 캡션이 안 뜬다(판단 아님)', async () => {
+    const gate = realApiShapedGate({
+      gate_type: 'external_publish', work_item_type: 'story', status: 'held', github_check_run_id: null,
+      neutral_facts: { kind: 'comment_reply', target_external_comment_id: 'ext-comment-1' },
+      sealed_content_body: '안녕하세요, 다음 주 월요일에 재입고됩니다.',
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).not.toContain(koMessages.cage.recipeApprovalSealedVersionMissing);
+  });
+
+  // voided는 gate.resolved_at을 채우지만(그라운딩 확認) 승인 판단이 아니라
+  // 행정 무효화다 — resolved_at 기준으로 재면 이 표본이 잘못 캡션을 띄운다
+  // (뮤테이션: isResolved를 `resolved_at !== null`로 바꾸면 이 assert가 RED).
+  it('⑥-4 voided(행정 무효화)인데 sealed_content_version이 null이면 캡션이 안 뜬다(승인 판단 아님)', async () => {
+    const gate = realApiShapedGate({
+      gate_type: 'external_publish', work_item_type: 'story', status: 'voided', github_check_run_id: null,
+      resolved_at: '2026-09-07T01:00:00Z',
+      neutral_facts: { kind: 'comment_reply', target_external_comment_id: 'ext-comment-1' },
+      sealed_content_body: '안녕하세요, 다음 주 월요일에 재입고됩니다.',
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).not.toContain(koMessages.cage.recipeApprovalSealedVersionMissing);
+  });
+
   it('⑥-4 sealed_content_version이 있으면(신규 3599 게이트) 기존 버전·해시 줄이 그대로 뜨고 확인불가 문구는 없다', async () => {
     const gate = realApiShapedGate({
       gate_type: 'external_publish', work_item_type: 'story', status: 'pending', github_check_run_id: null,

--- a/apps/web/src/components/cage/gate-evidence-render.test.tsx
+++ b/apps/web/src/components/cage/gate-evidence-render.test.tsx
@@ -563,6 +563,62 @@ describe('GateEvidence — 댓글 답변 게이트 봉인 축(story #3517)', () 
 
     expect(container.textContent).not.toContain(koMessages.cage.commentReplyTargetLabel);
   });
+
+  // story #3599(유나 §22-17 ⑥-4, PO 決 2026-09-07) — sealed_content_version이
+  // null인데 봉인 본문은 있는 행(옛 comment_reply 게이트, scope_key가 reply
+  // 단위로 쪼개지기 전)은 「쌍」이 안 서 대조 불가하다. 「덮였습니다」로 단정
+  // 하지 않고 「확인할 수 없습니다」만 말한다 — 자리는 버전·해시 줄이 서던
+  // 그 자리(줄을 새로 만들지 않는다). 뮤테이션(이 분기 제거 → "v" 텍스트가
+  // 다시 보여 RED).
+  it('⑥-4 sealed_content_version이 null이면 「확인할 수 없습니다」만 서고 v숫자는 안 뜬다', async () => {
+    const gate = commentReplyGate({ target_external_comment_id: 'ext-comment-1' });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).toContain(koMessages.cage.recipeApprovalSealedVersionMissing);
+    expect(container.textContent).not.toMatch(/\bv\d/);
+  });
+
+  it('⑥-4 sealed_content_version이 있으면(신규 3599 게이트) 기존 버전·해시 줄이 그대로 뜨고 확인불가 문구는 없다', async () => {
+    const gate = realApiShapedGate({
+      gate_type: 'external_publish', work_item_type: 'story', status: 'pending', github_check_run_id: null,
+      neutral_facts: { kind: 'comment_reply', target_external_comment_id: 'ext-comment-1' },
+      sealed_content_body: '답변 본문', sealed_content_version: 1, sealed_content_sha256: 'abcdef123456',
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).toContain('v1');
+    expect(container.textContent).not.toContain(koMessages.cage.recipeApprovalSealedVersionMissing);
+  });
+
+  // story #3599(유나 §22-17 ⑥-1, 페드루 PO 追加 2026-09-07) — 답변 다이얼로그
+  // (content.commentsReplyAlreadySentCount)와 짝인 승인자 쪽 줄. 게이트 생성
+  // 시점 neutral_facts.sent_replies_count 스냅샷 — 0/없음이면 줄 자체가 없다.
+  // 뮤테이션(alreadySentCount 배선 제거 → 항상 null 취급돼 RED).
+  it('⑥-1 neutral_facts.sent_replies_count>0이면 「이미 보낸 답변 N건」 줄이 대상 댓글 블록에 선다', async () => {
+    const gate = commentReplyGate({ target_external_comment_id: 'ext-comment-1', sent_replies_count: 2 });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).toContain('이 댓글에 이미 보낸 답변 2건');
+  });
+
+  it('⑥-1 sent_replies_count가 0이거나 없으면 그 줄이 없다', async () => {
+    const gate = commentReplyGate({ target_external_comment_id: 'ext-comment-1', sent_replies_count: 0 });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).not.toContain('이미 보낸 답변');
+  });
 });
 
 // story #2975 AC4(PO 확定 2026-08-24) — 결재 이력(GET /gates/{id}/activity) 실 응답 shape

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -178,8 +178,9 @@ interface RecipeApprovalFacts {
   // (§content.commentsReplyAlreadySentCount와 같은 규율: 수만·0이면 미표시).
   alreadySentCount: number | null;
   // story #3599(유나 §22-17 ⑥-4 조건 갱신, 페드루 PO 정정 2026-09-07) — 버전-미상
-  // 캡션은 «결정이 난» 행에서만(pending 옛 게이트는 아직 아무도 승인/반려한 적이
-  // 없어 "이 승인이 무엇을 봉인했는지" 물음 자체가 아직 안 선다 — 지어내지 않는다).
+  // 캡션은 «승인/반려 판단이 실제로 난» 행에서만. pending·held(일시정지)는
+  // 아직 판단 자체가 없고, voided는 판단이 아니라 행정 무효화라 지어낼 것도
+  // 없다 — approved/rejected/auto_passed만 이 조건을 만족한다.
   isResolved: boolean;
   // story #3560(concept_approval, 페드루 PO 確定 2026-09-06) — sealed_content_*와
   // 동형이나 대상이 doc(external_publish=본문 텍스트 봉인·concept_approval=doc
@@ -219,7 +220,13 @@ function recipeApprovalFacts(gate: GateItem): RecipeApprovalFacts | null {
     targetExternalCommentId: isCommentReply ? realString(f?.['target_external_comment_id']) : null,
     targetText: isCommentReply ? realString(f?.['target_text']) : null,
     alreadySentCount: isCommentReply && typeof f?.['sent_replies_count'] === 'number' ? f['sent_replies_count'] : null,
-    isResolved: gate.status !== 'pending',
+    // story #3599(페드루 PO 정정 2026-09-07, 그라운딩 2026-09-07) — gate.status!==
+    // 'pending'은 held(일시정지·가역)·voided까지 "결정 남"으로 세어버린다. PO가
+    // 제시한 대안(resolved_at!==null)도 실측해 보니 안 맞는다 — void_gate(gate_
+    // service.py:1592)가 resolved_at을 채운다(voided도 포함돼 버림). "승인/반려
+    // 판단이 실제로 난" 상태만 명시 열거한다(GATE_STATUSES 중 이 셋만 본문에
+    // 대한 판단 — held는 판단 자체가 없고 voided는 판단이 아니라 행정 무효화).
+    isResolved: gate.status === 'approved' || gate.status === 'rejected' || gate.status === 'auto_passed',
     sealedDocRef,
     sealedDocBodySha256: realString(gate.sealed_doc_body_sha256),
   };
@@ -613,10 +620,11 @@ function RecipeApprovalFactsBlock({ facts }: { facts: RecipeApprovalFacts }) {
           comment_id 단위였던 옛 comment_reply 게이트 — 마이그레이션 0, 그대로
           둔다는 §5 판정)은 「쌍」이 안 서 대조 불가하다. 「덮였습니다」로 단정
           하지 않는다(못 대조하는 게이트 중엔 한 번 승인되고 끝난 정상 옛 행도
-          있다) — 아는 것만 말한다: 「확인할 수 없다」. isResolved(pending이
-          아님) 한정 — 아직 아무도 승인/반려한 적 없는 pending 옛 게이트는
-          "무엇을 승인했나" 물음 자체가 아직 안 선다(지어내지 않는다). 이
-          자리(버전·해시 줄)를 대신할 뿐 줄을 새로 만들지 않는다. */}
+          있다) — 아는 것만 말한다: 「확인할 수 없다」. isResolved(resolved_at
+          있음) 한정 — 아직 아무도 승인/반려한 적 없는 pending 옛 게이트는
+          "무엇을 승인했나" 물음 자체가 아직 안 선다(지어내지 않는다·held·
+          voided는 resolved_at이 없어 이 조건에서도 자동 제외). 이 자리
+          (버전·해시 줄)를 대신할 뿐 줄을 새로 만들지 않는다. */}
       {facts.contentVersion === null && facts.contentBody && facts.isResolved ? (
         <p className="text-muted-foreground">{t('recipeApprovalSealedVersionMissing')}</p>
       ) : facts.contentVersion !== null || facts.contentSha256 ? (

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -620,10 +620,11 @@ function RecipeApprovalFactsBlock({ facts }: { facts: RecipeApprovalFacts }) {
           comment_id 단위였던 옛 comment_reply 게이트 — 마이그레이션 0, 그대로
           둔다는 §5 판정)은 「쌍」이 안 서 대조 불가하다. 「덮였습니다」로 단정
           하지 않는다(못 대조하는 게이트 중엔 한 번 승인되고 끝난 정상 옛 행도
-          있다) — 아는 것만 말한다: 「확인할 수 없다」. isResolved(resolved_at
-          있음) 한정 — 아직 아무도 승인/반려한 적 없는 pending 옛 게이트는
-          "무엇을 승인했나" 물음 자체가 아직 안 선다(지어내지 않는다·held·
-          voided는 resolved_at이 없어 이 조건에서도 자동 제외). 이 자리
+          있다) — 아는 것만 말한다: 「확인할 수 없다」. isResolved = status가
+          approved|rejected|auto_passed 중 하나(명시 열거) 한정 — resolved_at은
+          판별 키가 아니다(void_gate도 resolved_at을 채운다, gate_service.py:1592
+          그라운딩 確認). held(판단 자체 없음)·voided(판단이 아니라 행정
+          무효화)는 이 열거에 없어 자동 제외. 이 자리
           (버전·해시 줄)를 대신할 뿐 줄을 새로 만들지 않는다. */}
       {facts.contentVersion === null && facts.contentBody && facts.isResolved ? (
         <p className="text-muted-foreground">{t('recipeApprovalSealedVersionMissing')}</p>

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -172,6 +172,11 @@ interface RecipeApprovalFacts {
   // 이 null이면 "제공되지 않음"으로 정직하게 비운다).
   targetExternalCommentId: string | null;
   targetText: string | null;
+  // story #3599(유나 §22-17 ⑥-1, 페드루 PO 追加 2026-09-07) — 게이트 생성 시점의
+  // sent 카운트 스냅샷(neutral_facts.sent_replies_count, additive). null=구버전
+  // 게이트(이 필드 자체가 없던 시절)·0=보낸 답변 없음 — 둘 다 줄을 안 그린다
+  // (§content.commentsReplyAlreadySentCount와 같은 규율: 수만·0이면 미표시).
+  alreadySentCount: number | null;
   // story #3560(concept_approval, 페드루 PO 確定 2026-09-06) — sealed_content_*와
   // 동형이나 대상이 doc(external_publish=본문 텍스트 봉인·concept_approval=doc
   // 봉인). BE additive(story #3569) — 그 전까진 항상 null. 「펼침」이 없다(본문
@@ -209,6 +214,7 @@ function recipeApprovalFacts(gate: GateItem): RecipeApprovalFacts | null {
     reapprovalRequired: gate.reapproval_required === true,
     targetExternalCommentId: isCommentReply ? realString(f?.['target_external_comment_id']) : null,
     targetText: isCommentReply ? realString(f?.['target_text']) : null,
+    alreadySentCount: isCommentReply && typeof f?.['sent_replies_count'] === 'number' ? f['sent_replies_count'] : null,
     sealedDocRef,
     sealedDocBodySha256: realString(gate.sealed_doc_body_sha256),
   };
@@ -597,7 +603,15 @@ function RecipeApprovalFactsBlock({ facts }: { facts: RecipeApprovalFacts }) {
           ) : null}
         </div>
       ) : null}
-      {facts.contentVersion !== null || facts.contentSha256 ? (
+      {/* story #3599(유나 §22-17 ⑥-4, PO 決 2026-09-07) — sealed_content_version이
+          null인데 봉인 본문은 있는 행(scope_key가 comment_id 단위였던 옛 comment_
+          reply 게이트 — 마이그레이션 0, 그대로 둔다는 §5 판정)은 「쌍」이 안 서
+          대조 불가하다. 「덮였습니다」로 단정하지 않는다(못 대조하는 게이트 중엔
+          한 번 승인되고 끝난 정상 옛 행도 있다) — 아는 것만 말한다: 「확인할 수
+          없다」. 이 자리(버전·해시 줄)를 대신할 뿐 줄을 새로 만들지 않는다. */}
+      {facts.contentVersion === null && facts.contentBody ? (
+        <p className="text-muted-foreground">{t('recipeApprovalSealedVersionMissing')}</p>
+      ) : facts.contentVersion !== null || facts.contentSha256 ? (
         <p className="font-mono text-muted-foreground">
           {facts.contentVersion !== null ? `${t('recipeApprovalVersionLabel')} v${facts.contentVersion}` : null}
           {facts.contentVersion !== null && facts.contentSha256 ? ' · ' : null}
@@ -639,6 +653,13 @@ function RecipeApprovalFactsBlock({ facts }: { facts: RecipeApprovalFacts }) {
             <span className="text-muted-foreground">{t('commentReplyTargetLabel')} · </span>
             <span className="font-mono text-foreground">{facts.targetExternalCommentId}</span>
           </p>
+          {/* story #3599(유나 §22-17 ⑥-1, 페드루 PO 追加 2026-09-07) — 답변 다이얼로그
+              (content.commentsReplyAlreadySentCount)와 같은 사실·같은 규율(수만·0이면
+              미표시)의 승인자 짝. 이 사실은 이 답변이 아니라 그 댓글에 대한 것이라
+              대상 댓글 블록 안에 선다(행이 아니라 이 카드가 지는 이유와 동형). */}
+          {facts.alreadySentCount != null && facts.alreadySentCount > 0 ? (
+            <p className="text-muted-foreground">{t('commentReplyAlreadySentCount', { count: facts.alreadySentCount })}</p>
+          ) : null}
           <div>
             <p className="text-[10px] font-medium text-muted-foreground">{t('commentReplyTargetTextLabel')}</p>
             <p className="whitespace-pre-wrap text-foreground">

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -177,6 +177,10 @@ interface RecipeApprovalFacts {
   // 게이트(이 필드 자체가 없던 시절)·0=보낸 답변 없음 — 둘 다 줄을 안 그린다
   // (§content.commentsReplyAlreadySentCount와 같은 규율: 수만·0이면 미표시).
   alreadySentCount: number | null;
+  // story #3599(유나 §22-17 ⑥-4 조건 갱신, 페드루 PO 정정 2026-09-07) — 버전-미상
+  // 캡션은 «결정이 난» 행에서만(pending 옛 게이트는 아직 아무도 승인/반려한 적이
+  // 없어 "이 승인이 무엇을 봉인했는지" 물음 자체가 아직 안 선다 — 지어내지 않는다).
+  isResolved: boolean;
   // story #3560(concept_approval, 페드루 PO 確定 2026-09-06) — sealed_content_*와
   // 동형이나 대상이 doc(external_publish=본문 텍스트 봉인·concept_approval=doc
   // 봉인). BE additive(story #3569) — 그 전까진 항상 null. 「펼침」이 없다(본문
@@ -215,6 +219,7 @@ function recipeApprovalFacts(gate: GateItem): RecipeApprovalFacts | null {
     targetExternalCommentId: isCommentReply ? realString(f?.['target_external_comment_id']) : null,
     targetText: isCommentReply ? realString(f?.['target_text']) : null,
     alreadySentCount: isCommentReply && typeof f?.['sent_replies_count'] === 'number' ? f['sent_replies_count'] : null,
+    isResolved: gate.status !== 'pending',
     sealedDocRef,
     sealedDocBodySha256: realString(gate.sealed_doc_body_sha256),
   };
@@ -603,13 +608,16 @@ function RecipeApprovalFactsBlock({ facts }: { facts: RecipeApprovalFacts }) {
           ) : null}
         </div>
       ) : null}
-      {/* story #3599(유나 §22-17 ⑥-4, PO 決 2026-09-07) — sealed_content_version이
-          null인데 봉인 본문은 있는 행(scope_key가 comment_id 단위였던 옛 comment_
-          reply 게이트 — 마이그레이션 0, 그대로 둔다는 §5 판정)은 「쌍」이 안 서
-          대조 불가하다. 「덮였습니다」로 단정하지 않는다(못 대조하는 게이트 중엔
-          한 번 승인되고 끝난 정상 옛 행도 있다) — 아는 것만 말한다: 「확인할 수
-          없다」. 이 자리(버전·해시 줄)를 대신할 뿐 줄을 새로 만들지 않는다. */}
-      {facts.contentVersion === null && facts.contentBody ? (
+      {/* story #3599(유나 §22-17 ⑥-4, PO 決 2026-09-07·조건 갱신 2026-09-07) —
+          sealed_content_version이 null인데 봉인 본문은 있는 행(scope_key가
+          comment_id 단위였던 옛 comment_reply 게이트 — 마이그레이션 0, 그대로
+          둔다는 §5 판정)은 「쌍」이 안 서 대조 불가하다. 「덮였습니다」로 단정
+          하지 않는다(못 대조하는 게이트 중엔 한 번 승인되고 끝난 정상 옛 행도
+          있다) — 아는 것만 말한다: 「확인할 수 없다」. isResolved(pending이
+          아님) 한정 — 아직 아무도 승인/반려한 적 없는 pending 옛 게이트는
+          "무엇을 승인했나" 물음 자체가 아직 안 선다(지어내지 않는다). 이
+          자리(버전·해시 줄)를 대신할 뿐 줄을 새로 만들지 않는다. */}
+      {facts.contentVersion === null && facts.contentBody && facts.isResolved ? (
         <p className="text-muted-foreground">{t('recipeApprovalSealedVersionMissing')}</p>
       ) : facts.contentVersion !== null || facts.contentSha256 ? (
         <p className="font-mono text-muted-foreground">
@@ -653,19 +661,20 @@ function RecipeApprovalFactsBlock({ facts }: { facts: RecipeApprovalFacts }) {
             <span className="text-muted-foreground">{t('commentReplyTargetLabel')} · </span>
             <span className="font-mono text-foreground">{facts.targetExternalCommentId}</span>
           </p>
-          {/* story #3599(유나 §22-17 ⑥-1, 페드루 PO 追加 2026-09-07) — 답변 다이얼로그
-              (content.commentsReplyAlreadySentCount)와 같은 사실·같은 규율(수만·0이면
-              미표시)의 승인자 짝. 이 사실은 이 답변이 아니라 그 댓글에 대한 것이라
-              대상 댓글 블록 안에 선다(행이 아니라 이 카드가 지는 이유와 동형). */}
-          {facts.alreadySentCount != null && facts.alreadySentCount > 0 ? (
-            <p className="text-muted-foreground">{t('commentReplyAlreadySentCount', { count: facts.alreadySentCount })}</p>
-          ) : null}
           <div>
             <p className="text-[10px] font-medium text-muted-foreground">{t('commentReplyTargetTextLabel')}</p>
             <p className="whitespace-pre-wrap text-foreground">
               {facts.targetText ?? <span className="italic text-muted-foreground">{t('commentReplyTargetTextNotSealed')}</span>}
             </p>
           </div>
+          {/* story #3599(유나 §22-17 ⑥-1, 페드루 PO 追加 2026-09-07·정정 2026-09-07) —
+              답변 다이얼로그(content.commentsReplyAlreadySentCount)와 같은 사실·같은
+              규율(수만·0이면 미표시)의 승인자 짝, 순서도 다이얼로그와 같게(본문 →
+              이미 보낸 답변 N건). 이 사실은 이 답변이 아니라 그 댓글에 대한 것이라
+              대상 댓글 블록 안에 선다(행이 아니라 이 카드가 지는 이유와 동형). */}
+          {facts.alreadySentCount != null && facts.alreadySentCount > 0 ? (
+            <p className="text-muted-foreground">{t('commentReplyAlreadySentCount', { count: facts.alreadySentCount })}</p>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/backend/app/services/channel_post_comment_replies.py
+++ b/backend/app/services/channel_post_comment_replies.py
@@ -236,6 +236,20 @@ async def submit_comment_reply(
 
     scope_key = f"comment:{comment.id}:{reply.id}"
     text_sha256 = hashlib.sha256(reply.text.encode("utf-8")).hexdigest()
+
+    # story #3599(유나 §22-17 ⑥-1, 페드루 PO 追加 2026-09-07) — 결재함 카드가
+    # 이 댓글에 이미 나간 답변 수를 추가 왕복 없이 말할 수 있게, 게이트 생성
+    # 시점의 sent 카운트를 neutral_facts에 스냅샷(0이면 FE가 그 줄을 안 그린다
+    # — comments-section.tsx의 sentRepliesCount>0 관례와 동형). 이 reply 자신은
+    # 아직 안 나갔으니(방금 submit) 카운트에 안 낀다 — "이미 보낸" 그대로.
+    from sqlalchemy import func as _func
+
+    sent_replies_count = (await db.execute(
+        select(_func.count()).select_from(ChannelPostCommentReply).where(
+            ChannelPostCommentReply.comment_id == comment.id, ChannelPostCommentReply.status == "sent",
+        )
+    )).scalar_one()
+
     neutral_facts = {
         "kind": "comment_reply", "reply_id": str(reply.id), "connection_id": str(pub.connection_id),
         "comment_id": str(comment.id), "target_external_comment_id": comment.external_comment_id,
@@ -245,6 +259,7 @@ async def submit_comment_reply(
         # 그린다. sha는 계속 정본 판정에 쓰고(target_text_sha256, 그대로 유지),
         # 이건 순수 표시용 additive 사본 — 대조·판정 로직은 절대 이 필드를 안 본다.
         "target_text": comment.text,
+        "sent_replies_count": sent_replies_count,
     }
 
     # find_gate_slot_with_pr_fallback는 (work_item_id, gate_type, scope_key) 슬롯을

--- a/backend/app/services/channel_post_comment_replies.py
+++ b/backend/app/services/channel_post_comment_replies.py
@@ -190,9 +190,19 @@ async def submit_comment_reply(
     db: AsyncSession, *, org_id: uuid.UUID, reply_id: uuid.UUID, requester_member_id: uuid.UUID,
 ) -> ChannelPostCommentReply:
     """AC3 상신(human-only, 라우터 가드) — external_publish 게이트(scope_key=
-    "comment:{comment_id}")를 만들고 봉인한다. draft 상태에서만 1회(재상신·재편집은
-    이 조각 스코프 밖 — 실패/반려 뒤 새 초안을 다시 만드는 편이 이 MVP엔 더 단순).
-    대상 댓글이 이미 삭제됐으면 게이트조차 안 만들고 즉시 거부(AC4)."""
+    "comment:{comment_id}:{reply_id}")를 만들고 봉인한다. draft 상태에서만 1회
+    (재상신·재편집은 이 조각 스코프 밖 — 실패/반려 뒤 새 초안을 다시 만드는 편이
+    이 MVP엔 더 단순 — 같은 reply_id를 다시 여는 경로 자체가 없다, 위 status
+    가드가 그 증거). 대상 댓글이 이미 삭제됐으면 게이트조차 안 만들고 즉시
+    거부(AC4).
+
+    story #3599(BE·결함, 페드루 PO 決 2026-09-07) — scope_key가 이전엔
+    "comment:{comment_id}"뿐이라 같은 댓글의 2차 답변 상신이 1차 답변의 게이트
+    행을 재사용(create_gate 멱등 재-open)해 1차의 sealed_content_sha256/body/
+    neutral_facts/resolved_at을 2차 것으로 덮어썼다 — 「14:07Z에 무엇을
+    승인했나」가 그 자리에서 사라지는 결함. reply_id를 scope_key에 편입해
+    답변마다 게이트 1행이 되게 한다(같은 reply_id 재상신 경로가 없으니 이
+    바꾼 scope_key로도 재-open 경합이 없다 — 이력 테이블 신설 불요)."""
     reply = await _get_owned_reply(db, org_id=org_id, reply_id=reply_id)
     if reply.status != "draft":
         raise CommentReplyWrongStatusError(status=reply.status)
@@ -224,7 +234,7 @@ async def submit_comment_reply(
     from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback
     from app.services.workflow_line_config import _default_role_id
 
-    scope_key = f"comment:{comment.id}"
+    scope_key = f"comment:{comment.id}:{reply.id}"
     text_sha256 = hashlib.sha256(reply.text.encode("utf-8")).hexdigest()
     neutral_facts = {
         "kind": "comment_reply", "reply_id": str(reply.id), "connection_id": str(pub.connection_id),
@@ -258,6 +268,12 @@ async def submit_comment_reply(
         gate.resolved_at = None
     gate.sealed_content_sha256 = text_sha256
     gate.sealed_content_body = reply.text
+    # story #3599(유나 지적 「쌍이 아예 안 선다」) — sha만 있고 version이 계속
+    # null이면 승인 카드가 "버전 ?"로 보인다(site_post/channel_post는 draft.
+    # version을 채운다). scope_key가 이제 reply_id 전용이라 이 게이트엔 항상
+    # 그 reply 하나만 산다 — "버전 1"은 항상 참(미래에 같은 reply_id 재편집·
+    # 재상신을 허용하게 되면 그때 증가시킬 자리, 지금은 상수).
+    gate.sealed_content_version = 1
 
     reply.gate_id = gate.id
     reply.status = "pending"

--- a/backend/app/services/channel_post_comment_replies.py
+++ b/backend/app/services/channel_post_comment_replies.py
@@ -283,12 +283,14 @@ async def submit_comment_reply(
         gate.resolved_at = None
     gate.sealed_content_sha256 = text_sha256
     gate.sealed_content_body = reply.text
-    # story #3599(유나 지적 「쌍이 아예 안 선다」) — sha만 있고 version이 계속
-    # null이면 승인 카드가 "버전 ?"로 보인다(site_post/channel_post는 draft.
-    # version을 채운다). scope_key가 이제 reply_id 전용이라 이 게이트엔 항상
-    # 그 reply 하나만 산다 — "버전 1"은 항상 참(미래에 같은 reply_id 재편집·
-    # 재상신을 허용하게 되면 그때 증가시킬 자리, 지금은 상수).
-    gate.sealed_content_version = 1
+    # story #3599(유나 지적 「쌍이 아예 안 선다」, 페드루 PO 정정 2026-09-07) —
+    # sha만 있고 version이 계속 null이면 승인 카드가 "버전 ?"로 보인다
+    # (site_post/channel_post는 draft.version을 채운다). scope_key가 이제
+    # reply_id 전용이라 지금은 이 게이트엔 항상 그 reply 하나만 산다 — 이 줄은
+    # 항상 1을 만들지만, 증가 형으로 둔다(동작 변화 0·미래에 같은 reply_id를
+    # 재봉인하는 경로가 생겨도 "그때 증가시킬 자리"를 사람이 따로 기억할
+    # 필요가 없어진다).
+    gate.sealed_content_version = (gate.sealed_content_version or 0) + 1
 
     reply.gate_id = gate.id
     reply.status = "pending"

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1212,6 +1212,15 @@ async def transition_gate(
             # 그 시점의 역사가 사라지므로, append-only인 이 context가 유일한 영속 기록이 된다.
             # merge 게이트가 아니면 애초에 None(무관 필드 — 조용히 무해).
             "head_sha": gate.github_check_run_sha,
+            # story #3599(BE·결함, 페드루 PO 決 2026-09-07) — 게이트 행 자체(sealed_
+            # content_sha256/body)는 이후 같은 슬롯이 재-open되면 새 내용으로 덮인다
+            # (comment_reply는 #3599로 슬롯을 reply 단위로 쪼갰지만, site_post·
+            # channel_post 등 다른 gate_type은 여전히 (work_item, scope_key) 슬롯
+            # 재사용이 정상 동작이다 — 편집→재승인마다 옛 sha가 사라진다). context는
+            # append-only라 "그 결정 시점에 무엇이 봉인돼 있었나"를 여기 스냅샷해야만
+            # 나중에 복원 가능(additive, 기존 키 불변).
+            "sealed_content_sha256": gate.sealed_content_sha256,
+            "sealed_content_version": gate.sealed_content_version,
         },
     )
 

--- a/backend/tests/test_3516_comment_reply.py
+++ b/backend/tests/test_3516_comment_reply.py
@@ -221,7 +221,10 @@ async def test_submit_comment_reply_creates_sealed_gate():
             gate = (await s.execute(
                 Gate.__table__.select().where(Gate.id == reply.gate_id)
             )).mappings().one()
-            assert gate["scope_key"] == f"comment:{comment.id}"
+            # story #3599(BE·결함, 페드루 PO 決 2026-09-07) — scope_key가 댓글
+            # 단위에서 답변(reply) 단위로 바뀌었다(2차 답변이 1차 게이트를
+            # 재사용·덮어쓰던 결함 봉함, test_3599_comment_reply_gate_per_reply.py).
+            assert gate["scope_key"] == f"comment:{comment.id}:{reply.id}"
             assert gate["work_item_id"] == work_item_id
             assert gate["sealed_content_sha256"] == hashlib.sha256("답변 초안".encode("utf-8")).hexdigest()
             assert gate["sealed_content_body"] == "답변 초안"

--- a/backend/tests/test_3599_comment_reply_gate_per_reply.py
+++ b/backend/tests/test_3599_comment_reply_gate_per_reply.py
@@ -1,0 +1,166 @@
+"""story #3599(BE·결함·결재 이력, 페드루 PO 決 2026-09-07) — 댓글 답변 2차 상신이
+1차 답변의 external_publish 게이트를 재개방·덮어쓰기하던 결함의 근본 수정.
+
+원인: submit_comment_reply의 scope_key가 "comment:{comment_id}"뿐이라 create_gate
+(work_item, gate_type, scope_key) 슬롯 재사용 멱등이 댓글당 게이트 1행으로
+수렴했다 — 2차 답변 상신이 1차 답변 게이트를 재-open해 sealed_content_sha256/
+body/neutral_facts/resolved_at을 2차 것으로 덮어썼다("14:07Z에 무엇을 승인
+했나"가 사라지는 감사 갭).
+
+처방: scope_key를 "comment:{comment_id}:{reply_id}"로 answer마다 쪼갠다(같은
+reply_id 재상신 경로가 없다 — submit_comment_reply가 status=="draft"만 허용,
+새 답변은 항상 새 reply_id — 이력 테이블 신설 불요, PR 그라운딩 근거). 추가로
+transition_gate의 ActivityLog context에 sealed_content_sha256·sealed_content_
+version을 얹어(append-only) 게이트 행 자체가 나중에 다른 이유로 재사용되더라도
+"그 결정 시점에 무엇을 승인했나"가 이력에 남게 한다.
+
+세팅 헬퍼는 test_3596_open_reply_draft_additive.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_default_role, _seed_human, _seed_org, _session_factory
+from app.main import app
+from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+from tests.test_3516_comment_reply import _seed_comment, _seed_full_publication_chain
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete,sandbox_manage_replies",
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+        insight_metrics=("impressions", "reach", "views", "engagements", "clicks", "spend", "conversions"),
+        supports_fetch_replies=True, supports_reply=True, reply_required_scope="sandbox_manage_replies",
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+async def _submit_and_approve(s, *, org_id, comment, human_id, text):
+    from app.services.channel_post_comment_replies import create_comment_reply_draft, submit_comment_reply
+    from app.services.gate_service import transition_gate
+
+    draft = await create_comment_reply_draft(
+        s, org_id=org_id, comment_id=comment.id, text=text,
+        created_by_member_id=human_id, created_by_kind="human",
+    )
+    reply = await submit_comment_reply(s, org_id=org_id, reply_id=draft.id, requester_member_id=human_id)
+    await transition_gate(s, org_id, reply.gate_id, "approved", human_id, "승인")
+    await s.commit()
+    # 실 워커(process_due_publication_commands) 없이도 다음 답변을 만들 수 있게
+    # sent로 종결(create_comment_reply_draft의 409 가드는 draft/pending만 막는다 —
+    # 이 스토리 관심사(게이트 슬롯 분리)와 무관한 축이라 워커까지 안 돌린다).
+    reply.status = "sent"
+    await s.commit()
+    await s.refresh(reply)
+    return reply
+
+
+@pytest.mark.anyio
+async def test_second_reply_submit_gets_own_gate_row_first_seal_untouched():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            first = await _submit_and_approve(s, org_id=org_id, comment=comment, human_id=human_id, text="1차 봉인 원문")
+            first_gate_id = first.gate_id
+            from app.models.gate import Gate
+            first_gate_snapshot = (await s.execute(
+                Gate.__table__.select().where(Gate.id == first_gate_id)
+            )).mappings().one()
+
+            second = await _submit_and_approve(s, org_id=org_id, comment=comment, human_id=human_id, text="2차 봉인 원문")
+
+            # 뮤테이션 대상①(scope_key 원복 → 같은 gate row 재사용 → 이 assert가 RED).
+            assert second.gate_id != first_gate_id, "2차 답변이 1차 게이트를 재사용하면 안 된다(scope_key가 reply 단위여야)"
+
+            first_gate_after = (await s.execute(
+                Gate.__table__.select().where(Gate.id == first_gate_id)
+            )).mappings().one()
+            assert first_gate_after["sealed_content_sha256"] == first_gate_snapshot["sealed_content_sha256"]
+            assert first_gate_after["sealed_content_body"] == "1차 봉인 원문"
+            assert first_gate_after["neutral_facts"]["reply_id"] == str(first.id)
+            assert first_gate_after["resolved_at"] == first_gate_snapshot["resolved_at"]
+            assert first_gate_after["sealed_content_version"] == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_approved_activity_log_context_carries_sealed_content_sha_and_version():
+    """뮤테이션 대상②(context에서 sealed_content_sha256 제거 → 이 assert가 RED)."""
+    from app.models.activity_log import ActivityLog
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id, _ = await _seed_human(s, org_id, role="owner")
+            _, _, _, pub = await _seed_full_publication_chain(s, org_id=org_id, project_id=project_id)
+            comment = await _seed_comment(s, org_id=org_id, publication_id=pub.id)
+
+            reply = await _submit_and_approve(s, org_id=org_id, comment=comment, human_id=human_id, text="승인 대상 답변")
+
+            log_row = (await s.execute(
+                ActivityLog.__table__.select().where(
+                    ActivityLog.entity_id == reply.gate_id, ActivityLog.action == "gate_approved",
+                )
+            )).mappings().one()
+            import hashlib
+            expected_sha = hashlib.sha256("승인 대상 답변".encode("utf-8")).hexdigest()
+            assert log_row["context"]["sealed_content_sha256"] == expected_sha
+            assert log_row["context"]["sealed_content_version"] == 1
+            # 기존 키 불변(additive) — head_sha 등 원래 있던 필드가 그대로.
+            assert "work_item_id" in log_row["context"]
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3599_comment_reply_gate_per_reply.py
+++ b/backend/tests/test_3599_comment_reply_gate_per_reply.py
@@ -131,6 +131,15 @@ async def test_second_reply_submit_gets_own_gate_row_first_seal_untouched():
             assert first_gate_after["neutral_facts"]["reply_id"] == str(first.id)
             assert first_gate_after["resolved_at"] == first_gate_snapshot["resolved_at"]
             assert first_gate_after["sealed_content_version"] == 1
+
+            # story #3599(유나 §22-17 ⑥-1) — 게이트 생성 시점 sent 카운트 스냅샷.
+            # 1차는 만들 당시 보낸 답변 0건, 2차는 1차가 이미 sent라 1건이어야
+            # 한다(뮤테이션 대상③ — sent_replies_count 배선 제거 → KeyError/None RED).
+            assert first_gate_snapshot["neutral_facts"]["sent_replies_count"] == 0
+            second_gate = (await s.execute(
+                Gate.__table__.select().where(Gate.id == second.gate_id)
+            )).mappings().one()
+            assert second_gate["neutral_facts"]["sent_replies_count"] == 1
     finally:
         await engine.dispose()
 

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1438,6 +1438,11 @@
       "source": "story-3596-open-reply-draft-additive(PR 개설 前 선제 등재 — 로컬 raw pytest 4건 3.88s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 18s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
+      "file": "tests/test_3599_comment_reply_gate_per_reply.py",
+      "sec": 13.9,
+      "source": "story-3599-comment-reply-gate-per-reply(PR#3955 CI 실측, run 34073227196 — destructive-schema shard 실 wall time)"
+    },
+    {
       "file": "tests/test_3597_ig_fb_connection_status_promote.py",
       "sec": 22.0,
       "source": "story-3597-ig-fb-connection-status-promote(페드루 PO 追加 2026-09-06 — [sandbox:expire-after-publish] 마커 라이브검증 테스트 2건 추가 뒤 재측정. 로컬 raw pytest 6건 3.15s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 22s 잠정값, 실 CI 샤드 로그로 재확認 필요)"


### PR DESCRIPTION
## 요약
- **원인**: `submit_comment_reply`의 게이트 `scope_key`가 `comment:{comment_id}`뿐이라 `create_gate`의 (work_item, gate_type, scope_key) 슬롯 재사용 멱등이 댓글당 게이트 1행으로 수렴 — 같은 댓글 2차 상신이 1차 답변의 게이트를 재-open해 `sealed_content_sha256`/`body`/`neutral_facts`/`resolved_at`을 2차 것으로 덮어썼다("14:07Z에 무엇을 승인했나"가 사라지는 결함).
- **그라운딩(물음1)**: 답변 발행은 `channel_publications`(gate_id, version_id 유니크)를 쓰지 않는다 — `_process_one_comment_reply_command`는 `ChannelPostCommentReply`를 직접 갱신할 뿐 그 테이블에 행을 안 만든다.
- **처방**: `scope_key`를 `comment:{comment_id}:{reply_id}`로 답변마다 쪼갠다. `gate.sealed_content_version=1`도 채운다(reply 1개=게이트 1행이라 "버전 1"은 항상 참).
- **그라운딩(물음2)**: 같은 reply_id를 다시 열어 재상신하는 경로는 코드에 없다(`submit_comment_reply`는 `status=="draft"`에서만 상신 허용 — "다시 상신"도 항상 **새** reply_id) → 결정 이력 테이블 신설 불요. 대신 `transition_gate`의 `activity_logs` context에 `sealed_content_sha256`·`sealed_content_version`을 additive로 얹어(기존 키 불변) 다른 gate_type(계속 슬롯을 재사용하는 site_post/channel_post 등)에서도 "그 결정 시점에 무엇을 승인했나"가 이력에 남게 한다.
- **옛 행**: `scope_key=comment:{comment_id}` 형태의 기존 게이트는 그대로 둔다(이미 덮인 이력은 복원 불가, 마이그레이션 0).
- **유나 §22-17 ⑥ 착지**(doc a0da40c9):
  - ⑥-1 게이트 생성 시 `neutral_facts.sent_replies_count` 스냅샷 → 결재함 카드가 "이 댓글에 이미 보낸 답변 {count}건"을 대상 댓글 블록에 그린다(0=미표시, #3953 답변 다이얼로그의 같은 줄과 짝).
  - ⑥-4 `sealed_content_version`이 null인데 봉인 본문은 있는 옛 comment_reply 게이트는 "쌍"이 안 서 대조 불가 — "덮였습니다" 대신 "확인할 수 없습니다"(신규 키 `cage.recipeApprovalSealedVersionMissing`)로 정직하게 비운다. 버전·해시 줄이 서던 자리를 대신할 뿐 새 줄은 안 만든다.
  - ⑥-2 새 문장에 버전 숫자를 안 실어 자동 충족.
- **readers grep**: `scope_key`로 게이트를 찾는 소비처는 `submit_comment_reply` 단 한 곳(쓰기)뿐 — 나머지(`gates.py:1601`·`gate_service.py:959`)는 이미 `neutral_facts.reply_id` 기준이라 이번 변경 영향 없음.

## 테스트
- `test_3599_comment_reply_gate_per_reply.py` 신규 2건: 2차 상신 → 게이트 2행·1차 봉인(sha·body·neutral_facts·resolved_at)·version 불변 + `sent_replies_count` 스냅샷(0→1) / 승인 ActivityLog context에 sha·version 실림.
- `gate-evidence-render.test.tsx` 신규 4건: ⑥-4 버전-없음 캡션·버전-있음 정상 표시 각 1 / ⑥-1 이미 보낸 답변 줄 있음·없음 각 1.
- 뮤테이션 5(scope_key 원복·context sha 제거·⑥-4 분기 제거·⑥-1 배선 제거·sent_replies_count 필드 제거) 전부 RED 확인 후 원복.
- 기존 `test_3516_comment_reply.py`의 scope_key 리터럴 assert 1건을 새 형으로 갱신.
- tsc --noEmit·vitest 전체(6573건)·check-i18n-keys(0 missing)·backend 관련 스위트(26건) 전부 초록.

## 스토리
[댓글 답변 게이트 재개방·덮어쓰기](entity:story:fb2f78a4-68ec-4c87-bcbe-fa17bf3e75bb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG