### PR TITLE
[SID:3613] fix: OAuth authorize BFF 봉투 형 정정 — 전 채널 「연결」·「다시 연결」 결함 + 샌드박스 브라우저 왕복(결함 2)

### DIFF
--- a/apps/web/src/app/api/oauth-channel/authorize/route.test.ts
+++ b/apps/web/src/app/api/oauth-channel/authorize/route.test.ts
@@ -45,9 +45,16 @@ describe('GET /api/oauth-channel/authorize (story #3376)', () => {
     expect(res.headers.get('location')).toContain('/login?next=');
   });
 
-  it('성공 — org_id를 oauth_channel_org_{channel} 쿠키에 남기고 BE가 준 url로 리다이렉트', async () => {
+  // story #3613(페드루 PO 確定 2026-09-07) — BE `authorize_channel_connection`
+  // (channel_connections.py:403, response_model=AuthorizeResponse)은 성공 시
+  // «맨몸» `{url,state}`를 낸다(backend/app에 성공 응답 전역 봉투 0). 이 mock을
+  // `{data:{url}}`로 두면(구판 그대로) 라우트의 구현 버그와 mock의 버그가 서로
+  // 상쇄돼 테스트가 «실패할 수 없는 표본»이 된다(2026-09-06 #3907 생성 시점부터
+  // 라이브가 실은 한 번도 성립한 적 없었는데 이 테스트는 계속 green이었던 원인) —
+  // BE 실제 형(맨몸)으로 mock해 라이브와 같은 경로를 통과하는지 검증한다.
+  it('성공 — org_id를 oauth_channel_org_{channel} 쿠키에 남기고 BE가 준 url로 리다이렉트(BE 실제 형=맨몸)', async () => {
     h.cookiesGetMock.mockReturnValue({ value: 'sp-at-token' });
-    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ data: { url: 'https://threads.net/oauth/authorize?x=1', state: 'opaque-state' } }) });
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ url: 'https://threads.net/oauth/authorize?x=1', state: 'opaque-state' }) });
     const res = await GET(makeRequest({ org: 'org-1', channel: 'threads' }));
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/organizations/org-1/channel-connections/threads/authorize'),
@@ -55,6 +62,30 @@ describe('GET /api/oauth-channel/authorize (story #3376)', () => {
     );
     expect(h.cookiesSetMock).toHaveBeenCalledWith('oauth_channel_org_threads', 'org-1', expect.any(Object));
     expect(res.headers.get('location')).toBe('https://threads.net/oauth/authorize?x=1');
+  });
+
+  // story #3613 — instagram/facebook/facebook_sandbox도 같은 라우트를 공유한다(채널명만
+  // 다름). 실 OAuth는 못 돌리니 BE의 맨몸 url을 그대로 리다이렉트하는지만 채널별로 고정.
+  it.each(['instagram', 'facebook', 'facebook_sandbox'])(
+    '%s — 같은 라우트가 BE 맨몸 url로 그대로 리다이렉트한다(회귀)',
+    async (channel) => {
+      h.cookiesGetMock.mockReturnValue({ value: 'sp-at-token' });
+      const providerUrl = `https://provider.example/${channel}/oauth?x=1`;
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ url: providerUrl, state: 'opaque-state' }) });
+      const res = await GET(makeRequest({ org: 'org-1', channel }));
+      expect(res.headers.get('location')).toBe(providerUrl);
+      expect(h.cookiesSetMock).toHaveBeenCalledWith(`oauth_channel_org_${channel}`, 'org-1', expect.any(Object));
+    },
+  );
+
+  // story #3613(양성 대조) — BE가 맨몸 응답에 url을 안 실은 극단(malformed) 사례도
+  // CHANNEL_AUTHORIZE_FAILED로 안전하게 떨어져야 한다(undefined url로 리다이렉트 금지).
+  it('BE가 맨몸 응답에 url이 없으면 CHANNEL_AUTHORIZE_FAILED로 리다이렉트(회귀)', async () => {
+    h.cookiesGetMock.mockReturnValue({ value: 'sp-at-token' });
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ state: 'opaque-state' }) });
+    const res = await GET(makeRequest({ org: 'org-1', channel: 'threads' }));
+    expect(h.cookiesSetMock).not.toHaveBeenCalled();
+    expect(res.headers.get('location')).toContain('connect_error=CHANNEL_AUTHORIZE_FAILED');
   });
 
   it('BE가 409 CHANNEL_APP_CREDENTIALS_MISSING을 주면 그 코드를 그대로 쿼리에 실어 되돌린다(쿠키 미설정)', async () => {

--- a/apps/web/src/app/api/oauth-channel/authorize/route.ts
+++ b/apps/web/src/app/api/oauth-channel/authorize/route.ts
@@ -38,8 +38,17 @@ export async function GET(request: Request) {
     return NextResponse.redirect(`${origin}/organization/channels?connect_error=${errCode}`);
   }
 
-  const json = await res.json() as { data?: { url?: string } };
-  const url = json.data?.url;
+  // story #3613(BE 그라운딩·페드루 PO 確定 2026-09-07) — BE `authorize_channel_
+  // connection`(channel_connections.py:403)은 `response_model=AuthorizeResponse`로
+  // 성공 응답을 맨몸(`{url,state}`)으로 낸다 — backend/app에 성공 응답 전역 봉투가
+  // 없어(에러만 http_exception_handler가 `{error:{code,message}}`로 감싼다) 이
+  // 원시 fetch 라우트가 성공 시 `json.data?.url`을 읽으면 항상 undefined였다(이
+  // 파일 생성 시점부터 한 번도 성립한 적 없던 형 — #3907 squash 유일 커밋).
+  // «형은 한 곳에서만 정의» 원칙: 이 라우트는 BE를 직접 부르므로 BE의 실제 성공
+  // 형(맨몸)을 그대로 읽는다(sibling proxy 라우트는 apiSuccess로 다시 감싸므로
+  // 그쪽만 `.data.url`이 맞다 — 두 라우트가 각자의 실제 소스 형을 따른다).
+  const json = await res.json() as { url?: string };
+  const url = json.url;
   if (!url) {
     return NextResponse.redirect(`${origin}/organization/channels?connect_error=CHANNEL_AUTHORIZE_FAILED`);
   }

--- a/backend/app/services/facebook_sandbox_oauth.py
+++ b/backend/app/services/facebook_sandbox_oauth.py
@@ -23,11 +23,28 @@ _PAGES_1_SUFFIX = ":pages-1"
 _FAKE_TOKEN_PREFIX = "sandbox-fb-user-token"
 
 
+_SANDBOX_FAKE_CODE = "sandbox-oauth-code"
+
+
 def build_authorize_url(*, redirect_uri: str, state: str, app_id: str) -> str:
-    """sandbox는 실제로 이 URL을 브라우저가 방문하지 않는다(테스트/QA가 callback을
-    직접 호출) — 값 자체는 authorize 응답 계약(AuthorizeResponse.url)을 채우기
-    위한 자리표시자."""
-    return f"https://sandbox.local/facebook-oauth?state={state}"
+    """story #3613(페드루 PO 確定 2026-09-07) — 원판은 `https://sandbox.local/...`
+    (실존하지 않는 도메인)을 냈다 — 자체 docstring이 "브라우저가 실제로 이 URL을
+    방문하지 않는다(테스트/QA가 callback을 직접 호출)"고 적어 뒀지만, /organization/
+    channels의 「다시 연결」 버튼은 이 URL로 «브라우저를» 리다이렉트한다(§13-8 AC5의
+    유일한 라이브 검증 경로) — 즉 실제로는 브라우저가 방문«해야»했는데 방문할 수
+    없는 도메인이라 그 경로 자체가 결함이었다(결함 2, #3613이 같은 스토리에서 닫음).
+
+    처방 — `redirect_uri`(=`_redirect_uri(org_id, channel)`, 이 채널의 콜백 URL 그
+    자체)로 가짜 `code`와 real `state`를 실어 곧장 리다이렉트한다. 브라우저 관점에서
+    "authorize" 리다이렉트가 즉시 "callback" 리다이렉트가 되는 셈 — real Meta 없이도
+    같은 코드 경로(FE callback route → BE callback endpoint → connection 갱신)를
+    전부 그대로 탄다(sandbox_publish.py "같은 코드 경로·가짜 데이터" 철학과 동일).
+    `code` 값 자체는 `exchange_code_for_short_lived_token`이 검증 없이 무조건 고정
+    가짜 토큰을 내므로 아무 문자열이나 무방 — `state`만 실물이어야 한다(BE가
+    `CHANNEL_OAUTH_STATE_INVALID`로 검증)."""
+    from urllib.parse import urlencode
+
+    return f"{redirect_uri}?{urlencode({'code': _SANDBOX_FAKE_CODE, 'state': state})}"
 
 
 async def exchange_code_for_short_lived_token(

--- a/backend/tests/test_3547_facebook_page_connection.py
+++ b/backend/tests/test_3547_facebook_page_connection.py
@@ -139,6 +139,66 @@ async def test_facebook_sandbox_list_pages_marker_branches():
     assert default_two[1]["name"] == "Sandbox Page 2"
 
 
+# ─── facebook_sandbox_oauth.py — story #3613(결함 2: 브라우저가 실제로 authorize
+# URL을 방문했을 때 콜백에 닿는 경로가 없었다) ────────────────────────────────
+
+
+def test_facebook_sandbox_build_authorize_url_redirects_straight_back_to_its_own_callback():
+    """story #3613 — 원판은 `https://sandbox.local/...`(실존 안 함)을 냈다. 이제
+    `redirect_uri`(=그 채널의 콜백 URL 그 자체)로 가짜 code+real state를 실어 곧장
+    돌아간다 — 브라우저가 이 URL을 실제로 따라가면 곧바로 콜백 라우트에 닿는다
+    (real Meta 없이도 같은 코드 경로, 새 엔드포인트 0)."""
+    from app.services.facebook_sandbox_oauth import build_authorize_url
+    from urllib.parse import urlparse, parse_qs
+
+    redirect_uri = "https://dev-app.sprintable.ai/api/oauth-channel/callback/facebook_sandbox"
+    url = build_authorize_url(redirect_uri=redirect_uri, state="signed-state-abc", app_id="app-id")
+
+    parsed = urlparse(url)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == redirect_uri, (
+        "브라우저가 authorize URL을 그대로 따라가면 이 채널의 콜백 라우트 자신에게 도착해야 한다"
+    )
+    qs = parse_qs(parsed.query)
+    assert qs["state"] == ["signed-state-abc"], "state는 반드시 실물(BE가 서명 검증한다) — 지어내면 안 됨"
+    assert qs["code"][0], "code는 exchange 단계에서 검증 없이 소비되므로 값 자체는 임의(비어있지만 않으면 됨)"
+
+
+@pytest.mark.anyio
+async def test_facebook_sandbox_authorize_url_is_navigable_back_into_the_real_callback_endpoint():
+    """story #3613 — 결함 2의 종단 재현: authorize가 낸 url을 «파싱해서 code/state를
+    꺼내» 실제 callback 엔드포인트에 그대로 태우면(브라우저가 그 URL을 따라갔을 때
+    벌어질 일 그대로) 연결이 정상적으로 만들어진다 — 원판(`sandbox.local`)이었다면
+    이 url 자체에서 code/state를 뽑아낼 수조차 없었다(도메인만 있고 쿼리에 code가
+    아예 없었다)."""
+    from app.main import app
+    from urllib.parse import urlparse, parse_qs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _register_facebook_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id, app_id="app:pages-1")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r_auth = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/facebook_sandbox/authorize")
+            assert r_auth.status_code == 200, r_auth.text
+            authorize_url = r_auth.json()["url"]
+
+            parsed = urlparse(authorize_url)
+            qs = parse_qs(parsed.query)
+            code, state = qs["code"][0], qs["state"][0]
+
+            r_cb = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook_sandbox/callback",
+                json={"code": code, "state": state},
+            )
+            assert r_cb.status_code == 200, r_cb.text
+    finally:
+        await engine.dispose()
+
+
 # ─── 콜백 3갈래(0/1/2+) — 실 authorize→callback 라우터 코드, HTTP 왕복 ────────
 
 


### PR DESCRIPTION
## 라이브 실측(dev 배포 47 · PO Test Org · 2026-09-07 05:04Z·05:06Z)
- /organization/channels에서 facebook_sandbox 「다시 연결」·「테스트용 계정 추가」 클릭 → FE 로그: `GET /api/oauth-channel/authorize?...` 307 → `?connect_error=CHANNEL_AUTHORIZE_FAILED` 307.
- 같은 순간 BE 로그: `POST .../authorize` **200**(성공했는데 FE가 실패로 오판).

## 결함 1 — BFF가 BE 실제 성공 응답 형을 안 읽음
`apps/web/src/app/api/oauth-channel/authorize/route.ts`가 BE `authorize_channel_connection`(response_model=`AuthorizeResponse`)을 원시 fetch로 부르면서 `json.data?.url`을 읽었다. backend/app은 **성공 응답 전역 봉투가 없다**(에러만 `http_exception_handler`가 `{error:{code,message}}`로 감싼다) — BE는 성공 시 맨몸 `{url,state}`를 낸다. 이 파일 생성 시점(2026-09-06 #3907 squash 유일 커밋)부터 threads/instagram/facebook/facebook_sandbox **전부**가 한 번도 성립한 적 없었다.

**처방**: `json.url`을 직접 읽는다 — sibling 프록시 라우트(`api/organizations/[id]/channel-connections/[channel]/authorize/route.ts`)는 `apiSuccess`로 다시 감싸므로 그쪽만 `.data.url`이 맞다. 두 라우트가 각자의 **실제 소스 형**을 따른다(「형은 한 곳에서만 정의」 원칙 — BE가 바뀌면 이 라우트가 바로 그 소스).

`route.test.ts`의 기존 성공 테스트가 `{data:{url}}`로 mock해 구현 버그와 mock 버그가 서로 상쇄된 **"실패할 수 없는 표본"**이었다(AC2) — BE 실제 형(맨몸)으로 정정, threads/instagram/facebook/facebook_sandbox 회귀 3건(AC4) + malformed 응답 양성대조 1건 추가.

## 결함 2(AC5, 착수 中 발견·같은 스토리에서 처리) — 샌드박스 authorize URL이 브라우저로 안 닿음
`facebook_sandbox_oauth.py::build_authorize_url`이 `https://sandbox.local/...`(실존하지 않는 도메인)을 냈다. 이 함수 자체 docstring이 "브라우저가 실제로 이 URL을 방문하지 않는다(테스트/QA가 callback을 직접 호출)"고 적어 뒀지만, `/organization/channels`의 「다시 연결」 버튼은 실제로 **브라우저를** 이 URL로 리다이렉트한다(§13-8 AC5의 유일한 라이브 검증 경로) — 방문**해야**하는데 방문할 수 없는 도메인이라 그 경로 자체가 결함이었다.

**처방**: `redirect_uri`(=그 채널의 콜백 URL 그 자체)로 가짜 `code`+실물 `state`를 실어 곧장 리다이렉트한다. 브라우저 관점에서 "authorize" 리다이렉트가 즉시 "callback" 리다이렉트가 되는 셈 — real Meta 없이도 같은 코드 경로(FE callback route → BE callback endpoint → connection 갱신)를 그대로 탄다(`sandbox_publish.py` "같은 코드 경로·가짜 데이터" 철학과 동일, 새 엔드포인트 0). `code` 값 자체는 `exchange_code_for_short_lived_token`이 검증 없이 고정 가짜 토큰을 내므로 임의 문자열, `state`만 실물이어야 한다(BE `CHANNEL_OAUTH_STATE_INVALID` 검증).

## 테스트
- **BE**: `test_3547_facebook_page_connection.py` 18건(기존 16+신규 2 — ① `build_authorize_url` 단위: redirect_uri로 code+real state를 실어 돌아가는지 ② authorize→url 파싱→callback 종단: 브라우저가 그 URL을 따라갔을 때 벌어질 일 그대로 재현, 연결 정상 생성 확認). 뮤테이션 2건(원판 `sandbox.local`로 되돌리면 RED) 확認 후 복구. 회귀(`test_3373_channel_connections_auth.py`·`test_3320_instagram_piece3.py` 포함) 48건 PASS.
- **FE**: `route.test.ts` 8건(기존 4+신규 4). 뮤테이션 4건(구 `.data.url` 접근으로 되돌리면 RED, threads/facebook/facebook_sandbox 3건 검출) 확認 후 복구. `tsc --noEmit`·`eslint` 클린.

## 남은 AC(라이브, PO 몫)
- AC3 — `/organization/channels`에서 실제 「다시 연결」(facebook_sandbox) 클릭 → 콜백 완주 → `status=active` 원복은 dev 배포 환경에서만 실측 가능.

## 범위 밖
- 리다이렉트 origin이 canonical(dev-app.sprintable.ai)인 것(`resolveAppUrl`)은 의도된 동작 — run.app 호스트 접속 세션이 로그인으로 떨어진 건 지름길 호스트 탓, 이 스토리 스코프 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA
