### PR TITLE
[SID:3610] fix: 온보딩 배너를 현재 org의 owner가 아닐 땐 안 그린다

### DIFF
--- a/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
@@ -9,8 +9,11 @@ import { _resetActivationStatusCacheForTests } from '@/hooks/use-activation-stat
 
 // story #3201 — useDashboardContext(projectId)·useRouter 신규 의존성. storage-capacity-
 // banner.test.tsx와 동일 패턴(실 dashboard-shell.tsx 전체 모듈 그래프를 끌어들이지 않음).
+// story #3610(3607 잔여) — orgId='org-1' 고정. 기존 픽스처(PARTIAL·COMPLETE)는
+// scope_org_id를 안 실어(undefined) 새 가드(`orgId && state.scope_org_id && ...`)가
+// 항상 false로 빠져 회귀 0 — 신규 테스트만 scope_org_id를 명시로 채운다.
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
-  useDashboardContext: () => ({ projectId: 'proj-1' }),
+  useDashboardContext: () => ({ projectId: 'proj-1', orgId: 'org-1' }),
 }));
 const routerPushMock = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -81,6 +84,7 @@ function stubChecklist(data: {
   total: number;
   all_complete: boolean;
   first_instruction_conversation_id?: string | null;
+  scope_org_id?: string | null;
 }) {
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data }) })));
 }
@@ -161,6 +165,22 @@ describe('ActivationChecklistBanner — 접기(collapse), 완전 dismiss는 없�
     await act(async () => { chip.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
     expect(container.textContent).toContain('이메일 인증하기');
+  });
+});
+
+describe('ActivationChecklistBanner — scope_org_id 불일치 시 미노출(story #3610, 3607 잔여)', () => {
+  it('scope_org_id가 현재 org(orgId)와 같으면 그대로 렌더된다(오탐 0)', async () => {
+    stubChecklist({ ...PARTIAL, scope_org_id: 'org-1' });
+    await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
+    await flush();
+    expect(container.textContent).toContain('가입을 마무리해 볼까요?');
+  });
+
+  it('scope_org_id가 현재 org(orgId)와 다르면 아무것도 렌더하지 않는다(초대받은 org에서 남의 owner-org 진행률을 안 보임)', async () => {
+    stubChecklist({ ...PARTIAL, scope_org_id: 'org-2' });
+    await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
+    await flush();
+    expect(container.textContent).toBe('');
   });
 });
 

--- a/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
@@ -9,11 +9,12 @@ import { _resetActivationStatusCacheForTests } from '@/hooks/use-activation-stat
 
 // story #3201 — useDashboardContext(projectId)·useRouter 신규 의존성. storage-capacity-
 // banner.test.tsx와 동일 패턴(실 dashboard-shell.tsx 전체 모듈 그래프를 끌어들이지 않음).
-// story #3610(3607 잔여) — orgId='org-1' 고정. 기존 픽스처(PARTIAL·COMPLETE)는
-// scope_org_id를 안 실어(undefined) 새 가드(`orgId && state.scope_org_id && ...`)가
-// 항상 false로 빠져 회귀 0 — 신규 테스트만 scope_org_id를 명시로 채운다.
+// story #3610(3607 잔여) CHANGES-2(유나 확認·PO 채택 2026-09-07) — orgId 비교를 폐기하고
+// BE가 낸 scope_is_requested_org 불리언만 본다(dashboard-shell 의존 0으로 축소). 기존
+// 픽스처(PARTIAL·COMPLETE)는 이 필드를 안 실어(undefined) 새 가드(`=== false`만 숨김)가
+// 항상 통과해 회귀 0 — 신규 테스트만 명시로 채운다.
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
-  useDashboardContext: () => ({ projectId: 'proj-1', orgId: 'org-1' }),
+  useDashboardContext: () => ({ projectId: 'proj-1' }),
 }));
 const routerPushMock = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -84,7 +85,7 @@ function stubChecklist(data: {
   total: number;
   all_complete: boolean;
   first_instruction_conversation_id?: string | null;
-  scope_org_id?: string | null;
+  scope_is_requested_org?: boolean;
 }) {
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data }) })));
 }
@@ -168,19 +169,26 @@ describe('ActivationChecklistBanner — 접기(collapse), 완전 dismiss는 없�
   });
 });
 
-describe('ActivationChecklistBanner — scope_org_id 불일치 시 미노출(story #3610, 3607 잔여)', () => {
-  it('scope_org_id가 현재 org(orgId)와 같으면 그대로 렌더된다(오탐 0)', async () => {
-    stubChecklist({ ...PARTIAL, scope_org_id: 'org-1' });
+describe('ActivationChecklistBanner — scope_is_requested_org 불일치 시 미노출(story #3610, 3607 잔여·CHANGES-2)', () => {
+  it('scope_is_requested_org===true면 그대로 렌더된다(오탐 0)', async () => {
+    stubChecklist({ ...PARTIAL, scope_is_requested_org: true });
     await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
     await flush();
     expect(container.textContent).toContain('가입을 마무리해 볼까요?');
   });
 
-  it('scope_org_id가 현재 org(orgId)와 다르면 아무것도 렌더하지 않는다(초대받은 org에서 남의 owner-org 진행률을 안 보임)', async () => {
-    stubChecklist({ ...PARTIAL, scope_org_id: 'org-2' });
+  it('scope_is_requested_org===false면 아무것도 렌더하지 않는다(요청 org와 판정 org가 갈리는 switch-org 전환 창 포함 — orgId 프레임 불일치 원인과 무관하게 BE 판단만 본다)', async () => {
+    stubChecklist({ ...PARTIAL, scope_is_requested_org: false });
     await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
     await flush();
     expect(container.textContent).toBe('');
+  });
+
+  it('scope_is_requested_org가 undefined(구 응답 shape)면 기존처럼 렌더 유지(과다 은닉 방지)', async () => {
+    stubChecklist({ ...PARTIAL });
+    await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
+    await flush();
+    expect(container.textContent).toContain('가입을 마무리해 볼까요?');
   });
 });
 

--- a/apps/web/src/components/dashboard/activation-checklist-banner.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.tsx
@@ -26,7 +26,7 @@ const COLLAPSE_KEY = 'sprintable_activation_checklist_collapsed';
 export function ActivationChecklistBanner() {
   const t = useTranslations('activation');
   const router = useRouter();
-  const { projectId } = useDashboardContext();
+  const { projectId, orgId } = useDashboardContext();
   const { state, allComplete } = useActivationStatus();
   const [navigatingToInstruction, setNavigatingToInstruction] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -39,6 +39,11 @@ export function ActivationChecklistBanner() {
   });
 
   if (allComplete || !state) return null;
+  // story #3610(3607 잔여, 페드루 PO 確定 2026-09-07) — scope_org_id(판정에 쓰인 org)가
+  // 지금 보는 org(orgId)와 다르면 이 판정은 이 화면 얘기가 아니다(초대받은 org에서 남의
+  // owner-org 진행률을 보이거나, 딥링크가 다른 org 대화로 새는 것을 막는다). 둘 다 확定된
+  // 값일 때만 가른다 — 아직 orgId를 모르는 초기 렌더는 기존 그대로(과다 은닉 방지).
+  if (orgId && state.scope_org_id && state.scope_org_id !== orgId) return null;
 
   const toggleCollapse = () => {
     const next = !collapsed;

--- a/apps/web/src/components/dashboard/activation-checklist-banner.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.tsx
@@ -26,7 +26,7 @@ const COLLAPSE_KEY = 'sprintable_activation_checklist_collapsed';
 export function ActivationChecklistBanner() {
   const t = useTranslations('activation');
   const router = useRouter();
-  const { projectId, orgId } = useDashboardContext();
+  const { projectId } = useDashboardContext();
   const { state, allComplete } = useActivationStatus();
   const [navigatingToInstruction, setNavigatingToInstruction] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -39,11 +39,12 @@ export function ActivationChecklistBanner() {
   });
 
   if (allComplete || !state) return null;
-  // story #3610(3607 잔여, 페드루 PO 確定 2026-09-07) — scope_org_id(판정에 쓰인 org)가
-  // 지금 보는 org(orgId)와 다르면 이 판정은 이 화면 얘기가 아니다(초대받은 org에서 남의
-  // owner-org 진행률을 보이거나, 딥링크가 다른 org 대화로 새는 것을 막는다). 둘 다 확定된
-  // 값일 때만 가른다 — 아직 orgId를 모르는 초기 렌더는 기존 그대로(과다 은닉 방지).
-  if (orgId && state.scope_org_id && state.scope_org_id !== orgId) return null;
+  // story #3610(3607 잔여) CHANGES-2(유나 확認·PO 채택 2026-09-07) — orgId(계정 기본
+  // org, me.org_id)와 비교하던 최초판을 폐기 — BE가 이미 "요청 org(X-Org-Id)==판정
+  // org"를 판정해 낸 불리언을 그대로 쓴다(다른 프레임 값 2개를 FE가 다시 맞대지
+  // 않는다). false일 때만 숨긴다 — undefined(구 응답 shape, 롤아웃 창)는 기존처럼
+  // 렌더 유지(과다 은닉 방지, 3610 최초판과 동일 원칙).
+  if (state.scope_is_requested_org === false) return null;
 
   const toggleCollapse = () => {
     const next = !collapsed;

--- a/apps/web/src/hooks/use-activation-status.ts
+++ b/apps/web/src/hooks/use-activation-status.ts
@@ -24,6 +24,10 @@ export interface ActivationState {
   all_complete: boolean;
   // story #3201 — 왕복 성사된 대화(또는 org 최초 agent DM) id, 없으면 null.
   first_instruction_conversation_id: string | null;
+  // story #3610(3607 잔여, 페드루 PO 確定 2026-09-07) — 판정에 실제로 쓰인 org. 요청 org의
+  // owner가 아니면(초대 admin/member) 폴백 org로 떨어져 요청 org와 달라진다 — 이 불일치로
+  // "이 판정은 지금 보는 org 얘기가 아니다"를 안다(어느 org도 owner가 아니면 null).
+  scope_org_id: string | null;
 }
 
 function readLocalFlag(key: string): boolean {

--- a/apps/web/src/hooks/use-activation-status.ts
+++ b/apps/web/src/hooks/use-activation-status.ts
@@ -24,10 +24,12 @@ export interface ActivationState {
   all_complete: boolean;
   // story #3201 — 왕복 성사된 대화(또는 org 최초 agent DM) id, 없으면 null.
   first_instruction_conversation_id: string | null;
-  // story #3610(3607 잔여, 페드루 PO 確定 2026-09-07) — 판정에 실제로 쓰인 org. 요청 org의
-  // owner가 아니면(초대 admin/member) 폴백 org로 떨어져 요청 org와 달라진다 — 이 불일치로
-  // "이 판정은 지금 보는 org 얘기가 아니다"를 안다(어느 org도 owner가 아니면 null).
-  scope_org_id: string | null;
+  // story #3610(3607 잔여) CHANGES-2(유나 확認·PO 채택 2026-09-07) — 최초판 scope_org_id
+  // (판정에 쓰인 org 값)를 폐기하고 불리언으로 대체했다. FE가 그 값을 orgId(실제로는
+  // me.org_id=계정 기본 org)와 비교했는데, X-Org-Id(탭 effective org)와 다른 프레임이라
+  // switch-org 전환 창에서 가드가 안 걸리는 구멍이 있었다 — BE가 "요청 org==판정 org"
+  // 비교를 직접 끝내 낸다. undefined(구 응답 shape, 롤아웃 창)면 기존처럼 렌더 유지.
+  scope_is_requested_org?: boolean;
 }
 
 function readLocalFlag(key: string): boolean {

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -237,12 +237,20 @@ async def get_activation_state(
         "first_instruction_conversation_id": (
             str(first_instruction_conv_id) if first_instruction_conv_id else None
         ),
-        # story #3610(3607 잔여, 페드루 PO 確定 2026-09-07) — 판정에 실제로 쓰인 org(
-        # resolve_activation_org_id의 반환값 그대로). 요청 org(현재 화면)의 owner가
-        # 아니면 이 값이 요청 org와 달라진다 — FE가 그 불일치로 "이 판정은 지금 보는
-        # org 얘기가 아니다"를 알고 배너를 안 그린다(딥링크가 다른 org 대화로 새는
-        # 자리 자체를 원천 차단, scope_org_id가 null이면 어느 org도 owner가 아님).
-        "scope_org_id": str(org_id) if org_id else None,
+        # story #3610(3607 잔여) 최초판은 scope_org_id(판정에 쓰인 org 값 자체)를
+        # 냈는데, 유나 CHANGES-2(2026-09-07, PR#3966 리뷰·PO 채택) — FE가 그 값을
+        # `orgId`(useDashboardContext, 실제로는 me.org_id=계정 기본 org, layout.tsx:140)
+        # 와 비교했다. 이 둘은 다른 프레임이다 — scope_org_id는 "요청 X-Org-Id(탭
+        # effective org)로 판정된 값"인데 orgId는 "계정 기본 org"라, 멀티-org 계정이
+        # URL로 다른 org에 들어와 DashboardShell 자동 switch-org가 끝나기 前 창
+        # (project-context-client.ts:40~52, me.org_id=A·X-Org-Id=B가 갈리는 그 자리)
+        # 에서 비-owner면 폴백 scope=A=orgId가 돼 가드가 안 걸린다(B 화면에 A 진행률이
+        # 새는, 이 스토리가 원래 닫으려던 바로 그 경우가 재발).
+        #
+        # BE는 "요청됐던 org"(requested_org_id)와 "판정에 실제로 쓰인 org"(org_id)
+        # 둘 다 안다 — 그 비교를 FE에 값 2개로 떠넘기지 않고 여기서 불리언 하나로
+        # 확定해 낸다. FE는 이제 orgId(다른 프레임)와 비교하지 않고 이 불리언만 본다.
+        "scope_is_requested_org": org_id is not None and org_id == requested_org_id,
     }
 
 

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -237,6 +237,12 @@ async def get_activation_state(
         "first_instruction_conversation_id": (
             str(first_instruction_conv_id) if first_instruction_conv_id else None
         ),
+        # story #3610(3607 잔여, 페드루 PO 確定 2026-09-07) — 판정에 실제로 쓰인 org(
+        # resolve_activation_org_id의 반환값 그대로). 요청 org(현재 화면)의 owner가
+        # 아니면 이 값이 요청 org와 달라진다 — FE가 그 불일치로 "이 판정은 지금 보는
+        # org 얘기가 아니다"를 알고 배너를 안 그린다(딥링크가 다른 org 대화로 새는
+        # 자리 자체를 원천 차단, scope_org_id가 null이면 어느 org도 owner가 아님).
+        "scope_org_id": str(org_id) if org_id else None,
     }
 
 

--- a/backend/tests/test_3159_onboarding_activation_realdb.py
+++ b/backend/tests/test_3159_onboarding_activation_realdb.py
@@ -152,11 +152,12 @@ async def test_resolve_activation_org_id_prefers_requested_context_when_owner_th
 
 
 @pytest.mark.anyio
-async def test_get_activation_state_scope_org_id_reveals_mismatch_for_non_owner_context():
-    """story #3610(3607 잔여, 페드루 PO 確定 2026-09-07) — 요청 org의 owner가 아닌 사용자
-    (초대받은 admin/member)에게 `scope_org_id`가 요청 org와 다른 값을 실어야 FE가 "이
-    판정은 지금 보는 org 얘기가 아니다"를 알 수 있다. owner인 요청 컨텍스트에서는
-    scope_org_id가 요청 org와 정확히 같아야 한다(오탐 0)."""
+async def test_get_activation_state_scope_is_requested_org_reveals_mismatch_for_non_owner_context():
+    """story #3610(3607 잔여) CHANGES-2(유나 확認·PO 채택 2026-09-07) — 최초판 scope_org_id
+    (판정에 쓰인 org 값 자체)를 폐기하고 `scope_is_requested_org` 불리언으로 대체했다.
+    요청 org의 owner가 아닌 사용자(초대받은 admin/member)는 폴백 org로 판정이 떨어져
+    요청 org와 달라지므로 False — FE가 "이 판정은 지금 보는 org 얘기가 아니다"를 안다.
+    owner인 요청 컨텍스트에서는 True(오탐 0)."""
     eng, Session = await _engine()
     async with Session() as s:
         await _wipe(s, ORG)
@@ -180,15 +181,14 @@ async def test_get_activation_state_scope_org_id_reveals_mismatch_for_non_owner_
             await s.commit()
             user = (await s.execute(select(User).where(User.id == uuid.UUID(user_id)))).scalar_one()
 
-            # 요청 컨텍스트=owner_org(그 org의 owner) — scope_org_id가 요청 org와 일치.
+            # 요청 컨텍스트=owner_org(그 org의 owner) — 요청 org==판정 org라 True.
             state_owner_ctx = await svc.get_activation_state(s, user, requested_org_id=uuid.UUID(owner_org))
-            assert state_owner_ctx["scope_org_id"] == owner_org
+            assert state_owner_ctx["scope_is_requested_org"] is True
 
-            # 요청 컨텍스트=invited_org(admin일 뿐 owner 아님) — scope_org_id가 폴백
-            # (owner_org)으로 떨어져 요청 org와 달라진다 — FE가 이 신호로 배너를 끈다.
+            # 요청 컨텍스트=invited_org(admin일 뿐 owner 아님) — 판정이 폴백(owner_org)
+            # 으로 떨어져 요청 org(invited_org)와 달라진다 — False, FE가 이 신호로 배너를 끈다.
             state_invited_ctx = await svc.get_activation_state(s, user, requested_org_id=uuid.UUID(invited_org))
-            assert state_invited_ctx["scope_org_id"] == owner_org
-            assert state_invited_ctx["scope_org_id"] != invited_org
+            assert state_invited_ctx["scope_is_requested_org"] is False
         finally:
             await _wipe(s, ORG)
             await s.execute(text(f"DELETE FROM organizations WHERE id='{invited_org}'"))

--- a/backend/tests/test_3159_onboarding_activation_realdb.py
+++ b/backend/tests/test_3159_onboarding_activation_realdb.py
@@ -15,9 +15,10 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+from app.models.user import User
 from app.services import onboarding_activation as svc
 
 _RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
@@ -145,6 +146,52 @@ async def test_resolve_activation_org_id_prefers_requested_context_when_owner_th
             await _wipe(s, ORG)
             await s.execute(text(f"DELETE FROM organizations WHERE id='{later_org}'"))
             await s.execute(text(f"DELETE FROM organizations WHERE id='{unrelated_org}'"))
+            await s.execute(text(f"DELETE FROM users WHERE email LIKE 'story3159-%'"))
+            await s.commit()
+    await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_activation_state_scope_org_id_reveals_mismatch_for_non_owner_context():
+    """story #3610(3607 잔여, 페드루 PO 確定 2026-09-07) — 요청 org의 owner가 아닌 사용자
+    (초대받은 admin/member)에게 `scope_org_id`가 요청 org와 다른 값을 실어야 FE가 "이
+    판정은 지금 보는 org 얘기가 아니다"를 알 수 있다. owner인 요청 컨텍스트에서는
+    scope_org_id가 요청 org와 정확히 같아야 한다(오탐 0)."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            owner_org, invited_org = ORG, _uuid()
+            user_id = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES "
+                f"('{owner_org}','O','story3159-o','free'),('{invited_org}','O2','story3159-o2','free')"
+            ))
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{user_id}','story3159-scope@t.test','x','U',true,false,0,false,0)"
+            ))
+            await s.execute(text(
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+                f"('{_uuid()}','{owner_org}','{user_id}','owner'),"
+                f"('{_uuid()}','{invited_org}','{user_id}','admin')"
+            ))
+            await s.commit()
+            user = (await s.execute(select(User).where(User.id == uuid.UUID(user_id)))).scalar_one()
+
+            # 요청 컨텍스트=owner_org(그 org의 owner) — scope_org_id가 요청 org와 일치.
+            state_owner_ctx = await svc.get_activation_state(s, user, requested_org_id=uuid.UUID(owner_org))
+            assert state_owner_ctx["scope_org_id"] == owner_org
+
+            # 요청 컨텍스트=invited_org(admin일 뿐 owner 아님) — scope_org_id가 폴백
+            # (owner_org)으로 떨어져 요청 org와 달라진다 — FE가 이 신호로 배너를 끈다.
+            state_invited_ctx = await svc.get_activation_state(s, user, requested_org_id=uuid.UUID(invited_org))
+            assert state_invited_ctx["scope_org_id"] == owner_org
+            assert state_invited_ctx["scope_org_id"] != invited_org
+        finally:
+            await _wipe(s, ORG)
+            await s.execute(text(f"DELETE FROM organizations WHERE id='{invited_org}'"))
             await s.execute(text(f"DELETE FROM users WHERE email LIKE 'story3159-%'"))
             await s.commit()
     await eng.dispose()


### PR DESCRIPTION
## 요약
3607 잔여(PR #3962 PO 대조 2026-09-07 03:52Z 발견) — `resolve_activation_org_id`는 요청 org에서 owner일 때만 그 org, 아니면 `get_owner_org_id`(가장 이른 owner org)로 폴백한다. sellerking(moonklabs admin, 다른 org owner)처럼 **현재 org의 owner가 아닌** 사용자는 여전히 폴백 org 기준으로 판정·딥링크가 나가 "다른 org의 대화" 404로 떨어진다.

**⚠️ 스택 PR** — base는 develop이 아니라 `fix/3607-onboarding-org-scope`(#3962, `resolve_activation_org_id`가 이 PR의 전제). #3962가 develop에 착지하면 base를 develop으로 재타깃 + rebase(페드루 PO 지시대로 "3962 착지 뒤 rebase 한 번").

## dev 실측(PO, 03:32Z, sellerking=moonklabs admin)
moonklabs 화면 `GET /api/activation/checklist` → 폴백=PO Test Org 기준 3/5, `first_instruction_conversation_id`=PO Test Org DM → moonklabs 스코프로 `/chats/{id}` **404**. 배너 문장이 "지금 보는 org"와 무관한 사실을 말한다.

## 그라운딩(디디, 2026-09-07 03:53Z — 3607 PR 작업 중 미리 확認)
FE 현재 org id = `useDashboardContext().orgId`(`dashboard-shell.tsx:326` `effectiveOrgId = resolveEffectiveOrgId(pathOrgId, jwtOrgId, orgId)` → `:385` Provider — X-Org-Id 헤더가 싣는 값과 같은 SSOT). `activation-checklist-banner.tsx`는 이미 `useDashboardContext()`를 쓰고 있어 `orgId` 구조분해만 추가하면 됨 — 새 훅·새 계산 0.

## 처방
1. BE: `get_activation_state` 응답에 `scope_org_id`(`resolve_activation_org_id`의 반환값 그대로) additive.
2. FE: `activation-checklist-banner.tsx`가 `orgId && state.scope_org_id && state.scope_org_id !== orgId`면 배너를 안 그린다(`return null`) — 둘 다 확定된 값일 때만 가른다(orgId를 아직 모르는 초기 렌더는 과다 은닉하지 않음, 기존 그대로). 새 UI·새 문구 0 — 표면은 "안 그림"뿐.
3. 리마인드 스윕(cron, `find_reminder_candidates`)은 `requested_org_id`를 안 줘 기존 동작 불변(코드 변경 0).

## 테스트
- `test_3159_onboarding_activation_realdb.py`(신규 1, 실 Postgres): `test_get_activation_state_scope_org_id_reveals_mismatch_for_non_owner_context` — owner인 요청 컨텍스트에서 `scope_org_id`가 요청 org와 일치, admin일 뿐 owner 아닌 컨텍스트에서 폴백(불일치)으로 떨어짐. 기존 16건 회귀 0.
- `activation-checklist-banner.test.tsx`(신규 2): `scope_org_id`가 `orgId`와 같으면 정상 렌더 / 다르면 빈 렌더. 기존 회귀 0(FE 38건 전체 통과).
- 뮤테이션 2건(BE: `scope_org_id`를 항상 null로 → 신규 테스트만 RED, FE: 가드 라인 제거 → 신규 "불일치" 테스트만 RED, "일치" 테스트는 그대로 통과해 격리 확認) — 둘 다 원복.

tsc --noEmit·eslint 전부 그린.

## 스토리
[3607 잔여 — 비-owner org 배너/딥링크 폴백](entity:story:b73344ef-4955-4405-9d39-e5f87c28ac2b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG