### PR TITLE
[SID:3611] fix: date-tolocalestring 가드 ALLOWLIST를 줄번호 핀 → 파일+내용 핀으로

### DIFF
--- a/apps/web/scripts/verify-no-date-tolocalestring.test.ts
+++ b/apps/web/scripts/verify-no-date-tolocalestring.test.ts
@@ -49,16 +49,16 @@ describe('extractHits — 순수 판정 함수(story #3486 원 가드 계승, #3
   });
 
   // story #3493 AC2 — 숫자 포맷(krw/포인트 잔액)은 날짜가 아니므로 ALLOWLIST에 등재된
-  // file+line은 이 가드가 봐줘야 한다(정확히 그 줄만 — 다른 줄은 여전히 걸린다).
-  it('ALLOWLIST에 등재된 file+line은 통과시킨다(숫자 포맷)', () => {
-    const entry = ALLOWLIST.find((e) => e.file === 'app/(authenticated)/rewards/page.tsx' && e.line === 153);
+  // 줄 내용은 이 가드가 봐줘야 한다(정확히 그 내용만 — 다른 줄은 여전히 걸린다).
+  it('ALLOWLIST에 등재된 줄 내용은 통과시킨다(숫자 포맷)', () => {
+    const entry = ALLOWLIST.find(
+      (e) => e.file === 'app/(authenticated)/rewards/page.tsx' && e.lineContent.includes('e.balance'),
+    );
     expect(entry).toBeDefined();
     expect(entry?.reason).toBeTruthy();
     expect(entry?.addedBy).toBeTruthy();
 
-    const content = Array.from({ length: 153 }, (_, i) =>
-      i === 152 ? "{e.balance.toLocaleString()} TJSB" : `// line ${i + 1}`,
-    ).join('\n');
+    const content = `const x = 1;\n${entry!.lineContent}\nconst y = 2;`;
     expect(extractHits(content, 'app/(authenticated)/rewards/page.tsx')).toEqual([]);
   });
 
@@ -66,7 +66,7 @@ describe('extractHits — 순수 판정 함수(story #3486 원 가드 계승, #3
     const hits = extractHits(
       'new Date(x).toLocaleString()',
       'app/(authenticated)/rewards/page.tsx',
-    ); // line 1 — ALLOWLIST는 이 파일의 153/224행만 등재, 1행은 미등재.
+    );
     expect(hits).toEqual([{ file: 'app/(authenticated)/rewards/page.tsx', line: 1 }]);
   });
 
@@ -75,6 +75,39 @@ describe('extractHits — 순수 판정 함수(story #3486 원 가드 계승, #3
       expect(entry.reason.length).toBeGreaterThan(0);
       expect(entry.addedBy.length).toBeGreaterThan(0);
     }
+  });
+
+  // story #3611(CI 후속, #3609와 같은 클래스) — 허용 목록이 file+line(줄번호) 키였을 때
+  // 무관한 줄이 위에 추가돼 뒷줄 번호가 밀리면 거짓 빨강이 났다(#3609 실사고). 키를
+  // «파일+줄 내용»으로 바꾼 뒤에도 그 내성이 실제로 성립하는지 selftest로 고정한다.
+  describe('#3611 — 줄번호 무관(file+내용) 핀 내성', () => {
+    const ALLOWED_ENTRY = ALLOWLIST[0]!; // rewards/page.tsx의 balance 줄.
+
+    it('(a) 허용 줄 «앞»에 무관한 줄을 여러 개 삽입해도 위반 0(줄번호가 밀려도 안 깨짐)', () => {
+      const content = [
+        '// unrelated line 1',
+        '// unrelated line 2',
+        '// unrelated line 3',
+        'const noise = 1;',
+        ALLOWED_ENTRY.lineContent,
+      ].join('\n');
+      expect(extractHits(content, ALLOWED_ENTRY.file)).toEqual([]);
+    });
+
+    it('(b) 허용 줄의 «내용 자체»가 바뀌면 더는 허용목록에 안 걸려 위반 1(내용 변화는 진짜 새 자리)', () => {
+      const mutatedLine = ALLOWED_ENTRY.lineContent.replace('balance', 'differentField');
+      const content = `const noise = 1;\n${mutatedLine}`;
+      expect(extractHits(content, ALLOWED_ENTRY.file)).toEqual([{ file: ALLOWED_ENTRY.file, line: 2 }]);
+    });
+
+    // 뮤테이션 대조 — isAllowed가 다시 줄번호 기반이 되면 (a)가 반드시 빨강이어야
+    // 이 selftest 자체가 그 회귀를 잡는다는 걸 증명한다(코드 자체를 되돌리지 않고,
+    // 판정 로직과 동형인 line-index 매칭을 이 테스트 안에서 직접 흉내내 대조).
+    it('뮤테이션 대조 — line-index 매칭이었다면 (a)의 그 줄(5번째)은 원래 153번째가 아니라 위반으로 남는다', () => {
+      const lineIndexBasedIsAllowed = (file: string, lineNumber: number) =>
+        file === ALLOWED_ENTRY.file && lineNumber === 153; // 옛 방식(고정 줄번호 153) 흉내.
+      expect(lineIndexBasedIsAllowed(ALLOWED_ENTRY.file, 5)).toBe(false);
+    });
   });
 });
 

--- a/apps/web/scripts/verify-no-date-tolocalestring.ts
+++ b/apps/web/scripts/verify-no-date-tolocalestring.ts
@@ -15,9 +15,19 @@
  * 한계 승계). ⛔이 가드가 못 보는 것(선언, 3486 원 문서와 동형) — ①주석·문자열 리터럴
  * 안의 단순 언급(테스트 파일은 이미 제외) ②숫자 포맷(`.toLocaleString('ko-KR')`류 —
  * krw·포인트 잔액 등)은 날짜가 아니지만 메서드명만으로는 날짜 호출과 구분이 안 되므로,
- * 알려진 소비처는 ALLOWLIST에 **file+line**으로 등재해 예외 처리한다(사유 없는 예외
- * 금지 — HANJA_EXCEPTIONS와 동형 원칙, reason·addedBy 필수). 등재분 4건은 이 스토리
- * grep으로 전수 확인한 값이다(rewards 포인트 잔액 2·ee billing KRW/AU 수량 2).
+ * 알려진 소비처는 ALLOWLIST에 등재해 예외 처리한다(사유 없는 예외 금지 — HANJA_
+ * EXCEPTIONS와 동형 원칙, reason·addedBy 필수). 등재분 4건은 이 스토리 grep으로
+ * 전수 확인한 값이다(rewards 포인트 잔액 2·ee billing KRW/AU 수량 2).
+ *
+ * story #3611(CI 후속, #3609와 같은 클래스) — 허용 목록이 원래 file+line(줄번호) 키였다.
+ * #3609 실사고(3592가 events/page.tsx에 줄을 추가하자 그 파일의 뒷줄 2개가 줄번호만
+ * 밀려 develop·열린 PR 전부 거짓 빨강)와 정확히 같은 구조적 위험 — 이 4파일 어디든
+ * 무관한 줄이 허용 줄 «위»에 추가되는 순간 이 가드도 똑같이 깨진다. 키를 «파일 +
+ * strip한 줄 내용 완전 일치»로 바꾼다(lint_fe_error_envelope_detail_mismatch.py의
+ * #3609 처방과 동형) — 줄번호가 몇 번이든 그 파일에 그 정확한 텍스트가 있으면 허용.
+ * reason·addedBy 구조 필드는 이 파일의 기존 관례(HANJA_EXCEPTIONS 동형)를 그대로
+ * 유지한다 — #3609가 인라인 주석으로 사유를 적은 것과 달리 여기는 이미 구조화된
+ * 필드가 있어 그걸 없앨 이유가 없다(둘 다 "사유 필수"라는 같은 목적, 형만 다름).
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
@@ -36,22 +46,26 @@ export interface DateToLocaleStringHit {
 
 export interface AllowlistEntry {
   file: string;
-  line: number;
+  /** story #3611 — 줄번호가 아니라 그 줄의 strip()된 내용 전체 일치(키가 «파일+내용»
+   * 이라 위쪽에 무관한 줄이 추가돼 실제 줄번호가 밀려도 안 깨진다). */
+  lineContent: string;
   reason: string;
   addedBy: string;
 }
 
 // story #3493 AC2 — 날짜가 아니라 숫자 포맷인 것으로 이 스토리에서 grep 전수 확인한 4곳.
 // 새 항목을 등재하려면 reason·addedBy를 반드시 채울 것(사유 없는 예외 금지).
+// story #3611 — lineContent는 develop 원문 그대로를 strip()해 등재(줄번호 무관).
 export const ALLOWLIST: AllowlistEntry[] = [
-  { file: 'app/(authenticated)/rewards/page.tsx', line: 153, reason: '포인트 잔액(TJSB) 숫자 포맷 — 날짜 아님', addedBy: 'story #3493' },
-  { file: 'app/(authenticated)/rewards/page.tsx', line: 224, reason: '포인트 잔액(TJSB) 숫자 포맷 — 날짜 아님', addedBy: 'story #3493' },
-  { file: 'ee/components/billing/pricing-data.ts', line: 130, reason: 'KRW 금액 숫자 포맷(formatKrw) — 날짜 아님', addedBy: 'story #3493' },
-  { file: 'ee/components/billing/billing-tab.tsx', line: 665, reason: '자동화 크레딧(AU) 수량 숫자 포맷 — 날짜 아님', addedBy: 'story #3493' },
+  { file: 'app/(authenticated)/rewards/page.tsx', lineContent: "{e.balance >= 0 ? '+' : ''}{e.balance.toLocaleString()} TJSB", reason: '포인트 잔액(TJSB) 숫자 포맷 — 날짜 아님', addedBy: 'story #3493' },
+  { file: 'app/(authenticated)/rewards/page.tsx', lineContent: "{e.amount >= 0 ? '+' : ''}{e.amount.toLocaleString()} TJSB", reason: '포인트 잔액(TJSB) 숫자 포맷 — 날짜 아님', addedBy: 'story #3493' },
+  { file: 'ee/components/billing/pricing-data.ts', lineContent: "return `${krw.toLocaleString('ko-KR')}원`;", reason: 'KRW 금액 숫자 포맷(formatKrw) — 날짜 아님', addedBy: 'story #3493' },
+  { file: 'ee/components/billing/billing-tab.tsx', lineContent: "? t('packDialogAutomationAmount', { amount: (AUTOMATION_PACK.auPerPack * target.quantity).toLocaleString('ko-KR') })", reason: '자동화 크레딧(AU) 수량 숫자 포맷 — 날짜 아님', addedBy: 'story #3493' },
 ];
 
-function isAllowed(file: string, line: number): boolean {
-  return ALLOWLIST.some((e) => e.file === file && e.line === line);
+function isAllowed(file: string, lineText: string): boolean {
+  const trimmed = lineText.trim();
+  return ALLOWLIST.some((e) => e.file === file && e.lineContent === trimmed);
 }
 
 export function extractHits(content: string, file: string): DateToLocaleStringHit[] {
@@ -59,7 +73,7 @@ export function extractHits(content: string, file: string): DateToLocaleStringHi
   const lines = content.split('\n');
   lines.forEach((lineText, i) => {
     LOCALE_DATE_CALL_RE.lastIndex = 0;
-    if (LOCALE_DATE_CALL_RE.test(lineText) && !isAllowed(file, i + 1)) hits.push({ file, line: i + 1 });
+    if (LOCALE_DATE_CALL_RE.test(lineText) && !isAllowed(file, lineText)) hits.push({ file, line: i + 1 });
   });
   return hits;
 }


### PR DESCRIPTION
## 요약
#3609와 같은 클래스(그 PR #3963 본문 grep이 잡은 나머지 1건) — `apps/web/scripts/verify-no-date-tolocalestring.ts`의 `ALLOWLIST`가 `{file, line}`(줄번호) 키였다. #3609 실사고(#3956이 events/page.tsx에 aria-label 39줄을 추가하자 그 파일 뒷줄 2개의 허용목록 줄번호가 밀려 develop·열린 PR 전부 거짓 빨강)와 정확히 같은 구조적 위험 — 이 4파일(rewards/page.tsx ×2·ee billing ×2) 어디든 무관한 줄이 허용 줄 위에 추가되는 순간 이 가드도 똑같이 깨진다.

## 처방
키를 «파일 + strip한 줄 내용 완전 일치»로 변경(`lint_fe_error_envelope_detail_mismatch.py`의 #3609 처방과 동형 원칙). `AllowlistEntry.line: number` → `lineContent: string`, `isAllowed(file, line)` → `isAllowed(file, lineText)`(trim 비교). `reason`·`addedBy` 구조 필드는 이 파일의 기존 관례(HANJA_EXCEPTIONS와 동형, "사유 없는 예외 금지")를 그대로 유지 — #3609가 인라인 주석으로 사유를 적은 것과 형만 다를 뿐 목적은 같다.

## 테스트
- 기존 2건(`verify-no-date-tolocalestring.test.ts`)을 줄번호 기반 합성 픽스처에서 실제 `lineContent` 값 기반으로 재작성(회귀 0).
- 신규 3건:
  - (a) 허용 줄 «앞»에 무관한 줄 4개 삽입 → 위반 0(양성대조 — 줄번호가 밀려도 안 깨짐).
  - (b) 허용 줄의 «내용 자체»가 바뀌면(예: `balance`→`differentField`) 위반 1(음성 내성 — 내용이 진짜 바뀌면 여전히 잡아야 함).
  - (c) 뮤테이션 대조 — 옛 line-index 매칭 방식을 그대로 흉내 낸 함수가 (a)의 실제 줄번호(5)에서 실패함을 직접 증명.
- 실 저장소 스캔(`npx tsx scripts/verify-no-date-tolocalestring.ts`) — 0 violations(등재 4건의 `lineContent`가 develop 원문과 정확히 일치함을 확認).
- 뮤테이션(`isAllowed`를 항상 `false`로) — 신규 2건(등재 통과 검증 테스트)만 정확히 RED, 나머지 12건은 그대로 통과(격리 확認) → 원복.

tsc --noEmit·eslint 전부 그린.

## 스토리
[verify-no-date-tolocalestring.ts ALLOWLIST 줄번호 핀 위험](entity:story:fd22f371-f1e7-4361-87a8-199e14d3898d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG