### PR TITLE
[SID:3604] chore: destructive-schema-shard-weights.json 잠정값→CI 실측치 갱신

### DIFF
--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1254,8 +1254,8 @@
     },
     {
       "file": "tests/test_3502_insights_board.py",
-      "sec": 14.0,
-      "source": "story-3604-insights-board-durations(원인 실측: from app.main import app 1회 비용 ~3.4s(로컬 무경합)가 이 파일에 섞여 있어 등재 39s 대비 경합 시 80s까지 늘던 원인 — 조각②(HTTP 라우터 6개 테스트, app.main 소비)를 test_3502_insights_board_endpoints.py로 분리. 남은 14개는 list_insights_board를 서비스 함수로 직접 부르며 app.main 무관 — 격리 uv run pytest 프로세스(ci.yml per-file 루프와 동형) 2회 로컬 실측 6.65~6.68s, 2배 안전마진 반영한 14s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 22.0,
+      "source": "story-3604-insights-board-durations(PR#3959 CI 실측 — run 34078092461 job 101608057452, elapsed 22s. 로컬 격리측정 6.65~6.68s×2배 잠정값 14s보다 CI가 더 느렸다 — CPU-bound app.main import 없는 파일도 CI 배율이 로컬 대비 3x대. 실측치로 갱신)"
     },
     {
       "file": "tests/test_3510_member_role_sync.py",
@@ -1454,8 +1454,8 @@
     },
     {
       "file": "tests/test_3502_insights_board_endpoints.py",
-      "sec": 10.0,
-      "source": "story-3604-insights-board-durations(신규 분리 파일 — story #3502 조각② HTTP 라우터 6개 테스트, from app.main import app 1회 비용 ~3.4s 포함. 격리 uv run pytest 프로세스 2회 로컬 실측 4.63~4.85s, 2배 안전마진 반영한 10s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 25.0,
+      "source": "story-3604-insights-board-durations(PR#3959 CI 실측 — run 34078092461 job 101608057407, elapsed 25s. 로컬 격리측정 4.63~4.85s×2배 잠정값 10s보다 CI가 더 느렸다. 실측치로 갱신)"
     },
     {
       "file": "tests/test_3603_connection_last_error.py",


### PR DESCRIPTION
## 배경
story #3604(PR #3959)에서 로컬 격리 `uv run pytest` 측정(×2배 안전마진)으로 잠정 등재한 값(`test_3502_insights_board.py`=14s·`test_3502_insights_board_endpoints.py`=10s)이 실제 CI 관측보다 낮았다.

## 실측(PR#3959 CI run 34078092461)
| 파일 | 잠정값 | 실측 | job |
|---|---|---|---|
| `tests/test_3502_insights_board.py` | 14s | **22s** | [101608057452](https://github.com/moonklabs/sprintable/actions/runs/34078092461/job/101608057452) |
| `tests/test_3502_insights_board_endpoints.py` | 10s | **25s** | [101608057407](https://github.com/moonklabs/sprintable/actions/runs/34078092461/job/101608057407) |

CPU-bound `app.main` import가 없는 파일(전자)도 CI 배율이 로컬 대비 3x대라 2배 마진이 부족했다 — 실측치로 정정.

## 범위
`infra/destructive-schema-shard-weights.json` 1파일만 — story #3605의 PR #3964와 리뷰 범위가 겹치지 않게 별도 PR로 분리(PO 지시).

story #3604 AC1("CI 2회 관측 등재값 이내")의 관측 1/2. 관측 2/2(develop clean run)는 이 PR 머지 뒤 첫 clean develop CI 완주분으로 별도 기록 예정.

## 검증
로컬 `lint_destructive_schema_weights_registered.py` 재실행 — 291파일 전부 등재, 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA
