### PR TITLE
[SID:3603] feat: 연결 상태 승격이 last_error_code·last_error_at도 채운다

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -208,6 +208,33 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
     expect(container.textContent).toContain('먼저 앱 자격을 설정해야');
   });
 
+  // story #3603(페드루 PO 確定 2026-09-07, 유나 3597 관찰) — 연결 상태 승격이 이제
+  // last_error_code·last_error_at도 채운다. 「서버 응답 보기」 토글이 그 둘을
+  // 기존 last_error 원문과 같은 자리에 나란히 보이는지 고정한다(새 UI 섹션 0).
+  it('last_error_code·last_error_at이 있으면 「서버 응답 보기」 토글에 원문과 나란히 선다', async () => {
+    stubFetch({
+      connections: [{
+        ...CONNECTION_ACTIVE, status: 'expired', last_error: '토큰이 만료되었습니다(401)',
+        last_error_code: 'CHANNEL_TOKEN_EXPIRED', last_error_at: '2026-09-07T02:30:00Z',
+      }],
+    });
+    await mount('owner');
+    expect(container.textContent).toContain('토큰이 만료되었습니다(401)');
+    expect(container.textContent).toContain('CHANNEL_TOKEN_EXPIRED');
+  });
+
+  it('last_error_code·last_error_at이 없는 옛 행은 last_error 원문 한 줄만(새 값 지어내지 않음)', async () => {
+    stubFetch({
+      connections: [{
+        ...CONNECTION_ACTIVE, status: 'expired', last_error: '토큰이 만료되었습니다(401)',
+        last_error_code: null, last_error_at: null,
+      }],
+    });
+    await mount('owner');
+    expect(container.textContent).toContain('토큰이 만료되었습니다(401)');
+    expect(container.textContent).not.toContain('CHANNEL_TOKEN_EXPIRED');
+  });
+
   it('member는 해제·다시 연결 버튼 대신 owner 안내 문구를 본다', async () => {
     // story #3504 — 해제·재인증은 owner 전용(_require_owner)이라 owner만 문구가 맞다
     // (옛 owner·admin 문구는 이 두 자리에선 거짓이었다).

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -507,7 +507,7 @@ function ConnectionRow({
               시각이 아직 없는 옛 행(3603 이전 승격·토큰 갱신 실패 경로)은 원문 한
               줄만 그대로 — 새 값을 지어내지 않는다. */}
           {conn.last_error_code || conn.last_error_at ? (
-            <p className="mt-1 font-mono opacity-70">
+            <p className="mt-1 font-mono">
               {[conn.last_error_code, conn.last_error_at ? formatRelativeTime(conn.last_error_at, locale, displayTimezone) : null]
                 .filter(Boolean)
                 .join(' · ')}

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -502,6 +502,17 @@ function ConnectionRow({
       {conn.last_error ? (
         <details className="text-xs text-muted-foreground">
           <summary className="cursor-pointer">{t('channelLastErrorToggle')}</summary>
+          {/* story #3603(페드루 PO 確定 2026-09-07, 유나 3597 관찰) — 새 UI 섹션 0,
+              같은 자리 안에 code·시각을 last_error 원문과 나란히(표면 변화 0). code·
+              시각이 아직 없는 옛 행(3603 이전 승격·토큰 갱신 실패 경로)은 원문 한
+              줄만 그대로 — 새 값을 지어내지 않는다. */}
+          {conn.last_error_code || conn.last_error_at ? (
+            <p className="mt-1 font-mono opacity-70">
+              {[conn.last_error_code, conn.last_error_at ? formatRelativeTime(conn.last_error_at, locale, displayTimezone) : null]
+                .filter(Boolean)
+                .join(' · ')}
+            </p>
+          ) : null}
           <p className="mt-1 font-mono">{conn.last_error}</p>
         </details>
       ) : null}

--- a/apps/web/src/components/channel-connect/types.ts
+++ b/apps/web/src/components/channel-connect/types.ts
@@ -12,6 +12,11 @@ export interface ChannelConnectionResponse {
   token_expires_at: string | null;
   last_refreshed_at: string | null;
   last_error: string | null;
+  // story #3603(additive) — last_error와 짝. 원문 message는 last_error 그대로,
+  // 이 둘은 "어느 code·언제"만 별도로(연결 상태 승격이 채우는 자리, 채워지지
+  // 않은 옛 행/토큰-갱신 실패 경로는 여전히 null일 수 있다).
+  last_error_code: string | null;
+  last_error_at: string | null;
   can_auto_refresh: boolean;
   connected_by: string | null;
   created_at: string;

--- a/backend/alembic/versions/0347_channel_connection_last_error_code_at.py
+++ b/backend/alembic/versions/0347_channel_connection_last_error_code_at.py
@@ -1,0 +1,29 @@
+"""story #3603(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-07, 유나 3597 관찰) —
+`channel_connections`에 `last_error_code`·`last_error_at` additive. `_promote_
+connection_status`(댓글)·`_promote_connection_status_for_snapshot`(인사이트)가
+CONNECTION 실패로 expired 승격할 때 이 둘을 채워야 /organization/channels 행의
+「서버 응답 보기」가 «왜 만료됐나»를 보일 수 있다 — 기존 `last_error`는 원문
+그대로 두는 관례(2026-09-03 07:09Z PO 확定)를 안 건드린다.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0347"
+down_revision = "0346"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("channel_connections", sa.Column("last_error_code", sa.Text(), nullable=True))
+    op.add_column(
+        "channel_connections",
+        sa.Column("last_error_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("channel_connections", "last_error_at")
+    op.drop_column("channel_connections", "last_error_code")

--- a/backend/app/models/channel_connection.py
+++ b/backend/app/models/channel_connection.py
@@ -48,7 +48,18 @@ class ChannelConnection(Base, TimestampMixin, OrgScopedMixin):
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default="active")  # active|expired|revoked|error
     last_refreshed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # 유나 화면설계 §8②(PO 채택) — 갱신 실패 사유를 화면이 보여줄 수 있게(토큰 자체는 절대 아님).
+    # channel_connection.py::apply_refresh_failure의 PO 확定(2026-09-03 07:09Z) 그대로
+    # provider/실패 원문을 가공 없이 담는다 — "사람이 읽을 말로 가공"은 화면(FE) 몫.
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #3603(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-07, 유나 3597 관찰) — additive.
+    # `_promote_connection_status`(댓글)·`_promote_connection_status_for_snapshot`(인사이트)가
+    # CONNECTION 실패로 expired 승격할 때 이 둘도 같이 채운다(no-op 분기=last_error 3종
+    # 전부 불변). last_error 자체는 위 원칙대로 원문 그대로 두고, «어느 code였는지»·
+    # «언제였는지»는 이 두 컬럼이 별도로 든다(last_error 문자열 안에 섞어 넣지 않음 —
+    # apply_refresh_failure가 이미 세운 "원문 그대로" 관례와 같은 컬럼을 다른 의미로
+    # 오염시키지 않는다).
+    last_error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_error_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     connected_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     # story #3492(0331) — 붙여넣기(pasted_secret) 자격 「제자리 교체」의 재방문 표시용
     # (§2 규격 3, app_id_suffix와 동형 — 원문은 절대 저장/반환하지 않는다, 끝 4자리뿐).

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -107,6 +107,10 @@ class ChannelConnectionResponse(BaseModel):
     token_expires_at: str | None
     last_refreshed_at: str | None
     last_error: str | None
+    # story #3603(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-07) — additive, last_error와
+    # 짝(원문 message는 last_error에 그대로, 이 둘은 "어느 code·언제"만 별도로).
+    last_error_code: str | None = None
+    last_error_at: str | None = None
     can_auto_refresh: bool
     connected_by: uuid.UUID | None
     created_at: str
@@ -186,7 +190,10 @@ def _to_response(row) -> ChannelConnectionResponse:
         credential_kind=row.credential_kind, status=row.status,
         token_expires_at=row.token_expires_at.isoformat() if row.token_expires_at else None,
         last_refreshed_at=row.last_refreshed_at.isoformat() if row.last_refreshed_at else None,
-        last_error=row.last_error, can_auto_refresh=can_auto_refresh(row.refresh_mode),
+        last_error=row.last_error,
+        last_error_code=row.last_error_code,
+        last_error_at=row.last_error_at.isoformat() if row.last_error_at else None,
+        can_auto_refresh=can_auto_refresh(row.refresh_mode),
         connected_by=row.connected_by, created_at=row.created_at.isoformat(), updated_at=row.updated_at.isoformat(),
         unpublish_blocked_reason=unpublish_blocked_reason,
         max_text_length=max_text_length, can_unpublish=can_unpublish,

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -636,7 +636,10 @@ async def refresh_comments_now(
         from app.services.publication_command import classify_failure_kind, FAILURE_KIND_CONNECTION
 
         if classify_failure_kind(exc.error_code) == FAILURE_KIND_CONNECTION:
-            await _promote_connection_status(db, publication_id=publication_id)
+            # story #3603(잔여, 페드루 PO 追加 2026-09-07) — error_code/message를 안 실으면
+            # 이 수동 경로만 last_error 3종이 안 채워져(3597과 같은 클래스 재발) 「서버
+            # 응답 보기」가 여기서 시작된 만료엔 비거나 옛 오류를 보인다.
+            await _promote_connection_status(db, publication_id=publication_id, error_code=exc.error_code, message=str(exc))
         schedule_row.status = "failed"
         schedule_row.error_code = exc.error_code
         await db.commit()

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -464,7 +464,9 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
             except CommentFetchError as exc:
                 failure_kind = classify_failure_kind(exc.error_code)
                 if failure_kind == FAILURE_KIND_CONNECTION:
-                    await _promote_connection_status(db, publication_id=row.publication_id)
+                    await _promote_connection_status(
+                        db, publication_id=row.publication_id, error_code=exc.error_code, message=str(exc),
+                    )
                     row.status = "failed"
                     row.error_code = exc.error_code
                     await _schedule_next_continuous_poll_if_active(
@@ -538,14 +540,25 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
     return counts
 
 
-async def _promote_connection_status(db: AsyncSession, *, publication_id: uuid.UUID) -> None:
+async def _promote_connection_status(
+    db: AsyncSession, *, publication_id: uuid.UUID, error_code: str | None = None, message: str | None = None,
+) -> None:
     """insight_snapshots.py::_promote_connection_status_for_snapshot과 동형 — 가드는
     channel 이름이 아니라 connection 유무(sandbox는 connection 자체가 없어 no-op).
     story #3597(Phase2·BE, 페드루 PO 確定 2026-09-06, 3595 실측 근거) — 이전엔
     `if channel != "threads": return`로 잘려 있어(#3517 원 구현이 threads만 구현하던
     시절 그대로 방치) IG/FB 댓글 수집 CONNECTION 실패는 에러코드까지 정확히
     분류되고도 /organization/channels 칩·재연결 버튼에 안 섰다 — insight_snapshots.py
-    쪽은 애초에 이 가드가 없었다(그쪽이 맞았다)."""
+    쪽은 애초에 이 가드가 없었다(그쪽이 맞았다).
+
+    story #3603(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-07, 유나 3597 관찰) —
+    `status`만 바꾸고 「왜」는 안 남겨 /organization/channels의 「서버 응답 보기」가
+    비거나 옛 오류를 보였다. 실제로 expired로 승격하는 이 분기에서만 `last_error`
+    3종(원문 그대로 · code · 시각)을 같이 채운다 — no-op(이미 revoked/error·sandbox
+    no-op) 분기는 전부 불변(호출자가 error_code/message를 안 줄 수도 있다, 예:
+    아래 `refresh_comments_now`가 아닌 다른 미래 호출자 대비 — 둘 다 optional)."""
+    from datetime import datetime, timezone
+
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
 
@@ -557,6 +570,10 @@ async def _promote_connection_status(db: AsyncSession, *, publication_id: uuid.U
     connection = await db.get(ChannelConnection, pub.connection_id)
     if connection is not None and connection.status not in ("revoked", "error"):
         connection.status = "expired"
+        if message is not None:
+            connection.last_error = message[:2000]
+        connection.last_error_code = error_code
+        connection.last_error_at = datetime.now(timezone.utc)
 
 
 async def refresh_comments_now(

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -507,7 +507,9 @@ async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | Non
             except InsightFetchError as exc:
                 failure_kind = classify_failure_kind(exc.error_code)
                 if failure_kind == FAILURE_KIND_CONNECTION:
-                    await _promote_connection_status_for_snapshot(db, snapshot)
+                    await _promote_connection_status_for_snapshot(
+                        db, snapshot, error_code=exc.error_code, message=str(exc),
+                    )
                     snapshot.status = "failed"
                     snapshot.error_code = exc.error_code
                     await db.commit()
@@ -546,11 +548,18 @@ async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | Non
     return counts
 
 
-async def _promote_connection_status_for_snapshot(db: AsyncSession, snapshot: InsightSnapshot) -> None:
+async def _promote_connection_status_for_snapshot(
+    db: AsyncSession, snapshot: InsightSnapshot, *, error_code: str | None = None, message: str | None = None,
+) -> None:
     """publication_command.py:454-461과 동형 inline 승격(그라운딩⑤, 새 상태값 0) —
     hosted_site/sandbox는 connection 자체가 없어 no-op(그 두 채널은 애초에
     FAILURE_KIND_CONNECTION을 못 낸다 — CHANNEL_TOKEN_EXPIRED류를 던지는 곳이
-    threads 경로뿐)."""
+    threads 경로뿐).
+
+    story #3603(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-07) — channel_post_
+    comments.py::_promote_connection_status와 동형 last_error 3종 additive."""
+    from datetime import datetime, timezone
+
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
 
@@ -564,6 +573,10 @@ async def _promote_connection_status_for_snapshot(db: AsyncSession, snapshot: In
     connection = await db.get(ChannelConnection, pub.connection_id)
     if connection is not None and connection.status not in ("revoked", "error"):
         connection.status = "expired"
+        if message is not None:
+            connection.last_error = message[:2000]
+        connection.last_error_code = error_code
+        connection.last_error_at = datetime.now(timezone.utc)
 
 
 _GA4_RUN_REPORT_URL_TMPL = "https://analyticsdata.googleapis.com/v1beta/properties/{property_id}:runReport"

--- a/backend/tests/test_3603_connection_last_error.py
+++ b/backend/tests/test_3603_connection_last_error.py
@@ -96,6 +96,44 @@ async def test_comment_collection_connection_failure_fills_last_error_trio(monke
 
 
 @pytest.mark.anyio
+async def test_manual_refresh_connection_failure_fills_last_error_trio(monkeypatch):
+    """story #3603(잔여, 페드루 PO 追加 2026-09-07) — 수동 「다시 수집」(refresh_comments_now,
+    #3597 잔여가 승격 자체는 이미 고침)도 last_error 3종을 채워야 한다. 승격 호출에
+    error_code/message를 안 실으면 이 경로만 last_error_code가 비어(3597과 같은
+    클래스) AC1이 스케줄 루프에서만 참이 된다."""
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_post_comments import CommentFetchError, refresh_comments_now
+    from app.services.threads_publish import ThreadsPublishError
+    import app.services.facebook_publish as facebook_publish
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+            await s.commit()
+
+            before = datetime.now(timezone.utc)
+
+            async def _raise_expired(client, *, access_token, media_id):
+                raise ThreadsPublishError("TOKEN_EXPIRED", "sandbox: 401 시뮬레이션", status_code=401)
+
+            monkeypatch.setattr(facebook_publish, "fetch_replies", _raise_expired)
+            with pytest.raises(CommentFetchError):
+                await refresh_comments_now(s, org_id=org_id, publication_id=pub.id)
+
+            refreshed = await s.get(ChannelConnection, conn.id)
+            assert refreshed.status == "expired"
+            assert refreshed.last_error is not None and "401" in refreshed.last_error
+            assert refreshed.last_error_code == "CHANNEL_TOKEN_EXPIRED"
+            assert refreshed.last_error_at is not None
+            assert refreshed.last_error_at >= before
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_insight_snapshot_connection_failure_fills_last_error_trio(monkeypatch):
     """AC1·AC2(인사이트 경로) — IG CONNECTION 실패도 동형."""
     import httpx

--- a/backend/tests/test_3603_connection_last_error.py
+++ b/backend/tests/test_3603_connection_last_error.py
@@ -1,0 +1,173 @@
+"""story #3603(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-07, 유나 3597 관찰) —
+`_promote_connection_status`(댓글)·`_promote_connection_status_for_snapshot`
+(인사이트)가 `status`만 바꾸고 `last_error`/`last_error_code`/`last_error_at`는
+안 건드려 /organization/channels 행의 「서버 응답 보기」가 비거나 옛 오류를
+보였다. CONNECTION 실패로 실제 expired 승격되는 분기에서만 이 3종을 채우고,
+no-op(이미 revoked/error·sandbox) 분기는 전부 불변임을 고정한다.
+
+세팅 헬퍼는 test_3597_ig_fb_connection_status_promote.py·test_3497_insight_
+snapshots.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+from tests.test_3497_insight_snapshots import _seed_channel_connection, _seed_channel_publication
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    """test_3597_ig_fb_connection_status_promote.py와 동형 — channel_connection 암호화
+    키가 없으면 _seed_channel_connection의 encrypt_channel_credential이 죽는다."""
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.mark.anyio
+async def test_comment_collection_connection_failure_fills_last_error_trio(monkeypatch):
+    """AC1·AC2(댓글 경로) — FB CONNECTION 실패가 last_error(원문)·last_error_code·
+    last_error_at을 전부 채운다."""
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+    from app.services.threads_publish import ThreadsPublishError
+    import app.services.facebook_publish as facebook_publish
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook", external_id="media-1", anchor_at=anchor,
+            )
+            await s.commit()
+
+            before = datetime.now(timezone.utc)
+
+            async def _raise_expired(client, *, access_token, media_id):
+                raise ThreadsPublishError("TOKEN_EXPIRED", "sandbox: 401 시뮬레이션", status_code=401)
+
+            monkeypatch.setattr(facebook_publish, "fetch_replies", _raise_expired)
+            counts = await process_due_comment_collections(s)
+            assert counts["failed"] == 1
+
+            refreshed = await s.get(ChannelConnection, conn.id)
+            assert refreshed.status == "expired"
+            assert refreshed.last_error is not None and "401" in refreshed.last_error
+            print("DEBUG last_error=", refreshed.last_error); assert refreshed.last_error_code == "CHANNEL_TOKEN_EXPIRED"
+            assert refreshed.last_error_at is not None
+            assert refreshed.last_error_at >= before, "last_error_at이 이 실패 시점보다 과거일 수 없다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_insight_snapshot_connection_failure_fills_last_error_trio(monkeypatch):
+    """AC1·AC2(인사이트 경로) — IG CONNECTION 실패도 동형."""
+    import httpx
+
+    from app.models.channel_connection import ChannelConnection
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from tests.test_3497_insight_snapshots import _patch_threads_transport
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="instagram")
+            work_item_id = uuid.uuid4()
+
+            # story #3603 그라운딩 — insight_snapshots._SNAPSHOT_OFFSETS=(+1d,+7d)뿐
+            # (댓글 쪽 +1h·+1d·+7d와 다름, 실측). anchor_at을 8일 전처럼 두 창이 다
+            # 지나게 주면(test_3497::test_threads_401_...와 동형) due 행이 2개 한
+            # 번에 처리돼, 첫 행이 승격→expired한 뒤 두 번째 행이 이미 expired인
+            # connection을 다시 봐 CHANNEL_CONNECTION_NOT_ACTIVE라는 별개(그러나
+            # 여전히 CONNECTION류) 실패로 last_error를 덮어쓴다 — 이 테스트가 원하는
+            # 건 "그 실패의 code"이지 "마지막에 처리된 행의 code"가 아니므로 +1d
+            # 창 하나만 지나고 +7d는 아직인 시점으로 anchor를 잡는다.
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="instagram", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=1, hours=1),
+            )
+            await s.commit()
+
+            before = datetime.now(timezone.utc)
+            _patch_threads_transport(
+                monkeypatch, lambda request: httpx.Response(401, json={"error": {"message": "expired"}}),
+            )
+            counts = await process_due_insight_snapshots(s)
+            assert counts["failed"] == 1, counts
+
+            refreshed = await s.get(ChannelConnection, conn.id)
+            assert refreshed.status == "expired"
+            assert refreshed.last_error is not None
+            assert refreshed.last_error_code == "CHANNEL_TOKEN_EXPIRED"
+            assert refreshed.last_error_at is not None
+            assert refreshed.last_error_at >= before
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_promote_no_op_leaves_last_error_trio_untouched():
+    """AC2 no-op 불변 — 이미 revoked인 연결은 status도 last_error 3종도 그대로
+    (test_3597_ig_fb_connection_status_promote.py::test_facebook_connection_failure_
+    does_not_downgrade_revoked_or_error와 동형, last_error 3종 축만 추가)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_post_comments import _promote_connection_status
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook", status="revoked")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+            await s.commit()
+
+            await _promote_connection_status(
+                s, publication_id=pub.id, error_code="CHANNEL_TOKEN_EXPIRED", message="이 값은 절대 안 들어가야 한다",
+            )
+            await s.commit()
+            refreshed = await s.get(ChannelConnection, conn.id)
+            assert refreshed.status == "revoked"
+            assert refreshed.last_error is None
+            assert refreshed.last_error_code is None
+            assert refreshed.last_error_at is None
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1456,6 +1456,11 @@
       "file": "tests/test_3502_insights_board_endpoints.py",
       "sec": 10.0,
       "source": "story-3604-insights-board-durations(신규 분리 파일 — story #3502 조각② HTTP 라우터 6개 테스트, from app.main import app 1회 비용 ~3.4s 포함. 격리 uv run pytest 프로세스 2회 로컬 실측 4.63~4.85s, 2배 안전마진 반영한 10s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3603_connection_last_error.py",
+      "sec": 14.0,
+      "source": "story-3603-connection-last-error(PR 개설 前 선제 등재 — 로컬 raw pytest 3건 2.20s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 14s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
유나 관찰(#3597 본문, 2026-09-07 00:29Z, 판정 아님·적기만) — `_promote_connection_status`(댓글)·`_promote_connection_status_for_snapshot`(인사이트)가 `status`만 바꾸고 `last_error`는 안 건드려 `/organization/channels` 행의 「서버 응답 보기」가 비거나 옛 오류를 보인다. `#3597`(승격 가드를 channel 이름→connection 유무로)이 배포 46에 실려 이제 IG/FB도 이 자리에 닿는다.

## 그라운딩(develop 42c250c83, 착수 時 실측)
- `ChannelConnection` 모델(`app/models/channel_connection.py:51`) — `last_error: Text | None` **단일 컬럼**. code도 `last_error_at`도 없음.
- 기존 다른 write 경로(`channel_connection.py::apply_refresh_failure`)의 PO 확定(2026-09-03 07:09Z) — "last_error는 provider 원문 그대로 저장, 사람이 읽을 말로 가공하는 건 화면(FE) 몫." 이 컬럼을 재의미로 오염시키지 않으려고 **원문은 `last_error`에 그대로 두고, code·시각은 별도 additive 컬럼**(`last_error_code`·`last_error_at`)으로 분리 — 스토리 그라운딩 절이 미리 승인한 폴백("없으면 additive 마이그레이션, 값은 코드+메시지+시각 셋")과 정확히 일치.
- FE 소비처(`app/(authenticated)/organization/channels/page.tsx:501`, `t('channelLastErrorToggle')`="서버 응답 보기") — `conn.last_error`를 `<p className="font-mono">`로 그대로 렌더하는 게 유일한 소비 자리.

## 처방
- 마이그레이션 0347: `channel_connections`에 `last_error_code`(Text, nullable)·`last_error_at`(DateTime tz, nullable) additive.
- `_promote_connection_status`·`_promote_connection_status_for_snapshot` 둘 다 `error_code`/`message` optional 파라미터를 받아, **실제 expired로 승격하는 분기에서만** 3종(원문·code·시각)을 채운다. no-op(이미 revoked/error 유지·sandbox no-op) 분기는 완전히 불변.
- 두 호출자(스케줄 루프 2곳)에서 `exc.error_code`/`str(exc)`를 넘긴다.
- 라우터(`ChannelConnectionResponse`)에 두 필드 추가·매핑.
- FE: **새 UI 섹션 0**(AC4 "표면 변화 0") — 기존 `<details>`(「서버 응답 보기」) 안에 code+상대시각(`formatRelativeTime` 재사용) 한 줄을 원문 위에 추가. **새 i18n 키 0**(구두점으로만 조합, `font-mono` 진단 영역이라 기존에도 원문 자체가 무번역). code/시각이 없는 옛 행은 원문 한 줄만 그대로(새 값을 지어내지 않음).

## 테스트
- `test_3603_connection_last_error.py`(신규 3): 댓글 FB CONNECTION 실패(3종 채워짐, `last_error_at >= before` 시각 검증), 인사이트 IG CONNECTION 실패(동형), no-op(revoked) 불변.
  - 그라운딩 메모: 인사이트 쪽 `_SNAPSHOT_OFFSETS=(+1d,+7d)`(댓글의 +1h·+1d·+7d와 다름, 실측) — anchor를 잘못 잡으면 due 행 2개가 한 번에 처리돼 두 번째 실패(CHANNEL_CONNECTION_NOT_ACTIVE)가 첫 실패의 last_error를 덮어써 버린다(PR 작업 중 실제로 걸려 anchor를 `-1d1h`로 정정).
- 기존 회귀: `test_3597_ig_fb_connection_status_promote.py`·`test_3497_insight_snapshots.py`·`test_3516_channel_post_comments.py`·`test_3373_channel_connections_app_credentials.py`·`test_3399_agent_visible_channel_connections.py` 43건 전부 통과.
- FE(`page.test.tsx`, 신규 2): 트리오 있으면 원문+code 둘 다 노출, 트리오 없으면(옛 행) 원문만·code 미노출.
- 뮤테이션 2건: BE(3종 대입 코드 제거 → 신규 BE 테스트 2건만 RED, no-op 테스트는 그대로 통과 — 격리 확認) 원복, FE(트리오 렌더 제거 → 신규 FE 테스트 1건 RED) 원복.
- `lint_destructive_schema_weights_registered.py` — shard-weights 등재 확認(OK).

tsc --noEmit·eslint·vitest(87/87 해당 파일) 전부 그린.

## 스토리
[연결 상태 승격이 status만 바꾸고 last_error를 안 남긴다](entity:story:6829d39c-43b3-4005-9841-4b5b9ff99303)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG