### PR TITLE
[SID:3612] fix: 댓글 수집 선검사 실패가 last_error를 순환 문구로 덮지 않게

### DIFF
--- a/backend/app/models/channel_post_comment.py
+++ b/backend/app/models/channel_post_comment.py
@@ -87,7 +87,12 @@ class CommentCollectionSchedule(Base):
     external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     due_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
     captured_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    # 'pending'|'in_progress'|'captured'|'unsupported'|'failed' — insight_snapshot.status와 동형.
+    # 'pending'|'in_progress'|'captured'|'unsupported'|'failed'|'connection_inactive' —
+    # insight_snapshot.status와 동형(마지막 값만 이쪽 전용, story #3612). connection_
+    # inactive=선검사(CHANNEL_CONNECTION_NOT_ACTIVE — 연결 비활성/없음/무자격)로 막힌
+    # 행. «연결에 대한 새 증거»가 아니라 이미 아는 사실의 재확인이라 승격·지속폴링
+    # 재생성 대상이 아니고(매 틱 재시도 0), pending처럼 due 스캔에도 안 걸린다 —
+    # 연결이 active로 복귀하면 wake_resting_comment_schedules()가 pending으로 되돌린다.
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default="pending")
     attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     error_code: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/services/channel_connection.py
+++ b/backend/app/services/channel_connection.py
@@ -96,6 +96,11 @@ async def upsert_channel_connection(
         existing.connected_by = connected_by
         existing.secret_hint = secret_hint
         row = existing
+        # story #3612 — 재연결(active 복귀)이 이 함수의 else 분기(기존 행 upsert)로만
+        # 일어난다(if existing is None 분기는 신규 연결이라 쉬는 스케줄이 있을 수
+        # 없음). wake_resting_comment_schedules 참고(단일 깨우는 손).
+        from app.services.channel_post_comments import wake_resting_comment_schedules
+        await wake_resting_comment_schedules(db, connection_id=existing.id)
 
     await db.commit()
     await db.refresh(row)
@@ -145,6 +150,10 @@ async def replace_channel_connection_credential(
     row.status = "active"
     row.last_error = None
     row.connected_by = updated_by
+    # story #3612 — 이 자격 교체도 non-active→active 복귀 경로다(wake_resting_
+    # comment_schedules 참고, 단일 깨우는 손).
+    from app.services.channel_post_comments import wake_resting_comment_schedules
+    await wake_resting_comment_schedules(db, connection_id=row.id)
 
     await db.commit()
     await db.refresh(row)
@@ -190,6 +199,10 @@ async def apply_refresh_result(
     connection.last_refreshed_at = datetime.now(timezone.utc)
     connection.last_error = None
     connection.status = "active"
+    # story #3612 — 자동 토큰 갱신 성공도 non-active→active 복귀 경로다(wake_
+    # resting_comment_schedules 참고, 단일 깨우는 손).
+    from app.services.channel_post_comments import wake_resting_comment_schedules
+    await wake_resting_comment_schedules(db, connection_id=connection.id)
     await db.commit()
 
 

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -81,6 +81,30 @@ async def schedule_comment_collection(
             external_id=external_id, due_at=anchor_at + offset, status="pending",
         ).on_conflict_do_nothing(constraint="uq_comment_collection_schedule_publication_due_at")
         await db.execute(stmt)
+
+
+async def wake_resting_comment_schedules(db: AsyncSession, *, connection_id: uuid.UUID) -> int:
+    """story #3612(라이브 결함, 배포 47) — `process_due_comment_collections`가
+    CHANNEL_CONNECTION_NOT_ACTIVE 선검사에 막히면 그 스케줄 행을 `status=
+    "connection_inactive"`로 쉬게 한다(AC2, 매 틱 재시도 0 — 승격/기록도 안 함).
+    쉬게만 하고 깨우는 손이 없으면 연결이 나중에 복귀해도 그 발행은 영영 재수집이
+    안 되는 반쪽 처방이 된다 — 연결이 non-active→active로 돌아오는 «모든» 경로
+    (재연결 upsert·자격 교체·자동 갱신 성공, `channel_connection.py`의 세 자리)가
+    공유하는 단일 깨우는 손이 이 함수다(호출부마다 각자 깨우는 로직을 새로 짜지
+    않는다). due_at=now()로 되돌려 다음 루프 틱이 즉시 다시 집는다."""
+    from app.models.channel_publication import ChannelPublication
+
+    result = await db.execute(
+        update(CommentCollectionSchedule)
+        .where(
+            CommentCollectionSchedule.status == "connection_inactive",
+            CommentCollectionSchedule.publication_id.in_(
+                select(ChannelPublication.id).where(ChannelPublication.connection_id == connection_id)
+            ),
+        )
+        .values(status="pending", due_at=func.now())
+    )
+    return result.rowcount
 
 
 def _text_sha256(text: str) -> str:
@@ -379,7 +403,15 @@ async def _sweep_orphaned_active_publications_for_self_recovery(db: AsyncSession
     has_open_row_due_soon = (
         select(func.count()).select_from(CommentCollectionSchedule).where(
             CommentCollectionSchedule.publication_id == ChannelPublication.id,
-            CommentCollectionSchedule.status.in_(("pending", "in_progress")),
+            # story #3612 — connection_inactive도 "열린 행"으로 센다. 이 스윕은 그
+            # 상태를 모르고 "due 3창 소진+최근활동없음"만 보는데, 뺴놓으면 매 틱
+            # (a) 루프가 connection_inactive로 쉬게 함 → (b) 이 스윕이 그 즉시
+            # "행 0"으로 보고 due_at=now 씨앗을 다시 심음 → (c) 다음 틱이 다시 그
+            # 씨앗을 집어 선검사에 또 막혀 connection_inactive → 반복. "쉬게 한다
+            # (AC2 매 틱 재시도 0)"가 이 스윕 때문에 무력화되던 것을 실측(로컬
+            # 재현)으로 잡음 — 연결이 복귀하면 wake_resting_comment_schedules가
+            # pending으로 되돌리므로 그 뒤엔 정상적으로 다시 열린 행으로 잡힌다.
+            CommentCollectionSchedule.status.in_(("pending", "in_progress", "connection_inactive")),
             CommentCollectionSchedule.due_at <= due_soon_cutoff,
         ).correlate(ChannelPublication).scalar_subquery()
     )
@@ -463,7 +495,20 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
                 continue
             except CommentFetchError as exc:
                 failure_kind = classify_failure_kind(exc.error_code)
-                if failure_kind == FAILURE_KIND_CONNECTION:
+                if exc.error_code == "CHANNEL_CONNECTION_NOT_ACTIVE":
+                    # story #3612(라이브 결함, 배포 47) — 이건 선검사(이미 비활성/연결
+                    # 없음/무자격)가 막은 것이지 provider가 새로 알려준 사실이 아니다.
+                    # 승격·last_error 기록 대상이 아니다(AC1 — 안 그러면 그 이전에
+                    # 적힌 진짜 원인(CHANNEL_TOKEN_EXPIRED 등)이 매 틱 이 순환 문구로
+                    # 덮인다, 실사고 재현). 지속폴링 재생성도 안 부른다 — 이 행을
+                    # "쉬게" 한다(pending이 아니라 connection_inactive라 다음 due
+                    # 스캔에서 안 잡힘, AC2 "매 틱 재시도 0"). 연결이 active로 복귀
+                    # 하면 wake_resting_comment_schedules()가 pending으로 되돌린다.
+                    row.status = "connection_inactive"
+                    row.error_code = exc.error_code
+                    await db.commit()
+                    counts["connection_inactive"] = counts.get("connection_inactive", 0) + 1
+                elif failure_kind == FAILURE_KIND_CONNECTION:
                     await _promote_connection_status(
                         db, publication_id=row.publication_id, error_code=exc.error_code, message=str(exc),
                     )
@@ -635,7 +680,12 @@ async def refresh_comments_now(
         # 전용 개념을 수동 경로에 섞지 않는다).
         from app.services.publication_command import classify_failure_kind, FAILURE_KIND_CONNECTION
 
-        if classify_failure_kind(exc.error_code) == FAILURE_KIND_CONNECTION:
+        # story #3612(라이브 결함, 배포 47) — CHANNEL_CONNECTION_NOT_ACTIVE는 선검사
+        # (이미 비활성/연결 없음/무자격)일 뿐 새 증거가 아니다 — 승격·기록 대상이
+        # 아니다(AC3, 스케줄 루프 쪽 AC1과 동형). 사람에게는 그대로 409로 알린다
+        # (schedule_row.status="failed"·raise는 불변) — «기록 안 함»과 «알림 안 함»은
+        # 다르다, 이 버튼을 누른 그 사람에게는 지금 실패했다는 사실 자체가 유효한 응답.
+        if classify_failure_kind(exc.error_code) == FAILURE_KIND_CONNECTION and exc.error_code != "CHANNEL_CONNECTION_NOT_ACTIVE":
             # story #3603(잔여, 페드루 PO 追加 2026-09-07) — error_code/message를 안 실으면
             # 이 수동 경로만 last_error 3종이 안 채워져(3597과 같은 클래스 재발) 「서버
             # 응답 보기」가 여기서 시작된 만료엔 비거나 옛 오류를 보인다.

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -43,6 +43,12 @@ _ACTIVE_PUBLICATIONS_ORG_CAP = 200
 # transient(429/5xx) 백오프 — next_attempt_at = now + min(2^attempt_count분, 60분).
 _TRANSIENT_BACKOFF_CAP_MINUTES = 60
 
+# story #3612 — _fetch_replies_raw의 선검사 실패 코드 전부(연결 비활성/연결 없음
+# ·발행 기록 없음/자격 없음). 전부 "provider가 알려준 새 사실"이 아니라 우리 쪽
+# 사전 조회가 막은 것이라 승격(_promote_connection_status)·기록 대상이 아니고,
+# 스케줄 루프는 이 코드들을 만나면 그 행을 "connection_inactive"로 쉬운다(AC1·AC2).
+_COMMENT_PRECHECK_CODES = frozenset({"CHANNEL_CONNECTION_NOT_ACTIVE", "COMMENT_PUBLICATION_NOT_FOUND"})
+
 
 class CommentFetchError(Exception):
     """어댑터 fetch_replies 실패 통로. error_code는 `publication_command.py::
@@ -164,8 +170,12 @@ async def _fetch_replies_raw(
         select(ChannelPublication).where(ChannelPublication.id == publication_id)
     )).scalar_one_or_none()
     if pub is None or pub.external_id is None:
+        # story #3612(PO 대조 CHANGES-1, insight_snapshots.py::_fetch_*_via_connection과
+        # 같은 패턴) — "발행 기록 없음"은 연결 상태와 무관한 다른 사실인데 CHANNEL_
+        # CONNECTION_NOT_ACTIVE를 재사용하고 있었다. 자기 코드로 분리(_COMMENT_
+        # PRECHECK_CODES에도 등재 — 선검사 성격은 동일해 승격/기록 대상은 아니다).
         raise CommentFetchError(
-            error_code="CHANNEL_CONNECTION_NOT_ACTIVE",
+            error_code="COMMENT_PUBLICATION_NOT_FOUND",
             message=f"channel_publication을 찾을 수 없습니다: {publication_id}",
         )
     connection = await db.get(ChannelConnection, pub.connection_id)
@@ -495,7 +505,7 @@ async def process_due_comment_collections(db: AsyncSession, *, now: datetime | N
                 continue
             except CommentFetchError as exc:
                 failure_kind = classify_failure_kind(exc.error_code)
-                if exc.error_code == "CHANNEL_CONNECTION_NOT_ACTIVE":
+                if exc.error_code in _COMMENT_PRECHECK_CODES:
                     # story #3612(라이브 결함, 배포 47) — 이건 선검사(이미 비활성/연결
                     # 없음/무자격)가 막은 것이지 provider가 새로 알려준 사실이 아니다.
                     # 승격·last_error 기록 대상이 아니다(AC1 — 안 그러면 그 이전에
@@ -685,7 +695,7 @@ async def refresh_comments_now(
         # 아니다(AC3, 스케줄 루프 쪽 AC1과 동형). 사람에게는 그대로 409로 알린다
         # (schedule_row.status="failed"·raise는 불변) — «기록 안 함»과 «알림 안 함»은
         # 다르다, 이 버튼을 누른 그 사람에게는 지금 실패했다는 사실 자체가 유효한 응답.
-        if classify_failure_kind(exc.error_code) == FAILURE_KIND_CONNECTION and exc.error_code != "CHANNEL_CONNECTION_NOT_ACTIVE":
+        if classify_failure_kind(exc.error_code) == FAILURE_KIND_CONNECTION and exc.error_code not in _COMMENT_PRECHECK_CODES:
             # story #3603(잔여, 페드루 PO 追加 2026-09-07) — error_code/message를 안 실으면
             # 이 수동 경로만 last_error 3종이 안 채워져(3597과 같은 클래스 재발) 「서버
             # 응답 보기」가 여기서 시작된 만료엔 비거나 옛 오류를 보인다.

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -317,7 +317,7 @@ async def _fetch_instagram_via_connection(db: AsyncSession, snapshot: InsightSna
     )).scalar_one_or_none()
     if pub is None or pub.external_id is None:
         raise InsightFetchError(
-            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
+            error_code="INSIGHT_PUBLICATION_NOT_FOUND", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
         )
     connection = await db.get(ChannelConnection, pub.connection_id)
     if connection is None or connection.status != "active":
@@ -400,7 +400,7 @@ async def _fetch_facebook_via_connection(db: AsyncSession, snapshot: InsightSnap
     )).scalar_one_or_none()
     if pub is None or pub.external_id is None:
         raise InsightFetchError(
-            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
+            error_code="INSIGHT_PUBLICATION_NOT_FOUND", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
         )
     connection = await db.get(ChannelConnection, pub.connection_id)
     if connection is None or connection.status != "active":
@@ -453,7 +453,7 @@ async def _fetch_threads_via_connection(db: AsyncSession, snapshot: InsightSnaps
     )).scalar_one_or_none()
     if pub is None or pub.external_id is None:
         raise InsightFetchError(
-            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
+            error_code="INSIGHT_PUBLICATION_NOT_FOUND", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
         )
     connection = await db.get(ChannelConnection, pub.connection_id)
     if connection is None or connection.status != "active":

--- a/backend/tests/test_3612_connection_notactive_precheck_norecord.py
+++ b/backend/tests/test_3612_connection_notactive_precheck_norecord.py
@@ -248,3 +248,48 @@ async def test_ac4_insight_publication_not_found_uses_own_code():
             assert exc_info.value.error_code != "CHANNEL_CONNECTION_NOT_ACTIVE"
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac4b_comment_publication_not_found_uses_own_code_and_is_precheck():
+    """PO 대조 CHANGES-1(2026-09-07) — channel_post_comments.py에도 insight :320과
+    같은 패턴("channel_publication을 찾을 수 없습니다"가 CHANNEL_CONNECTION_NOT_ACTIVE
+    재사용)이 1곳 있었다. 자기 코드(COMMENT_PUBLICATION_NOT_FOUND)로 분리하되,
+    선검사 성격(승격/기록 대상 아님·스케줄은 쉼)은 그대로 유지되는지 함께 고정한다
+    (그냥 코드만 바꾸고 _COMMENT_PRECHECK_CODES 갱신을 빠뜨리면 이 자리만 다시
+    "failed"로 승격 대상이 되는 회귀가 조용히 생긴다)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.services.channel_post_comments import CommentFetchError, _fetch_replies_raw, refresh_comments_now
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook", status="active")
+            missing_publication_id = uuid.uuid4()
+
+            with pytest.raises(CommentFetchError) as exc_info:
+                await _fetch_replies_raw(
+                    s, org_id=org_id, publication_id=missing_publication_id, channel="facebook", external_id="media-x",
+                )
+            assert exc_info.value.error_code == "COMMENT_PUBLICATION_NOT_FOUND"
+            assert exc_info.value.error_code != "CHANNEL_CONNECTION_NOT_ACTIVE"
+
+            # 선검사 성격 유지 확인 — 이 코드로도 refresh_comments_now가 승격/기록 없이
+            # 그대로 실패만 낸다(connection은 active 그대로, last_error 3필드 불변).
+            original_error_at = datetime.now(timezone.utc) - timedelta(hours=1)
+            conn.last_error = "이전 원인"
+            conn.last_error_code = "CHANNEL_TOKEN_EXPIRED"
+            conn.last_error_at = original_error_at
+            await s.commit()
+
+            with pytest.raises(CommentFetchError):
+                await refresh_comments_now(s, org_id=org_id, publication_id=missing_publication_id)
+
+            refreshed = await s.get(ChannelConnection, conn.id)
+            assert refreshed.last_error == "이전 원인"
+            assert refreshed.last_error_code == "CHANNEL_TOKEN_EXPIRED"
+            assert refreshed.last_error_at == original_error_at
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3612_connection_notactive_precheck_norecord.py
+++ b/backend/tests/test_3612_connection_notactive_precheck_norecord.py
@@ -1,0 +1,250 @@
+"""story #3612(Phase2·BE·소형·결함, 라이브 결함·배포 47·PO Test Org 실측 2026-09-07) —
+`channel_post_comments.py`의 CHANNEL_CONNECTION_NOT_ACTIVE 선검사(이미 비활성/연결
+없음/무자격)가 «연결에 대한 새 증거»가 아닌데도 스케줄 루프·수동 재수집 두 경로가
+`_promote_connection_status`를 불러 last_error 3종을 매 틱 이 순환 문구로 덮어썼다
+(「왜 만료됐나」가 「연결이 활성 상태가 아닙니다」가 되는 실사고, 원래 원인
+CHANNEL_TOKEN_EXPIRED는 소실). 이 파일은 AC1~AC5를 각각 고정한다.
+
+세팅 헬퍼는 test_3603_connection_last_error.py·test_3497_insight_snapshots.py와
+동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+from tests.test_3497_insight_snapshots import _seed_channel_connection, _seed_channel_publication
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    """test_3603_connection_last_error.py와 동형 — channel_connection 암호화 키가
+    없으면 _seed_channel_connection의 encrypt_channel_credential이 죽는다."""
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.mark.anyio
+async def test_ac1_precheck_not_active_does_not_clobber_last_error(monkeypatch):
+    """AC1 — expired+TOKEN_EXPIRED 기록된 연결에 루프 1틱 → last_error_code 그대로
+    TOKEN_EXPIRED(라이브 실사고 재현: 이전엔 이 값이 CHANNEL_CONNECTION_NOT_ACTIVE로
+    덮였다). 스케줄 행은 connection_inactive로 쉰다(AC2 절반)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook", status="expired")
+            original_error_at = datetime.now(timezone.utc) - timedelta(hours=3)
+            conn.last_error = "토큰이 만료되었습니다: 401"
+            conn.last_error_code = "CHANNEL_TOKEN_EXPIRED"
+            conn.last_error_at = original_error_at
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook", external_id="media-1", anchor_at=anchor,
+            )
+            await s.commit()
+
+            counts = await process_due_comment_collections(s)
+            assert counts.get("connection_inactive") == 1, counts
+            assert counts.get("failed", 0) == 0
+
+            refreshed = await s.get(ChannelConnection, conn.id)
+            assert refreshed.status == "expired"
+            assert refreshed.last_error == "토큰이 만료되었습니다: 401", "선검사 실패가 원래 원인을 덮으면 안 된다"
+            assert refreshed.last_error_code == "CHANNEL_TOKEN_EXPIRED"
+            assert refreshed.last_error_at == original_error_at
+
+            rows = (await s.execute(
+                __import__("sqlalchemy").select(CommentCollectionSchedule).where(
+                    CommentCollectionSchedule.publication_id == pub.id,
+                ).order_by(CommentCollectionSchedule.due_at.asc())
+            )).scalars().all()
+            # schedule_comment_collection이 +1h·+1d·+7d 3행을 심는다 — 그중 +1h만
+            # anchor(now-2h) 기준 이미 due라 이번 틱에 처리된다(나머지 2행은 미래라
+            # 그대로 pending).
+            assert len(rows) == 3
+            assert rows[0].status == "connection_inactive"
+            assert rows[0].error_code == "CHANNEL_CONNECTION_NOT_ACTIVE"
+            assert rows[1].status == "pending" and rows[2].status == "pending"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac2_resting_row_not_retried_next_tick():
+    """AC2 — connection_inactive로 쉰 행은 다음 틱 due 스캔에도 안 걸린다(매 틱
+    재시도 0). pending이었다면 두 번째 호출도 counts["connection_inactive"]==1이
+    또 나왔을 것 — 여기선 0이어야 한다."""
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook", status="expired")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook", external_id="media-1", anchor_at=anchor,
+            )
+            await s.commit()
+
+            first = await process_due_comment_collections(s)
+            assert first.get("connection_inactive") == 1, first
+
+            second = await process_due_comment_collections(s)
+            assert second.get("connection_inactive", 0) == 0, second
+            assert sum(second.values()) == 0, second
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac3_manual_refresh_not_active_no_promote_still_raises():
+    """AC3 — 수동 「다시 수집」은 non-active 연결에서 지금과 같이 실패(409로 매핑)
+    하되 승격/기록은 없다(last_error 3종 불변)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_post_comments import CommentFetchError, refresh_comments_now
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook", status="expired")
+            original_error_at = datetime.now(timezone.utc) - timedelta(hours=3)
+            conn.last_error = "토큰이 만료되었습니다: 401"
+            conn.last_error_code = "CHANNEL_TOKEN_EXPIRED"
+            conn.last_error_at = original_error_at
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+            await s.commit()
+
+            with pytest.raises(CommentFetchError) as exc_info:
+                await refresh_comments_now(s, org_id=org_id, publication_id=pub.id)
+            assert exc_info.value.error_code == "CHANNEL_CONNECTION_NOT_ACTIVE"
+
+            refreshed = await s.get(ChannelConnection, conn.id)
+            assert refreshed.status == "expired"
+            assert refreshed.last_error == "토큰이 만료되었습니다: 401"
+            assert refreshed.last_error_code == "CHANNEL_TOKEN_EXPIRED"
+            assert refreshed.last_error_at == original_error_at
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac2_wake_resets_resting_schedule_on_reconnect():
+    """AC2(복귀 경로) — 쉬는 행이 재연결(upsert_channel_connection, 같은 org/channel/
+    account_id) 뒤 pending으로 깨어나고 due_at도 즉시로 되돌아온다(다음 루프 틱이
+    바로 집는다)."""
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.services.channel_connection import upsert_channel_connection
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook", status="expired")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook", external_id="media-1", anchor_at=anchor,
+            )
+            await s.commit()
+
+            rested = await process_due_comment_collections(s)
+            assert rested.get("connection_inactive") == 1, rested
+
+            import sqlalchemy
+            resting_row_id = (await s.execute(
+                sqlalchemy.select(CommentCollectionSchedule.id).where(
+                    CommentCollectionSchedule.publication_id == pub.id,
+                    CommentCollectionSchedule.status == "connection_inactive",
+                )
+            )).scalar_one()
+
+            await upsert_channel_connection(
+                s, org_id=org_id, channel="facebook", account_id=conn.account_id, account_label=None,
+                credential_kind="oauth", access_token="new-token-after-reconnect", refresh_token=None,
+                token_expires_at=None, refresh_mode="reissue_from_access_token", scopes=[], connected_by=uuid.uuid4(),
+            )
+
+            row = await s.get(CommentCollectionSchedule, resting_row_id)
+            assert row.status == "pending", "재연결 뒤에도 쉬는 상태로 남으면 그 발행은 영영 재수집이 안 된다"
+            assert row.due_at <= datetime.now(timezone.utc)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac5_mutation_removing_precheck_guard_fails_ac1():
+    """AC5 뮤테이션 대조 — AC1 가드(exc.error_code == "CHANNEL_CONNECTION_NOT_ACTIVE"
+    분기)가 없다고 가정하면 last_error가 덮인다는 것을 옛 분기 로직을 직접 흉내내
+    증명한다(소스 자체를 되돌리지 않고, 그 옛 조건문과 동형인 계산을 재현)."""
+    from app.services.publication_command import classify_failure_kind, FAILURE_KIND_CONNECTION
+
+    error_code = "CHANNEL_CONNECTION_NOT_ACTIVE"
+    failure_kind = classify_failure_kind(error_code)
+    # 옛(가드 제거) 분기 조건: `if failure_kind == FAILURE_KIND_CONNECTION:` 만 있었다면
+    # 이 코드도 그 안에 들어가 promote가 불렸을 것 — 그게 바로 이 스토리의 버그였다.
+    assert failure_kind == FAILURE_KIND_CONNECTION, (
+        "이 코드가 CONNECTION류로 분류되는 한, AC1의 명시적 코드-문자열 예외 분기가 "
+        "없으면 반드시 promote가 불려 last_error가 덮인다(회귀 대상)"
+    )
+
+
+@pytest.mark.anyio
+async def test_ac4_insight_publication_not_found_uses_own_code():
+    """AC4 — insight_snapshots._fetch_instagram_via_connection의 "channel_publication을
+    찾을 수 없습니다" 실패가 더는 CHANNEL_CONNECTION_NOT_ACTIVE를 재사용하지 않고
+    자기 코드(INSIGHT_PUBLICATION_NOT_FOUND)를 쓴다 — 다른 사실(발행 기록 없음)에
+    같은 낱말(연결 비활성)을 쓰지 않는다."""
+    from app.services.insight_snapshots import InsightFetchError, _fetch_instagram_via_connection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            fake_snapshot = SimpleNamespace(publication_id=uuid.uuid4())
+            with pytest.raises(InsightFetchError) as exc_info:
+                await _fetch_instagram_via_connection(s, fake_snapshot)
+            assert exc_info.value.error_code == "INSIGHT_PUBLICATION_NOT_FOUND"
+            assert exc_info.value.error_code != "CHANNEL_CONNECTION_NOT_ACTIVE"
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1461,6 +1461,11 @@
       "file": "tests/test_3603_connection_last_error.py",
       "sec": 14.0,
       "source": "story-3603-connection-last-error(PR 개설 前 선제 등재 — 로컬 raw pytest 3건 2.20s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 14s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3612_connection_notactive_precheck_norecord.py",
+      "sec": 16.0,
+      "source": "story-3612-connection-notactive-precheck-norecord(PR 개설 前 선제 등재 — 페드루 PO 追加 2026-09-07, PO 대조 CHANGES-1 반영. 로컬 raw pytest 6건 2.60s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 16s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 라이브 결함(배포 47·PO Test Org 실측 2026-09-07)
`/organization/channels` 행 641adabf(facebook_sandbox): `status=expired`·`last_error_code=CHANNEL_CONNECTION_NOT_ACTIVE`·`last_error="연결이 활성 상태가 아닙니다: …"` — PO는 아무것도 누르지 않았다, 스케줄 루프가 쓴 값. 「왜 만료됐나」의 답이 「이미 만료돼서」가 되는 순환. 실제 원인(CHANNEL_TOKEN_EXPIRED)은 어디에도 안 남는다 — 한 번 만료된 연결은 매 루프 틱마다 이 값으로 덮인다.

## 원인
`channel_post_comments.py:148~150`의 선검사(`connection.status != "active"`)가 `CommentFetchError(CHANNEL_CONNECTION_NOT_ACTIVE)`를 던지는데, 이건 provider가 알려준 새 사실이 아니라 **이미 아는 사실의 재확인**이다. 그런데 스케줄 루프(:465)·수동 재수집(:642) 둘 다 이걸 CONNECTION류 실패로 취급해 `_promote_connection_status`를 불러 last_error 3필드를 매번 덮었다.

## 처방
- **AC1** — 두 경로 모두 이 코드에서 `_promote_connection_status`를 호출하지 않는다(last_error 3필드 불변). 수동 경로는 그대로 409를 낸다 — 「기록 안 함」과 「알림 안 함」은 다르다.
- **AC2** — 그 스케줄 행을 새 `status="connection_inactive"`로 쉬운다(due 스캔·지속폴링 재생성 모두 제외 — 매 틱 재시도 0). 연결이 active로 복귀하는 3개 경로(재연결 upsert·자격 교체·자동 토큰갱신 성공, 전부 `channel_connection.py`)가 공유하는 단일 깨우는 손 `wake_resting_comment_schedules()`가 pending으로 되돌린다.
  - **부수 발견(로컬 재현, 같은 스토리 범위에서 해소)** — 기존 `_sweep_orphaned_active_publications_for_self_recovery`(#3528)가 "connection_inactive"라는 상태를 모르고 "열린 행 0"으로 오판, 매 틱 즉시 재파종해 AC2를 무력화하는 것을 로컬 테스트로 실제 재현했다. 그 스윕의 "열린 행" 판정에 `connection_inactive`를 추가해 막음.
- **AC3** — 수동 「다시 수집」은 지금처럼 409(CHANNEL_CONNECTION_NOT_ACTIVE)를 내되 기록은 없다.
- **AC4** — `insight_snapshots.py`의 "channel_publication을 찾을 수 없습니다"(3곳)가 `CHANNEL_CONNECTION_NOT_ACTIVE`를 재사용하던 것을 `INSIGHT_PUBLICATION_NOT_FOUND`로 분리. FE allowlist(#3957) 영향 0(신규 코드, 등재된 적 없음).

## 범위 밖(잔여, 참고용)
`channel_post_comments.py`에도 insight의 :320과 같은 패턴("pub 없음"이 CHANNEL_CONNECTION_NOT_ACTIVE 재사용)이 1곳 있다. AC4가 insight_snapshots.py만 지정했고, AC1의 코드-문자열 분기가 그 사이트도 이미 올바르게(승격 안 함) 처리하므로 기능 버그는 아니다 — 순수 명칭 정밀도 이슈라 이번 스코프에서 안 건드림. 필요하면 별도 스토리로.

## 테스트
`backend/tests/test_3612_connection_notactive_precheck_norecord.py` 신규 6건(AC1~AC5). 회귀 스윕(test_3603·3597·3528·3527·3497·3516) 100건 전체 그린. 뮤테이션(AC1 코드-문자열 분기 제거) → AC1/AC2 의존 테스트 3건 정확히 RED(failed=1로 떨어짐) 확認 후 원복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG