### PR TITLE
[SID:3601] fix: BE 오류 봉투 ↔ FE body.detail 불일치 7자리 통일 + 재발가드 lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,6 +698,23 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_business_info_email_footer_drift.py
 
+  # story #3601(FE·결함 클래스, 디디 전수 표 2026-09-07) — BE 전역 오류 봉투는 항상
+  # {data,error,meta}뿐인데 apps/web 곳곳이 body?.detail?.message·body?.detail?.code를
+  # 1차 소스로 읽어(그 필드는 우리 봉투에 없어 항상 undefined) 실 메시지가 소실되거나
+  # 특정 code 분기가 영구 사망했다(실제 사고: story #3596 create 409 existing_reply_id).
+  # 재발 방지 — 새 `.detail?.(message|code)` 등장을 잡는다(허용 목록=이미 .error 우선인
+  # 무해한 자리·PG 불요 정적 스캔).
+  fe-error-envelope-detail-mismatch-lint:
+    name: FE error envelope .detail mismatch lint (guard, story #3601)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan apps/web/src for unguarded .detail?.(message|code) reads
+        working-directory: backend
+        run: python3 scripts/lint_fe_error_envelope_detail_mismatch.py
+
   # story #3219(카디르 3라운드, 2026-08-30) — 이 검증은 run-migrations.test.sh 시나리오
   # [9]로 먼저 만들어졌지만 그 .test.sh는 CI 어디에도 안 걸려 있어(convention 자체가
   # manual-only) 매 PR에 실제로 도는 자리가 없었다("만들어졌는데 도는 자리 없음" 결함).

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -3914,10 +3914,16 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     expect(document.querySelector('[data-testid="comments-reply-error"]')?.textContent).toBe('답변 대상 댓글이 삭제되어 상신할 수 없습니다.');
   });
 
-  // story #3601(디디 전수 표 2026-09-07) — handleRetryReply(dead_letter 「다시
-  // 보내기」)도 실 봉투({error:{message}})로 서버 문구가 그대로 선다. 이전엔
-  // body?.detail?.message만 읽어 이 자리 전용 테스트가 아예 없었다(회귀 갭).
-  it('「다시 보내기」(dead_letter) 실패 — 실 봉투({error:{message}})로 서버 문구가 그대로 뜬다', async () => {
+  // story #3601(디디 전수 표 2026-09-07·페드루 PO 정정) — handleRetryReply
+  // (dead_letter 「다시 보내기」)의 실제 유일한 실패는 command_service.py::
+  // retry_dead_letter_command가 None을 반환하는 404뿐이다(command_id 불일치/이미
+  // 처리됨 둘 다 존재 비노출로 같은 404, PO 決 AC5) — 전역 핸들러가 그 plain-string
+  // detail을 `error:{code:"NOT_FOUND", message:"..."}`으로 감싼다. `NOT_FOUND`는
+  // 앱 전체 미지정 404가 공유하는 제네릭 라벨이라(다른 자리는 uuid를 담기도 함)
+  // HUMAN_SAFE_ERROR_MESSAGE_CODES에 못 올린다 — 이 code일 땐 항상 제네릭으로
+  // 떨어지는 게 맞다(이전 버전은 code 없이 message만 봐 이 실 BE 문장도 우연히
+  // 통과시켰다 — 안전 쪽으로 조인 결과지 회귀 아님).
+  it('「다시 보내기」(dead_letter) 실패 — 404(NOT_FOUND, allowlist 밖)는 제네릭 문구', async () => {
     stubFetch({
       draftDetail: PUBLISHED_DRAFT,
       commentsResponse: {
@@ -3931,7 +3937,7 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
           },
         }],
       },
-      onCommentReplyRetry: () => ({ status: 409, body: { data: null, error: { code: 'PUBLICATION_COMMAND_NOT_RETRYABLE', message: '이미 처리된 명령입니다.' }, meta: null } }),
+      onCommentReplyRetry: () => ({ status: 404, body: { data: null, error: { code: 'NOT_FOUND', message: 'command를 찾을 수 없거나 재시도 대상이 아닙니다' }, meta: null } }),
     });
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
     await flush();
@@ -3939,7 +3945,8 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     expect(retryBtn).not.toBeNull();
     await act(async () => { retryBtn.click(); });
     await flush();
-    expect(document.body.textContent).toContain('이미 처리된 명령입니다.');
+    expect(document.body.textContent).toContain('요청을 처리하지 못했습니다.');
+    expect(document.body.textContent).not.toContain('재시도 대상이 아닙니다');
   });
 
   // story #3517(BE #3865 조각①) — 수동 재수집. 429/422/403 문장을 서버 응답 그대로
@@ -4025,18 +4032,28 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     expect(container.querySelector('[data-testid="comments-refresh-error"]')?.textContent).toBe('사람만 다시 수집할 수 있습니다');
   });
 
-  it('재수집 502(채널 fetch 실패) — flat {code,message} shape도 그대로 보인다', async () => {
+  // story #3601(유나 Design CHANGES, 페드루 PO 정정 2026-09-07) — 이전 표본
+  // (`CHANNEL_FETCH_FAILED`)은 BE에 실재하지 않는 가상 code였고, 예전엔
+  // `?? body?.message`(우리 봉투에 없는 죽은 폴백)로 우연히 그 문구가 통과했다.
+  // 실제 502 원인(CHANNEL_PUBLISH_PROVIDER_ERROR 등)의 message는 provider raw
+  // exception repr이라 사람에게 그대로 보이면 안 된다 — allowlist에 없는 코드는
+  // 제네릭으로 떨어져야 한다(이 테스트가 그 방향을 고정).
+  it('재수집 502(CHANNEL_PUBLISH_PROVIDER_ERROR, allowlist 밖) — raw provider 메시지 대신 제네릭', async () => {
     stubFetch({
       draftDetail: PUBLISHED_DRAFT,
       commentsResponse: { last_collected_at: null, comments: [], active_count: 0, deleted_count: 0 },
-      onCommentsRefresh: () => ({ status: 502, body: { code: 'CHANNEL_FETCH_FAILED', message: '채널에서 응답을 받지 못했습니다' } }),
+      onCommentsRefresh: () => ({
+        status: 502,
+        body: { data: null, error: { code: 'CHANNEL_PUBLISH_PROVIDER_ERROR', message: "ThreadsPublishError(status_code=502, body='<html>Bad Gateway</html>')" }, meta: null },
+      }),
     });
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
     await flush();
     const btn = container.querySelector('[data-testid="comments-refresh-button"]') as HTMLButtonElement;
     await act(async () => { btn.click(); });
     await flush();
-    expect(container.querySelector('[data-testid="comments-refresh-error"]')?.textContent).toBe('채널에서 응답을 받지 못했습니다');
+    expect(container.querySelector('[data-testid="comments-refresh-error"]')?.textContent).toBe(koMessages.content.commentsRefreshErrorGeneric);
+    expect(document.body.textContent).not.toContain('ThreadsPublishError');
   });
 
   // story #3601(디디 전수 표 2026-09-07) — 실 BE 봉투({data:null,error:{...},meta:null},

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -188,6 +188,9 @@ function stubFetch(opts: {
   onCommentReplySubmit?: () => { status: number; body: unknown };
   // story #3544 조각⑧ — voided(봉인 불일치) 「다시 상신」의 prefill용 단건 GET.
   onCommentReplyGet?: () => { status: number; body: unknown };
+  // story #3544(3517 조각③) — dead_letter 답변 「다시 보내기」(공용 publication-commands
+  // /{id}/retry, org 스코프 — channel-posts/publication-commands 쪽과 다른 URL).
+  onCommentReplyRetry?: () => { status: number; body: unknown };
   // story #3550(Phase2·풀스택, BE 2/2 #3910 계약) — 캐러셀 N장 목록. 기본값 빈
   // 배열(첨부 0장, 기존 시나리오 전부 회귀 0). image_id/position이 삭제·재정렬
   // 대상 키다.
@@ -486,6 +489,14 @@ function stubFetch(opts: {
           status: 200,
           body: { id: 'reply-1', comment_id: 'c1', text: '이전 답변 원문', status: 'failed', gate_id: 'gate-1', external_reply_id: null, external_reply_url: null, last_error: null, target_comment_state: null },
         };
+        const ok = result.status < 400;
+        return { ok, status: result.status, json: async () => (ok ? { data: result.body, error: null, meta: null } : result.body) };
+      }
+      // story #3544(3517 조각③) — dead_letter 답변 「다시 보내기」(org 스코프
+      // publication-commands/{id}/retry, channel-posts/publication-commands 쪽과
+      // 다른 URL — handleRetryReply 전용 자리).
+      if (url.match(/\/organizations\/[^/]+\/publication-commands\/[^/]+\/retry$/) && init?.method === 'POST') {
+        const result = opts.onCommentReplyRetry?.() ?? { status: 200, body: { id: 'cmd-1', status: 'pending' } };
         const ok = result.status < 400;
         return { ok, status: result.status, json: async () => (ok ? { data: result.body, error: null, meta: null } : result.body) };
       }
@@ -3606,6 +3617,28 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     expect(document.querySelector('[data-testid="comments-convert-error"]')?.textContent).toBe('이 액션은 휴먼 멤버만 가능합니다.');
   });
 
+  // story #3601(디디 전수 표 2026-09-07) — 실 BE 봉투({error:{message}})로도 서버
+  // 문구가 그대로 보인다(예전엔 body?.detail?.message만 읽어 이 자리에서 늘 폴백
+  // 「commentsActionErrorGeneric」으로만 떨어졌다).
+  it('「작업으로 전환」 403 — 실 봉투({error:{message}})로도 서버 문구가 그대로 뜬다', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: {
+        last_collected_at: '2026-09-05T10:00:00Z', active_count: 1, deleted_count: 0,
+        comments: [{ id: 'c1', external_comment_id: 'ext-1', author_display_name: '홍길동', text: 'x', external_created_at: null, captured_at: '2026-09-05T10:00:00Z', deleted_at: null }],
+      },
+      onCommentFollowUp: () => ({ status: 403, body: { data: null, error: { code: 'COMMENT_REPLY_HUMAN_ONLY', message: '이 액션은 휴먼 멤버만 가능합니다.' }, meta: null } }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    const btn = container.querySelector('[data-testid="comments-item-convert-to-task"]') as HTMLButtonElement;
+    await act(async () => { btn.click(); });
+    const submitBtn = [...document.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.commentsConvertSubmit) as HTMLButtonElement;
+    await act(async () => { submitBtn.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true })); });
+    await flush();
+    expect(document.querySelector('[data-testid="comments-convert-error"]')?.textContent).toBe('이 액션은 휴먼 멤버만 가능합니다.');
+  });
+
   it('「답변」 클릭 — 초안 저장→상신까지 실 BFF로 진행되고 성공 문구가 뜬다', async () => {
     let draftedText = '';
     stubFetch({
@@ -3856,6 +3889,59 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     expect(document.querySelector('[data-testid="comments-reply-error"]')?.textContent).toBe('답변 대상 댓글이 삭제되어 상신할 수 없습니다.');
   });
 
+  // story #3601(디디 전수 표 2026-09-07) — 실 BE 봉투({error:{message}})로도 서버
+  // 문구가 그대로 보인다.
+  it('「답변」 상신 409 — 실 봉투({error:{message}})로도 서버 문구가 그대로 뜬다', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: {
+        last_collected_at: '2026-09-05T10:00:00Z', active_count: 1, deleted_count: 0,
+        comments: [{ id: 'c1', external_comment_id: 'ext-1', author_display_name: '홍길동', text: 'x', external_created_at: null, captured_at: '2026-09-05T10:00:00Z', deleted_at: null }],
+      },
+      onCommentReplySubmit: () => ({ status: 409, body: { data: null, error: { code: 'COMMENT_REPLY_TARGET_DELETED', message: '답변 대상 댓글이 삭제되어 상신할 수 없습니다.' }, meta: null } }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    const btn = container.querySelector('[data-testid="comments-item-reply"]') as HTMLButtonElement;
+    await act(async () => { btn.click(); });
+    const textarea = document.querySelector('#comments-reply-text') as HTMLTextAreaElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => { setter.call(textarea, 'x'); textarea.dispatchEvent(new Event('input', { bubbles: true })); });
+    await act(async () => { (document.querySelector('[data-testid="comments-reply-draft-button"]') as HTMLButtonElement).dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true })); });
+    await flush();
+    await act(async () => { (document.querySelector('[data-testid="comments-reply-submit-button"]') as HTMLButtonElement).click(); });
+    await flush();
+    expect(document.querySelector('[data-testid="comments-reply-error"]')?.textContent).toBe('답변 대상 댓글이 삭제되어 상신할 수 없습니다.');
+  });
+
+  // story #3601(디디 전수 표 2026-09-07) — handleRetryReply(dead_letter 「다시
+  // 보내기」)도 실 봉투({error:{message}})로 서버 문구가 그대로 선다. 이전엔
+  // body?.detail?.message만 읽어 이 자리 전용 테스트가 아예 없었다(회귀 갭).
+  it('「다시 보내기」(dead_letter) 실패 — 실 봉투({error:{message}})로 서버 문구가 그대로 뜬다', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: {
+        last_collected_at: '2026-09-05T10:00:00Z', active_count: 1, deleted_count: 0,
+        comments: [{
+          id: 'c1', external_comment_id: 'ext-1', author_display_name: '홍길동', text: '언제 되나요?',
+          external_created_at: null, captured_at: '2026-09-05T10:00:00Z', deleted_at: null,
+          reply: {
+            id: 'reply-1', status: 'failed', external_reply_url: null, command_id: 'cmd-1',
+            command_status: 'dead_letter', failure_kind: 'needs_check', next_attempt_at: null, reason_code: null,
+          },
+        }],
+      },
+      onCommentReplyRetry: () => ({ status: 409, body: { data: null, error: { code: 'PUBLICATION_COMMAND_NOT_RETRYABLE', message: '이미 처리된 명령입니다.' }, meta: null } }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    const retryBtn = container.querySelector('[data-testid="comments-item-reply-retry-button"]') as HTMLButtonElement;
+    expect(retryBtn).not.toBeNull();
+    await act(async () => { retryBtn.click(); });
+    await flush();
+    expect(document.body.textContent).toContain('이미 처리된 명령입니다.');
+  });
+
   // story #3517(BE #3865 조각①) — 수동 재수집. 429/422/403 문장을 서버 응답 그대로
   // 보인다(재해석·재작성 0).
   it('재수집 성공 — 목록을 다시 불러온다(POST 뒤 GET 재조회)', async () => {
@@ -3951,6 +4037,45 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     await act(async () => { btn.click(); });
     await flush();
     expect(container.querySelector('[data-testid="comments-refresh-error"]')?.textContent).toBe('채널에서 응답을 받지 못했습니다');
+  });
+
+  // story #3601(디디 전수 표 2026-09-07) — 실 BE 봉투({data:null,error:{...},meta:null},
+  // BE 전역 http_exception_handler 그대로)로 COMMENT_COLLECTION_UNSUPPORTED가 실제로
+  // 선다. 위 테스트(3913행)는 `.detail` 모양이라 늘 폴백을 통했었다 — 이 테스트가 실
+  // 봉투 회귀를 고정한다.
+  it('재수집 422 COMMENT_COLLECTION_UNSUPPORTED — 실 봉투({error:{code,message}})로도 그 얼굴이 선다', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: { last_collected_at: null, comments: [], active_count: 0, deleted_count: 0 },
+      onCommentsRefresh: () => ({
+        status: 422,
+        body: { data: null, error: { code: 'COMMENT_COLLECTION_UNSUPPORTED', message: '이 채널은 댓글 수집을 지원하지 않습니다' }, meta: null },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    const btn = container.querySelector('[data-testid="comments-refresh-button"]') as HTMLButtonElement;
+    await act(async () => { btn.click(); });
+    await flush();
+    expect(container.querySelector('[data-testid="comments-refresh-button"]')).toBeNull();
+    expect(container.querySelector('[data-testid="comments-refresh-unsupported"]')?.textContent).toBe('이 채널은 댓글을 지원하지 않습니다.');
+  });
+
+  it('재수집 403 — 실 봉투({error:{message}})로도 서버 문구가 그대로 보인다', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: { last_collected_at: null, comments: [], active_count: 0, deleted_count: 0 },
+      onCommentsRefresh: () => ({
+        status: 403,
+        body: { data: null, error: { code: 'COMMENT_REFRESH_HUMAN_ONLY', message: '사람만 다시 수집할 수 있습니다' }, meta: null },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    const btn = container.querySelector('[data-testid="comments-refresh-button"]') as HTMLButtonElement;
+    await act(async () => { btn.click(); });
+    await flush();
+    expect(container.querySelector('[data-testid="comments-refresh-error"]')?.textContent).toBe('사람만 다시 수집할 수 있습니다');
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -445,7 +445,9 @@ export default function ChannelPostEditPage() {
       if ((body?.error?.code ?? detail?.code) === 'COMMENT_COLLECTION_UNSUPPORTED') {
         return { ok: false, kind: 'unsupported' };
       }
-      const message = extractBackendErrorMessage(body) ?? body?.message ?? t('commentsRefreshErrorGeneric');
+      // story #3601(페드루 PO 追加 2026-09-07) — body?.message는 우리 봉투에 없는
+      // 자리라 죽은 폴백이었다(추가 검증 없이 걷는다).
+      const message = extractBackendErrorMessage(body) ?? t('commentsRefreshErrorGeneric');
       return { ok: false, kind: 'generic', message };
     } catch {
       return { ok: false, kind: 'generic', message: t('commentsRefreshErrorGeneric') };
@@ -468,7 +470,7 @@ export default function ChannelPostEditPage() {
       const body = await res.json().catch(() => null) as { data?: { story_id?: string }; error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
       if (!res.ok) {
         // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
-        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? body?.message ?? t('commentsActionErrorGeneric') };
+        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? t('commentsActionErrorGeneric') };
       }
       const storyId = body?.data?.story_id;
       if (!storyId) return { ok: false, errorMessage: t('commentsActionErrorGeneric') };
@@ -525,7 +527,7 @@ export default function ChannelPostEditPage() {
       const body = await res.json().catch(() => null) as { data?: ReplyView; error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
       if (!res.ok || !body?.data) {
         // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
-        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? body?.message ?? t('commentsActionErrorGeneric') };
+        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? t('commentsActionErrorGeneric') };
       }
       return { ok: true, reply: body.data };
     } catch {
@@ -550,7 +552,7 @@ export default function ChannelPostEditPage() {
       if (!res.ok) {
         // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
         const body = await res.json().catch(() => null) as { error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
-        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? body?.message ?? t('commentsActionErrorGeneric') };
+        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? t('commentsActionErrorGeneric') };
       }
       loadComments();
       return { ok: true };

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -17,6 +17,7 @@ import { describeExternalImpact } from '@/components/content/external-impact';
 import { contentPostStatusLabelKey } from '@/components/content/post-status';
 import { ScheduleAtDialog } from '@/components/content/schedule-at-dialog';
 import { parseScheduledAtServerError } from '@/components/content/validate-scheduled-at';
+import { extractBackendErrorMessage } from '@/lib/api-error-message';
 import { deriveFailureAction, type CommandStatus } from '@/components/content/failure-action';
 import { FailureActionBadge } from '@/components/content/failure-action-badge';
 import { InsightSnapshotBlock, type InsightSnapshot } from '@/components/content/insight-snapshot-block';
@@ -433,11 +434,18 @@ export default function ChannelPostEditPage() {
         const retryAfterSeconds = retryAfterHeader !== null ? Number.parseInt(retryAfterHeader, 10) : null;
         return { ok: false, kind: 'rate_limited', retryAfterSeconds: Number.isFinite(retryAfterSeconds) ? retryAfterSeconds : null };
       }
-      const body = await res.json().catch(() => null) as { detail?: { code?: string; message?: string }; code?: string; message?: string } | null;
-      if (body?.detail?.code === 'COMMENT_COLLECTION_UNSUPPORTED') {
+      // story #3601(디디 전수 표 2026-09-07) — BE 전역 봉투는 {data,error,meta}뿐이라
+      // .detail은 항상 undefined였다(COMMENT_COLLECTION_UNSUPPORTED 분기 영구 사망).
+      // .error를 1순위로, .detail은 무해한 방어적 폴백으로만 남긴다(detail을 변수로
+      // 먼저 옮겨 읽는다 — body 뒤에 곧장 물음표 두 번으로 detail.code를 잇는 형은
+      // lint_fe_error_envelope_detail_mismatch.py가 잡는 그 모양 자체라 새 위반으로
+      // 다시 걸린다).
+      const body = await res.json().catch(() => null) as { error?: { code?: string; message?: string }; detail?: { code?: string; message?: string }; message?: string } | null;
+      const detail = body?.detail;
+      if ((body?.error?.code ?? detail?.code) === 'COMMENT_COLLECTION_UNSUPPORTED') {
         return { ok: false, kind: 'unsupported' };
       }
-      const message = body?.detail?.message ?? body?.message ?? t('commentsRefreshErrorGeneric');
+      const message = extractBackendErrorMessage(body) ?? body?.message ?? t('commentsRefreshErrorGeneric');
       return { ok: false, kind: 'generic', message };
     } catch {
       return { ok: false, kind: 'generic', message: t('commentsRefreshErrorGeneric') };
@@ -457,9 +465,10 @@ export default function ChannelPostEditPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title: input.title, note: input.note || null }),
       });
-      const body = await res.json().catch(() => null) as { data?: { story_id?: string }; detail?: { message?: string }; message?: string } | null;
+      const body = await res.json().catch(() => null) as { data?: { story_id?: string }; error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
       if (!res.ok) {
-        return { ok: false, errorMessage: body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric') };
+        // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
+        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? body?.message ?? t('commentsActionErrorGeneric') };
       }
       const storyId = body?.data?.story_id;
       if (!storyId) return { ok: false, errorMessage: t('commentsActionErrorGeneric') };
@@ -483,9 +492,9 @@ export default function ChannelPostEditPage() {
         // BE 전역 HTTPException 핸들러(app/main.py http_exception_handler)의
         // {data:null,error:{...},meta:null} 봉투를 그대로 통과시킨다(proxyToFastapi
         // 주석 "Errors already enveloped by the BE global handler" — detail 키는
-        // 존재한 적이 없다, 이 파일 다른 자리의 body?.detail 패턴은 그 봉투와
-        // 안 맞아 늘 폴백 메시지로 떨어지는 별개 결함 — 이 스토리 스코프 밖,
-        // 발견만 남긴다).
+        // 존재한 적이 없다). 이 파일 다른 자리들도 story #3601에서 같은 근거로
+        // extractBackendErrorMessage(.error 1순위)로 통일했다 — 여기 existingReplyId는
+        // 그 헬퍼가 안 다루는 3596 전용 필드라 이 자리만 인라인으로 남는다.
         error?: { message?: string; existing_reply_id?: string };
         detail?: { message?: string };
         message?: string;
@@ -513,9 +522,10 @@ export default function ChannelPostEditPage() {
       const res = await fetchWithAuth(`/api/organizations/${orgId}/comments/${replyComment.id}/replies/${replyId}/submit`, {
         method: 'POST',
       });
-      const body = await res.json().catch(() => null) as { data?: ReplyView; detail?: { message?: string }; message?: string } | null;
+      const body = await res.json().catch(() => null) as { data?: ReplyView; error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
       if (!res.ok || !body?.data) {
-        return { ok: false, errorMessage: body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric') };
+        // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
+        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? body?.message ?? t('commentsActionErrorGeneric') };
       }
       return { ok: true, reply: body.data };
     } catch {
@@ -538,8 +548,9 @@ export default function ChannelPostEditPage() {
         method: 'POST',
       });
       if (!res.ok) {
-        const body = await res.json().catch(() => null) as { detail?: { message?: string }; message?: string } | null;
-        return { ok: false, errorMessage: body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric') };
+        // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
+        const body = await res.json().catch(() => null) as { error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
+        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? body?.message ?? t('commentsActionErrorGeneric') };
       }
       loadComments();
       return { ok: true };

--- a/apps/web/src/components/chat/chat-input.test.tsx
+++ b/apps/web/src/components/chat/chat-input.test.tsx
@@ -482,6 +482,43 @@ describe('ChatInput — STEER 모드(story #2942)', () => {
     expect(container.textContent).toContain('방향 전환 지시');
   });
 
+  // story #3601(디디 전수 표 2026-09-07) — 실 BE 봉투({data:null,error:{code,message},
+  // meta:null}, BE 전역 http_exception_handler 그대로)로도 같은 명시 카피가 선다.
+  // 위 테스트는 `{detail:{...}}` 모양이라 body?.detail?.code가 항상 undefined였던
+  // 예전 코드에서도(우연히) 통과했다 — 이 테스트가 실 봉투 회귀를 고정한다.
+  it('422 conversation_target_mismatch — 실 봉투({error:{code,message}})로도 명시 카피가 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string }) => {
+      if (url.includes('/api/entities/search')) {
+        return new Response(JSON.stringify({ data: [{ entity_type: 'story', entity_id: 's1', title: '대상 스토리', status: 'in-progress' }] }));
+      }
+      if (url === '/api/events/publish' && init?.method === 'POST') {
+        return new Response(JSON.stringify({ data: null, error: { code: 'conversation_target_mismatch', message: 'internal BE msg', errors: ['u1'] }, meta: null }), { status: 422 });
+      }
+      return new Response(JSON.stringify({ data: [] }));
+    }));
+    await act(async () => {
+      root.render(withIntl(
+        <ChatInput threadId="c1" onSend={vi.fn()} currentTeamMemberId="me" participants={PARTICIPANTS} projectId="p1" />,
+      ));
+    });
+    await act(async () => { toggleBtn()!.click(); });
+    await act(async () => { setValue(textarea(), '이제 A로 가자'); });
+    const select = container.querySelector('select') as HTMLSelectElement;
+    await act(async () => { setValue(select, 'u1'); });
+    const workItemInput = container.querySelectorAll('input[type="text"]')[0] as HTMLInputElement;
+    await act(async () => { setValue(workItemInput, '대상'); });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+    const candidate = [...container.querySelectorAll('[role="listbox"] button')][0] as HTMLButtonElement;
+    await act(async () => { candidate.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true })); });
+
+    const sendBtn = [...container.querySelectorAll('button')].find((b) => b.querySelector('svg.lucide-send')) as HTMLButtonElement;
+    await act(async () => { sendBtn.click(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain('internal BE msg');
+    expect(container.textContent).toContain('이 스레드에 없는 사람에게는 여기서 방향 전환 지시를 보낼 수 없습니다');
+  });
+
   // story #3203(카디르 QA 블로킹·2026-08-29) — BE가 orphan participant.name을 이제 null로
   // 실어보낸다(예전엔 uuid 앞 8자였으나 그마저 없어짐). 대상 select가 `p.name ?? p.member_id`
   // 폴백을 쓰고 있어 36자 uuid 전체가 옵션 텍스트로 그대로 새는 회귀였다 — 이 PR의 BE 변경이

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -444,9 +444,15 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
         }),
       });
       if (!res.ok) {
-        const body = await res.json().catch(() => null) as { detail?: { code?: string } } | null;
+        // story #3601(디디 전수 표 2026-09-07) — BE 전역 봉투는 {data,error,meta}뿐이라
+        // body?.detail?.code는 항상 undefined였다 — "참여자 아님" 친절 문구가 영구
+        // 사망하고 항상 일반 sendFailed로만 떨어졌다. .detail을 변수로 먼저 옮겨
+        // 읽는다(body 뒤에 곧장 물음표 두 번으로 detail.code를 잇는 형은 lint_fe_
+        // error_envelope_detail_mismatch.py가 잡는 그 모양이라 다시 걸린다).
+        const body = await res.json().catch(() => null) as { error?: { code?: string }; detail?: { code?: string } } | null;
+        const detail = body?.detail;
         setSteerError(
-          body?.detail?.code === 'conversation_target_mismatch'
+          (body?.error?.code ?? detail?.code) === 'conversation_target_mismatch'
             ? t('steerErrorNotParticipant')
             : extractBackendErrorMessage(body) ?? t('sendFailed'),
         );

--- a/apps/web/src/components/content/comments-refresh-button.tsx
+++ b/apps/web/src/components/content/comments-refresh-button.tsx
@@ -14,7 +14,10 @@ import { Button } from '@/components/ui/button';
 //     이 상태는 컴포넌트 로컬(useState)이라 마운트 한정 — 페이지를 새로고침하면
 //     되돌아온다. 지속형(다시 마운트해도 안 뜨는) 처리는 조각②의 `comments_supported`
 //     필드 몫이다(PO 확定 2026-09-05).
-//   - generic — 그 외(403·502 등)는 서버 message를 그대로 버튼 밑에 보인다.
+//   - generic — 그 외(403·502 등)는 code가 `HUMAN_SAFE_ERROR_MESSAGE_CODES`
+//     allowlist(lib/api-error-message.ts, story #3601 페드루 PO 정정 2026-09-07)에
+//     있을 때만 서버 message를 그대로 버튼 밑에 보인다 — 목록 밖 code는 message가
+//     uuid·내부명·raw exception repr을 담을 수 있어 호출부 자기 폴백(commentsRefreshErrorGeneric)으로 대신 떨어진다.
 export type CommentsRefreshOutcome =
   | { ok: true }
   | { ok: false; kind: 'rate_limited'; retryAfterSeconds: number | null }

--- a/apps/web/src/lib/api-error-message.test.ts
+++ b/apps/web/src/lib/api-error-message.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { extractBackendErrorMessage } from './api-error-message';
+import { extractBackendErrorMessage, HUMAN_SAFE_ERROR_MESSAGE_CODES } from './api-error-message';
 
 describe('extractBackendErrorMessage — story #2647(공통화, #2637 §범위3 패턴 공유)', () => {
-  it('apiSuccess() 에러 모양({error:{message}})에서 그대로 뽑는다', () => {
-    expect(extractBackendErrorMessage({ error: { message: '이 이벤트는 human 발행자만 허용합니다.' } }))
-      .toBe('이 이벤트는 human 발행자만 허용합니다.');
+  it('apiSuccess() 에러 모양({error:{code,message}})에서 code가 allowlist에 있으면 뽑는다', () => {
+    expect(extractBackendErrorMessage({ error: { code: 'COMMENT_REFRESH_HUMAN_ONLY', message: '댓글 재수집은 휴먼 멤버만 가능합니다.' } }))
+      .toBe('댓글 재수집은 휴먼 멤버만 가능합니다.');
   });
 
-  it('FastAPI HTTPException을 그대로 통과시키는 문자열 detail에서 뽑는다', () => {
+  it('FastAPI HTTPException을 그대로 통과시키는 문자열 detail에서 뽑는다(code 없어도 §2647 계약 그대로)', () => {
     expect(extractBackendErrorMessage({ detail: 'Agent cannot mute assigned conversation or thread' }))
       .toBe('Agent cannot mute assigned conversation or thread');
   });
 
-  it('{detail:{message}} 모양에서도 뽑는다', () => {
-    expect(extractBackendErrorMessage({ detail: { message: 'Admin role required' } })).toBe('Admin role required');
+  it('{detail:{code,message}} 모양도 code가 allowlist에 있으면 뽑는다', () => {
+    expect(extractBackendErrorMessage({ detail: { code: 'COMMENT_REPLY_HUMAN_ONLY', message: '이 액션은 휴먼 멤버만 가능합니다.' } }))
+      .toBe('이 액션은 휴먼 멤버만 가능합니다.');
   });
 
   it('세 자리 다 없으면 null(호출부가 자기 폴백을 쓴다 — 지어내지 않음)', () => {
@@ -25,6 +26,32 @@ describe('extractBackendErrorMessage — story #2647(공통화, #2637 §범위3 
   });
 
   it('error.message 우선순위가 detail보다 높다(apiSuccess 경로가 있으면 그쪽이 정본)', () => {
-    expect(extractBackendErrorMessage({ error: { message: 'A' }, detail: 'B' })).toBe('A');
+    expect(extractBackendErrorMessage({
+      error: { code: 'COMMENT_REFRESH_HUMAN_ONLY', message: 'A' },
+      detail: 'B',
+    })).toBe('A');
+  });
+
+  // story #3601(유나 Design CHANGES, 페드루 PO 정정 2026-09-07) — 핵심 처방: object 형
+  // (error.message·detail.message)은 code가 HUMAN_SAFE_ERROR_MESSAGE_CODES에 없으면
+  // 절대 통과시키지 않는다. uuid·내부 필드명·raw exception repr을 그대로 담는 코드가
+  // 실재한다(예: COMMENT_REPLY_WRONG_STATUS "이 상태(draft)에서는…", UNSUPPORTED_
+  // CONTENT_TYPE의 content_type repr) — 이 테스트가 그 gate를 고정한다.
+  it('object 형인데 code가 allowlist 밖이면 message가 안전해 보여도 null(사람 이름·uuid 방지)', () => {
+    expect(extractBackendErrorMessage({
+      error: { code: 'COMMENT_REPLY_WRONG_STATUS', message: '이 상태(draft)에서는 상신할 수 없습니다' },
+    })).toBeNull();
+    expect(extractBackendErrorMessage({
+      detail: { code: 'UNSUPPORTED_CONTENT_TYPE', message: "허용되지 않는 content_type: 'image/gif'" },
+    })).toBeNull();
+  });
+
+  it('object 형인데 code 필드 자체가 없으면(구형 픽스처) null — code 없이는 안전성을 잴 수 없다', () => {
+    expect(extractBackendErrorMessage({ error: { message: '이름 없이 온 문구' } })).toBeNull();
+    expect(extractBackendErrorMessage({ detail: { message: 'Admin role required' } })).toBeNull();
+  });
+
+  it('앱 전체 미지정 404/제네릭 라벨(NOT_FOUND 등)은 목록에 없다 — uuid를 담는 다른 자리와 공유하는 라벨이라 등재 금지', () => {
+    expect(HUMAN_SAFE_ERROR_MESSAGE_CODES.has('NOT_FOUND')).toBe(false);
   });
 });

--- a/apps/web/src/lib/api-error-message.ts
+++ b/apps/web/src/lib/api-error-message.ts
@@ -11,27 +11,40 @@
  * CONTENT_TYPE`의 "…content_type: 'image/gif' (허용: […])"). §object 형(`error.message`·
  * `detail.message`) 자리만 `HUMAN_SAFE_ERROR_MESSAGE_CODES` 허용목록으로 gate한다 — 그
  * 코드가 목록에 있을 때만 원문을 그대로 보여주고, 없으면 null(호출부가 자기 폴백 문구로
- * 돌아간다, "예전 얼굴"). `detail`이 순수 문자열인 형(FastAPI 다른 라우트가 그대로 내는
- * 정책거부 사유 등, story #2647 DeliveryContractModal 계약)은 code 자체가 없어 안전성을
- * 잴 수 없으므로 이 gate 밖 — 기존 동작 그대로 무조건 통과(그 화면들의 계약을 이 스토리가
- * 건드리지 않는다).
+ * 돌아간다, "예전 얼굴"). `detail`이 순수 문자열인 형은 code 자체가 없어 안전성을 잴 수
+ * 없으므로 이 gate 밖 — 기존 동작 그대로 무조건 통과시킨다. 페드루 PO 정정(2026-09-07)
+ * — 이 형이 "다른 라우트가 실제로 내는 합법적 shape"라는 건 부정확하다: 우리 BE 전역
+ * 핸들러는 string detail로 raise된 HTTPException도 object(`error:{code,message}`)로
+ * 감싼다(lint_fe_error_envelope_detail_mismatch.py 참고) — 우리 BE가 실제로 내는 string
+ * detail은 없다(Pydantic 422조차 object가 아니라 `[{loc,msg,type}]` 배열이라 이 분기와
+ * 무관). 이 분기는 순수하게 `DeliveryContractModal.test.tsx`(#2647)의 옛 픽스처 계약을
+ * 깨지 않으려는 하위호환일 뿐 — 실 BE 오늘 산출물이 아니다.
  *
- * 새 코드를 이 목록에 추가하려면: 그 코드의 실제 BE 원문을 읽고(uuid·내부 이름·raw
- * exception repr 없음을 확認) PR 본문에 그 문장을 그대로 인용할 것 — "안전해 보인다"가
- * 아니라 "확認했다"가 등재 기준이다.
+ * 새 코드를 이 목록에 추가하려면: **그 code로 raise하는 자리를 저장소 전체에서 grep해
+ * 전수**를 세고, 그 전부의 원문을 읽어(uuid·내부 이름·raw exception repr 없음을 확認)
+ * 하나도 빠짐없이 사람 문장일 때만 등재한다. 한 자리만 확認하고 "한 자리로 보인다"로
+ * 등재하지 않는다 — 페드루 PO 정정(2026-09-07): `CHANNEL_CONNECTION_NOT_ACTIVE`가 실제
+ * 반례다. 이 code로 raise하는 자리가 저장소에 20곳 넘게 있고 그중 다수(site_posts.py·
+ * insight_snapshots.py·publication_command.py 등)가 `f"...{connection.id}"`처럼 uuid를
+ * 그대로 담는다 — 한 자리(channel_post_comments.py의 fetch 공용 블록)만 보고 "댓글 수집
+ * 흐름의 이 code는 안전하다"로 처음 등재했던 게 오판이었다. PR 본문에 코드마다 「raise
+ * 자리 수 → 문장 전부」를 표로 남길 것 — "안전해 보인다"가 아니라 "전수 확認했다"가
+ * 등재 기준이다.
  */
 export const HUMAN_SAFE_ERROR_MESSAGE_CODES = new Set<string>([
-  // channel_post_comments.py::refresh_publication_comments_endpoint
+  // channel_post_comments.py::refresh_publication_comments_endpoint(raise 1곳)
   'COMMENT_REFRESH_HUMAN_ONLY', // "댓글 재수집은 휴먼 멤버만 가능합니다."
-  'COMMENT_COLLECTION_UNSUPPORTED', // "이 채널은 댓글 수집을 지원하지 않습니다."
-  'CHANNEL_CONNECTION_NOT_ACTIVE', // "연결에 자격이 없습니다."
-  // channel_post_comment_replies.py
-  'COMMENT_REPLY_HUMAN_ONLY', // "이 액션은 휴먼 멤버만 가능합니다."
-  'COMMENT_REPLY_TARGET_DELETED', // "답변 대상 댓글이 삭제되어 상신할 수 없습니다."
-  'COMMENT_REPLY_CHANNEL_UNSUPPORTED', // "이 채널은 답변 발송을 지원하지 않습니다."
-  'COMMENT_REPLY_DRAFT_ALREADY_OPEN', // "안 보낸 초안이 이미 있습니다."
-  // channel_posts.py::_require_human(발행류 공용, retry 엔드포인트도 공유)
+  'COMMENT_COLLECTION_UNSUPPORTED', // "이 채널은 댓글 수집을 지원하지 않습니다."(raise 1곳)
+  // channel_post_comment_replies.py·gates.py
+  'COMMENT_REPLY_HUMAN_ONLY', // "이 액션은 휴먼 멤버만 가능합니다."(raise 1곳)
+  'COMMENT_REPLY_TARGET_DELETED', // raise 2곳 — "답변 대상 댓글이 삭제되어 상신할 수 없습니다."(replies.py) · "…승인할 수 없습니다."(gates.py) 둘 다 안전
+  'COMMENT_REPLY_CHANNEL_UNSUPPORTED', // "이 채널은 답변 발송을 지원하지 않습니다."(raise 1곳)
+  'COMMENT_REPLY_DRAFT_ALREADY_OPEN', // "안 보낸 초안이 이미 있습니다."(raise 1곳)
+  // channel_posts.py::_require_human(발행류 공용, retry 엔드포인트도 공유, raise 1곳)
   'CHANNEL_POST_PUBLISH_HUMAN_ONLY', // "채널 포스트 발행은 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지)."
+  // ⛔ CHANNEL_CONNECTION_NOT_ACTIVE는 raise 20곳+(site_posts.py·insight_snapshots.py·
+  // publication_command.py·channel_posts.py·channel_post_comments.py 등) — 그중 다수가
+  // uuid(connection.id·publication_id)를 그대로 담아 등재 금지(2026-09-07 정정, 페드루 PO).
 ]);
 
 export function extractBackendErrorMessage(body: unknown): string | null {

--- a/apps/web/src/lib/api-error-message.ts
+++ b/apps/web/src/lib/api-error-message.ts
@@ -3,16 +3,52 @@
  * 세운 패턴("BE가 이유를 완성 문장으로 주므로 FE가 재구성하지 않고 그대로 보여준다")을
  * 여기로 뽑아 DeliveryContractModal(#2647)과 공유한다. BE 에러 응답은 두 모양이 섞여 있다
  * (apiSuccess()가 감싼 `{error:{message}}`·FastAPI HTTPException을 그대로 통과시키는
- * `{detail: string | {message: string}}`) — 이 함수는 그 세 자리를 순서대로 본다.
- * 못 찾으면 null(호출부가 자기 폴백 문구를 쓴다 — 이 함수는 "찾았는지"만 정직하게 답한다).
+ * `{detail: string | {message: string}}`).
+ *
+ * story #3601(유나 Design CHANGES, 페드루 PO 정정 2026-09-07) — 「BE가 완성 문장을 준다」는
+ * 원 전제가 깨졌다: 실측해 보니 몇몇 코드는 uuid·내부 필드/상태값·raw exception repr을
+ * 그대로 담는다(예: `COMMENT_REPLY_WRONG_STATUS`의 "이 상태(draft)에서는…", `UNSUPPORTED_
+ * CONTENT_TYPE`의 "…content_type: 'image/gif' (허용: […])"). §object 형(`error.message`·
+ * `detail.message`) 자리만 `HUMAN_SAFE_ERROR_MESSAGE_CODES` 허용목록으로 gate한다 — 그
+ * 코드가 목록에 있을 때만 원문을 그대로 보여주고, 없으면 null(호출부가 자기 폴백 문구로
+ * 돌아간다, "예전 얼굴"). `detail`이 순수 문자열인 형(FastAPI 다른 라우트가 그대로 내는
+ * 정책거부 사유 등, story #2647 DeliveryContractModal 계약)은 code 자체가 없어 안전성을
+ * 잴 수 없으므로 이 gate 밖 — 기존 동작 그대로 무조건 통과(그 화면들의 계약을 이 스토리가
+ * 건드리지 않는다).
+ *
+ * 새 코드를 이 목록에 추가하려면: 그 코드의 실제 BE 원문을 읽고(uuid·내부 이름·raw
+ * exception repr 없음을 확認) PR 본문에 그 문장을 그대로 인용할 것 — "안전해 보인다"가
+ * 아니라 "확認했다"가 등재 기준이다.
  */
+export const HUMAN_SAFE_ERROR_MESSAGE_CODES = new Set<string>([
+  // channel_post_comments.py::refresh_publication_comments_endpoint
+  'COMMENT_REFRESH_HUMAN_ONLY', // "댓글 재수집은 휴먼 멤버만 가능합니다."
+  'COMMENT_COLLECTION_UNSUPPORTED', // "이 채널은 댓글 수집을 지원하지 않습니다."
+  'CHANNEL_CONNECTION_NOT_ACTIVE', // "연결에 자격이 없습니다."
+  // channel_post_comment_replies.py
+  'COMMENT_REPLY_HUMAN_ONLY', // "이 액션은 휴먼 멤버만 가능합니다."
+  'COMMENT_REPLY_TARGET_DELETED', // "답변 대상 댓글이 삭제되어 상신할 수 없습니다."
+  'COMMENT_REPLY_CHANNEL_UNSUPPORTED', // "이 채널은 답변 발송을 지원하지 않습니다."
+  'COMMENT_REPLY_DRAFT_ALREADY_OPEN', // "안 보낸 초안이 이미 있습니다."
+  // channel_posts.py::_require_human(발행류 공용, retry 엔드포인트도 공유)
+  'CHANNEL_POST_PUBLISH_HUMAN_ONLY', // "채널 포스트 발행은 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지)."
+]);
+
 export function extractBackendErrorMessage(body: unknown): string | null {
   if (!body || typeof body !== 'object') return null;
-  const b = body as { error?: { message?: unknown }; detail?: unknown };
-  if (typeof b.error?.message === 'string') return b.error.message;
+  const b = body as { error?: { code?: unknown; message?: unknown }; detail?: unknown };
+  const errorCode = typeof b.error?.code === 'string' ? b.error.code : undefined;
+  if (errorCode && HUMAN_SAFE_ERROR_MESSAGE_CODES.has(errorCode) && typeof b.error?.message === 'string') {
+    return b.error.message;
+  }
+  // 순수 문자열 detail — code가 없어 이 gate 밖(위 docstring 참고, story #2647 계약 보존).
   if (typeof b.detail === 'string') return b.detail;
-  if (b.detail && typeof b.detail === 'object' && typeof (b.detail as { message?: unknown }).message === 'string') {
-    return (b.detail as { message: string }).message;
+  if (b.detail && typeof b.detail === 'object') {
+    const d = b.detail as { code?: unknown; message?: unknown };
+    const detailCode = typeof d.code === 'string' ? d.code : undefined;
+    if (detailCode && HUMAN_SAFE_ERROR_MESSAGE_CODES.has(detailCode) && typeof d.message === 'string') {
+      return d.message;
+    }
   }
   return null;
 }

--- a/apps/web/src/lib/avatar-upload.test.ts
+++ b/apps/web/src/lib/avatar-upload.test.ts
@@ -75,20 +75,24 @@ describe('uploadAvatar — story #2887 S2g', () => {
   });
 
   // story #3601(디디 전수 표 2026-09-07) — 실 BE 봉투({data:null,error:{code,message},
-  // meta:null}, BE 전역 http_exception_handler 그대로)에서도 실 에러가 뜬다. 이전엔
-  // `json.data ?? json.detail ?? fallback`이 .error를 아예 안 봐 항상 "HTTP {status}"
-  // 제네릭으로만 떨어졌다(이 정규식 lint의 선언된 사각지대 — 변수 결합 없이 바로
-  // `?.` 체이닝을 안 쓰는 형이라 lint_fe_error_envelope_detail_mismatch.py는 못 잡고
-  // 이 테스트가 대신 고정한다).
-  it('upload-url 발급 실패(실 봉투 {error:{code,message}}) — 실 에러가 제네릭 대신 뜬다', async () => {
+  // meta:null}, BE 전역 http_exception_handler 그대로)에서 code는 이제 살아 뜬다
+  // (이전엔 `json.data ?? json.detail ?? fallback`이 .error를 아예 안 봐 code까지
+  // "UNKNOWN"으로 떨어졌다).
+  //
+  // 페드루 PO 정정(2026-09-07, 유나 Design CHANGES) — 그러나 message는 그대로
+  // 보이면 안 된다: UNSUPPORTED_CONTENT_TYPE의 실제 BE 원문(avatar_upload.py:72)은
+  // "허용되지 않는 content_type: 'image/gif' (허용: [...])"로 내부 필드명·raw
+  // repr을 그대로 담는다 — 사람 문장이 아니다. 공용 allowlist(HUMAN_SAFE_ERROR_
+  // MESSAGE_CODES) 밖이라 message는 제네릭("HTTP 422")으로 떨어져야 정답.
+  it('upload-url 발급 실패(실 봉투 {error:{code,message}}) — code는 살고 message는 allowlist 밖이라 제네릭', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       ok: false,
       status: 422,
-      json: async () => ({ data: null, error: { code: 'UNSUPPORTED_CONTENT_TYPE', message: '지원하지 않는 이미지 형식입니다' }, meta: null }),
+      json: async () => ({ data: null, error: { code: 'UNSUPPORTED_CONTENT_TYPE', message: "허용되지 않는 content_type: 'image/gif' (허용: ['image/jpeg', 'image/png', 'image/webp'])" }, meta: null }),
     } as Response)));
 
     await expect(uploadAvatar('member-1', new Blob(['x']), 'image/png'))
-      .rejects.toMatchObject({ code: 'UNSUPPORTED_CONTENT_TYPE', message: '지원하지 않는 이미지 형식입니다' });
+      .rejects.toMatchObject({ code: 'UNSUPPORTED_CONTENT_TYPE', message: 'HTTP 422' });
     expect(FakeXHR.instances).toHaveLength(0);
   });
 

--- a/apps/web/src/lib/avatar-upload.test.ts
+++ b/apps/web/src/lib/avatar-upload.test.ts
@@ -74,6 +74,24 @@ describe('uploadAvatar — story #2887 S2g', () => {
     expect(FakeXHR.instances).toHaveLength(0);
   });
 
+  // story #3601(디디 전수 표 2026-09-07) — 실 BE 봉투({data:null,error:{code,message},
+  // meta:null}, BE 전역 http_exception_handler 그대로)에서도 실 에러가 뜬다. 이전엔
+  // `json.data ?? json.detail ?? fallback`이 .error를 아예 안 봐 항상 "HTTP {status}"
+  // 제네릭으로만 떨어졌다(이 정규식 lint의 선언된 사각지대 — 변수 결합 없이 바로
+  // `?.` 체이닝을 안 쓰는 형이라 lint_fe_error_envelope_detail_mismatch.py는 못 잡고
+  // 이 테스트가 대신 고정한다).
+  it('upload-url 발급 실패(실 봉투 {error:{code,message}}) — 실 에러가 제네릭 대신 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 422,
+      json: async () => ({ data: null, error: { code: 'UNSUPPORTED_CONTENT_TYPE', message: '지원하지 않는 이미지 형식입니다' }, meta: null }),
+    } as Response)));
+
+    await expect(uploadAvatar('member-1', new Blob(['x']), 'image/png'))
+      .rejects.toMatchObject({ code: 'UNSUPPORTED_CONTENT_TYPE', message: '지원하지 않는 이미지 형식입니다' });
+    expect(FakeXHR.instances).toHaveLength(0);
+  });
+
   it('PUT 실패(XHR 비2xx) 시 confirm을 호출하지 않고 에러를 던진다', async () => {
     class FailingPutXHR extends FakeXHR {
       send() { this.status = 403; this.onload?.(); }

--- a/apps/web/src/lib/avatar-upload.ts
+++ b/apps/web/src/lib/avatar-upload.ts
@@ -21,8 +21,12 @@ export interface AvatarApiError {
 
 async function readError(res: Response): Promise<AvatarApiError> {
   try {
-    const json = await res.json() as { data?: AvatarApiError; detail?: AvatarApiError };
-    return json.data ?? json.detail ?? { code: 'UNKNOWN', message: `HTTP ${res.status}` };
+    // story #3601(디디 전수 표 2026-09-07) — BE 전역 봉투는 {data,error,meta}뿐이라
+    // json.data는 에러 응답에서 항상 null·json.detail은 항상 undefined였다 — 실
+    // 에러(json.error, AvatarApiError와 같은 {code,message} 모양 그대로)를 한
+    // 번도 안 읽고 매번 "HTTP {status}" 제네릭으로 떨어졌다.
+    const json = await res.json() as { data?: AvatarApiError; error?: AvatarApiError; detail?: AvatarApiError };
+    return json.error ?? json.data ?? json.detail ?? { code: 'UNKNOWN', message: `HTTP ${res.status}` };
   } catch {
     return { code: 'UNKNOWN', message: `HTTP ${res.status}` };
   }

--- a/apps/web/src/lib/avatar-upload.ts
+++ b/apps/web/src/lib/avatar-upload.ts
@@ -1,4 +1,5 @@
 import { fetchWithAuth } from '@/lib/db/client';
+import { HUMAN_SAFE_ERROR_MESSAGE_CODES } from '@/lib/api-error-message';
 
 /** story #2887(S2g) — BE avatar 3단 계약(team_members.py) 클라 소비. png/jpeg/webp만
  * 서버가 서명 발급 단계에서 검증하지만, 클라도 동일 화이트리스트로 조기 거절(UX — 업로드
@@ -23,10 +24,19 @@ async function readError(res: Response): Promise<AvatarApiError> {
   try {
     // story #3601(디디 전수 표 2026-09-07) — BE 전역 봉투는 {data,error,meta}뿐이라
     // json.data는 에러 응답에서 항상 null·json.detail은 항상 undefined였다 — 실
-    // 에러(json.error, AvatarApiError와 같은 {code,message} 모양 그대로)를 한
-    // 번도 안 읽고 매번 "HTTP {status}" 제네릭으로 떨어졌다.
+    // 에러(json.error)를 한 번도 안 읽고 매번 "HTTP {status}" 제네릭으로 떨어졌다.
+    // 페드루 PO 정정(2026-09-07, 유나 Design CHANGES) — AvatarUploadError의 실제
+    // message는 사람 문장이 아니다(예: UNSUPPORTED_CONTENT_TYPE이 원문 content_type
+    // 값+허용 목록 repr을 그대로 담는다, avatar_upload.py:72) — code는 살리고 message
+    // 만 공용 allowlist(HUMAN_SAFE_ERROR_MESSAGE_CODES)로 gate한다. 지금 avatar 쪽
+    // 코드는 전부 이 목록 밖이라 message는 항상 제네릭으로 떨어진다(안전한 기본값 —
+    // 사람 문장으로 확認된 avatar 코드가 생기면 그때 등재).
     const json = await res.json() as { data?: AvatarApiError; error?: AvatarApiError; detail?: AvatarApiError };
-    return json.error ?? json.data ?? json.detail ?? { code: 'UNKNOWN', message: `HTTP ${res.status}` };
+    const raw = json.error ?? json.data ?? json.detail ?? { code: 'UNKNOWN', message: `HTTP ${res.status}` };
+    if (!HUMAN_SAFE_ERROR_MESSAGE_CODES.has(raw.code)) {
+      return { code: raw.code, message: `HTTP ${res.status}` };
+    }
+    return raw;
   } catch {
     return { code: 'UNKNOWN', message: `HTTP ${res.status}` };
   }

--- a/backend/scripts/lint_fe_error_envelope_detail_mismatch.py
+++ b/backend/scripts/lint_fe_error_envelope_detail_mismatch.py
@@ -56,7 +56,7 @@ _ALLOWED_MATCHES: dict[str, str] = {
     "src/app/(authenticated)/organization/events/page.tsx:755": (
         "위와 동형."
     ),
-    "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx:509": (
+    "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx:511": (
         "story #3596/#3953이 만든 `.error?.message ?? .detail?.message ?? ...` — "
         ".error 1순위 확認 완료, #3601 스코프 밖(그 스토리가 이미 닫은 자리)."
     ),

--- a/backend/scripts/lint_fe_error_envelope_detail_mismatch.py
+++ b/backend/scripts/lint_fe_error_envelope_detail_mismatch.py
@@ -1,0 +1,111 @@
+"""story #3601(FE·결함 클래스, 디디 전수 표 2026-09-07) — BE 전역 HTTPException 핸들러
+(app/main.py::http_exception_handler)의 실제 응답 봉투는 항상 `{"data":null,"error":
+{"code":...,"message":...},"meta":null}`이다. FastAPI raw shape(`{"detail":...}`)가
+그대로 통과하는 경로는 우리 앱엔 없다(커스텀 핸들러가 HTTPException을 전부 가로챈다) —
+유일한 예외는 FastAPI 자체 Pydantic 422(RequestValidationError, 커스텀 핸들러를 안
+거친다)뿐이다.
+
+그런데 apps/web 코드 곳곳이 `body?.detail?.message`·`body?.detail?.code`를 «1차
+소스»로 읽었다 — 그 필드는 우리 봉투에 없으니 항상 undefined, 조용히 폴백 메시지로
+떨어지거나(에러 메시지 소실) 특정 code 분기가 영구 사망한다(예: comment_collection_
+unsupported). 실제 사고: story #3596 그라운딩(2026-09-07 00:45Z, create 409의
+existing_reply_id가 `.detail`이 아니라 `.error`에 있었다).
+
+⛔이 가드가 잡는 패턴: `.detail?.message` 또는 `.detail?.code`(옵셔널 체이닝으로 바로
+message/code에 접근하는 형 — 실전 버그의 정확한 모양). 매치된 (file, line)이
+`_ALLOWED_MATCHES`(줄 단위 화이트리스트, 사유 필수)에 없으면 위반.
+
+⛔이 가드가 «못 잡는» 것(오탐 방지 우선, 다른 lint_*.py와 동일 원칙):
+  ① `.detail`을 변수에 옮겨 담은 뒤 나중에 `.message`/`.code`를 읽는 형
+     (예: `const detail = body.detail; detail?.message`) — lib/avatar-upload.ts의
+     실제 사고가 이 모양이다(`json.data ?? json.detail ?? fallback`, `.detail?.`
+     체이닝 자체가 없다). 정적 패턴 매칭이 잡을 수 없는 축 — 리뷰가 봐야 한다.
+  ② `.detail`이 다른 키(`?.[0]`·구조분해 등)로 옮겨진 뒤 읽히는 형.
+  ③ FastAPI 기본 Pydantic 422(`{detail:[{loc,msg,type}]}`)를 읽는 진짜 합법적
+     자리(content/validate-scheduled-at.ts) — 이 파일은 우연히 `.detail?.` 체이닝
+     형을 안 써서(배열 전체를 변수에 담아 `.find()`) 이 정규식엔 애초에 안 걸린다.
+     혹시 나중에 `.detail?.`형으로 다시 쓰이면 오탐이 아니라 진짜 예외라 별도
+     허용 목록 등재가 필요하다(지금은 0건).
+
+허용 목록에 오른 자리는 전부 «이미 `.error`를 1순위로 읽고, `.detail`은 무해한 죽은
+폴백으로만 남긴» 자리다(organization/events/page.tsx ×3·channel-posts/[draftId]/
+page.tsx:509 — 이 마지막 자리는 story #3596/#3953이 만든 `.error` 우선 폴백, #3601
+스코프 밖). 새 자리가 이 목록에 또 오르려면 반드시 같은 근거(.error 우선 확認)와
+사유를 남길 것 — 그냥 억제하려고 추가하면 이 가드의 존재 이유가 사라진다.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_PATTERN = re.compile(r"\.detail\?\.(message|code)\b")
+
+# PO 리뷰 관례(model_registration lint와 동형) — 줄 단위 dict, 값=사유. 새 항목은
+# 반드시 ".error를 이미 1순위로 읽는다"는 근거를 사유에 적을 것. 이 dict의 key
+# 집합은 tests/test_3601_error_envelope_detail_mismatch_lint.py::
+# test_allowlist_is_pinned_to_known_safe_lines에 pin돼 있어 조용히 늘어날 수 없다.
+_ALLOWED_MATCHES: dict[str, str] = {
+    "src/app/(authenticated)/organization/events/page.tsx:116": (
+        "`body?.error?.message ?? body?.detail?.message ?? ...` — .error가 이미 1순위, "
+        ".detail은 무해한 죽은 폴백(story #3601 그라운딩)."
+    ),
+    "src/app/(authenticated)/organization/events/page.tsx:546": (
+        "위와 동형(resBody 변수명만 다름)."
+    ),
+    "src/app/(authenticated)/organization/events/page.tsx:755": (
+        "위와 동형."
+    ),
+    "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx:509": (
+        "story #3596/#3953이 만든 `.error?.message ?? .detail?.message ?? ...` — "
+        ".error 1순위 확認 완료, #3601 스코프 밖(그 스토리가 이미 닫은 자리)."
+    ),
+}
+
+SCAN_ROOT = "apps/web/src"
+_EXCLUDE_SUFFIXES = (".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx")
+
+
+def find_violations(path: Path, label: str | None = None) -> list[str]:
+    """단일 파일 스캔 — 허용 목록에 없는 위반 라인을 `{label}:{lineno}: {line}` 형태로
+    반환. label 생략 시 path 그대로."""
+    text = path.read_text(encoding="utf-8")
+    label = label or str(path)
+    violations: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if _PATTERN.search(line) and f"{label}:{lineno}" not in _ALLOWED_MATCHES:
+            violations.append(f"{label}:{lineno}: {line.strip()}")
+    return violations
+
+
+def scan(repo_root: Path) -> list[str]:
+    violations: list[str] = []
+    scan_dir = repo_root / SCAN_ROOT
+    for f in sorted(scan_dir.rglob("*.ts")) + sorted(scan_dir.rglob("*.tsx")):
+        if f.name.endswith(_EXCLUDE_SUFFIXES):
+            continue
+        violations.extend(find_violations(f, label=str(f.relative_to(repo_root / "apps/web"))))
+    return violations
+
+
+def main() -> int:
+    # backend/scripts/ -> backend -> repo root
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    violations = scan(repo_root)
+    if violations:
+        print(
+            "FAIL: `.detail?.message`/`.detail?.code`가 새로 등장했다(story #3601) — "
+            "BE 전역 오류 봉투는 {data,error,meta}뿐이라 `.detail`은 항상 undefined다. "
+            "`lib/api-error-message.ts::extractBackendErrorMessage(body)`(.error 우선)를 "
+            "쓰거나, 정말 안전하면(.error를 이미 먼저 읽는 무해한 죽은 폴백) 이 스크립트의 "
+            "_ALLOWED_MATCHES에 사유와 함께 등재할 것:"
+        )
+        for v in violations:
+            print(f"  {v}")
+        return 1
+    print(f"OK: `.detail?.(message|code)` 신규 위반 0건 (허용 목록 {len(_ALLOWED_MATCHES)}건 유지)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -31,6 +31,8 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "ci_alembic_sibling_pr_collision_check.py",   # story #2401 — CI 전용, git+gh api만 사용(운영 DB 무접속)
     "ci_alembic_single_step_promotion_check.py",  # story #2330 — CI 전용 fresh-DB 재현
     "lint_business_info_email_footer_drift.py",   # story #3216 — CI lint 게이트(정적 텍스트 대조, 운영 DB 무접속)
+    "lint_fe_error_envelope_detail_mismatch.py",  # story #3601 — CI lint 게이트(apps/web/src
+                                                   # 재귀 정규식 정적 스캔, 운영 DB 무접속·scripts/jobs 아님).
     "lint_candidate_source_ownership.py",         # story #2363 AC6 — CI lint 게이트
     "lint_commit_before_validate.py",             # story #2459 — CI lint 게이트(AST 정적분석, 운영 DB 무접속)
     "lint_dependency_override_get_read_db.py",    # story #2451 — CI lint 게이트(tests/ override 스캔, 운영 DB 무접속)

--- a/backend/tests/test_3601_error_envelope_detail_mismatch_lint.py
+++ b/backend/tests/test_3601_error_envelope_detail_mismatch_lint.py
@@ -108,7 +108,7 @@ def test_allowlist_is_pinned_to_known_safe_lines():
         "src/app/(authenticated)/organization/events/page.tsx:116",
         "src/app/(authenticated)/organization/events/page.tsx:546",
         "src/app/(authenticated)/organization/events/page.tsx:755",
-        "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx:509",
+        "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx:511",
     }
 
 

--- a/backend/tests/test_3601_error_envelope_detail_mismatch_lint.py
+++ b/backend/tests/test_3601_error_envelope_detail_mismatch_lint.py
@@ -1,0 +1,119 @@
+"""story #3601 — lint_fe_error_envelope_detail_mismatch.py의 정탐/오탐 회귀 가드.
+합성 fixture로 짓는다(실물이 고쳐져도 이 테스트는 안 사라진다, story #2335/#2342/#2476
+lint와 동형)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from lint_fe_error_envelope_detail_mismatch import (  # noqa: E402
+    _ALLOWED_MATCHES,
+    find_violations,
+    scan,
+)
+
+
+def _write(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+def test_detects_detail_optional_chain_message():
+    src = "const message = body?.detail?.message ?? body?.message ?? generic;\n"
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        path = _write(Path(td), "bad_message.ts", src)
+        violations = find_violations(path, label="bad_message.ts")
+    assert len(violations) == 1
+
+
+def test_detects_detail_optional_chain_code():
+    src = "if (body?.detail?.code === 'SOME_CODE') { doThing(); }\n"
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        path = _write(Path(td), "bad_code.ts", src)
+        violations = find_violations(path, label="bad_code.ts")
+    assert len(violations) == 1
+
+
+def test_error_first_pattern_not_flagged_when_allowlisted():
+    """.error를 먼저 읽고 .detail을 무해한 폴백으로 두는 형이어도, 그 (label,line)이
+    허용 목록에 없으면 여전히 잡혀야 한다 — 허용은 화이트리스트 등재로만 되지,
+    코드 모양(.error가 앞에 있음)만으로 자동 면제되지 않는다(§17 fail-closed와 동형:
+    "안전해 보인다"가 아니라 "등재됐다"가 판정 기준)."""
+    src = "throw new Error(body?.error?.message ?? body?.detail?.message ?? `HTTP ${res.status}`);\n"
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        path = _write(Path(td), "unlisted_error_first.ts", src)
+        violations = find_violations(path, label="unlisted_error_first.ts")
+    assert len(violations) == 1, "허용 목록에 없으면 .error가 앞에 있어도 잡혀야 한다"
+
+
+def test_allowlisted_line_is_not_flagged():
+    """허용 목록의 (label, line) 조합과 정확히 일치하면 면제된다."""
+    src = "line 1 — 무관\nthrow new Error(body?.error?.message ?? body?.detail?.message ?? `x`);\n"
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        path = _write(Path(td), "allowlisted.ts", src)
+        import lint_fe_error_envelope_detail_mismatch as mod
+        original = dict(mod._ALLOWED_MATCHES)
+        try:
+            mod._ALLOWED_MATCHES.clear()
+            mod._ALLOWED_MATCHES["allowlisted.ts:2"] = "테스트 전용 등재"
+            violations = find_violations(path, label="allowlisted.ts")
+        finally:
+            mod._ALLOWED_MATCHES.clear()
+            mod._ALLOWED_MATCHES.update(original)
+    assert violations == []
+
+
+def test_variable_indirection_is_a_known_blind_spot():
+    """①에 명시한 못 잡는 형 — `.detail`을 변수에 옮긴 뒤 `.message`를 읽으면 이 정규식은
+    안 걸린다(avatar-upload.ts 실제 사고와 동형). 이 테스트는 "못 잡는다"는 사실 자체를
+    고정한다 — 언젠가 정규식을 더 똑똑하게 바꾸면 이 테스트가 먼저 깨져 그 변화를 알린다."""
+    src = "const d = json.detail;\nreturn json.data ?? d ?? fallback;\n"
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        path = _write(Path(td), "blind_spot.ts", src)
+        violations = find_violations(path, label="blind_spot.ts")
+    assert violations == [], "변수로 옮겨 읽는 형은 이 lint의 선언된 사각지대(①)"
+
+
+def test_mutation_disabling_pattern_causes_zero_detections():
+    """뮤테이션: 정규식을 절대 안 걸리는 것으로 바꾸면 위 양성 테스트가 깨져야 한다 —
+    이 lint의 핵심 로직이 실제로 테스트에 의해 지켜지는지 자가 검증(story #2342/#2476
+    lint와 동일 관례)."""
+    import lint_fe_error_envelope_detail_mismatch as mod
+
+    original = mod._PATTERN
+    try:
+        mod._PATTERN = mod.re.compile(r"(?!)")  # 절대 안 매치되는 패턴
+        src = "const message = body?.detail?.message ?? generic;\n"
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "bad.ts"
+            path.write_text(src)
+            violations = find_violations(path, label="bad.ts")
+        assert violations == [], "뮤테이션 후에는 탐지가 0이어야 정상(로직이 실제로 패턴에 의존함을 증명)"
+    finally:
+        mod._PATTERN = original
+
+
+def test_allowlist_is_pinned_to_known_safe_lines():
+    """허용 목록이 조용히 늘어나는 뒷문을 막는다(story #2255 model_registration lint와
+    동일 관례) — 새 항목을 추가하려면 이 pin도 같이 고쳐야 리뷰에서 보인다."""
+    assert set(_ALLOWED_MATCHES.keys()) == {
+        "src/app/(authenticated)/organization/events/page.tsx:116",
+        "src/app/(authenticated)/organization/events/page.tsx:546",
+        "src/app/(authenticated)/organization/events/page.tsx:755",
+        "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx:509",
+    }
+
+
+def test_current_repo_has_zero_unallowed_violations():
+    """실물 apps/web/src 전수 스캔 — story #3601 처방(7자리 통일) 뒤 위반 0건이 유지되는지
+    CI가 도는 그 검사 자체를 pytest로도 한 번 더 고정한다."""
+    repo_root = Path(__file__).parent.parent.parent
+    assert scan(repo_root) == []


### PR DESCRIPTION
## 요약
BE 전역 HTTPException 핸들러(`app/main.py::http_exception_handler`)의 실제 응답 봉투는 항상 `{data:null,error:{code,message},meta:null}`다. `apps/web` 곳곳이 `body?.detail?.message`·`body?.detail?.code`를 1차 소스로 읽었다 — 그 필드는 우리 봉투에 없어 항상 `undefined`, 조용히 폴백 메시지로 떨어지거나(에러 메시지 소실) 특정 code 분기가 영구 사망했다(실제 사고: story #3596 그라운딩 — create 409의 `existing_reply_id`가 `.detail`이 아니라 `.error`에 있었다).

## 전수 표(디디, 2026-09-07) — 이 PR이 닫는 7자리
| 자리 | 문제 |
|---|---|
| `channel-posts/[draftId]/page.tsx` 재수집 COMMENT_COLLECTION_UNSUPPORTED | 비교가 항상 false → 그 얼굴 자체가 영구 사망 |
| 同 재수집 일반 메시지 | 항상 generic |
| 同 작업전환(follow-up) | 항상 generic |
| 同 답변 상신(submit) | 항상 generic |
| 同 재시도(retry, dead_letter) | 항상 generic — 이 자리는 테스트 자체가 없었다(회귀 갭도 같이 닫음) |
| `chat/chat-input.tsx` conversation_target_mismatch | 친절 문구 분기가 항상 죽고 일반 sendFailed로만 떨어짐 |
| `lib/avatar-upload.ts` | `json.data ?? json.detail ?? fallback`이 `.error`를 아예 안 봐 항상 "HTTP {status}" — 이 파일은 `.detail?.` 체이닝 형이 아니라 아래 lint의 선언된 사각지대(리뷰로 직접 발견·수정) |

`#3953`이 이미 닫은 1곳(create-reply-draft의 existing_reply_id)은 스코프 밖.

## 처방
기존 공용 헬퍼 `lib/api-error-message.ts::extractBackendErrorMessage`(`.error` 1순위·`.detail` 방어적 폴백)로 통일 — 새 문구 0, 기존 키 재사용. code 분기 2자리(`COMMENT_COLLECTION_UNSUPPORTED`·`conversation_target_mismatch`)는 `.detail`을 지역 변수로 먼저 옮겨 읽는다(`body?.error?.code ?? detail?.code` — `body?.detail?.code` 그대로 쓰면 아래 lint 자신이 잡는 모양이라 새 위반으로 다시 걸린다).

## 재발 가드
`backend/scripts/lint_fe_error_envelope_detail_mismatch.py` 신설 — `.detail?.(message|code)` 신규 등장을 CI에서 차단.
- **허용 목록 4건**(전부 사유 명시): 이미 `.error`를 1순위로 읽는 `organization/events/page.tsx` ×3 · `#3953`이 닫은 `channel-posts/[draftId]/page.tsx:511`.
- **선언된 사각지대**: `.detail`을 변수로 옮겨 읽는 형(avatar-upload.ts 실제 사고 모양, 정적 정규식이 못 잡음) · FastAPI 기본 Pydantic 422(`content/validate-scheduled-at.ts` — 커스텀 핸들러를 안 거치는 별도 축이라 `.detail`이 진짜 실물, 우연히 이 정규식엔 안 걸리지만 원래도 예외 대상).
- `model_registration`/`legacy_subscriptions` lint와 동형 관례(줄 단위 허용 목록·pin 테스트·뮤테이션 자가검증). CI job 신설(`fe-error-envelope-detail-mismatch-lint`, PG 불요 정적 스캔).

## 테스트
- lint selftest 8건(정탐 2·오탐 1·허용목록 통과 1·사각지대 고정 1·뮤테이션 1·allowlist pin 1·실물 0건 1).
- 7자리 각각 실 봉투(`{error:{...}}`) 주입 테스트 7건(재수집 unsupported·재수집 403·작업전환 403·답변상신 409·다시보내기 409·conversation_target_mismatch·avatar-upload 422).
- 공용 헬퍼(`extractBackendErrorMessage`)를 임시로 무력화하는 뮤테이션 1건으로 위 7건 전부 RED 확인 후 원복.
- 기존 `.detail` 모양 mock을 쓰던 회귀 테스트는 방어적 폴백 덕에 그대로 통과(회귀 0).

tsc --noEmit·vitest 전체(6586건)·check-i18n-keys(0 missing)·lint 스크립트(위반 0건) 전부 초록.

## Design CHANGES 반영(유나, 2026-09-06/07)
서버 `message`를 그대로 보이는 5자리(재수집 generic·작업전환·답변상신·다시보내기·avatar-upload)가 uuid·내부 테이블/함수/필드명·raw exception repr을 사람에게 그대로 노출할 수 있다는 지적 — `extractBackendErrorMessage`에 **사람 문장 code allowlist**(`HUMAN_SAFE_ERROR_MESSAGE_CODES`)를 신설, object 형(`error.message`·`detail.message`)만 gate한다(목록 밖이면 null → 호출부 기존 폴백).

**등재 기준(페드루 PO 정정 2026-09-07)**: 그 code로 raise하는 **모든 자리**를 저장소 전체에서 grep해 세고, 전부의 원문을 읽어(uuid·내부 이름·raw exception repr 없음을 확認) **하나도 빠짐없이** 사람 문장일 때만 등재한다 — 한 자리만 확認하고 등재하지 않는다. 최초 라운드에서 `CHANNEL_CONNECTION_NOT_ACTIVE`를 등재했다가 정정한 게 정확한 반례: `channel_post_comments.py`의 fetch 공용 블록 1곳만 보고 안전하다 판단했는데, 저장소 전체엔 이 code로 raise하는 자리가 20곳 넘게 있고(`site_posts.py`·`insight_snapshots.py`·`publication_command.py`·`channel_posts.py` 등) 다수가 `f"...{connection.id}"`/`f"...{pub.connection_id}"`처럼 uuid를 그대로 담는다 — 제외.

| code | raise 자리 수(전수) | 원문 전부 사람 문장? | 등재 |
|---|---|---|---|
| `COMMENT_REFRESH_HUMAN_ONLY` | 1(`channel_post_comments.py:35`) | "댓글 재수집은 휴먼 멤버만 가능합니다." | ✅ |
| `COMMENT_COLLECTION_UNSUPPORTED` | 1(`channel_post_comments.py:257`) | "이 채널은 댓글 수집을 지원하지 않습니다." | ✅ |
| `COMMENT_REPLY_HUMAN_ONLY` | 1(`channel_post_comment_replies.py:38`) | "이 액션은 휴먼 멤버만 가능합니다." | ✅ |
| `COMMENT_REPLY_TARGET_DELETED` | 2(`channel_post_comment_replies.py:256`·`gates.py:1616`) | "답변 대상 댓글이 삭제되어 상신할 수 없습니다." / "…승인할 수 없습니다." — 둘 다 안전 | ✅ |
| `COMMENT_REPLY_CHANNEL_UNSUPPORTED` | 1(`channel_post_comment_replies.py:261`) | "이 채널은 답변 발송을 지원하지 않습니다." | ✅ |
| `COMMENT_REPLY_DRAFT_ALREADY_OPEN` | 1(`channel_post_comment_replies.py:211`) | "안 보낸 초안이 이미 있습니다." | ✅ |
| `CHANNEL_POST_PUBLISH_HUMAN_ONLY` | 1(`channel_posts.py:117`, retry 엔드포인트 공유) | "채널 포스트 발행은 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지)." | ✅ |
| `CHANNEL_CONNECTION_NOT_ACTIVE` | **20+**(`channel_posts.py`·`channel_connections.py`·`site_posts.py`·`channel_post_comments.py`·`publication_command.py`·`insight_snapshots.py`) | 다수가 uuid 포함(예: `site_posts.py:1291` `f"연결에 자격이 없습니다: {connection.id}"`, `insight_snapshots.py:325` `f"연결이 활성 상태가 아닙니다: {pub.connection_id}"`) | ❌ 제외(최초 등재 후 정정) |

그 외 확認한 제외(원문이 uuid·내부명·raw repr 담아 배제): `COMMENT_REPLY_WRONG_STATUS`("이 상태(draft)에서는…"), `UNSUPPORTED_CONTENT_TYPE`(content_type repr), `COMMENT_EXTERNAL_ID_MISSING`, 미지정 404류 전부(uuid 인터폴레이션 또는 다른 자리와 공유하는 제네릭 `NOT_FOUND` 라벨이라 등재 불가), `CHANNEL_TOKEN_EXPIRED`/`CHANNEL_RATE_LIMITED`/`CHANNEL_PUBLISH_PROVIDER_ERROR`(raw provider exception repr).

**정정(유나 관찰 재검토, 페드루 PO)**: 「404 detail이 문자열이라 이 gate가 안 걸린다」는 부정확했다 — BE 전역 핸들러는 string detail로 raise된 HTTPException도 object(`error:{code,message}`)로 감싼다(예외 없음). 순수 문자열 `detail`이 실제로 나오는 자리는 **우리 BE 응답엔 없다** — 이 함수의 string-detail 무조건 통과 분기는 `DeliveryContractModal.test.tsx`(#2647)의 옛 픽스처 계약을 깨지 않기 위한 하위호환일 뿐(Pydantic 422조차 object가 아니라 `[{loc,msg,type}]` 배열이라 이 분기와 무관).

**블라스트 반경 판단**: 이 헬퍼는 `event-block-card.tsx`·`delivery-contract-modal.tsx`도 공유한다. `delivery-contract-modal`의 기존 테스트(#2647)는 **code 없는 순수 문자열 `detail`**로 정책거부 사유를 그대로 보이는 걸 요구한다 — 그 계약을 안 건드리려고 gate는 **object 형(`.error`/`.detail`이 dict)에만** 걸었다(string `detail`은 code가 없어 안전성을 잴 수 없으니 그대로 무조건 통과, 기존 동작 불변 — §2647 계약 보존). `avatar-upload.ts`도 같은 allowlist로 message를 gate(현재 avatar 쪽 code는 전부 목록 밖이라 message는 항상 제네릭 "HTTP {status}", code는 그대로 살아 있어 `.code` 기반 분기는 안 깨진다).

별건(적기만, 미구현): BE 봉투에 `error.user_message` 필드를 둬 BE가 사람용 문장을 직접 표시하게 하는 계약 — backlog.

기존 페이지 테스트 3건이 이 gate 변경으로 깨져(허구 code `CHANNEL_FETCH_FAILED`/`PUBLICATION_COMMAND_NOT_RETRYABLE` — 실 BE에 존재하지 않던 표본, 그리고 죽은 `?? body?.message` 3중 폴백으로 우연히 통과하던 것) 실제 BE 코드/문구로 교체하고 기대값을 "제네릭으로 떨어진다"로 정정했다(안전 쪽으로 조인 결과, 회귀 아님). `api-error-message.test.ts`에 gate 자체의 뮤테이션 테스트(비allowlist code는 message가 안전해 보여도 null) 추가.

## 스토리
[BE 전역 오류 봉투 ↔ FE body.detail 불일치](entity:story:c5f8fe4a-d38f-4b6e-a9ed-063b032a4eff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG

