### PR TITLE
[SID:3597] fix: 수동 「다시 수집」 CONNECTION 실패 시 connection 승격 누락

### DIFF
--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -606,6 +606,20 @@ async def refresh_comments_now(
         await db.commit()
         raise
     except CommentFetchError as exc:
+        # story #3597(잔여, PO 라이브 회차 2026-09-07 02:27~02:33Z 실측·PO 確定) —
+        # 스케줄 루프(process_due_comment_collections)는 CONNECTION 실패 시
+        # `_promote_connection_status`를 부르는데 이 수동 경로는 그 호출이 아예
+        # 없었다(AC1 「수집이 connection 실패로 끝나면 칩이 선다」가 「다시 수집」
+        # 버튼에서 안 섬 — 라이브 실측: FB 샌드박스 502 CHANNEL_TOKEN_EXPIRED 뒤에도
+        # connection.status가 active 그대로). 루프와 같은 순서(승격 먼저, 그 다음
+        # schedule_row 상태 기록)로 맞춘다. `_schedule_next_continuous_poll_if_active`
+        # 는 여기서 안 부른다 — 그건 «다음 자동 폴링 예약» 개념인데 이 경로는 사람이
+        # 그 자리에서 손으로 누른 1회성 재수집이라 다음 폴링 스케줄과 무관하다(루프
+        # 전용 개념을 수동 경로에 섞지 않는다).
+        from app.services.publication_command import classify_failure_kind, FAILURE_KIND_CONNECTION
+
+        if classify_failure_kind(exc.error_code) == FAILURE_KIND_CONNECTION:
+            await _promote_connection_status(db, publication_id=publication_id)
         schedule_row.status = "failed"
         schedule_row.error_code = exc.error_code
         await db.commit()

--- a/backend/tests/test_3597_ig_fb_connection_status_promote.py
+++ b/backend/tests/test_3597_ig_fb_connection_status_promote.py
@@ -259,6 +259,72 @@ async def test_instagram_sandbox_expire_after_publish_marker_promotes_status_exp
         await engine.dispose()
 
 
+# ─── story #3597(잔여, PO 라이브 회차 2026-09-07 02:27~02:33Z 실측·PO 確定) ────────
+# 스케줄 루프(process_due_comment_collections)는 위 테스트들처럼 CONNECTION 실패
+# 시 승격을 부르는데, 휴먼 수동 「다시 수집」(refresh_comments_now)은 그 호출
+# 자체가 없었다 — 라이브 실측: FB 샌드박스 502 CHANNEL_TOKEN_EXPIRED 뒤에도
+# connection.status가 active 그대로(/organization/channels 칩 「연결됨」).
+
+
+@pytest.mark.anyio
+async def test_manual_refresh_connection_failure_promotes_status_expired(monkeypatch):
+    """AC1(수동 경로) — 「다시 수집」 버튼이 부르는 refresh_comments_now도 CONNECTION
+    실패면 connection.status를 expired로 승격해야 칩이 선다."""
+    from app.services.channel_post_comments import CommentFetchError, refresh_comments_now
+    from app.services.threads_publish import ThreadsPublishError
+    import app.services.instagram_publish as instagram_publish
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="instagram", external_id="media-1")
+            await s.commit()
+
+            async def _raise_expired(client, *, access_token, media_id):
+                raise ThreadsPublishError("TOKEN_EXPIRED", "sandbox: 401 시뮬레이션", status_code=401)
+
+            monkeypatch.setattr(instagram_publish, "fetch_replies", _raise_expired)
+            with pytest.raises(CommentFetchError):
+                await refresh_comments_now(s, org_id=org_id, publication_id=pub.id)
+
+            await s.refresh(conn)
+            assert conn.status == "expired"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_manual_refresh_transient_failure_does_not_touch_connection(monkeypatch):
+    """루프와 동형 불변 — TRANSIENT(CHANNEL_RATE_LIMITED)는 사람이 고칠 대상이
+    아니라 connection을 건드리지 않는다(재시도가 유효할 수 있는 실패류를
+    「재연결 필요」로 잘못 몰지 않는다)."""
+    from app.services.channel_post_comments import CommentFetchError, refresh_comments_now
+    from app.services.threads_publish import ThreadsPublishError
+    import app.services.instagram_publish as instagram_publish
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="instagram", external_id="media-1")
+            await s.commit()
+
+            async def _raise_rate_limited(client, *, access_token, media_id):
+                raise ThreadsPublishError("RATE_LIMITED", "sandbox: 429 시뮬레이션", status_code=429)
+
+            monkeypatch.setattr(instagram_publish, "fetch_replies", _raise_rate_limited)
+            with pytest.raises(CommentFetchError):
+                await refresh_comments_now(s, org_id=org_id, publication_id=pub.id)
+
+            await s.refresh(conn)
+            assert conn.status == "active"
+    finally:
+        await engine.dispose()
+
+
 @pytest.mark.anyio
 async def test_facebook_sandbox_expire_after_publish_marker_promotes_status_expired():
     from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection


### PR DESCRIPTION
## 요약
라이브 회차(PO, 배포 46, 2026-09-07 02:27~02:33Z, PO Test Org) 실측 — FB 샌드박스에 `[sandbox:expire-after-publish]` 마커 글을 발행하고 「다시 수집」을 누르면 502 `CHANNEL_TOKEN_EXPIRED`가 뜨는데도 연결(641adabf) status가 **active 그대로**·`/organization/channels` 칩이 「연결됨」에 머문다.

원인: `refresh_comments_now`(수동 재수집, `channel_post_comments.py:562~619`)의 `except CommentFetchError` 분기가 `schedule_row` 실패 기록(status="failed"·error_code·commit)만 하고 `_promote_connection_status`를 안 불렀다 — 그 호출은 스케줄 루프(`process_due_comment_collections`, `:465~467`)에만 있었다. 원 스토리 #3597의 AC1(「수집이 connection 실패로 끝나면 칩이 선다」)이 **수동 경로에서만** 안 섰다(스케줄 루프는 이미 정상).

## 처방
`except CommentFetchError` 분기에서 `classify_failure_kind(exc.error_code) == FAILURE_KIND_CONNECTION`이면 `_promote_connection_status` 호출을 `schedule_row` 상태 기록보다 먼저 — 루프와 같은 순서. `_schedule_next_continuous_poll_if_active`는 여기서 안 부른다 — 그건 "다음 자동 폴링 예약" 개념인데 이 경로는 사람이 그 자리에서 손으로 누른 1회성 재수집이라 다음 폴링 스케줄과 무관하다(루프 전용 개념을 수동 경로에 섞지 않는다, 코드 주석에도 명시).

인사이트 쪽 수동 재수집 경로는 **존재 자체가 없다** — 서비스 레이어(`insight_snapshots.py`엔 `process_due_insight_snapshots` 스케줄 루프뿐)뿐 아니라 **라우터 레이어도 grep으로 확認**:
```
$ grep -rn "@router\.\(post\|get\|put\|patch\)" app/routers/*.py | grep -i insight
app/routers/insights_board.py:78:@router.get("/{org_id}/insights-board", ...)      # 보드 조회
app/routers/insights_board.py:123:@router.post("/{org_id}/publications/{publication_id}/follow-ups", ...)  # story 전환, 재수집 아님
app/routers/insight_snapshots.py:34:@router.get("/{org_id}/publications/{publication_id}/insights", ...)  # 스냅샷 목록 조회(GET)
```
insight 관련 라우터 엔드포인트 3개 전부 조회/전환류이고 **POST 재수집 엔드포인트가 0개** — `refresh_comments_now`(댓글) 같은 "휴먼이 그 자리에서 누르는 수동 재수집" 개념 자체가 인사이트 쪽엔 없다. 동형 결함 대상이 아니라 이 PR 스코프는 댓글 수집만.

## 테스트
`test_3597_ig_fb_connection_status_promote.py`에 추가:
- `test_manual_refresh_connection_failure_promotes_status_expired`(신규) — instagram CONNECTION 실패(401) → `refresh_comments_now`가 예외를 다시 던지면서도 connection.status를 expired로 승격.
- `test_manual_refresh_transient_failure_does_not_touch_connection`(신규) — CHANNEL_RATE_LIMITED(429, TRANSIENT)는 사람이 고칠 대상이 아니므로 connection 무변(루프와 동형 불변).
- 기존 6건(스케줄 루프 경로) 회귀 0.
- 뮤테이션 1건 — 승격 호출을 `if False:`로 무력화 → 신규 CONNECTION 테스트만 정확히 RED(TRANSIENT 테스트는 그대로 통과, 격리 확認) → 원복 후 재통과.

로컬 실 Postgres(alembic head 0346) 전체 27건 통과(`test_3597_*`·`test_3516_channel_post_comments.py`).

## 스토리
[IG/FB 댓글 수집·인사이트 실패의 연결 승격이 threads 전용](entity:story:85375184-0056-4436-9a03-519120bd4e5e)(원 스토리 #3597 — 원 구현은 #3948로 이미 머지됐고, 이 PR은 같은 라이브 검증 회차에서 나온 잔여 결함 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG
