### PR TITLE
[SID:3605] fix: 3598 AC6 일반화 — Graph API code 10/200-299 CONNECTION 승격+경로 4곳 일관화

### DIFF
--- a/apps/web/src/components/content/api-error.test.ts
+++ b/apps/web/src/components/content/api-error.test.ts
@@ -172,6 +172,18 @@ describe('parseSitePostApiError (story #3368, doc phase0-post-manager-screen-des
       expect(result.humanMessageKey).toBe('errorChannelTokenExpired');
     });
 
+    // story #3605 CHANGES-3(페드루 PO 確定 2026-09-07) — BE가 revoked·auth_error를
+    // CHANNEL_TOKEN_EXPIRED로 뭉뚱그리지 않고 각자의 code로 명시하게 됐다(계약 변경).
+    // 화면은 셋 다 같은 "다시 연결" 유도로 충분해 기존 키·kind를 그대로 재사용한다.
+    test.each(['CHANNEL_CONNECTION_REVOKED', 'CHANNEL_CONNECTION_AUTH_ERROR'])(
+      '%s — kind=token_expired(기존 키 재사용, 새 낱말 0)',
+      (code) => {
+        const result = parseSitePostApiError({ error: { code, message: '연결 실패' } });
+        expect(result.kind).toBe('token_expired');
+        expect(result.humanMessageKey).toBe('errorChannelTokenExpired');
+      },
+    );
+
     test('CHANNEL_CONNECTION_NOT_ACTIVE — kind=connection_not_active', () => {
       const result = parseSitePostApiError({ error: { code: 'CHANNEL_CONNECTION_NOT_ACTIVE', message: '연결 비활성' } });
       expect(result.kind).toBe('connection_not_active');

--- a/apps/web/src/components/content/api-error.ts
+++ b/apps/web/src/components/content/api-error.ts
@@ -173,6 +173,13 @@ const KNOWN_ERRORS: Record<string, KnownError> = {
   // except 매핑, PR#3752 277debe92·#3757 eb55c4221·#3395·PR#3764 c6049add1 실측).
   CHANNEL_RATE_LIMITED: { labelKey: 'errorChannelRateLimited', kind: 'rate_limited' },
   CHANNEL_TOKEN_EXPIRED: { labelKey: 'errorChannelTokenExpired', kind: 'token_expired' },
+  // story #3605 CHANGES-3(페드루 PO 確定 2026-09-07) — BE가 이제 revoked(사용자/보안
+  // 행동으로 세션 무효화)·auth_error(권한 계열, 사유 불명)를 CHANNEL_TOKEN_EXPIRED로
+  // 뭉뚱그리지 않고 각자의 code로 명시한다(3605 계약 변경). 화면 문구·다음 행동은
+  // 셋 다 동일("연결이 끊겼습니다 — owner가 다시 연결해야 합니다", 재연결 하나로
+  // 전부 풀린다는 점에서 사용자 관점 구분 불필요) — 기존 키 그대로 재사용, 새 낱말 0.
+  CHANNEL_CONNECTION_REVOKED: { labelKey: 'errorChannelTokenExpired', kind: 'token_expired' },
+  CHANNEL_CONNECTION_AUTH_ERROR: { labelKey: 'errorChannelTokenExpired', kind: 'token_expired' },
   CHANNEL_CONNECTION_NOT_ACTIVE: { labelKey: 'errorChannelConnectionNotActive', kind: 'connection_not_active' },
   CHANNEL_POST_APPROVER_ROLE_MISSING: { labelKey: 'errorChannelApproverRoleMissing', kind: 'approver_role_missing' },
   // doc §5 v8 — 발행은 사람이 화면에서 한다. 에이전트에겐 이 화면 자체가 없어(AC14)

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -17,7 +17,9 @@ from app.models.pm import Story
 from app.services.content_rules import get_org_content_rules, lint_content
 from app.services.project_auth import require_project_access
 from app.services.channel_posts import (
+    ChannelConnectionAuthError,
     ChannelConnectionNotActiveError,
+    ChannelConnectionRevokedError,
     ChannelImageContainerFailedError,
     ChannelImageRequiredError,
     ChannelPostApproverRoleMissingError,
@@ -1564,6 +1566,35 @@ async def publish_channel_post_draft_endpoint(
             status_code=409,
             detail=_with_command_state({"code": "CHANNEL_CONNECTION_NOT_ACTIVE", "message": str(exc)}),
         ) from exc
+    # story #3605(실측 정정) — ChannelConnectionRevokedError·ChannelConnectionAuthError
+    # 둘 다 ChannelTokenExpiredError의 서브클래스라 부모보다 먼저 잡아야 한다. 안 그러면
+    # channel_posts.py::publish_channel_post_draft가 이미 inline으로 정확히 승격해 둔
+    # connection.status(revoked/error)를, 이 핸들러가 apply_command_failure를
+    # error_code="CHANNEL_TOKEN_EXPIRED"로 다시 호출해 "expired"로 덮어써 버리는
+    # 실사고가 났다(_process_one_command 워커의 동형 함정과 같은 근본원인, 3605
+    # 그라운딩) — publish_channel_post_draft가 이미 apply_connection_failure로
+    # connection은 처리해 뒀으므로 여기선 command 상태·HTTP 응답 코드만 그 사유에
+    # 맞게 정확히 남긴다(connection.status 재승격 없음, 이중 기록 방지).
+    except ChannelConnectionRevokedError as exc:
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_CONNECTION_REVOKED")
+        await apply_command_failure(
+            db, command, error_code="CHANNEL_CONNECTION_REVOKED", last_error=str(exc), now=now,
+        )
+        await db.commit()
+        raise HTTPException(
+            status_code=409,
+            detail=_with_command_state({"code": "CHANNEL_CONNECTION_REVOKED", "message": str(exc)}),
+        ) from exc
+    except ChannelConnectionAuthError as exc:
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_CONNECTION_AUTH_ERROR")
+        await apply_command_failure(
+            db, command, error_code="CHANNEL_CONNECTION_AUTH_ERROR", last_error=str(exc), now=now,
+        )
+        await db.commit()
+        raise HTTPException(
+            status_code=409,
+            detail=_with_command_state({"code": "CHANNEL_CONNECTION_AUTH_ERROR", "message": str(exc)}),
+        ) from exc
     except ChannelTokenExpiredError as exc:
         await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_TOKEN_EXPIRED")
         await apply_command_failure(
@@ -1839,6 +1870,17 @@ async def unpublish_channel_post_endpoint(
         raise HTTPException(
             status_code=409,
             detail={"code": "CHANNEL_CONNECTION_NOT_ACTIVE", "message": str(exc)},
+        ) from exc
+    # story #3605 — 회수/사유불명 예외도 부모(ChannelTokenExpiredError)보다 먼저 잡아
+    # HTTP 응답 code가 정확한 사유를 말하게 한다(unpublish는 command가 없어 connection
+    # 승격 자체는 이미 publish 경로에서 끝났다는 전제 — 여긴 응답 코드만의 문제).
+    except ChannelConnectionRevokedError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "CHANNEL_CONNECTION_REVOKED", "message": str(exc)},
+        ) from exc
+    except ChannelConnectionAuthError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "CHANNEL_CONNECTION_AUTH_ERROR", "message": str(exc)},
         ) from exc
     except ChannelTokenExpiredError as exc:
         raise HTTPException(

--- a/backend/app/services/channel_connection.py
+++ b/backend/app/services/channel_connection.py
@@ -213,9 +213,21 @@ async def apply_connection_failure(
     `_classify_threads_error`가 code==190/OAuthException을 expired|revoked로 세분화한
     뒤 이 함수로 정확한 status를 남긴다(모델 컬럼 주석 그대로 active|expired|revoked|
     error 중 하나). last_error는 provider 원문 그대로(가공은 화면 몫, apply_refresh_
-    failure와 동일 규율)."""
-    connection.status = status
+    failure와 동일 규율).
+
+    story #3605(3598 AC6 일반화) — 신설 status="error"(사유 불명, code 10·200~299
+    family 등)는 이미 더 구체적인 종결 상태(expired·revoked)를 덮지 않는다 — "더
+    약한 정보로 되돌리지 않기"(publication_command.py::apply_command_failure의
+    동형 가드와 같은 원칙, 새 기전 발명 아님). last_error는 그래도 최신 원문으로
+    갱신한다(사유는 그대로여도 "최근에도 계속 실패 中"이라는 사실 자체는 갱신할
+    가치가 있다). expired↔revoked 상호 덮어쓰기 규율은 이 스토리 스코프 밖(기존
+    그대로 — 이 함수는 그 둘 사이는 그대로 덮어쓴다, 호출부가 이미 정확한 값만
+    넘긴다는 전제)."""
     connection.last_error = error_message[:2000]
+    if status == "error" and connection.status in ("expired", "revoked"):
+        await db.commit()
+        return
+    connection.status = status
     await db.commit()
 
 

--- a/backend/app/services/channel_connection.py
+++ b/backend/app/services/channel_connection.py
@@ -215,19 +215,18 @@ async def apply_connection_failure(
     error 중 하나). last_error는 provider 원문 그대로(가공은 화면 몫, apply_refresh_
     failure와 동일 규율).
 
-    story #3605(3598 AC6 일반화) — 신설 status="error"(사유 불명, code 10·200~299
-    family 등)는 이미 더 구체적인 종결 상태(expired·revoked)를 덮지 않는다 — "더
-    약한 정보로 되돌리지 않기"(publication_command.py::apply_command_failure의
-    동형 가드와 같은 원칙, 새 기전 발명 아님). last_error는 그래도 최신 원문으로
-    갱신한다(사유는 그대로여도 "최근에도 계속 실패 中"이라는 사실 자체는 갱신할
-    가치가 있다). expired↔revoked 상호 덮어쓰기 규율은 이 스토리 스코프 밖(기존
-    그대로 — 이 함수는 그 둘 사이는 그대로 덮어쓴다, 호출부가 이미 정확한 값만
-    넘긴다는 전제)."""
+    story #3605 CHANGES-2(유나 코드 리뷰 재확認, 페드루 PO 채택 2026-09-07) —
+    "되돌아가지 않기" 규율이 한때 이 함수 안에 따로 구현돼 있었다(status=="error"
+    일 때만 막고 expired↔revoked는 서로 덮게 둠) — `graph_api_errors.
+    connection_status_for_error_code`가 쓰던 규율(expired·revoked는 서로도 안
+    덮는 완전 sticky)과 «같은 사실»을 다르게 말하고 있어 하나는 거짓이었다.
+    이제 `graph_api_errors.sticky_connection_status`(공유 단일 지점) 하나로
+    통일한다. last_error는 그래도 최신 원문으로 갱신한다(status가 안 바뀌어도
+    "최근에도 계속 실패 中"이라는 사실 자체는 갱신할 가치가 있다)."""
+    from app.services.graph_api_errors import sticky_connection_status
+
     connection.last_error = error_message[:2000]
-    if status == "error" and connection.status in ("expired", "revoked"):
-        await db.commit()
-        return
-    connection.status = status
+    connection.status = sticky_connection_status(connection.status, status)
     await db.commit()
 
 

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -154,11 +154,17 @@ async def _fetch_replies_raw(
             # 예외를 낼 일이 없어(sandbox_publish.py는 fetch_replies에서 절대
             # raise 안 함) 이 try/except 자체가 없었다 — 아래 공용 블록(157행대)의
             # 매핑을 그대로 재사용(새 판정 로직 0).
-            if exc.status_code in (401, 403):
-                raise CommentFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message=str(exc)) from exc
-            if exc.status_code == 429:
-                raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message=str(exc)) from exc
-            raise CommentFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
+            # story #3605 — 401/403만 보던 휴리스틱을 classify_graph_error_code
+            # (graph_api_errors.py, channel_posts.py::_classify_threads_error와
+            # 같은 공용 함수)로 교체 — Graph subcode·10·200~299 family까지 정밀
+            # 판정(발행 경로와 드리프트 0).
+            from app.services.graph_api_errors import classify_graph_error_code
+
+            error_code = classify_graph_error_code(
+                status_code=exc.status_code, provider_error_code=exc.provider_error_code,
+                provider_error_subcode=exc.provider_error_subcode, provider_error_type=exc.provider_error_type,
+            )
+            raise CommentFetchError(error_code=error_code, message=str(exc)) from exc
 
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
@@ -203,11 +209,15 @@ async def _fetch_replies_raw(
             return await _publish_client.fetch_replies(client, access_token=access_token, media_id=pub.external_id)
     except Exception as exc:  # noqa: BLE001 — ThreadsPublishError는 상태코드로 분류(threads/instagram/facebook 공용)
         if isinstance(exc, ThreadsPublishError):
-            if exc.status_code in (401, 403):
-                raise CommentFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message=str(exc)) from exc
-            if exc.status_code == 429:
-                raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message=str(exc)) from exc
-            raise CommentFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
+            # story #3605 — 위 sandbox 분기와 동일하게 classify_graph_error_code로
+            # 교체(새 판정 로직 0, 공용 함수 재사용).
+            from app.services.graph_api_errors import classify_graph_error_code
+
+            error_code = classify_graph_error_code(
+                status_code=exc.status_code, provider_error_code=exc.provider_error_code,
+                provider_error_subcode=exc.provider_error_subcode, provider_error_type=exc.provider_error_type,
+            )
+            raise CommentFetchError(error_code=error_code, message=str(exc)) from exc
         raise
 
 
@@ -608,14 +618,22 @@ async def _promote_connection_status(
 
     story #3603(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-07, 유나 3597 관찰) —
     `status`만 바꾸고 「왜」는 안 남겨 /organization/channels의 「서버 응답 보기」가
-    비거나 옛 오류를 보였다. 실제로 expired로 승격하는 이 분기에서만 `last_error`
-    3종(원문 그대로 · code · 시각)을 같이 채운다 — no-op(이미 revoked/error·sandbox
-    no-op) 분기는 전부 불변(호출자가 error_code/message를 안 줄 수도 있다, 예:
-    아래 `refresh_comments_now`가 아닌 다른 미래 호출자 대비 — 둘 다 optional)."""
+    비거나 옛 오류를 보였다. `last_error_code`·`last_error_at`은 status의 sticky
+    여부와 무관하게 항상 갱신한다("지금도 실패 中"이라는 사실 자체가 갱신할
+    가치가 있다, `channel_connection.apply_connection_failure`와 같은 규율).
+    `last_error`(원문)는 message가 주어질 때만 채운다(호출자가 안 줄 수도 있다 —
+    둘 다 optional).
+
+    story #3605(실측 정정) — error_code 무관하게 항상 "expired"로 굳혔던 것을
+    바로잡는다(publication_command.py::apply_command_failure와 같은 결함 클래스,
+    같은 스토리에서 같이 고침). `graph_api_errors.sticky_connection_status`(공유
+    단일 지점, CHANGES-2)가 정확한 status를 고른다 — #3603의 `not in ("revoked",
+    "error")` 가드를 이 함수가 대체한다(expired도 이제 동등하게 sticky)."""
     from datetime import datetime, timezone
 
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
+    from app.services.graph_api_errors import connection_status_for_error_code
 
     pub = (await db.execute(
         select(ChannelPublication).where(ChannelPublication.id == publication_id)
@@ -623,12 +641,13 @@ async def _promote_connection_status(
     if pub is None:
         return
     connection = await db.get(ChannelConnection, pub.connection_id)
-    if connection is not None and connection.status not in ("revoked", "error"):
-        connection.status = "expired"
-        if message is not None:
-            connection.last_error = message[:2000]
-        connection.last_error_code = error_code
-        connection.last_error_at = datetime.now(timezone.utc)
+    if connection is None:
+        return
+    connection.status = connection_status_for_error_code(error_code, current_status=connection.status)
+    if message is not None:
+        connection.last_error = message[:2000]
+    connection.last_error_code = error_code
+    connection.last_error_at = datetime.now(timezone.utc)
 
 
 async def refresh_comments_now(
@@ -688,6 +707,9 @@ async def refresh_comments_now(
         # 는 여기서 안 부른다 — 그건 «다음 자동 폴링 예약» 개념인데 이 경로는 사람이
         # 그 자리에서 손으로 누른 1회성 재수집이라 다음 폴링 스케줄과 무관하다(루프
         # 전용 개념을 수동 경로에 섞지 않는다).
+        # story #3605(rebase 반영) — `_promote_connection_status`에 `error_code`가
+        # 추가돼(어떤 status로 승격할지 error_code로 정확히 고르기 위해) 호출부도
+        # 그 값을 넘긴다.
         from app.services.publication_command import classify_failure_kind, FAILURE_KIND_CONNECTION
 
         # story #3612(라이브 결함, 배포 47) — CHANNEL_CONNECTION_NOT_ACTIVE는 선검사

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -125,7 +125,27 @@ class ChannelConnectionRevokedError(ChannelTokenExpiredError):
     `except ChannelTokenExpiredError`(라우터·publication_command.py) 전부가 신규
     except 절 없이 그대로 이 예외도 잡는다. `connection.status`만 "expired" 대신
     "revoked"로 정확히 남기는 것이 이 클래스가 존재하는 유일한 이유(3595 표 행
-    ②「권한 회수」가 "미감지"에서 "감지+표시"로 바뀌는 지점)."""
+    ②「권한 회수」가 "미감지"에서 "감지+표시"로 바뀌는 지점).
+
+    ⚠️story #3605(실측 정정) — "그대로 잡는다"는 catch 자체는 맞지만, 잡는 쪽이
+    예외 인스턴스가 아니라 **error_code 문자열을 다시 하드코딩**하면(예:
+    `except ChannelTokenExpiredError as exc: error_code = "CHANNEL_TOKEN_EXPIRED"`)
+    이 서브클래스로 온 사실 자체가 그 자리에서 조용히 지워진다 — publication_
+    command.py::_process_one_command가 정확히 이 함정에 있었다(하위 클래스 except
+    절을 부모보다 먼저 두는 방식으로 정정, #3605). 이 클래스를 새로 잡는 자리를
+    추가할 때마다 "인스턴스 타입으로 갈라 문자열을 새로 짓는지"를 확認할 것."""
+
+
+class ChannelConnectionAuthError(ChannelTokenExpiredError):
+    """story #3605(3598 AC6 일반화, PO 確定) — Graph API 권한/인증 계열 오류인 건
+    확실하지만(code==190·10·200~299 범위·type=="OAuthException") 정확한 사유(만료
+    vs 회수)는 모를 때(`classify_graph_oauth_error`가 "error"를 반환하는 자리 —
+    190의 미지 subcode든, 10·200~299 family든 전부 이 버킷). `ChannelConnection.
+    status` enum의 네 번째 값 "error"(active|expired|revoked|error)가 정확히 이
+    자리를 위해 존재한다 — expired/revoked로 섣불리 단정하지 않고 fail-closed로
+    "재인증이 필요한 건 확실하다"만 말한다. `ChannelTokenExpiredError`를 상속해
+    기존 except 절이 계속 잡되(위 ⚠️와 같은 주의), connection.status만 "error"로
+    정확히 남긴다."""
 
 
 class ChannelRateLimitedError(Exception):
@@ -1126,40 +1146,34 @@ def _classify_threads_error(
     파서, IG·FB·threads 어댑터가 전부 `error_from_response()`로 채운 `.provider_
     error_*` 3필드를 읽는다)로 먼저 세분화한다: expired는 기존 CHANNEL_TOKEN_EXPIRED
     그대로(회귀 0), revoked는 신설 CHANNEL_CONNECTION_REVOKED(ChannelTokenExpiredError
-    상속이라 기존 except 절 무변경). error 버킷은 AC6(fail-closed 승격·재시도 상한,
-    다음 커밋)에서 다룬다 — 지금은 미분류 provider 오류와 동일하게 아래 401/403/429
-    휴리스틱으로 떨어진다(회귀 0). 파서가 관할 밖(None — code!=190 ∧ type!=
-    OAuthException, 또는 애초에 파싱 가능한 Graph 오류 envelope이 없던 경우)이면
-    기존 401/403 휴리스틱이 계속 유일한 판정 근거다(비-Meta 오류·malformed body 대비)."""
-    from app.services.graph_api_errors import classify_graph_oauth_error
+    상속이라 기존 except 절 무변경).
 
-    oauth_reason = classify_graph_oauth_error(
-        error_code=exc.provider_error_code, error_subcode=exc.provider_error_subcode,
-        error_type=exc.provider_error_type,
+    story #3605(3598 AC6 일반화) — error 버킷(190의 미지 subcode·10·200~299
+    family·fail-closed)은 신설 CHANNEL_CONNECTION_AUTH_ERROR로 승격한다(더 이상
+    아래 401/403 휴리스틱으로 안 떨어진다 — 그러면 CHANNEL_TOKEN_EXPIRED로
+    뭉개져 "만료"라고 거짓 확信하는 꼴이라 fail-closed 취지와 반대다). 실제 판정
+    (오류 코드 하나 고르는 부분)은 `graph_api_errors.classify_graph_error_code`
+    로 옮겼다 — 댓글 수집(channel_post_comments.py)도 같은 함수를 쓴다(3605에서
+    통합, 그 전엔 자기만의 401/403 휴리스틱을 따로 갖고 있어 발행 경로만 정밀
+    판정을 받는 드리프트였다). 이 함수는 이제 그 문자열에 맞는 예외 인스턴스만
+    조립한다(connection_id가 필요한 이 도메인 전용 사정)."""
+    from app.services.graph_api_errors import classify_graph_error_code
+
+    error_code = classify_graph_error_code(
+        status_code=exc.status_code, provider_error_code=exc.provider_error_code,
+        provider_error_subcode=exc.provider_error_subcode, provider_error_type=exc.provider_error_type,
     )
-    if oauth_reason is not None:
-        status, _reason = oauth_reason
-        if status == "expired":
-            return "CHANNEL_TOKEN_EXPIRED", ChannelTokenExpiredError(
-                connection_id=connection_id, provider_message=exc.message,
-            )
-        if status == "revoked":
-            return "CHANNEL_CONNECTION_REVOKED", ChannelConnectionRevokedError(
-                connection_id=connection_id, provider_message=exc.message,
-            )
-        # status == "error" — AC6(다음 커밋)에서 fail-closed 승격·재시도 상한과 함께
-        # 처리. 지금은 아래 401/403/429 휴리스틱으로 폴스루(회귀 0).
-    if exc.status_code in (401, 403):
-        return "CHANNEL_TOKEN_EXPIRED", ChannelTokenExpiredError(
-            connection_id=connection_id, provider_message=exc.message,
-        )
-    if exc.status_code == 429:
-        return "CHANNEL_RATE_LIMITED", ChannelRateLimitedError(
+    if error_code == "CHANNEL_TOKEN_EXPIRED":
+        return error_code, ChannelTokenExpiredError(connection_id=connection_id, provider_message=exc.message)
+    if error_code == "CHANNEL_CONNECTION_REVOKED":
+        return error_code, ChannelConnectionRevokedError(connection_id=connection_id, provider_message=exc.message)
+    if error_code == "CHANNEL_CONNECTION_AUTH_ERROR":
+        return error_code, ChannelConnectionAuthError(connection_id=connection_id, provider_message=exc.message)
+    if error_code == "CHANNEL_RATE_LIMITED":
+        return error_code, ChannelRateLimitedError(
             reset_at=datetime.now(timezone.utc) + timedelta(seconds=_RATE_LIMIT_DEFAULT_RESET_SECONDS),
         )
-    return "CHANNEL_PUBLISH_PROVIDER_ERROR", ChannelPublishProviderError(
-        provider_code=exc.code, provider_message=exc.message,
-    )
+    return error_code, ChannelPublishProviderError(provider_code=exc.code, provider_message=exc.message)
 
 
 async def resolve_command_target(
@@ -1474,6 +1488,15 @@ async def publish_channel_post_draft(
                         await apply_connection_failure(
                             db, connection=connection, status="revoked", error_message=exc.message,
                         )
+                    elif error_code == "CHANNEL_CONNECTION_AUTH_ERROR":
+                        # story #3605 — 사유(만료/회수) 불명이지만 인증 계열인 건
+                        # 확실 — 기존 두 상태를 덮지 않는다는 점은 apply_connection_
+                        # failure 호출부 규율과 같다(connection.status 컬럼 자체가
+                        # revoked/error를 서로 안 덮게 짜여 있음, publication_command.
+                        # py::apply_command_failure의 동형 가드 참고).
+                        await apply_connection_failure(
+                            db, connection=connection, status="error", error_message=exc.message,
+                        )
                     raise mapped_exc from exc
                 row.external_container_id = container_id
                 row.status = "container_created"
@@ -1508,6 +1531,15 @@ async def publish_channel_post_draft(
                     elif error_code == "CHANNEL_CONNECTION_REVOKED":
                         await apply_connection_failure(
                             db, connection=connection, status="revoked", error_message=exc.message,
+                        )
+                    elif error_code == "CHANNEL_CONNECTION_AUTH_ERROR":
+                        # story #3605 — 사유(만료/회수) 불명이지만 인증 계열인 건
+                        # 확실 — 기존 두 상태를 덮지 않는다는 점은 apply_connection_
+                        # failure 호출부 규율과 같다(connection.status 컬럼 자체가
+                        # revoked/error를 서로 안 덮게 짜여 있음, publication_command.
+                        # py::apply_command_failure의 동형 가드 참고).
+                        await apply_connection_failure(
+                            db, connection=connection, status="error", error_message=exc.message,
                         )
                     raise mapped_exc from exc
                 if container_status == "IN_PROGRESS":
@@ -1560,6 +1592,10 @@ async def publish_channel_post_draft(
                 elif error_code == "CHANNEL_CONNECTION_REVOKED":
                     await apply_connection_failure(
                         db, connection=connection, status="revoked", error_message=exc.message,
+                    )
+                elif error_code == "CHANNEL_CONNECTION_AUTH_ERROR":
+                    await apply_connection_failure(
+                        db, connection=connection, status="error", error_message=exc.message,
                     )
                 raise mapped_exc from exc
 

--- a/backend/app/services/graph_api_errors.py
+++ b/backend/app/services/graph_api_errors.py
@@ -21,8 +21,8 @@ subcode 그라운딩(PO 코드 확認 2026-09-06 15:36Z, 스토리 본문 確定
   실패인 건 확실하지만 정확한 사유는 모른다"로 fail-closed(만료·회수를 섣불리
   단정하지 않는다 — AC6 「알 수 없는 오류는 CONNECTION kind로 fail-closed, reason만
   모른다」와 같은 원칙).
-- code!=190 이고 type!="OAuthException"이면 이 함수의 관할이 아니다(None) — 호출부가
-  429/5xx 등 다른 분류로 넘어간다.
+- code!=190이면(아래 3605 정정 뒤로는 type과 무관하게) 이 함수의 관할이 아니다
+  (None) — 호출부가 429/5xx 등 다른 분류로 넘어간다.
 
 story #3605(3598 AC6 일반화, PO 確定 2026-09-07 · 유나 §22-16류 6-정정 「한 방향
 문」) — Graph API 권한/인증 계열 오류 family를 190/OAuthException 밖으로 넓힌다:
@@ -43,7 +43,23 @@ story #3605(3598 AC6 일반화, PO 確定 2026-09-07 · 유나 §22-16류 6-정�
   되돌아오는 길이 사람뿐이므로 사람이 못 고치는 원인을 넣으면 조직이 스스로
   잠긴다).
 - 알 수 없는(미지) code — 여전히 None(이 함수의 관할 밖). 새 code를 이 family에
-  넣는 것은 항상 PO 確定을 거친다(추측으로 넓히지 않는다)."""
+  넣는 것은 항상 PO 確定을 거친다(추측으로 넓히지 않는다).
+
+⛔story #3605 CHANGES-1(유나 코드 리뷰 재확認, 페드루 PO 채택 2026-09-07) —
+family 문을 `error_type == "OAuthException"` 단독으로도 열던 자리(원래 #3598
+코드 그대로 물려받은 것)가 심각한 자해 잠금이었다. Graph는 한도 초과(4·17·32·
+613)·잘못된 파라미터(100)·일시 장애(1·2) 등 **이 family가 전혀 아닌 오류도
+전부 `type: "OAuthException"`으로 싣는다**(Meta 오류 응답 형 — code만이 실제로
+그 오류의 «종류»를 가른다, type은 그 아래 인증 관련 하위체계 전체의 공통
+포장지에 가깝다). type 단독 통과를 열어 두면 한도 초과 한 번이 "error"로
+떨어져 CHANNEL_CONNECTION_AUTH_ERROR→CONNECTION kind→connection.status="error"
+→ 화면이 "다시 연결"을 요구하는 자해 잠금이 된다(정확히 이 스토리 §37~44가
+막으려던 그 시나리오를 이 스토리 자신이 다시 열어 놨던 것).
+
+처방 — family 판정은 **code 소속으로만**(190 / 10 / 200..299), type은 더 이상
+문을 여는 조건이 아니다(190 밖에서 type만 보고 통과시키는 경로 삭제). 한도
+초과 코드는 판정 맨 앞에서 명시적으로 걸러 그 사실 자체를 코드로 고정한다
+(`_RATE_LIMIT_CODES`를 정의만 하고 실제로 읽지 않던 것도 이 정정으로 해소)."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -54,44 +70,49 @@ if TYPE_CHECKING:
 _EXPIRED_SUBCODES = frozenset({463})
 _REVOKED_SUBCODES = frozenset({458, 460, 467, 490})
 
-_OAUTH_ERROR_TYPE = "OAuthException"
 _OAUTH_ERROR_CODE = 190
 
 # story #3605 — code==10(권한 없음)·200~299(permission error 대역)도 이 family에
-# 속한다(그라운딩: Meta 문서 인용은 이 모듈 docstring 참고). ⛔rate-limit 코드
-# (4·17·32·613)는 이 범위 밖이라는 사실 자체가 이 family를 좁게 유지하는 방어선 —
-# 새 코드를 이 상수들에 추가할 때마다 rate-limit 코드와 안 겹치는지 재확認할 것.
+# 속한다(그라운딩: Meta 문서 인용은 이 모듈 docstring 참고).
 _PERMISSION_ERROR_CODE = 10
 _PERMISSION_ERROR_RANGE = range(200, 300)
+# story #3605 CHANGES-1 — 이 family에서 명시적으로 배제하는 한도 초과 코드.
+# classify_graph_oauth_error 맨 앞에서 실제로 읽는다(#3605 원판은 이 상수를
+# 정의만 하고 어디서도 참조하지 않아 «검증된 배제»가 아니라 «문서 주장」에
+# 불과했다 — 유나 코드 리뷰가 이 갭을 실측으로 잡았다).
 _RATE_LIMIT_CODES = frozenset({4, 17, 32, 613})
 
 
 def classify_graph_oauth_error(
     *, error_code: int | None, error_subcode: int | None, error_type: str | None,
 ) -> tuple[str, str] | None:
-    """Graph API 오류 응답의 `error.code`·`error.error_subcode`·`error.type`을
-    연결 (status, reason) 튜플로 매핑한다 — 둘 다 "expired"|"revoked"|"error" 중
-    하나(GA4 커넥션의 status/reason 어휘, story #3583과 같은 축).
+    """Graph API 오류 응답의 `error.code`·`error.error_subcode`를 연결 (status,
+    reason) 튜플로 매핑한다 — 둘 다 "expired"|"revoked"|"error" 중 하나(GA4
+    커넥션의 status/reason 어휘, story #3583과 같은 축).
 
-    code==190·type=="OAuthException"·code==10·code in 200..299 중 어느 것도
-    아니면 이 함수의 관할이 아니라 None을 반환한다 — 이 오류가 아예 이 family가
-    아니라는 뜻이므로 호출부가 별도 분류(429 rate limit, 5xx provider 오류 등)로
-    넘어가야 한다."""
-    is_oauth_family = error_code == _OAUTH_ERROR_CODE or error_type == _OAUTH_ERROR_TYPE
-    is_permission_family = (
-        error_code == _PERMISSION_ERROR_CODE or error_code in _PERMISSION_ERROR_RANGE
-    )
-    if not is_oauth_family and not is_permission_family:
+    story #3605 CHANGES-1 — family 판정은 **code 소속으로만**(190 / 10 /
+    200..299) 이뤄진다. `error_type`은 더 이상 문을 여는 조건이 아니다(파라미터
+    자체는 그대로 받되 판정에 안 쓴다 — 호출부 시그니처 무변경, 회귀 0) — Graph가
+    한도 초과·파라미터 오류 등 이 family가 전혀 아닌 오류도 전부 `type:
+    "OAuthException"`으로 싣기 때문(모듈 docstring ⛔ 참고). 한도 초과 코드는
+    맨 앞에서 명시적으로 배제한다.
+
+    code==190·10·200..299 중 어느 것도 아니면(한도 초과 코드 포함) 이 함수의
+    관할이 아니라 None을 반환한다 — 호출부가 별도 분류(429 rate limit, 5xx
+    provider 오류 등)로 넘어가야 한다."""
+    if error_code in _RATE_LIMIT_CODES:
         return None
-    # story #3605 — permission family(10·200~299)는 subcode 체계가 190처럼
-    # 표준화돼 있지 않아 항상 error(사유 불명, fail-closed)로만 떨어진다 — expired/
-    # revoked 세분화는 190 전용(아래 subcode 매핑은 여기 안 닿는다).
-    if is_oauth_family:
+    if error_code == _OAUTH_ERROR_CODE:
         if error_subcode in _EXPIRED_SUBCODES:
             return "expired", "expired"
         if error_subcode in _REVOKED_SUBCODES:
             return "revoked", "revoked"
-    return "error", "error"
+        return "error", "error"
+    # story #3605 — permission family(10·200~299)는 subcode 체계가 190처럼
+    # 표준화돼 있지 않아 항상 error(사유 불명, fail-closed)로만 떨어진다.
+    if error_code == _PERMISSION_ERROR_CODE or error_code in _PERMISSION_ERROR_RANGE:
+        return "error", "error"
+    return None
 
 
 def classify_graph_error_code(
@@ -136,6 +157,32 @@ CONNECTION_ERROR_CODE_TO_STATUS: dict[str, str] = {
 }
 
 
+def sticky_connection_status(current: str, new: str) -> str:
+    """story #3605 CHANGES-2(유나 §13-9 ④-2, 페드루 PO 채택 2026-09-07) — connection.
+    status가 "되돌아가지 않는다"는 사실 하나를 이 함수 하나로 고정한다. 이 규율이
+    한때 두 곳에 따로 구현돼 있었다(`connection_status_for_error_code`는 expired·
+    revoked를 서로도 안 덮게 sticky했는데, `channel_connection.apply_connection_
+    failure`는 `status=="error"`일 때만 막고 expired↔revoked는 서로 덮게 뒀다 —
+    같은 사실을 두 규칙으로 말하면 하나는 거짓이다). 이제 두 소비처 다 이 함수만
+    쓴다.
+
+    규율(유나 표 그대로 — 「active 아니면 그대로」로 줄이면 error→expired 승급이
+    죽는다, 반드시 3구간):
+    - current가 "active"(첫 실패)면 new를 그대로 쓴다.
+    - current가 "error"(사유 불명)면, new가 "error"가 아닌 한(더 구체적인 정보)
+      그 값으로 올린다 — "error"→"error"는 그대로 무해.
+    - current가 "expired" 또는 "revoked"(이미 확정된 구체적 사실)면 new가
+      무엇이든 절대 안 바꾼다 — 이 둘은 서로도 안 덮는다. status="active"로
+      되돌리는 대입(재연결 upsert·자격 교체·apply_refresh_result)이 전부
+      last_error=None까지 같이 지우므로, 이 얼음은 한 실패 국면 안에서만 서고
+      "지금도 실패하나"는 last_error{code,message,at}가 진다(#3960)."""
+    if current in ("revoked", "expired"):
+        return current
+    if current == "error" and new == "error":
+        return current
+    return new
+
+
 def connection_status_for_error_code(error_code: str | None, *, current_status: str) -> str:
     """story #3605 — connection.status 승격 지점 4곳(publication_command.py::
     apply_command_failure·channel_post_comments.py::_promote_connection_status·
@@ -143,27 +190,10 @@ def connection_status_for_error_code(error_code: str | None, *, current_status: 
     자리)이 전부 이 함수 하나로 값을 고른다. 이전엔 4곳 전부 error_code를 무시하고
     항상 "expired"로 하드코딩돼 있어, CHANNEL_CONNECTION_REVOKED/CHANNEL_CONNECTION_
     AUTH_ERROR가 이 분기에 와도 "expired"로 뭉개지는 결함이 반복됐다(3605 실측
-    그라운딩 — 등재만 하고 이 매핑을 안 고치면 반쪽 수리라는 교훈).
-
-    ⚠️정밀도 규율(기존 4곳의 `not in ("revoked", "error")` 가드를 일반화한 것,
-    새 기전 발명 아님 — 목표 status가 여럿으로 늘어난 이 스토리에서 그 가드를
-    그대로 옮기다 처음엔 "error"만 보호하도록 좁게 썼다가, 기존 테스트(연결이
-    이미 revoked인데 다른 코드가 "expired"로 매핑되는 경우 그대로 revoked로
-    남아야 한다 — test_3597_ig_fb_connection_status_promote.py::test_facebook_
-    connection_failure_does_not_downgrade_revoked_or_error)가 그 좁힘이 회귀임을
-    실측으로 잡았다):
-    - current_status가 "revoked" 또는 "expired"(이미 확정된 구체적 사실)면 새
-      값이 무엇이든 절대 안 바꾼다 — 이 둘은 서로도 안 덮는다(기존 프로덕션 코드가
-      "expired" 하나만 목표값이던 시절부터 지켜 온 그대로의 sticky 규율).
-    - current_status가 "error"(사유 불명)면, 새 값이 "error"가 아닌 한(더 구체적인
-      정보) 그 값으로 올린다 — "error"→"error"는 그대로 무해.
-    - current_status가 "active"(첫 실패)면 새 값을 그대로 쓴다."""
+    그라운딩 — 등재만 하고 이 매핑을 안 고치면 반쪽 수리라는 교훈). 되돌아가지
+    않기 규율 자체는 `sticky_connection_status`(공유 단일 지점, CHANGES-2)."""
     new_status = CONNECTION_ERROR_CODE_TO_STATUS.get(error_code, "expired")
-    if current_status in ("revoked", "expired"):
-        return current_status
-    if current_status == "error" and new_status == "error":
-        return current_status
-    return new_status
+    return sticky_connection_status(current_status, new_status)
 
 
 def parse_graph_error_envelope(resp: "httpx.Response") -> tuple[int | None, int | None, str | None]:

--- a/backend/app/services/graph_api_errors.py
+++ b/backend/app/services/graph_api_errors.py
@@ -22,14 +22,48 @@ subcode 그라운딩(PO 코드 확認 2026-09-06 15:36Z, 스토리 본문 確定
   단정하지 않는다 — AC6 「알 수 없는 오류는 CONNECTION kind로 fail-closed, reason만
   모른다」와 같은 원칙).
 - code!=190 이고 type!="OAuthException"이면 이 함수의 관할이 아니다(None) — 호출부가
-  429/5xx 등 다른 분류로 넘어간다."""
+  429/5xx 등 다른 분류로 넘어간다.
+
+story #3605(3598 AC6 일반화, PO 確定 2026-09-07 · 유나 §22-16류 6-정정 「한 방향
+문」) — Graph API 권한/인증 계열 오류 family를 190/OAuthException 밖으로 넓힌다:
+- code==10(Meta 문서: "Application does not have permission for this action" —
+  앱 자체가 그 액션에 필요한 권한이 없다는 뜻, OAuthException과는 다른 최상위
+  error.code지만 같은 「사람이 재연결/재승인해야 풀리는」 계열) → error(사유
+  세분화 불가 — 10은 subcode 체계가 190처럼 표준화돼 있지 않아 expired/revoked를
+  섣불리 못 가른다, fail-closed).
+- code in 200..299(Meta 문서: 이 대역 전체가 "Permission error" 계열 — 페이지
+  권한 부족·필요 확장 권한 없음 등 세부 code가 다양해 여기서 전부 개별 매핑하지
+  않는다) → error(같은 이유로 세분화 불가, fail-closed).
+- ⛔한도 초과(rate limit) 코드는 이 family가 «아니다» — 4(Application request
+  limit reached)·17(User request limit reached)·32(Page request limit
+  reached)·613(Calls to this api have exceeded the rate limit) 전부 200..299
+  밖이라 구조적으로 이 함수에 안 걸린다(우연이 아니라 검증됨 — 아래 테스트).
+  「연결 상태 승격은 사람이 고칠 수 있는 원인에만」(재연결) — 한도 초과는 시간이
+  지나면 스스로 풀리는 별도 축이라 절대 이 family에 넣지 않는다(한 방향 문 —
+  되돌아오는 길이 사람뿐이므로 사람이 못 고치는 원인을 넣으면 조직이 스스로
+  잠긴다).
+- 알 수 없는(미지) code — 여전히 None(이 함수의 관할 밖). 새 code를 이 family에
+  넣는 것은 항상 PO 確定을 거친다(추측으로 넓히지 않는다)."""
 from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import httpx
 
 _EXPIRED_SUBCODES = frozenset({463})
 _REVOKED_SUBCODES = frozenset({458, 460, 467, 490})
 
 _OAUTH_ERROR_TYPE = "OAuthException"
 _OAUTH_ERROR_CODE = 190
+
+# story #3605 — code==10(권한 없음)·200~299(permission error 대역)도 이 family에
+# 속한다(그라운딩: Meta 문서 인용은 이 모듈 docstring 참고). ⛔rate-limit 코드
+# (4·17·32·613)는 이 범위 밖이라는 사실 자체가 이 family를 좁게 유지하는 방어선 —
+# 새 코드를 이 상수들에 추가할 때마다 rate-limit 코드와 안 겹치는지 재확認할 것.
+_PERMISSION_ERROR_CODE = 10
+_PERMISSION_ERROR_RANGE = range(200, 300)
+_RATE_LIMIT_CODES = frozenset({4, 17, 32, 613})
 
 
 def classify_graph_oauth_error(
@@ -39,13 +73,118 @@ def classify_graph_oauth_error(
     연결 (status, reason) 튜플로 매핑한다 — 둘 다 "expired"|"revoked"|"error" 중
     하나(GA4 커넥션의 status/reason 어휘, story #3583과 같은 축).
 
-    code==190이 아니고 type도 "OAuthException"이 아니면 이 함수의 관할이 아니라
-    None을 반환한다 — 이 오류가 아예 OAuth/권한 계열이 아니라는 뜻이므로 호출부가
-    별도 분류(429 rate limit, 5xx provider 오류 등)로 넘어가야 한다."""
-    if error_code != _OAUTH_ERROR_CODE and error_type != _OAUTH_ERROR_TYPE:
+    code==190·type=="OAuthException"·code==10·code in 200..299 중 어느 것도
+    아니면 이 함수의 관할이 아니라 None을 반환한다 — 이 오류가 아예 이 family가
+    아니라는 뜻이므로 호출부가 별도 분류(429 rate limit, 5xx provider 오류 등)로
+    넘어가야 한다."""
+    is_oauth_family = error_code == _OAUTH_ERROR_CODE or error_type == _OAUTH_ERROR_TYPE
+    is_permission_family = (
+        error_code == _PERMISSION_ERROR_CODE or error_code in _PERMISSION_ERROR_RANGE
+    )
+    if not is_oauth_family and not is_permission_family:
         return None
-    if error_subcode in _EXPIRED_SUBCODES:
-        return "expired", "expired"
-    if error_subcode in _REVOKED_SUBCODES:
-        return "revoked", "revoked"
+    # story #3605 — permission family(10·200~299)는 subcode 체계가 190처럼
+    # 표준화돼 있지 않아 항상 error(사유 불명, fail-closed)로만 떨어진다 — expired/
+    # revoked 세분화는 190 전용(아래 subcode 매핑은 여기 안 닿는다).
+    if is_oauth_family:
+        if error_subcode in _EXPIRED_SUBCODES:
+            return "expired", "expired"
+        if error_subcode in _REVOKED_SUBCODES:
+            return "revoked", "revoked"
     return "error", "error"
+
+
+def classify_graph_error_code(
+    *, status_code: int, provider_error_code: int | None, provider_error_subcode: int | None,
+    provider_error_type: str | None,
+) -> str:
+    """story #3605 — `classify_graph_oauth_error`의 결과를 이 코드베이스의 공유
+    error_code 문자열(`publication_command.py::classify_failure_kind`가 아는
+    어휘)로 옮기는 단일 지점. IG/FB/Threads 발행(`channel_posts.py::
+    _classify_threads_error`)과 댓글 수집(`channel_post_comments.py`, 이전엔 각자
+    401/403만 보고 따로 판정하던 걸 이 스토리에서 하나로 합침) 둘 다 이 함수 하나를
+    쓴다 — 같은 Graph 오류가 소비처에 따라 다른 kind로 갈리는 드리프트를 원천
+    차단한다(story #3405/#3406과 동일 사상, "판정 로직 두 곳에 각자 안 짠다").
+
+    파서가 관할 밖(None)이면 기존 401/403/429 상태코드 휴리스틱으로 폴백 —
+    비-Meta 오류·malformed body 대비(회귀 0)."""
+    oauth_reason = classify_graph_oauth_error(
+        error_code=provider_error_code, error_subcode=provider_error_subcode, error_type=provider_error_type,
+    )
+    if oauth_reason is not None:
+        status, _reason = oauth_reason
+        if status == "expired":
+            return "CHANNEL_TOKEN_EXPIRED"
+        if status == "revoked":
+            return "CHANNEL_CONNECTION_REVOKED"
+        return "CHANNEL_CONNECTION_AUTH_ERROR"
+    if status_code in (401, 403):
+        return "CHANNEL_TOKEN_EXPIRED"
+    if status_code == 429:
+        return "CHANNEL_RATE_LIMITED"
+    return "CHANNEL_PUBLISH_PROVIDER_ERROR"
+
+
+# story #3605 — CONNECTION kind로 승격할 때 ChannelConnection.status(active|expired|
+# revoked|error)를 어떤 값으로 남길지. 매핑 밖 코드(CHANNEL_TOKEN_EXPIRED·
+# CHANNEL_CONNECTION_NOT_ACTIVE·CHANNEL_PUBLISH_AUTH_REJECTED 등, wordpress/webhook
+# 등 Graph 밖 도메인 포함)는 기존 그대로 "expired"(회귀 0) — 이 스토리에서 새로
+# 추가한 두 코드만 정확한 값을 갖는다.
+CONNECTION_ERROR_CODE_TO_STATUS: dict[str, str] = {
+    "CHANNEL_CONNECTION_REVOKED": "revoked",
+    "CHANNEL_CONNECTION_AUTH_ERROR": "error",
+}
+
+
+def connection_status_for_error_code(error_code: str | None, *, current_status: str) -> str:
+    """story #3605 — connection.status 승격 지점 4곳(publication_command.py::
+    apply_command_failure·channel_post_comments.py::_promote_connection_status·
+    insight_snapshots.py::_promote_connection_status_for_snapshot·향후 추가될
+    자리)이 전부 이 함수 하나로 값을 고른다. 이전엔 4곳 전부 error_code를 무시하고
+    항상 "expired"로 하드코딩돼 있어, CHANNEL_CONNECTION_REVOKED/CHANNEL_CONNECTION_
+    AUTH_ERROR가 이 분기에 와도 "expired"로 뭉개지는 결함이 반복됐다(3605 실측
+    그라운딩 — 등재만 하고 이 매핑을 안 고치면 반쪽 수리라는 교훈).
+
+    ⚠️정밀도 규율(기존 4곳의 `not in ("revoked", "error")` 가드를 일반화한 것,
+    새 기전 발명 아님 — 목표 status가 여럿으로 늘어난 이 스토리에서 그 가드를
+    그대로 옮기다 처음엔 "error"만 보호하도록 좁게 썼다가, 기존 테스트(연결이
+    이미 revoked인데 다른 코드가 "expired"로 매핑되는 경우 그대로 revoked로
+    남아야 한다 — test_3597_ig_fb_connection_status_promote.py::test_facebook_
+    connection_failure_does_not_downgrade_revoked_or_error)가 그 좁힘이 회귀임을
+    실측으로 잡았다):
+    - current_status가 "revoked" 또는 "expired"(이미 확정된 구체적 사실)면 새
+      값이 무엇이든 절대 안 바꾼다 — 이 둘은 서로도 안 덮는다(기존 프로덕션 코드가
+      "expired" 하나만 목표값이던 시절부터 지켜 온 그대로의 sticky 규율).
+    - current_status가 "error"(사유 불명)면, 새 값이 "error"가 아닌 한(더 구체적인
+      정보) 그 값으로 올린다 — "error"→"error"는 그대로 무해.
+    - current_status가 "active"(첫 실패)면 새 값을 그대로 쓴다."""
+    new_status = CONNECTION_ERROR_CODE_TO_STATUS.get(error_code, "expired")
+    if current_status in ("revoked", "expired"):
+        return current_status
+    if current_status == "error" and new_status == "error":
+        return current_status
+    return new_status
+
+
+def parse_graph_error_envelope(resp: "httpx.Response") -> tuple[int | None, int | None, str | None]:
+    """story #3605 — Graph 표준 오류 envelope(`{"error": {"code","error_subcode",
+    "type",...}}`)에서 3필드를 뽑는다. threads_publish.py::error_from_response의
+    내부 파싱 로직을 그대로 옮긴 것(새 판정 로직 0) — 그 함수는 이제 이 함수를
+    호출해 `ThreadsPublishError`를 조립하고, insight_snapshots.py의 3개 fetch
+    함수(_fetch_threads·_fetch_instagram·_fetch_facebook — 이전엔 `resp.json()`의
+    `error` 키를 아예 안 읽고 status_code만 보던 자리)도 이 함수로 직접 envelope을
+    읽는다. envelope이 없거나(malformed body·비-JSON 응답) `error` 키가 dict가
+    아니면 3필드 전부 None — 지어내지 않는다(호출부의 기존 status_code 휴리스틱
+    폴백이 그 경우를 계속 담당)."""
+    code: int | None = None
+    subcode: int | None = None
+    error_type: str | None = None
+    try:
+        err: Any = resp.json().get("error")
+    except Exception:
+        err = None
+    if isinstance(err, dict):
+        code = err.get("code")
+        subcode = err.get("error_subcode")
+        error_type = err.get("type")
+    return code, subcode, error_type

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -232,6 +232,21 @@ async def _fetch_threads(client: "httpx.AsyncClient", *, access_token: str, medi
         _THREADS_INSIGHTS_URL_TMPL.format(media_id=media_id),
         params={"metric": _THREADS_INSIGHTS_METRICS, "access_token": access_token},
     )
+    if resp.status_code >= 400:
+        # story #3605 — 401/403 뭉뚱그림을 Graph envelope 파싱으로 먼저 세분화한다
+        # (code==190/OAuthException·10·200~299 family). 이 family 밖(None)이면
+        # 기존 status_code 휴리스틱(아래)이 그대로 유일한 판정 근거 — 403의
+        # CHANNEL_PUBLISH_AUTH_REJECTED류 기존 분류는 안 건드린다(회귀 0).
+        from app.services.graph_api_errors import classify_graph_oauth_error, parse_graph_error_envelope
+
+        _code, _subcode, _type = parse_graph_error_envelope(resp)
+        oauth_reason = classify_graph_oauth_error(error_code=_code, error_subcode=_subcode, error_type=_type)
+        if oauth_reason is not None:
+            _status, _ = oauth_reason
+            _error_code = {
+                "expired": "CHANNEL_TOKEN_EXPIRED", "revoked": "CHANNEL_CONNECTION_REVOKED",
+            }.get(_status, "CHANNEL_CONNECTION_AUTH_ERROR")
+            raise InsightFetchError(error_code=_error_code, message=f"Threads 인사이트 인증 오류: {resp.text[:500]}")
     if resp.status_code == 401:
         raise InsightFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message="Threads 액세스 토큰이 만료되었습니다")
     if resp.status_code == 429:
@@ -284,6 +299,19 @@ async def _fetch_instagram(client: "httpx.AsyncClient", *, access_token: str, me
         _INSTAGRAM_INSIGHTS_URL_TMPL.format(media_id=media_id),
         params={"metric": _INSTAGRAM_INSIGHTS_METRICS, "access_token": access_token},
     )
+    if resp.status_code >= 400:
+        # story #3605 — _fetch_threads와 동형(Graph envelope 파싱 우선, 밖이면
+        # 기존 status_code 휴리스틱 폴백, 회귀 0).
+        from app.services.graph_api_errors import classify_graph_oauth_error, parse_graph_error_envelope
+
+        _code, _subcode, _type = parse_graph_error_envelope(resp)
+        oauth_reason = classify_graph_oauth_error(error_code=_code, error_subcode=_subcode, error_type=_type)
+        if oauth_reason is not None:
+            _status, _ = oauth_reason
+            _error_code = {
+                "expired": "CHANNEL_TOKEN_EXPIRED", "revoked": "CHANNEL_CONNECTION_REVOKED",
+            }.get(_status, "CHANNEL_CONNECTION_AUTH_ERROR")
+            raise InsightFetchError(error_code=_error_code, message=f"Instagram 인사이트 인증 오류: {resp.text[:500]}")
     if resp.status_code == 401:
         raise InsightFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message="Instagram 액세스 토큰이 만료되었습니다")
     if resp.status_code == 429:
@@ -364,6 +392,19 @@ async def _fetch_facebook(client: "httpx.AsyncClient", *, access_token: str, med
         _FACEBOOK_INSIGHTS_URL_TMPL.format(post_id=media_id),
         params={"metric": _FACEBOOK_INSIGHTS_METRICS, "access_token": access_token},
     )
+    if resp.status_code >= 400:
+        # story #3605 — _fetch_threads와 동형(Graph envelope 파싱 우선, 밖이면
+        # 기존 status_code 휴리스틱 폴백, 회귀 0).
+        from app.services.graph_api_errors import classify_graph_oauth_error, parse_graph_error_envelope
+
+        _code, _subcode, _type = parse_graph_error_envelope(resp)
+        oauth_reason = classify_graph_oauth_error(error_code=_code, error_subcode=_subcode, error_type=_type)
+        if oauth_reason is not None:
+            _status, _ = oauth_reason
+            _error_code = {
+                "expired": "CHANNEL_TOKEN_EXPIRED", "revoked": "CHANNEL_CONNECTION_REVOKED",
+            }.get(_status, "CHANNEL_CONNECTION_AUTH_ERROR")
+            raise InsightFetchError(error_code=_error_code, message=f"Facebook 인사이트 인증 오류: {resp.text[:500]}")
     if resp.status_code == 401:
         raise InsightFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message="Facebook 액세스 토큰이 만료되었습니다")
     if resp.status_code == 429:
@@ -557,11 +598,20 @@ async def _promote_connection_status_for_snapshot(
     threads 경로뿐).
 
     story #3603(Phase2·BE·소형·결함, 페드루 PO 確定 2026-09-07) — channel_post_
-    comments.py::_promote_connection_status와 동형 last_error 3종 additive."""
+    comments.py::_promote_connection_status와 동형 last_error 3종 additive
+    (status의 sticky 여부와 무관하게 last_error_code·last_error_at은 항상 갱신).
+
+    story #3605(실측 정정) — error_code 무관하게 항상 "expired"로 굳혔던 것을
+    바로잡는다(channel_post_comments.py::_promote_connection_status·publication_
+    command.py::apply_command_failure와 같은 결함 클래스, 같은 스토리에서 같이
+    고침). `graph_api_errors.sticky_connection_status`(공유 단일 지점, CHANGES-2)
+    가 정확한 status를 고른다 — #3603의 `not in ("revoked", "error")` 가드를 이
+    함수가 대체한다(expired도 이제 동등하게 sticky)."""
     from datetime import datetime, timezone
 
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
+    from app.services.graph_api_errors import connection_status_for_error_code
 
     if snapshot.publication_kind != "channel_publication":
         return
@@ -571,12 +621,13 @@ async def _promote_connection_status_for_snapshot(
     if pub is None:
         return
     connection = await db.get(ChannelConnection, pub.connection_id)
-    if connection is not None and connection.status not in ("revoked", "error"):
-        connection.status = "expired"
-        if message is not None:
-            connection.last_error = message[:2000]
-        connection.last_error_code = error_code
-        connection.last_error_at = datetime.now(timezone.utc)
+    if connection is None:
+        return
+    connection.status = connection_status_for_error_code(error_code, current_status=connection.status)
+    if message is not None:
+        connection.last_error = message[:2000]
+    connection.last_error_code = error_code
+    connection.last_error_at = datetime.now(timezone.utc)
 
 
 _GA4_RUN_REPORT_URL_TMPL = "https://analyticsdata.googleapis.com/v1beta/properties/{property_id}:runReport"

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -61,6 +61,11 @@ _CONNECTION_BLOCKED_CODES = frozenset({
     # 승격하고 무한 백오프 재시도 대신 사람의 재연결을 기다린다(site_posts.py::
     # publish_site_post_external_command가 상태코드 401/403일 때만 이 코드를 쓴다).
     "CHANNEL_PUBLISH_AUTH_REJECTED",
+    # story #3605(실측 정정) — #3598이 신설한 두 코드가 이 집합에 빠져 있었다(발행
+    # 워커 경로에서 이 error_code로는 classify_failure_kind가 needs_check로 떨어져,
+    # connection.status가 첫 실패에도 즉시 승격되지 않고 재시도 상한까지 기다리는
+    # 결함이었다 — CHANNEL_TOKEN_EXPIRED와 대칭이 안 맞았다).
+    "CHANNEL_CONNECTION_REVOKED", "CHANNEL_CONNECTION_AUTH_ERROR",
 })
 # story 620beefc(PO 決定, 2026-09-04) — IMAGE 컨테이너가 Threads 쪽에서 ERROR/EXPIRED로
 # 끝났다. 폴링을 몇 번 더 반복해도 같은 결과이므로(결정적) transient 백오프가 아니라
@@ -264,7 +269,9 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
 
     from app.models.channel_post_version import ChannelPostVersion
     from app.services.channel_posts import (
+        ChannelConnectionAuthError,
         ChannelConnectionNotActiveError,
+        ChannelConnectionRevokedError,
         ChannelImageContainerFailedError,
         ChannelPostDraftNotFoundError,
         ChannelPostReapprovalRequiredError,
@@ -368,6 +375,16 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
         error_code, last_error = "CHANNEL_TEXT_TOO_LONG", str(exc)
     except ChannelConnectionNotActiveError as exc:
         error_code, last_error = "CHANNEL_CONNECTION_NOT_ACTIVE", str(exc)
+    # story #3605(실측 정정) — ChannelConnectionRevokedError·ChannelConnectionAuthError
+    # 둘 다 ChannelTokenExpiredError의 서브클래스(신규 except 절 없이 기존 라우터가
+    # 계속 잡는다는 설계, #3598)라 Python except 순서상 **부모보다 먼저** 와야 한다
+    # — 순서가 바뀌면 부모 절이 먼저 잡아 아래 하드코딩된 "CHANNEL_TOKEN_EXPIRED"
+    # 문자열로 뭉개진다(이 워커 경로가 정확히 이 함정에 있었다 — revoked/error가
+    # 전부 "expired"로 오분류되던 실사고, 3605 그라운딩).
+    except ChannelConnectionRevokedError as exc:
+        error_code, last_error = "CHANNEL_CONNECTION_REVOKED", str(exc)
+    except ChannelConnectionAuthError as exc:
+        error_code, last_error = "CHANNEL_CONNECTION_AUTH_ERROR", str(exc)
     except ChannelTokenExpiredError as exc:
         error_code, last_error = "CHANNEL_TOKEN_EXPIRED", str(exc)
     except ChannelRateLimitedError as exc:
@@ -643,15 +660,24 @@ async def apply_command_failure(
         # "quota_exceeded" 상태값은 죽은 코드였다(CHANNEL_RATE_LIMITED는 _TRANSIENT_
         # CODES라 애초에 이 분기(connection)에 못 옴 — 아래처럼 백오프 재시도로 간다).
         # ChannelConnection.status enum(active|expired|revoked|error)에도 없는 값이라
-        # 제거. 이미 revoked/error로 더 구체적인 종결 상태면 그걸 expired로 덮어쓰지
-        # 않는다(더 약한 정보로 되돌리지 않기).
+        # 제거.
+        #
+        # story #3605(실측 정정) — error_code 무관하게 항상 "expired"로 굳혔던 것을
+        # 바로잡는다. CHANNEL_CONNECTION_REVOKED·CHANNEL_CONNECTION_AUTH_ERROR가
+        # 이 분기에 오도록(_CONNECTION_BLOCKED_CODES 등재) 이 스토리에서 처음
+        # 고쳤으므로, 여기서 status 자체도 그 error_code에 맞게 골라야 한다(안 그러면
+        # "revoked"가 이 경로를 타는 순간 다시 "expired"로 뭉개진다 — 등재만 하고
+        # 이 매핑을 안 고치면 반쪽 수리). graph_api_errors.connection_status_for_
+        # error_code가 이 판정을 3곳(여기·channel_post_comments.py::_promote_
+        # connection_status·insight_snapshots.py::_promote_connection_status_
+        # for_snapshot)과 공유하는 단일 지점이다.
         from app.models.channel_connection import ChannelConnection
+        from app.services.graph_api_errors import connection_status_for_error_code
 
         connection = await db.get(ChannelConnection, command.destination)
         if connection is not None:
             connection.last_error = (last_error or "")[:2000]
-            if connection.status not in ("revoked", "error"):
-                connection.status = "expired"
+            connection.status = connection_status_for_error_code(error_code, current_status=connection.status)
         command.status = "blocked"
         return
 

--- a/backend/app/services/sandbox_publish.py
+++ b/backend/app/services/sandbox_publish.py
@@ -40,6 +40,12 @@
   =467(앱이 꺼지면 그 앱으로 발급된 토큰이 "무효"가 된다는 해석). 셋 다 classify_graph_
   oauth_error 안에서는 동일하게 "revoked"로 수렴한다(현재 reason 어휘가 expired|
   revoked|error 3종뿐이라 그 이상 세분화할 자리가 없다 — 어휘가 늘면 재배정).
+- `[sandbox:permission-error]`(story #3605, 3598 AC6 일반화 시뮬레이션) — `create_
+  container`가 401로 실패하되 `provider_error_code=10`(type 없음 — code==10은
+  190과 달리 OAuthException 타입 표기 없이도 이 family에 걸린다, 그라운딩:
+  graph_api_errors.py 모듈 docstring)을 실어 `classify_graph_oauth_error`가
+  "error"(사유 불명, CHANNEL_CONNECTION_AUTH_ERROR)로 분류하게 한다 — 190 밖의
+  family가 실제로 fail-closed 승격되는지 확인하는 마커.
 - `[sandbox:container-error]` — 컨테이너 생성 자체는 성공하지만, 폴링(get_container_
   status)이 ERROR를 낸다(AC3 "컨테이너 ERROR"). ⚠️**이미지 첨부 초안 전용** — 오케스트
   레이션(channel_posts.py::publish_channel_post_draft)이 `has_image`일 때만 폴링을
@@ -79,6 +85,8 @@ _MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
 _MARKER_REVOKED = "[sandbox:revoked]"
 _MARKER_PAGE_UNLINKED = "[sandbox:page-unlinked]"
 _MARKER_APP_INACTIVE = "[sandbox:app-inactive]"
+# story #3605 — 190 밖 family(code==10)의 fail-closed 승격 시뮬레이션.
+_MARKER_PERMISSION_ERROR = "[sandbox:permission-error]"
 _MARKER_CONTAINER_ERROR = "[sandbox:container-error]"
 _MARKER_CONTAINER_SLOW = "[sandbox:container-slow]"
 # story #3516 AC8(페드루 PO 確定 2026-09-05) — 라이브 런북 재료. 댓글 수집 리컨실
@@ -158,6 +166,11 @@ async def create_container(
         raise ThreadsPublishError(
             "SANDBOX_APP_INACTIVE", "sandbox: [sandbox:app-inactive] 마커 시뮬레이션", status_code=401,
             provider_error_code=190, provider_error_subcode=467, provider_error_type="OAuthException",
+        )
+    if _MARKER_PERMISSION_ERROR in text:
+        raise ThreadsPublishError(
+            "SANDBOX_PERMISSION_ERROR", "sandbox: [sandbox:permission-error] 마커 시뮬레이션", status_code=401,
+            provider_error_code=10, provider_error_subcode=None, provider_error_type=None,
         )
 
     mode = "error" if _MARKER_CONTAINER_ERROR in text else "ok"

--- a/backend/app/services/threads_publish.py
+++ b/backend/app/services/threads_publish.py
@@ -54,18 +54,14 @@ def error_from_response(code: str, resp: httpx.Response) -> ThreadsPublishError:
     """story #3598 — `resp.text[:500]`/`resp.status_code`는 기존 그대로(회귀 0), Graph
     표준 오류 envelope이 파싱되면 `.provider_error_*` 3필드도 함께 채운다. envelope이
     없거나(malformed body·비-JSON 응답) `error` 키가 dict가 아니면 3필드 전부 None —
-    지어내지 않는다(기존 401/403 휴리스틱 폴백이 그 경우를 계속 담당)."""
-    provider_error_code: int | None = None
-    provider_error_subcode: int | None = None
-    provider_error_type: str | None = None
-    try:
-        err = resp.json().get("error")
-    except Exception:
-        err = None
-    if isinstance(err, dict):
-        provider_error_code = err.get("code")
-        provider_error_subcode = err.get("error_subcode")
-        provider_error_type = err.get("type")
+    지어내지 않는다(기존 401/403 휴리스틱 폴백이 그 경우를 계속 담당).
+
+    story #3605 — 실제 파싱은 `graph_api_errors.parse_graph_error_envelope`로
+    옮겼다(insight_snapshots.py의 3개 fetch 함수도 같은 파서를 쓴다, 새 판정
+    로직 0 — 한 곳에서만 envelope 모양을 안다)."""
+    from app.services.graph_api_errors import parse_graph_error_envelope
+
+    provider_error_code, provider_error_subcode, provider_error_type = parse_graph_error_envelope(resp)
     return ThreadsPublishError(
         code, resp.text[:500], status_code=resp.status_code,
         provider_error_code=provider_error_code, provider_error_subcode=provider_error_subcode,

--- a/backend/tests/test_3597_ig_fb_connection_status_promote.py
+++ b/backend/tests/test_3597_ig_fb_connection_status_promote.py
@@ -165,8 +165,11 @@ async def test_facebook_connection_failure_promotes_status_expired(monkeypatch):
 @pytest.mark.anyio
 async def test_facebook_connection_failure_does_not_downgrade_revoked_or_error():
     """기존 규율 불변 — 이미 revoked·error인 연결은 expired로 덮어쓰지 않는다
-    (_promote_connection_status의 `not in ("revoked", "error")` 가드는 이 PR이
-    안 건드린다, 여기서 회귀 0을 고정)."""
+    (story #3605 — `_promote_connection_status`에 `error_code` 인자가 추가되며
+    이 가드가 graph_api_errors.connection_status_for_error_code로 옮겨갔다.
+    여기선 "다른 코드가 expired로 매핑돼도 이미 revoked면 안 바뀐다"는 sticky
+    규율이 여전히 지켜지는지 고정 — 이 스토리 리팩터 中 한 번 실제로 좁혀져서
+    회귀했던 자리, 이 테스트가 그 회귀를 실측으로 잡았다)."""
     from app.services.channel_post_comments import _promote_connection_status
 
     engine, Session = await _session_factory()
@@ -177,7 +180,7 @@ async def test_facebook_connection_failure_does_not_downgrade_revoked_or_error()
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
             await s.commit()
 
-            await _promote_connection_status(s, publication_id=pub.id)
+            await _promote_connection_status(s, publication_id=pub.id, error_code="CHANNEL_TOKEN_EXPIRED")
             await s.commit()
             await s.refresh(conn)
             assert conn.status == "revoked"

--- a/backend/tests/test_3598_classify_threads_error_wiring.py
+++ b/backend/tests/test_3598_classify_threads_error_wiring.py
@@ -13,6 +13,7 @@ import uuid
 import httpx
 
 from app.services.channel_posts import (
+    ChannelConnectionAuthError,
     ChannelConnectionRevokedError,
     ChannelPublishProviderError,
     ChannelTokenExpiredError,
@@ -57,14 +58,17 @@ def test_revoked_error_is_still_a_channel_token_expired_error_so_old_except_clau
     assert isinstance(mapped, ChannelTokenExpiredError)
 
 
-def test_unknown_subcode_under_oauth_exception_falls_through_to_existing_401_heuristic():
-    """code==190/OAuthException인데 subcode가 미지(AC6 이전 — error 버킷은 아직 이
-    분기에서 직접 처리 안 함, 다음 커밋 몫) → 기존 401 휴리스틱으로 폴스루해
-    CHANNEL_TOKEN_EXPIRED(회귀 0, 미분류 revoked/error로 잘못 새지 않는다)."""
+def test_unknown_subcode_under_oauth_exception_classifies_as_auth_error():
+    """story #3605 CHANGES-4(페드루 PO 채택 2026-09-07) — 계약 변경: code==190/
+    OAuthException인데 subcode가 미지면 이제 fail-closed로 CHANNEL_CONNECTION_
+    AUTH_ERROR(사유 불명이지만 인증 계열은 확실 — AC6 원칙 그대로). 옛 계약(이
+    경우를 401 휴리스틱으로 폴스루시켜 CHANNEL_TOKEN_EXPIRED로 뭉뚱그림)은 3605가
+    도입한 code-only family 판정과 맞물려 더는 사실이 아니다 — «미지 subcode»와
+    «순수 401(Graph envelope 없음)»은 이제 서로 다른 낱말이어야 한다."""
     exc = _exc(status_code=401, provider_error_code=190, provider_error_subcode=999, provider_error_type="OAuthException")
     error_code, mapped = _classify_threads_error(exc, connection_id=_CONN_ID)
-    assert error_code == "CHANNEL_TOKEN_EXPIRED"
-    assert type(mapped) is ChannelTokenExpiredError
+    assert error_code == "CHANNEL_CONNECTION_AUTH_ERROR"
+    assert type(mapped) is ChannelConnectionAuthError
 
 
 def test_non_oauth_5xx_error_is_unchanged_provider_error():

--- a/backend/tests/test_3598_graph_oauth_error_parser.py
+++ b/backend/tests/test_3598_graph_oauth_error_parser.py
@@ -52,10 +52,17 @@ def test_non_oauth_error_returns_none_so_caller_falls_through_to_other_classific
     assert classify_graph_oauth_error(error_code=100, error_subcode=None, error_type="GraphMethodException") is None
 
 
-def test_oauth_exception_type_without_code_190_still_matches_by_type_alone():
-    """일부 Graph 응답은 code가 다른 값(예: 200번대)이어도 type=="OAuthException"으로
-    권한 계열임을 알린다 — code만 보고 판단하면 이런 경우를 놓친다(3595 표의 「페이지
-    연결 해제」류가 이 경로로 잡힐 가능성)."""
+def test_type_alone_no_longer_opens_the_family_door_changes_1():
+    """story #3605 CHANGES-1(유나 코드 리뷰, 페드루 PO 채택 2026-09-07) — 이 테스트가
+    한때 검증하던 동작("code가 190이 아니어도 type=='OAuthException'이면 subcode로
+    세분화") 자체가 자해 잠금의 원인이었다: Graph는 한도 초과·파라미터 오류 등
+    이 family가 전혀 아닌 오류도 전부 type: "OAuthException"으로 싣는다 — type
+    단독 통과를 열어 두면 그런 무관한 오류까지 "error"(fail-closed)로 떨어져
+    CONNECTION kind로 승격되는 자해 잠금이 된다. family 판정은 이제 code
+    소속으로만(190/10/200..299) — code=200은 200~299 family에 걸려 "error"로
+    떨어지지만(아래), subcode(463=expired) 기반 세분화는 code==190 전용이라
+    code=200에는 적용되지 않는다(그 세분화 체계 자체가 190 전용이라는 게 이
+    family의 전제 그대로)."""
     assert classify_graph_oauth_error(error_code=200, error_subcode=463, error_type="OAuthException") == (
-        "expired", "expired",
+        "error", "error",
     )

--- a/backend/tests/test_3603_connection_last_error.py
+++ b/backend/tests/test_3603_connection_last_error.py
@@ -183,10 +183,16 @@ async def test_insight_snapshot_connection_failure_fills_last_error_trio(monkeyp
 
 
 @pytest.mark.anyio
-async def test_promote_no_op_leaves_last_error_trio_untouched():
-    """AC2 no-op 불변 — 이미 revoked인 연결은 status도 last_error 3종도 그대로
-    (test_3597_ig_fb_connection_status_promote.py::test_facebook_connection_failure_
-    does_not_downgrade_revoked_or_error와 동형, last_error 3종 축만 추가)."""
+async def test_promote_no_op_keeps_status_but_still_updates_last_error_trio():
+    """story #3605 CHANGES-2(유나 §13-9 ④-2, 페드루 PO 채택 2026-09-07)로 이
+    테스트의 기대값이 갱신됐다 — status는 sticky(이미 revoked면 절대 안 바뀜)지만
+    last_error 3종은 sticky 여부와 무관하게 항상 갱신된다. 근거(PO 원문): status=
+    "active"로 되돌리는 대입 셋(재연결 upsert·자격 교체·apply_refresh_result)이
+    전부 last_error=None까지 같이 지우므로, 얼음은 한 실패 국면 안에서만 서고
+    「지금도 실패하나」는 last_error{code,message,at}가 진다 — status가 얼어
+    있는 동안에도 last_error가 최신 실패를 계속 반영해야 그 역할을 할 수 있다.
+    (원래 이 테스트는 이 트리오도 no-op으로 불변이길 기대했다 — #3605가 그
+    가정 자체를 교정한다.)"""
     from app.models.channel_connection import ChannelConnection
     from app.services.channel_post_comments import _promote_connection_status
 
@@ -199,13 +205,13 @@ async def test_promote_no_op_leaves_last_error_trio_untouched():
             await s.commit()
 
             await _promote_connection_status(
-                s, publication_id=pub.id, error_code="CHANNEL_TOKEN_EXPIRED", message="이 값은 절대 안 들어가야 한다",
+                s, publication_id=pub.id, error_code="CHANNEL_TOKEN_EXPIRED", message="지금도 계속 실패 中",
             )
             await s.commit()
             refreshed = await s.get(ChannelConnection, conn.id)
             assert refreshed.status == "revoked"
-            assert refreshed.last_error is None
-            assert refreshed.last_error_code is None
-            assert refreshed.last_error_at is None
+            assert refreshed.last_error == "지금도 계속 실패 中"
+            assert refreshed.last_error_code == "CHANNEL_TOKEN_EXPIRED"
+            assert refreshed.last_error_at is not None
     finally:
         await engine.dispose()

--- a/backend/tests/test_3605_graph_error_family_generalize.py
+++ b/backend/tests/test_3605_graph_error_family_generalize.py
@@ -45,11 +45,45 @@ class TestPermissionFamilyExtension:
 class TestRateLimitCodesNeverEnterThisFamily:
     """⛔story #3605 핵심 요구 — 「연결 상태 승격은 사람이 고칠 수 있는 원인에만」
     (한 방향 문). rate-limit 코드가 우연히라도 이 family에 안 걸리는지 직접 검증
-    (200~299 범위 밖이라는 사실을 구조적으로 고정, 문서 주장만 두지 않는다)."""
+    (200~299 범위 밖이라는 사실을 구조적으로 고정, 문서 주장만 두지 않는다).
+
+    story #3605 CHANGES-1(유나 코드 리뷰, 페드루 PO 채택 2026-09-07) — 원판 배제
+    테스트는 `error_type=None` 표본만 써서 "type 단독 통과" 버그가 있어도 절대
+    실패할 수 없었다(양성대조 실패 — `_EXPIRED_SUBCODES`류는 code==190에서 이미
+    자기 스스로 검증되는데, 이 축만 그 반례가 없었다). 이제 `error_type=
+    "OAuthException"`을 실은 표본으로 실제 위험 시나리오(Graph가 한도 초과·
+    파라미터 오류도 전부 이 type으로 싣는 것)를 재현한다."""
 
     @pytest.mark.parametrize("code", [4, 17, 32, 613])
     def test_known_rate_limit_codes_are_never_classified_as_oauth_family(self, code: int):
         assert classify_graph_oauth_error(error_code=code, error_subcode=None, error_type=None) is None
+
+    @pytest.mark.parametrize("code", [4, 17, 32, 613])
+    def test_rate_limit_codes_stay_excluded_even_with_oauthexception_type(self, code: int):
+        """⭐뮤테이션 표적 — family 문을 다시 `type == "OAuthException"` 단독으로
+        열면(CHANGES-1 이전 상태로 되돌리면) 이 assert가 None이 아닌 ("error",
+        "error")로 깨져야 한다. `_RATE_LIMIT_CODES`가 실제로 읽히는지도 이 테스트로
+        같이 고정(정의만 있고 참조 0이던 원판 결함, 페드루 PO 지적)."""
+        assert classify_graph_oauth_error(
+            error_code=code, error_subcode=None, error_type="OAuthException",
+        ) is None
+
+    def test_param_error_code_100_stays_excluded_even_with_oauthexception_type(self):
+        """code==100(잘못된 파라미터류, 페드루 PO 리뷰가 든 예시)도 type만으로
+        가족에 들어오면 안 된다."""
+        assert classify_graph_oauth_error(
+            error_code=100, error_subcode=None, error_type="OAuthException",
+        ) is None
+
+    def test_classify_graph_error_code_end_to_end_rate_limit_with_oauthexception_type(self):
+        """AC — `classify_graph_error_code(429, code=4, type="OAuthException")` →
+        CHANNEL_RATE_LIMITED(CONNECTION 계열이 아니라 TRANSIENT). 이 종단 케이스가
+        실제로 CI에서 관측된 위험(429 응답에 code=4·type=OAuthException을 함께
+        싣는 것)과 정확히 같은 모양이다."""
+        assert classify_graph_error_code(
+            status_code=429, provider_error_code=4, provider_error_subcode=None,
+            provider_error_type="OAuthException",
+        ) == "CHANNEL_RATE_LIMITED"
 
 
 class TestClassifyGraphErrorCode:

--- a/backend/tests/test_3605_graph_error_family_generalize.py
+++ b/backend/tests/test_3605_graph_error_family_generalize.py
@@ -1,0 +1,145 @@
+"""story #3605(BE·소형·신뢰, PO 確定 2026-09-07) — 3598 AC6 일반화. Graph API
+권한/인증 계열 오류 family를 190/OAuthException 밖으로 넓힌다(code==10·200~299)
+— 사람이 재연결해야 풀리는 원인만 CONNECTION kind로 fail-closed 승격. 순수 함수
+단위테스트, DB 불요(test_3598_graph_oauth_error_parser.py와 동형 관례)."""
+from __future__ import annotations
+
+import pytest
+
+from app.services.graph_api_errors import (
+    classify_graph_error_code,
+    classify_graph_oauth_error,
+    connection_status_for_error_code,
+)
+
+
+class TestPermissionFamilyExtension:
+    def test_code_10_falls_closed_to_error(self):
+        """code==10("Application does not have permission") — subcode 체계가 190
+        처럼 표준화돼 있지 않아 expired/revoked를 못 가른다, fail-closed로 error."""
+        assert classify_graph_oauth_error(error_code=10, error_subcode=None, error_type=None) == (
+            "error", "error",
+        )
+
+    @pytest.mark.parametrize("code", [200, 250, 299])
+    def test_permission_error_range_200_to_299_falls_closed_to_error(self, code: int):
+        assert classify_graph_oauth_error(error_code=code, error_subcode=None, error_type=None) == (
+            "error", "error",
+        )
+
+    def test_code_300_is_outside_the_permission_range_boundary(self):
+        """뮤테이션 표적 — range(200,300) 상한이 300을 포함하면 이 assert가 깨진다."""
+        assert classify_graph_oauth_error(error_code=300, error_subcode=None, error_type=None) is None
+
+    def test_code_199_is_outside_the_permission_range_boundary(self):
+        """뮤테이션 표적 — range(200,300) 하한이 199를 포함하면 이 assert가 깨진다."""
+        assert classify_graph_oauth_error(error_code=199, error_subcode=None, error_type=None) is None
+
+    def test_code_9_is_not_code_10(self):
+        assert classify_graph_oauth_error(error_code=9, error_subcode=None, error_type=None) is None
+
+    def test_code_11_is_not_code_10(self):
+        assert classify_graph_oauth_error(error_code=11, error_subcode=None, error_type=None) is None
+
+
+class TestRateLimitCodesNeverEnterThisFamily:
+    """⛔story #3605 핵심 요구 — 「연결 상태 승격은 사람이 고칠 수 있는 원인에만」
+    (한 방향 문). rate-limit 코드가 우연히라도 이 family에 안 걸리는지 직접 검증
+    (200~299 범위 밖이라는 사실을 구조적으로 고정, 문서 주장만 두지 않는다)."""
+
+    @pytest.mark.parametrize("code", [4, 17, 32, 613])
+    def test_known_rate_limit_codes_are_never_classified_as_oauth_family(self, code: int):
+        assert classify_graph_oauth_error(error_code=code, error_subcode=None, error_type=None) is None
+
+
+class TestClassifyGraphErrorCode:
+    """classify_graph_error_code — error_code 문자열 하나로 옮기는 공유 지점.
+    발행(_classify_threads_error)·댓글 수집(channel_post_comments.py) 둘 다 이
+    함수를 쓴다(3605에서 통합)."""
+
+    def test_code_190_expired_subcode_maps_to_channel_token_expired(self):
+        assert classify_graph_error_code(
+            status_code=401, provider_error_code=190, provider_error_subcode=463,
+            provider_error_type="OAuthException",
+        ) == "CHANNEL_TOKEN_EXPIRED"
+
+    def test_code_190_revoked_subcode_maps_to_channel_connection_revoked(self):
+        assert classify_graph_error_code(
+            status_code=401, provider_error_code=190, provider_error_subcode=490,
+            provider_error_type="OAuthException",
+        ) == "CHANNEL_CONNECTION_REVOKED"
+
+    def test_code_10_maps_to_channel_connection_auth_error(self):
+        """AC1 핵심 — code 10 → CONNECTION kind(구체적으로는 CHANNEL_CONNECTION_
+        AUTH_ERROR, publication_command.py::_CONNECTION_BLOCKED_CODES 등재 확認은
+        test_3605_connection_promotion_paths_consistent.py)."""
+        assert classify_graph_error_code(
+            status_code=401, provider_error_code=10, provider_error_subcode=None, provider_error_type=None,
+        ) == "CHANNEL_CONNECTION_AUTH_ERROR"
+
+    def test_code_200_maps_to_channel_connection_auth_error(self):
+        """AC1 핵심 — code 200 → CONNECTION kind."""
+        assert classify_graph_error_code(
+            status_code=401, provider_error_code=200, provider_error_subcode=None, provider_error_type=None,
+        ) == "CHANNEL_CONNECTION_AUTH_ERROR"
+
+    def test_rate_limit_code_4_falls_through_to_status_code_heuristic_not_connection(self):
+        """AC1 핵심 — code 4(Application request limit reached)는 이 family 밖이라
+        status_code(429)만으로 판정 → CHANNEL_RATE_LIMITED(TRANSIENT), CONNECTION
+        이 아니다. 뮤테이션 표적 — family 범위가 code 4까지 잘못 넓어지면 이 assert가
+        CHANNEL_CONNECTION_AUTH_ERROR로 깨져야 한다."""
+        assert classify_graph_error_code(
+            status_code=429, provider_error_code=4, provider_error_subcode=None, provider_error_type=None,
+        ) == "CHANNEL_RATE_LIMITED"
+
+    def test_unclassified_error_falls_through_to_status_code_401_heuristic(self):
+        assert classify_graph_error_code(
+            status_code=401, provider_error_code=None, provider_error_subcode=None, provider_error_type=None,
+        ) == "CHANNEL_TOKEN_EXPIRED"
+
+    def test_unclassified_error_falls_through_to_status_code_429_heuristic(self):
+        assert classify_graph_error_code(
+            status_code=429, provider_error_code=None, provider_error_subcode=None, provider_error_type=None,
+        ) == "CHANNEL_RATE_LIMITED"
+
+    def test_unclassified_error_falls_through_to_provider_error_fallback(self):
+        assert classify_graph_error_code(
+            status_code=502, provider_error_code=None, provider_error_subcode=None, provider_error_type=None,
+        ) == "CHANNEL_PUBLISH_PROVIDER_ERROR"
+
+
+class TestConnectionStatusForErrorCode:
+    """connection_status_for_error_code — 4개 승격 지점이 공유하는 status 선택.
+    이전엔 4곳 전부 error_code 무관하게 항상 "expired"였다(3605 실측 정정)."""
+
+    def test_revoked_error_code_maps_to_revoked_status(self):
+        assert connection_status_for_error_code("CHANNEL_CONNECTION_REVOKED", current_status="active") == "revoked"
+
+    def test_auth_error_code_maps_to_error_status(self):
+        assert connection_status_for_error_code("CHANNEL_CONNECTION_AUTH_ERROR", current_status="active") == "error"
+
+    def test_token_expired_code_maps_to_expired_status_unchanged(self):
+        assert connection_status_for_error_code("CHANNEL_TOKEN_EXPIRED", current_status="active") == "expired"
+
+    def test_unmapped_code_defaults_to_expired_for_backward_compat(self):
+        assert connection_status_for_error_code("CHANNEL_CONNECTION_NOT_ACTIVE", current_status="active") == "expired"
+
+    def test_none_error_code_defaults_to_expired(self):
+        assert connection_status_for_error_code(None, current_status="active") == "expired"
+
+    def test_auth_error_does_not_downgrade_existing_revoked(self):
+        """뮤테이션 표적 — 이 가드를 지우면 이미 알려진 「revoked」가 새로 들어온
+        사유불명 「error」로 조용히 덮여 정밀도를 잃는다."""
+        assert connection_status_for_error_code(
+            "CHANNEL_CONNECTION_AUTH_ERROR", current_status="revoked",
+        ) == "revoked"
+
+    def test_auth_error_does_not_downgrade_existing_expired(self):
+        assert connection_status_for_error_code(
+            "CHANNEL_CONNECTION_AUTH_ERROR", current_status="expired",
+        ) == "expired"
+
+    def test_revoked_error_code_does_upgrade_existing_unspecified_error(self):
+        """error(사유불명) → revoked(더 구체적)는 업그레이드라 허용된다 — "error"만
+        다운그레이드 방지 대상이지 revoked/expired는 새 정보로 계속 갱신된다."""
+        assert connection_status_for_error_code("CHANNEL_CONNECTION_REVOKED", current_status="error") == "revoked"

--- a/backend/tests/test_3605_worker_exception_ordering.py
+++ b/backend/tests/test_3605_worker_exception_ordering.py
@@ -1,0 +1,199 @@
+"""story #3605(BE·소형·신뢰, PO 確定 2026-09-07) — 3598 AC6 일반화 도중 실측으로
+드러난 결함: `publication_command.py::_process_one_command`(발행 cron 워커)의
+`except ChannelTokenExpiredError as exc: error_code = "CHANNEL_TOKEN_EXPIRED"`가
+그 서브클래스(`ChannelConnectionRevokedError`·`ChannelConnectionAuthError`, 둘 다
+#3598/#3605이 ChannelTokenExpiredError를 상속해 기존 except 절이 그대로 잡게
+설계)도 먼저 잡아 error_code 문자열을 무조건 "CHANNEL_TOKEN_EXPIRED"로 하드코딩
+— channel_posts.py::publish_channel_post_draft가 inline으로 이미 정확히 승격해
+둔 connection.status(revoked/error)를, 이 워커가 `apply_command_failure`를
+잘못된 error_code로 다시 호출해 "expired"로 덮어써 버렸다. 서브클래스 except
+절을 부모보다 먼저 두는 순서로 고쳤다(3605) — 이 파일은 그 수정이 실제로 최종
+connection.status를 지키는지 실DB로 고정한다.
+
+세팅 헬퍼는 test_3414_publication_command_core.py 재사용(중복 재발명 0)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_3414_publication_command_core import (
+    _client_for,
+    _create_draft_submit_approve,
+    _seed_agent,
+    _seed_connection,
+    _seed_default_role,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _seed_command_targeting_new_draft(
+    *, org_id, project_id, agent_id, connection_id, session_factory_result,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """draft 생성→제출→승인 뒤, 그 승인된 버전을 향하는 pending PublicationCommand
+    1건을 직접 만든다(test_3414_publication_command_cron_retry.py::
+    test_cron_token_expired_blocks_command_and_escalates_connection_status와
+    동형 — cron 워커가 그 command를 집도록)."""
+    from app.models.publication_command import PublicationCommand
+    from app.models.channel_post_version import ChannelPostVersion
+    from sqlalchemy import select
+
+    _, Session = session_factory_result
+    from app.main import app
+    _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+    async with _client_for(app) as client, Session() as s:
+        story_id = await _seed_story(s, org_id, project_id)
+        draft_id, gate_id = await _create_draft_submit_approve(
+            client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+        )
+
+    now = datetime.now(timezone.utc)
+    async with Session() as s:
+        version_id = (await s.execute(
+            select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+        )).scalar_one()
+        cmd = PublicationCommand(
+            id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+            approved_version=version_id, operation="publish",
+            scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+        )
+        s.add(cmd)
+        await s.commit()
+        cmd_id = cmd.id
+    return cmd_id, gate_id
+
+
+@pytest.mark.anyio
+async def test_cron_worker_revoked_connection_stays_revoked_not_downgraded_to_expired():
+    """⭐뮤테이션 대상 — except 절 순서를 원복(ChannelConnectionRevokedError를
+    ChannelTokenExpiredError보다 아래로)하면 이 assert가 "expired"로 깨져야 한다."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        cmd_id, _ = await _seed_command_targeting_new_draft(
+            org_id=org_id, project_id=project_id, agent_id=agent_id, connection_id=connection_id,
+            session_factory_result=(engine, Session),
+        )
+
+        from app.services.threads_publish import ThreadsPublishError
+        now = datetime.now(timezone.utc)
+        with (
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "create_container", AsyncMock(side_effect=ThreadsPublishError(
+                status_code=401, code="REVOKED", message="session revoked",
+                provider_error_code=190, provider_error_subcode=490, provider_error_type="OAuthException",
+            ))),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_connection import ChannelConnection
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.status == "blocked"
+            assert cmd.failure_kind == "connection"
+            conn = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == connection_id))).scalar_one()
+            assert conn.status == "revoked"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_worker_permission_error_family_promotes_connection_to_error_status():
+    """AC1 — code==10(190 밖 family)도 발행 워커 경로에서 실제로 CONNECTION kind로
+    승격되는지 종단 확認(단위테스트는 classify_graph_error_code만 검증, 이건 그
+    결과가 실제 connection.status에 도달하는지까지)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        cmd_id, _ = await _seed_command_targeting_new_draft(
+            org_id=org_id, project_id=project_id, agent_id=agent_id, connection_id=connection_id,
+            session_factory_result=(engine, Session),
+        )
+
+        from app.services.threads_publish import ThreadsPublishError
+        now = datetime.now(timezone.utc)
+        with (
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "create_container", AsyncMock(side_effect=ThreadsPublishError(
+                status_code=401, code="PERMISSION_ERROR", message="app lacks permission",
+                provider_error_code=10, provider_error_subcode=None, provider_error_type=None,
+            ))),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_connection import ChannelConnection
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.status == "blocked"
+            assert cmd.failure_kind == "connection"
+            conn = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == connection_id))).scalar_one()
+            assert conn.status == "error"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_5b27b32f_sandbox_channel.py
+++ b/backend/tests/test_5b27b32f_sandbox_channel.py
@@ -511,6 +511,23 @@ async def test_sandbox_publish_app_inactive_marker_classifies_as_connection_revo
 
 
 @pytest.mark.anyio
+async def test_sandbox_publish_permission_error_marker_classifies_as_connection_auth_error():
+    """story #3605 — code==10(190 밖 family) 시뮬레이션. 위 세 마커(revoked류)와
+    달리 CHANNEL_CONNECTION_AUTH_ERROR(사유 불명, fail-closed)로 분류돼야 한다."""
+    import uuid
+    from app.services import sandbox_publish as sp
+    from app.services.threads_publish import ThreadsPublishError
+    from app.services.channel_posts import _classify_threads_error
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await sp.create_container(None, access_token="x", threads_user_id="u", text="[sandbox:permission-error]")
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.provider_error_code == 10
+    error_code, _ = _classify_threads_error(exc_info.value, connection_id=uuid.uuid4())
+    assert error_code == "CHANNEL_CONNECTION_AUTH_ERROR"
+
+
+@pytest.mark.anyio
 async def test_sandbox_publish_container_error_marker():
     from app.services import sandbox_publish as sp
 

--- a/backend/tests/test_f8f7cb0f_channel_post_publish.py
+++ b/backend/tests/test_f8f7cb0f_channel_post_publish.py
@@ -737,13 +737,15 @@ async def test_token_expired_returns_409_and_marks_connection_expired():
 # 지나 connection.status가 (expired가 아니라) "revoked"로 정확히 남는 것은 다른
 # 주장이다 — 위 test_token_expired_*와 완전히 동형으로 HTTP 왕복까지 실측한다.
 @pytest.mark.anyio
-async def test_revoked_returns_409_with_token_expired_code_but_marks_connection_revoked():
-    """AC4 「화면 문장은 기존 needs_reauth 낱말 재사용(새 낱말 0)」 — HTTP 응답
-    error.code는 그대로 CHANNEL_TOKEN_EXPIRED(상속 덕에 기존 except 절이 그대로
-    잡는다, 새 HTTP 코드 0)이지만, connection.status는 "expired"가 아니라 정확히
-    "revoked"로 남아야 한다(3595 표 행 ② 「권한 회수」가 "미감지"→"감지+표시"로
-    바뀌는 지점 — status가 여전히 expired로 뭉개지면 이 스토리는 아무것도 안 고친
-    것과 같다)."""
+async def test_revoked_returns_409_with_connection_revoked_code_and_marks_connection_revoked():
+    """story #3605 CHANGES-2(페드루 PO 판정 2026-09-07) — HTTP error.code 계약이
+    바뀌었다: 원래 이 테스트는 「상속 덕에 기존 except 절이 그대로 잡아 HTTP
+    응답 code가 CHANNEL_TOKEN_EXPIRED 그대로」를 AC4의 "새 낱말 0"으로 못박았으나,
+    #3964가 `_process_one_command`/라우터의 except 절 순서를 서브클래스 우선으로
+    정정하면서(⚠️story #3605 except-ordering 주석 참고) revoked는 이제 정확히
+    CHANNEL_CONNECTION_REVOKED로 낸다 — "다른 메커니즘은 다른 낱말이어야 한다,
+    옛 계약(전부 TOKEN_EXPIRED로 뭉뚱그림)은 거짓말"이 새 판정. connection.status
+    ="revoked"는 원래 의도 그대로(3595 표 행 ② 「권한 회수」 감지)."""
     from unittest.mock import AsyncMock, patch
     import app.services.threads_publish as tp
     from app.services.threads_publish import ThreadsPublishError
@@ -782,8 +784,9 @@ async def test_revoked_returns_409_with_token_expired_code_but_marks_connection_
                     f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
                 )
         assert r_publish.status_code == 409, r_publish.text
-        # 상속 덕에 기존 except 절이 잡는다 — HTTP 응답 code는 새 낱말 0(AC4).
-        assert r_publish.json()["error"]["code"] == "CHANNEL_TOKEN_EXPIRED"
+        # story #3605 CHANGES-2 — 새 계약: revoked는 CHANNEL_CONNECTION_REVOKED로
+        # 명시(구 계약이었던 CHANNEL_TOKEN_EXPIRED 뭉뚱그림은 폐기).
+        assert r_publish.json()["error"]["code"] == "CHANNEL_CONNECTION_REVOKED"
 
         async with Session() as s:
             from app.models.channel_connection import ChannelConnection

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1466,6 +1466,11 @@
       "file": "tests/test_3612_connection_notactive_precheck_norecord.py",
       "sec": 16.0,
       "source": "story-3612-connection-notactive-precheck-norecord(PR 개설 前 선제 등재 — 페드루 PO 追加 2026-09-07, PO 대조 CHANGES-1 반영. 로컬 raw pytest 6건 2.60s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 16s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3605_worker_exception_ordering.py",
+      "sec": 15.0,
+      "source": "story-3605-oauth-connection-kind-generalize(PR 개설 前 선제 등재 — 로컬 raw pytest 2건 2.81s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 15s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## AC1 — Graph API family 확장(code 190 밖까지)
`classify_graph_oauth_error`의 family 판정을 `error_code==190`·`type=="OAuthException"` 밖으로 넓혔다:
- `error_code==10`(Meta 문서: "Application does not have permission for this action")
- `error_code in 200..299`(Meta 문서: permission error 대역)

둘 다 subcode 체계가 190처럼 표준화돼 있지 않아 expired/revoked로 세분화하지 않고 신설 `CHANNEL_CONNECTION_AUTH_ERROR`(→`ChannelConnection.status="error"`)로 fail-closed 승격한다.

⛔**한도 초과 코드는 이 family가 아니다** — 4(Application request limit reached)·17(User request limit reached)·32(Page request limit reached)·613(Calls to this api have exceeded the rate limit) 전부 200~299 밖이라는 사실 자체가 이 family를 좁게 유지하는 방어선이다. 우연이 아니라 단위테스트로 직접 검증(`TestRateLimitCodesNeverEnterThisFamily`).

## AC2 — 승격 경로 판정 불일치 실측 → 전부 수정(1pt를 넘어선 실측 규모)
"승격 경로 셋이 같은 kind 판정을 쓰는가 확認"이 실제로 **아니오**였다 — 그라운딩 도중 4가지 별개 결함을 발견해 전부 이 PR에서 닫았다:

1. **`CHANNEL_CONNECTION_REVOKED`가 `_CONNECTION_BLOCKED_CODES`에 미등재** — 발행 워커 경로에서 이 error_code로는 `classify_failure_kind`가 needs_check로 떨어져, connection.status가 첫 실패 즉시 승격이 아니라 재시도 상한까지 기다리는 결함이었다(CHANNEL_TOKEN_EXPIRED와 대칭 안 맞음). 등재로 해소.
2. **connection.status 승격 지점 4곳 전부가 error_code 무관하게 항상 "expired"로 하드코딩** — `publication_command.py::apply_command_failure`·`channel_post_comments.py::_promote_connection_status`·`insight_snapshots.py::_promote_connection_status_for_snapshot` 전부, revoked/error로 이미 정확히 분류된 사유가 이 승격 단계에서 "expired"로 뭉개지는 반쪽 수리 상태였다. `graph_api_errors.connection_status_for_error_code`(4곳 공유 단일 지점) 신설로 닫음 — "error"(사유 불명)는 이미 확정된 expired/revoked를 덮지 않는 sticky 정밀도 규율 포함(기존 회귀 테스트로 이 규율이 실제로 필요함을 리팩터 中 실측 확認).
3. **댓글수집·인사이트가 애초에 `classify_graph_oauth_error` 자체를 안 쓰던 자기 401 휴리스틱** — 발행 경로만 Graph subcode 정밀 판정을 받던 드리프트. `classify_graph_error_code`(공유 error_code 선택 지점, `parse_graph_error_envelope` 공유 파서 포함)로 통합.
4. **발행 워커의 except 절 순서 버그** — `publication_command.py::_process_one_command`가 `except ChannelTokenExpiredError`로 그 서브클래스(`ChannelConnectionRevokedError`·`ChannelConnectionAuthError`)까지 먼저 잡아 error_code를 항상 `"CHANNEL_TOKEN_EXPIRED"`로 하드코딩 — `channel_posts.py`가 inline으로 이미 정확히 승격해 둔 connection.status를 워커가 다시 "expired"로 덮어쓰는 실사고. 서브클래스 except 절을 부모보다 먼저 두는 순서로 정정(라우터 쪽 동형 except 절 2곳도 함께).

## AC3 — 테스트
- 순수 단위테스트 37건(`test_3605_graph_error_family_generalize.py` — family 확장·rate-limit 배제·classify_graph_error_code·connection_status_for_error_code 정밀도 규율).
- 실DB 종단 테스트 2건(`test_3605_worker_exception_ordering.py`) — 워커 except 순서 버그가 실제로 connection.status에 영향을 미치는지 종단 확認, 뮤테이션(except 절 원복 → RED) 확認 후 복구.
- 샌드박스 마커 1종(`[sandbox:permission-error]`, code=10 시뮬레이션) — 기존 3598 마커 관례 그대로.
- `test_3597_ig_fb_connection_status_promote.py` 기존 회귀(#3597/#3958 develop 병합분 rebase 반영, `_promote_connection_status` 시그니처 변경에 맞춰 호출부 수정) 전부 PASS.
- 실DB 회귀 123건 PASS(발행/댓글수집/인사이트 관련 15개 파일).

## AC4 — 3595 표 갱신
아티팩트 `4f7f6d33`(story #3595) v8에 "3605 진행 갱신" 절 덧적음 — ③④(페이지 연결 해제·앱 비활성) subcode 배정은 그대로(3598 잠정값 458·467), 이번 일반화가 그 불확실성을 fail-closed로 흡수하는 더 넓은 그물임을 명시.

## CHANGES-1(유나 코드 리뷰, 페드루 PO 채택 2026-09-07) — family 문 code-only 정정
`is_oauth_family = error_code == 190 or error_type == "OAuthException"`의 **type 단독 통과**가 자해 잠금이었다 — Graph는 한도 초과(4·17·32·613)·잘못된 파라미터(100)·일시 장애(1·2)도 전부 `type: "OAuthException"`으로 싣는다. type 단독 통과를 열어 두면 한도 초과 한 번이 `CHANNEL_CONNECTION_AUTH_ERROR`로 떨어져 connection.status="error"→"다시 연결" 요구로 자해 잠금 — 정확히 이 스토리 AC1이 막으려던 시나리오가 이 스토리 자신의 구현으로 재발한 것.

처방: family 판정을 **code 소속으로만**(190/10/200..299), `_RATE_LIMIT_CODES`를 판정 맨 앞에서 실제로 읽게(원판은 정의만 하고 참조 0). 뮤테이션 검증(원래 type-alone 로직으로 되돌리면 신규 6테스트 RED). `test_3598_graph_oauth_error_parser.py`의 기존 테스트(code=200+type=OAuthException→expired 기대)를 새 계약(→error)으로 갱신.

## CHANGES-2(유나 §13-9 ④-2, 페드루 PO 채택 2026-09-07) — sticky 규율 단일화
`connection_status_for_error_code`(expired·revoked 상호 불변)와 `channel_connection.apply_connection_failure`(status=="error"일 때만 막고 expired↔revoked는 서로 덮음)가 **같은 사실을 다르게** 구현하고 있었다. `graph_api_errors.sticky_connection_status(current, new)` 공유 헬퍼 신설(active→new / error→구체값 있으면 갱신·error→error 무해 / expired·revoked→절대 불변 상호도), 두 소비처 다 이거 하나로 통합.

rebase(#3960) 충돌 해소 중 last_error 3종(`last_error`·`last_error_code`·`last_error_at`) 채움 로직과 병합 — **status는 sticky여도 last_error 3종은 sticky 여부와 무관하게 항상 갱신**한다("지금도 실패하나"는 last_error가 진다, PO 원문). `test_3603_connection_last_error.py::test_promote_no_op_leaves_last_error_trio_untouched`가 반대로(no-op=last_error도 불변) pin하고 있던 것을 새 규율로 갱신 — **기존 기대치가 원칙과 반대였음**(카디르군 QA 참고).

## CHANGES-2(2차) — HTTP error.code 계약 변경(CI 실 회귀 1건)
`test_f8f7cb0f_channel_post_publish.py::test_revoked_returns_409_with_token_expired_code_but_marks_connection_revoked`가 CI 빨강 — 옛 계약("상속 덕에 기존 except 절이 그대로 잡아 HTTP 응답 code가 CHANNEL_TOKEN_EXPIRED 그대로")이 이 PR의 except-ordering 정정(서브클래스 우선)으로 사실이 아니게 됐다.

**페드루 PO 판정: 의도된 계약 변경으로 수용.** "다른 메커니즘은 다른 낱말이어야 한다 — 옛 계약(전부 CHANNEL_TOKEN_EXPIRED로 뭉뚱그림)은 거짓말." 새 계약:
- **revoked** → HTTP `error.code` = `CHANNEL_CONNECTION_REVOKED`(구: CHANNEL_TOKEN_EXPIRED)
- **권한/불명(auth_error)** → HTTP `error.code` = `CHANNEL_CONNECTION_AUTH_ERROR`(구: CHANNEL_TOKEN_EXPIRED로 뭉뚱그림)
- **진짜 expired**(순수 401, Graph envelope 없음)만 여전히 CHANNEL_TOKEN_EXPIRED — 회귀 0, 같은 파일의 다른 테스트로 확認.

테스트를 새 계약으로 갱신(이름도 `test_revoked_returns_409_with_connection_revoked_code_and_marks_connection_revoked`), `test_f8f7cb0f_channel_post_publish.py` 16건 전부 PASS 재확認.

### 소비처 grep(PO 지시 ③ — 결과만, 수정은 별건 후보)
`CHANNEL_TOKEN_EXPIRED` 문자열을 읽는 자리 전수(`apps/web/src`·`connectors` — `sprintable-mcp`·`sprintable-agent-plugins`는 별도 레포라 이 체크아웃에 없어 grep 불가, 별도 확認 필요):

- **`apps/web/src/components/content/api-error.ts:175`** — **CHANGES-3으로 이 PR에서 직접 닫음**(페드루 PO 판정: 계약을 바꾼 손이 소비처도 같이 고쳐야, 별도 스토리 아님). `KNOWN_ERRORS`에 `CHANNEL_CONNECTION_REVOKED`·`CHANNEL_CONNECTION_AUTH_ERROR` 두 항목을 `CHANNEL_TOKEN_EXPIRED`와 같은 kind(`token_expired`)·같은 문구 키(`errorChannelTokenExpired`)로 매핑 — 새 낱말 0, 테스트 2건 추가.
- `apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx:1593` · `route.test.ts:25-27` · `api-error.test.ts:169-271` — 전부 테스트 픽스처(코드 예시 나열)일 뿐 별도 분기 로직 없음, 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA

## CHANGES-4(페드루 PO 채택 2026-09-07) — 190+미지 subcode 계약 갱신
`test_unknown_subcode_under_oauth_exception_falls_through_to_existing_401_heuristic`가 CI 빨강 — 옛 계약(code=190+미지 subcode는 401 휴리스틱으로 폴스루해 CHANNEL_TOKEN_EXPIRED로 뭉뚱그림)이 이 PR의 code-only family 판정 정정과 맞물려 사실이 아니게 됐다. 이제 이 경우는 fail-closed로 **CHANNEL_CONNECTION_AUTH_ERROR**(사유 불명이지만 인증 계열은 확실 — AC6 원칙 그대로)로 분류된다. "미지 subcode"와 "순수 401(Graph envelope 없음)"이 이제 서로 다른 낱말 — 테스트를 새 계약으로 갱신(이름도 갱신), 8건 PASS.

## 범위 밖(적기만)
- code 190·10·200~299 확장에도 여전히 ③④의 정확한 subcode는 미확認 — 실 Meta 응답 표본 확보 전까지 정밀 매핑 불가.
- 다른 도메인(wordpress/webhook)의 `CHANNEL_PUBLISH_AUTH_REJECTED` 등은 이번 스코프 밖, 기존 "expired" fallback 그대로.

