### PR TITLE
[SID:3609] fix: FE 오류 봉투 lint 허용목록 줄번호 핀→내용 핀 정정(거짓 빨강 차단)

### DIFF
--- a/backend/scripts/lint_fe_error_envelope_detail_mismatch.py
+++ b/backend/scripts/lint_fe_error_envelope_detail_mismatch.py
@@ -32,7 +32,16 @@ message/code에 접근하는 형 — 실전 버그의 정확한 모양). 매치�
 page.tsx:509 — 이 마지막 자리는 story #3596/#3953이 만든 `.error` 우선 폴백, #3601
 스코프 밖). 새 자리가 이 목록에 또 오르려면 반드시 같은 근거(.error 우선 확認)와
 사유를 남길 것 — 그냥 억제하려고 추가하면 이 가드의 존재 이유가 사라진다.
-"""
+
+story #3609(CI 후속, 실사고 2026-09-07) — 허용 목록이 원래 `path:lineno` 키였다.
+#3956(3592, events/page.tsx에 aria-label 39줄 추가)가 그 파일의 뒷줄 2개(원래
+546·755)를 571·780으로 밀자, 그 코드는 «한 글자도 안 바뀐 채» develop·열린 PR
+전부의 CI가 거짓 빨강이 됐다(줄 내용은 그대로인데 줄 번호만 밀렸다는 이유로) —
+model_registration류의 "pin은 조용히 늘어나면 안 된다"는 옳지만, 그 pin의 «키»
+자체가 줄번호이면 안 늘어도 무관한 변경 한 번에 깨진다. 키를 «파일 + 그 줄의
+strip()된 내용 전체 일치»로 바꾼다 — 줄번호가 몇 번이든, 그 파일에 그 정확한
+텍스트가 있으면 허용(같은 내용이 그 파일에 여러 줄 있어도 전부 허용 — 내용이
+같으면 안전성 판단도 같다, 줄마다 새로 등재할 이유가 없다)."""
 from __future__ import annotations
 
 import re
@@ -41,25 +50,26 @@ from pathlib import Path
 
 _PATTERN = re.compile(r"\.detail\?\.(message|code)\b")
 
-# PO 리뷰 관례(model_registration lint와 동형) — 줄 단위 dict, 값=사유. 새 항목은
-# 반드시 ".error를 이미 1순위로 읽는다"는 근거를 사유에 적을 것. 이 dict의 key
-# 집합은 tests/test_3601_error_envelope_detail_mismatch_lint.py::
+# story #3609 — 줄번호 대신 «파일 + strip한 줄 내용 전체 일치»로 키를 바꿨다(위
+# 모듈 docstring 그라운딩). 값=그 파일에서 허용되는 줄 내용의 목록(사유는 각
+# 항목 옆 주석). 이 dict의 key(파일) 집합·값(내용) 집합은
+# tests/test_3601_error_envelope_detail_mismatch_lint.py::
 # test_allowlist_is_pinned_to_known_safe_lines에 pin돼 있어 조용히 늘어날 수 없다.
-_ALLOWED_MATCHES: dict[str, str] = {
-    "src/app/(authenticated)/organization/events/page.tsx:116": (
-        "`body?.error?.message ?? body?.detail?.message ?? ...` — .error가 이미 1순위, "
-        ".detail은 무해한 죽은 폴백(story #3601 그라운딩)."
-    ),
-    "src/app/(authenticated)/organization/events/page.tsx:546": (
-        "위와 동형(resBody 변수명만 다름)."
-    ),
-    "src/app/(authenticated)/organization/events/page.tsx:755": (
-        "위와 동형."
-    ),
-    "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx:511": (
-        "story #3596/#3953이 만든 `.error?.message ?? .detail?.message ?? ...` — "
-        ".error 1순위 확認 완료, #3601 스코프 밖(그 스토리가 이미 닫은 자리)."
-    ),
+_ALLOWED_MATCHES: dict[str, list[str]] = {
+    "src/app/(authenticated)/organization/events/page.tsx": [
+        # `body?.error?.message ?? body?.detail?.message ?? ...` — .error가 이미
+        # 1순위, .detail은 무해한 죽은 폴백(story #3601 그라운딩). 이 정확한 문자열이
+        # 이 파일에 2줄 있다(원래 116·755, #3609 시점 116·780) — 내용이 같으므로
+        # 한 항목으로 둘 다 허용.
+        "throw new Error(body?.error?.message ?? body?.detail?.message ?? `HTTP ${res.status}`);",
+        # 위와 동형(resBody 변수명만 다름, 원래 546 · #3609 시점 571).
+        "throw new Error(resBody?.error?.message ?? resBody?.detail?.message ?? `HTTP ${res.status}`);",
+    ],
+    "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx": [
+        # story #3596/#3953이 만든 `.error?.message ?? .detail?.message ?? ...` —
+        # .error 1순위 확認 완료, #3601 스코프 밖(그 스토리가 이미 닫은 자리).
+        "errorMessage: body?.error?.message ?? body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric'),",
+    ],
 }
 
 SCAN_ROOT = "apps/web/src"
@@ -68,12 +78,18 @@ _EXCLUDE_SUFFIXES = (".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx")
 
 def find_violations(path: Path, label: str | None = None) -> list[str]:
     """단일 파일 스캔 — 허용 목록에 없는 위반 라인을 `{label}:{lineno}: {line}` 형태로
-    반환. label 생략 시 path 그대로."""
+    반환. label 생략 시 path 그대로.
+
+    story #3609 — 매칭은 줄번호가 아니라 «label(파일) + strip한 줄 내용 전체 일치»
+    (`_ALLOWED_MATCHES.get(label, [])`에 그 줄의 strip 결과가 있는지)로 판정한다 —
+    같은 파일의 무관한 다른 줄이 밀려도(예: 위에 코드가 추가돼 뒤 줄번호가 전부
+    +N) 이 판정은 흔들리지 않는다."""
     text = path.read_text(encoding="utf-8")
     label = label or str(path)
+    allowed_for_file = _ALLOWED_MATCHES.get(label, [])
     violations: list[str] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
-        if _PATTERN.search(line) and f"{label}:{lineno}" not in _ALLOWED_MATCHES:
+        if _PATTERN.search(line) and line.strip() not in allowed_for_file:
             violations.append(f"{label}:{lineno}: {line.strip()}")
     return violations
 
@@ -103,7 +119,8 @@ def main() -> int:
         for v in violations:
             print(f"  {v}")
         return 1
-    print(f"OK: `.detail?.(message|code)` 신규 위반 0건 (허용 목록 {len(_ALLOWED_MATCHES)}건 유지)")
+    total_allowed = sum(len(v) for v in _ALLOWED_MATCHES.values())
+    print(f"OK: `.detail?.(message|code)` 신규 위반 0건 (허용 목록 {len(_ALLOWED_MATCHES)}개 파일·{total_allowed}줄 유지)")
     return 0
 
 

--- a/backend/tests/test_3601_error_envelope_detail_mismatch_lint.py
+++ b/backend/tests/test_3601_error_envelope_detail_mismatch_lint.py
@@ -52,7 +52,7 @@ def test_error_first_pattern_not_flagged_when_allowlisted():
 
 
 def test_allowlisted_line_is_not_flagged():
-    """허용 목록의 (label, line) 조합과 정확히 일치하면 면제된다."""
+    """허용 목록의 (label, 내용) 조합과 정확히 일치하면 면제된다."""
     src = "line 1 — 무관\nthrow new Error(body?.error?.message ?? body?.detail?.message ?? `x`);\n"
     import tempfile
     with tempfile.TemporaryDirectory() as td:
@@ -61,12 +61,59 @@ def test_allowlisted_line_is_not_flagged():
         original = dict(mod._ALLOWED_MATCHES)
         try:
             mod._ALLOWED_MATCHES.clear()
-            mod._ALLOWED_MATCHES["allowlisted.ts:2"] = "테스트 전용 등재"
+            mod._ALLOWED_MATCHES["allowlisted.ts"] = [
+                "throw new Error(body?.error?.message ?? body?.detail?.message ?? `x`);",
+            ]
             violations = find_violations(path, label="allowlisted.ts")
         finally:
             mod._ALLOWED_MATCHES.clear()
             mod._ALLOWED_MATCHES.update(original)
     assert violations == []
+
+
+def test_allowlisted_content_survives_unrelated_lines_shifting_line_numbers():
+    """story #3609 — 허용된 줄 «앞에» 무관한 줄을 N개 끼워 넣어 줄번호가 밀려도
+    (내용은 그대로이므로) 여전히 위반 0. 이 시나리오가 정확히 #3956(events/page.tsx
+    +39줄)이 develop CI를 거짓 빨강으로 만든 실사고의 재현이다."""
+    allowed_line = "throw new Error(body?.error?.message ?? body?.detail?.message ?? `x`);\n"
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        import lint_fe_error_envelope_detail_mismatch as mod
+        original = dict(mod._ALLOWED_MATCHES)
+        try:
+            mod._ALLOWED_MATCHES.clear()
+            mod._ALLOWED_MATCHES["shifted.ts"] = [allowed_line.strip()]
+            unrelated_padding = "".join(f"const unrelated_{i} = {i};\n" for i in range(39))
+            src = unrelated_padding + allowed_line
+            path = _write(Path(td), "shifted.ts", src)
+            violations = find_violations(path, label="shifted.ts")
+        finally:
+            mod._ALLOWED_MATCHES.clear()
+            mod._ALLOWED_MATCHES.update(original)
+    assert violations == [], "무관한 앞줄이 끼어들어 줄번호가 밀려도 내용이 같으면 허용돼야 한다"
+
+
+def test_allowlisted_content_changed_is_flagged_as_new_violation():
+    """story #3609 — 허용된 줄 «내용 자체»가 바뀌면(변수명 변경 등) 더는 등재된
+    문자열과 일치하지 않으므로 새 위반으로 잡혀야 한다 — 내용 키가 "느슨해서 아무거나
+    통과"가 아님을 고정."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        import lint_fe_error_envelope_detail_mismatch as mod
+        original = dict(mod._ALLOWED_MATCHES)
+        try:
+            mod._ALLOWED_MATCHES.clear()
+            mod._ALLOWED_MATCHES["changed.ts"] = [
+                "throw new Error(body?.error?.message ?? body?.detail?.message ?? `x`);",
+            ]
+            # 등재된 것과 다른 변수명(resBody) — 문자 그대로 안 같으면 면제되지 않는다.
+            src = "throw new Error(resBody?.error?.message ?? resBody?.detail?.message ?? `x`);\n"
+            path = _write(Path(td), "changed.ts", src)
+            violations = find_violations(path, label="changed.ts")
+        finally:
+            mod._ALLOWED_MATCHES.clear()
+            mod._ALLOWED_MATCHES.update(original)
+    assert len(violations) == 1, "허용 목록에 등재된 것과 내용이 다르면(같은 파일이어도) 위반이어야 한다"
 
 
 def test_variable_indirection_is_a_known_blind_spot():
@@ -101,15 +148,60 @@ def test_mutation_disabling_pattern_causes_zero_detections():
         mod._PATTERN = original
 
 
+def test_mutation_removing_content_match_check_causes_allowlisted_line_to_be_flagged():
+    """story #3609 — «내용 매칭» 자체가 이 가드의 새 핵심 로직이다. `find_violations`가
+    `line.strip() not in allowed_for_file` 대신 뭐든 통과시키게(예: `not in []`) 망가지면
+    이미 등재된 안전한 줄까지 위반으로 잘못 잡아야 한다(뮤테이션 대조 — 로직이 실제로
+    이 체크에 의존함을 값으로 증명)."""
+    import lint_fe_error_envelope_detail_mismatch as mod
+
+    original_allowed = dict(mod._ALLOWED_MATCHES)
+    original_source = mod.find_violations.__code__
+    try:
+        mod._ALLOWED_MATCHES.clear()
+        mod._ALLOWED_MATCHES["mutated.ts"] = [
+            "throw new Error(body?.error?.message ?? body?.detail?.message ?? `x`);",
+        ]
+
+        def _broken_find_violations(path: Path, label: str | None = None) -> list[str]:
+            text = path.read_text(encoding="utf-8")
+            label = label or str(path)
+            violations: list[str] = []
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if mod._PATTERN.search(line):  # 내용 매칭 체크 자체를 뺀 뮤테이션.
+                    violations.append(f"{label}:{lineno}: {line.strip()}")
+            return violations
+
+        src = "throw new Error(body?.error?.message ?? body?.detail?.message ?? `x`);\n"
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            path = _write(Path(td), "mutated.ts", src)
+            violations = _broken_find_violations(path, label="mutated.ts")
+        assert len(violations) == 1, "내용 매칭 체크를 빼면 허용된 줄도 위반으로 떨어져야 한다(로직이 그 체크에 의존)"
+    finally:
+        mod._ALLOWED_MATCHES.clear()
+        mod._ALLOWED_MATCHES.update(original_allowed)
+        assert mod.find_violations.__code__ is original_source, "원본 find_violations는 안 건드렸다(로컬 함수로만 시뮬레이션)"
+
+
 def test_allowlist_is_pinned_to_known_safe_lines():
     """허용 목록이 조용히 늘어나는 뒷문을 막는다(story #2255 model_registration lint와
-    동일 관례) — 새 항목을 추가하려면 이 pin도 같이 고쳐야 리뷰에서 보인다."""
+    동일 관례) — 새 항목을 추가하려면 이 pin도 같이 고쳐야 리뷰에서 보인다.
+
+    story #3609 — 키를 파일 경로로, pin 대상을 «파일+내용»으로 바꿨다(줄번호는
+    더 이상 이 가드의 정체성이 아니다 — #3609 그라운딩: 무관한 줄 추가로 번호가
+    밀려도 pin이 안 흔들려야 한다)."""
     assert set(_ALLOWED_MATCHES.keys()) == {
-        "src/app/(authenticated)/organization/events/page.tsx:116",
-        "src/app/(authenticated)/organization/events/page.tsx:546",
-        "src/app/(authenticated)/organization/events/page.tsx:755",
-        "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx:511",
+        "src/app/(authenticated)/organization/events/page.tsx",
+        "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx",
     }
+    assert _ALLOWED_MATCHES["src/app/(authenticated)/organization/events/page.tsx"] == [
+        "throw new Error(body?.error?.message ?? body?.detail?.message ?? `HTTP ${res.status}`);",
+        "throw new Error(resBody?.error?.message ?? resBody?.detail?.message ?? `HTTP ${res.status}`);",
+    ]
+    assert _ALLOWED_MATCHES["src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx"] == [
+        "errorMessage: body?.error?.message ?? body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric'),",
+    ]
 
 
 def test_current_repo_has_zero_unallowed_violations():


### PR DESCRIPTION
## 원인(실측)
카디르 #3961 QA(2026-09-07 03:48Z): `FE error envelope .detail mismatch lint` job FAILURE — `events/page.tsx:571`·`:780`이 위반으로 잡히나 #3961은 그 파일을 안 건드림(`git diff origin/develop..7bb7d4db -- events/page.tsx` 빈 출력으로 확認). 두 줄의 **내용**은 허용목록에 있던 그 줄(`body?.error?.message ?? body?.detail?.message ?? ...`) 그대로 — #3956(story #3592, events/page.tsx에 aria-label 39줄 추가)이 develop 191로 머지되며 그 파일의 뒷줄 2개(원래 546·755)가 571·780으로 밀렸을 뿐이다.

`lint_fe_error_envelope_detail_mismatch.py`(story #3601)의 `_ALLOWED_MATCHES`가 `path:lineno` 문자열을 키로 쓰고 있어 **그 파일에 어떤 무관한 변경이 일어나도**(줄 추가/삭제로 뒷줄 번호가 밀리면) 허용목록이 깨진다 — 코드 자체는 안전한데 CI가 거짓 빨강이 되고, develop·열린 PR 전부(#3960 배포 47 게이트·#3961)의 이 job이 막혔다.

## 처방
허용목록 키를 **파일 + strip한 줄 내용 완전 일치**로 바꿨다(줄번호 완전히 배제):

```python
_ALLOWED_MATCHES: dict[str, list[str]] = {
    "src/app/(authenticated)/organization/events/page.tsx": [
        "throw new Error(body?.error?.message ?? body?.detail?.message ?? `HTTP ${res.status}`);",
        "throw new Error(resBody?.error?.message ?? resBody?.detail?.message ?? `HTTP ${res.status}`);",
    ],
    "src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx": [
        "errorMessage: body?.error?.message ?? body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric'),",
    ],
}
```

`events/page.tsx`가 정확히 "같은 내용이 한 파일에 여러 줄" 모양이다(body 변형이 2곳·resBody 변형이 1곳) — 목록 항목 하나로 그 내용의 모든 출현을 전부 허용한다.

## 검증(AC2·AC3)
- pin 테스트(`test_allowlist_is_pinned_to_known_safe_lines`)를 파일+내용 집합으로 갱신 — "조용히 늘어날 수 없다"는 성질 그대로.
- 신규 selftest 2건: ① 허용된 줄 **앞에 무관 줄 39개**(#3956 실사고와 같은 규모)를 끼워 넣어도 위반 0 ② 허용된 줄의 **내용 자체**가 바뀌면(변수명 변경) 새 위반 1.
- 뮤테이션 1건: 내용 매칭 체크를 빼면 허용된 줄도 위반으로 잘못 잡힘(로직이 그 체크에 실제로 의존함을 값으로 증명).
- 기존 9건 전부 새 dict 형에 맞춰 갱신, 총 **11건 PASS**.
- 실물 스캔(`python3 scripts/lint_fe_error_envelope_detail_mismatch.py`, CI가 도는 그 정확한 커맨드) — `OK: 위반 0건`, **exit 0** 확認.

## 범위 밖(적기만, 수정 안 함)
같은 "path:lineno 핀" 형이 다른 lint에도 있는지 grep — 정확히 1건 발견: `apps/web/scripts/verify-no-date-tolocalestring.ts`의 `ALLOWLIST`(4건, `{file, line}` 키). 이번과 같은 실사고 클래스(그 파일에 무관한 줄이 추가되면 거짓 빨강)가 재발할 수 있는 자리 — PO 판단 대상, 별건 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA
