### PR TITLE
[SID:3615] feat: 오류 봉투 user_message/user_message_key 계약 — BE가 채우고 FE는 그대로

### DIFF
--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -3887,6 +3887,37 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     expect(document.querySelector('[data-testid="comments-reply-submit-button"]')).not.toBeNull();
   });
 
+  // story #3615 CHANGES(유나 재판정 2026-09-07) — handleCreateReplyDraft의 errorMessage가
+  // extractBackendErrorMessage(user_message 계약)를 거치지 않고 error.message를 직접
+  // 읽던 것을 고쳤다. user_message가 message와 다르면 user_message가 떠야 이 fix가
+  // 실제로 작동한다는 것을 증명한다(existing_reply_id 없는 일반 실패 — 레이스 복구
+  // 분기와 다른 코드 경로).
+  it('일반 「답변」 임시저장 실패(existing_reply_id 없음)에서 user_message가 원문 message보다 우선한다', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: {
+        last_collected_at: '2026-09-05T10:00:00Z', active_count: 1, deleted_count: 0,
+        comments: [{ id: 'c1', external_comment_id: 'ext-1', author_display_name: '홍길동', text: '언제 되나요?', external_created_at: null, captured_at: '2026-09-05T10:00:00Z', deleted_at: null }],
+      },
+      onCommentReplyDraft: () => ({
+        status: 422,
+        body: { data: null, error: { code: 'SOME_OTHER_CODE', message: '원문(진단용): field=x', user_message: '지금은 답변을 만들 수 없습니다.' }, meta: null },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const replyBtn = container.querySelector('[data-testid="comments-item-reply"]') as HTMLButtonElement;
+    await act(async () => { replyBtn.click(); });
+    const textarea = document.querySelector('#comments-reply-text') as HTMLTextAreaElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => { setter.call(textarea, '내가 막 쓰던 것'); textarea.dispatchEvent(new Event('input', { bubbles: true })); });
+    await act(async () => { (document.querySelector('[data-testid="comments-reply-draft-button"]') as HTMLButtonElement).dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true })); });
+    await flush();
+
+    expect(document.querySelector('[data-testid="comments-reply-error"]')?.textContent).toBe('지금은 답변을 만들 수 없습니다.');
+  });
+
   it('「답변」 상신 409(대상 삭제) — 서버 문구가 그대로 뜬다', async () => {
     stubFetch({
       draftDetail: PUBLISHED_DRAFT,

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -3918,6 +3918,39 @@ describe('ChannelPostEditPage — 댓글 섹션(story #3517)', () => {
     expect(document.querySelector('[data-testid="comments-reply-error"]')?.textContent).toBe('지금은 답변을 만들 수 없습니다.');
   });
 
+  // story #3615 CHANGES-2(페드루 재확認 2026-09-07) — 헬퍼가 null인(user_message 없고
+  // allowlist 밖) 코드에서는 원문 message가 어떤 경우에도 사람 화면에 안 나가야 한다
+  // (AC2). CHANGES-1 직후엔 헬퍼 뒤에 원문 폴백 셋(error.message 등)이 남아 있어 이
+  // 갈래가 여전히 원문을 보였다 — 이 테스트가 그 회귀를 잡는다.
+  it('일반 「답변」 임시저장 실패에서 user_message/allowlist 둘 다 없으면 generic만 뜨고 원문은 0', async () => {
+    stubFetch({
+      draftDetail: PUBLISHED_DRAFT,
+      commentsResponse: {
+        last_collected_at: '2026-09-05T10:00:00Z', active_count: 1, deleted_count: 0,
+        comments: [{ id: 'c1', external_comment_id: 'ext-1', author_display_name: '홍길동', text: '언제 되나요?', external_created_at: null, captured_at: '2026-09-05T10:00:00Z', deleted_at: null }],
+      },
+      onCommentReplyDraft: () => ({
+        status: 422,
+        body: { data: null, error: { code: 'SOME_OTHER_CODE', message: '원문(진단용): internal_id=abc123' }, meta: null },
+      }),
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const replyBtn = container.querySelector('[data-testid="comments-item-reply"]') as HTMLButtonElement;
+    await act(async () => { replyBtn.click(); });
+    const textarea = document.querySelector('#comments-reply-text') as HTMLTextAreaElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => { setter.call(textarea, '내가 막 쓰던 것'); textarea.dispatchEvent(new Event('input', { bubbles: true })); });
+    await act(async () => { (document.querySelector('[data-testid="comments-reply-draft-button"]') as HTMLButtonElement).dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true })); });
+    await flush();
+
+    const errorText = document.querySelector('[data-testid="comments-reply-error"]')?.textContent;
+    expect(errorText).toBe(koMessages.content.commentsActionErrorGeneric);
+    expect(errorText).not.toContain('원문');
+    expect(errorText).not.toContain('internal_id');
+  });
+
   it('「답변」 상신 409(대상 삭제) — 서버 문구가 그대로 뜬다', async () => {
     stubFetch({
       draftDetail: PUBLISHED_DRAFT,

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -508,13 +508,13 @@ export default function ChannelPostEditPage() {
         // 이어가게 한다.
         return {
           ok: false,
-          // story #3615 CHANGES(유나 재판정) — 이 자리만 extractBackendErrorMessage를
-          // 안 거치고 error.message를 직접 읽었다(같은 파일 다른 8곳은 헬퍼 경유) —
-          // 지금은 두 문자열이 같아 차이가 없어도 계약의 구멍이다(BE가 나중에 이
-          // 코드에 user_message를 다르게 채우면 이 자리만 조용히 원문을 계속 보인다).
-          // 헬퍼를 먼저 보고, existingReplyId는 헬퍼가 안 다루는 3596 전용 필드라
-          // 기존처럼 별도로 뽑는다.
-          errorMessage: extractBackendErrorMessage(body, t) ?? body?.error?.message ?? body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric'),
+          // story #3615 CHANGES-2(페드루 재확認) — 형제 4곳(:450/:473/:536/:561)과
+          // 같은 형으로 통일: extractBackendErrorMessage(body, t) ?? generic 딱 둘.
+          // CHANGES-1에서 헬퍼를 앞에 붙였지만 원문 폴백 셋(error.message 등)이 뒤에
+          // 남아 있어, 헬퍼가 null인(user_message 없고 allowlist 밖) 코드에서는 여전히
+          // 원문이 새는 구멍이었다(AC2 "원문 message는 어떤 분기에서도 사람 화면에 0"
+          // 위반). existingReplyId(헬퍼가 안 다루는 #3596 전용 필드)만 별도로 뽑는다.
+          errorMessage: extractBackendErrorMessage(body, t) ?? t('commentsActionErrorGeneric'),
           existingReplyId: body?.error?.existing_reply_id,
         };
       }

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -447,7 +447,7 @@ export default function ChannelPostEditPage() {
       }
       // story #3601(페드루 PO 追加 2026-09-07) — body?.message는 우리 봉투에 없는
       // 자리라 죽은 폴백이었다(추가 검증 없이 걷는다).
-      const message = extractBackendErrorMessage(body) ?? t('commentsRefreshErrorGeneric');
+      const message = extractBackendErrorMessage(body, t) ?? t('commentsRefreshErrorGeneric');
       return { ok: false, kind: 'generic', message };
     } catch {
       return { ok: false, kind: 'generic', message: t('commentsRefreshErrorGeneric') };
@@ -470,7 +470,7 @@ export default function ChannelPostEditPage() {
       const body = await res.json().catch(() => null) as { data?: { story_id?: string }; error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
       if (!res.ok) {
         // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
-        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? t('commentsActionErrorGeneric') };
+        return { ok: false, errorMessage: extractBackendErrorMessage(body, t) ?? t('commentsActionErrorGeneric') };
       }
       const storyId = body?.data?.story_id;
       if (!storyId) return { ok: false, errorMessage: t('commentsActionErrorGeneric') };
@@ -527,7 +527,7 @@ export default function ChannelPostEditPage() {
       const body = await res.json().catch(() => null) as { data?: ReplyView; error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
       if (!res.ok || !body?.data) {
         // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
-        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? t('commentsActionErrorGeneric') };
+        return { ok: false, errorMessage: extractBackendErrorMessage(body, t) ?? t('commentsActionErrorGeneric') };
       }
       return { ok: true, reply: body.data };
     } catch {
@@ -552,7 +552,7 @@ export default function ChannelPostEditPage() {
       if (!res.ok) {
         // story #3601 — extractBackendErrorMessage(.error 1순위)로 통일.
         const body = await res.json().catch(() => null) as { error?: { message?: string }; detail?: { message?: string }; message?: string } | null;
-        return { ok: false, errorMessage: extractBackendErrorMessage(body) ?? t('commentsActionErrorGeneric') };
+        return { ok: false, errorMessage: extractBackendErrorMessage(body, t) ?? t('commentsActionErrorGeneric') };
       }
       loadComments();
       return { ok: true };

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -508,7 +508,13 @@ export default function ChannelPostEditPage() {
         // 이어가게 한다.
         return {
           ok: false,
-          errorMessage: body?.error?.message ?? body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric'),
+          // story #3615 CHANGES(유나 재판정) — 이 자리만 extractBackendErrorMessage를
+          // 안 거치고 error.message를 직접 읽었다(같은 파일 다른 8곳은 헬퍼 경유) —
+          // 지금은 두 문자열이 같아 차이가 없어도 계약의 구멍이다(BE가 나중에 이
+          // 코드에 user_message를 다르게 채우면 이 자리만 조용히 원문을 계속 보인다).
+          // 헬퍼를 먼저 보고, existingReplyId는 헬퍼가 안 다루는 3596 전용 필드라
+          // 기존처럼 별도로 뽑는다.
+          errorMessage: extractBackendErrorMessage(body, t) ?? body?.error?.message ?? body?.detail?.message ?? body?.message ?? t('commentsActionErrorGeneric'),
           existingReplyId: body?.error?.existing_reply_id,
         };
       }

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -454,7 +454,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
         setSteerError(
           (body?.error?.code ?? detail?.code) === 'conversation_target_mismatch'
             ? t('steerErrorNotParticipant')
-            : extractBackendErrorMessage(body) ?? t('sendFailed'),
+            : extractBackendErrorMessage(body, t) ?? t('sendFailed'),
         );
         return;
       }

--- a/apps/web/src/components/chat/delivery-contract-modal.tsx
+++ b/apps/web/src/components/chat/delivery-contract-modal.tsx
@@ -111,7 +111,7 @@ export function DeliveryContractModal({
         // 안 붙인다(재시도해도 같은 정책 거부라 오도). 5xx/사유 미상은 기존 일반 문구+재시도
         // 안내를 유지한다(원인 모름 — 재시도가 유효할 수 있어 그 안내가 정직하다).
         const body = await res.json().catch(() => null);
-        const backendMsg = extractBackendErrorMessage(body);
+        const backendMsg = extractBackendErrorMessage(body, t);
         if (backendMsg && res.status >= 400 && res.status < 500) {
           setLevel(prev);
           setError(backendMsg);

--- a/apps/web/src/components/chat/event-block-card.tsx
+++ b/apps/web/src/components/chat/event-block-card.tsx
@@ -278,7 +278,7 @@ function EventPublishActionButton({
         // 그대로 보여준다(BE가 실 권위이자 유일한 메시지 출처). story #2647에서
         // extractBackendErrorMessage로 공통화(DeliveryContractModal과 동형 패턴 공유).
         const body = await res.json().catch(() => null);
-        const msg = extractBackendErrorMessage(body) ?? `HTTP ${res.status}`;
+        const msg = extractBackendErrorMessage(body, t) ?? `HTTP ${res.status}`;
         throw new Error(msg);
       }
       setPublished(true);

--- a/apps/web/src/lib/api-error-message.test.ts
+++ b/apps/web/src/lib/api-error-message.test.ts
@@ -55,3 +55,46 @@ describe('extractBackendErrorMessage — story #2647(공통화, #2637 §범위3 
     expect(HUMAN_SAFE_ERROR_MESSAGE_CODES.has('NOT_FOUND')).toBe(false);
   });
 });
+
+// story #3615(BE·계약, 페드루 PO 確定 2026-09-07) — error.user_message/user_message_key
+// 계약. allowlist 조회 없이(=code가 뭐든) 최우선으로 쓰인다는 것이 이 계약의 핵심 —
+// "FE가 코드별로 안전한지 암기"하던 구조를 "BE가 이미 판단해 냈다"로 뒤집는다.
+describe('extractBackendErrorMessage — story #3615 user_message/user_message_key 계약', () => {
+  it('user_message가 있으면 allowlist에 없는 임의 코드여도 그대로 쓴다(BE가 이미 판단했다)', () => {
+    expect(extractBackendErrorMessage({
+      error: { code: 'SOME_BRAND_NEW_CODE', message: 'raw diag: conn=641adabf', user_message: '연결이 만료되었습니다. 다시 연결해주세요.' },
+    })).toBe('연결이 만료되었습니다. 다시 연결해주세요.');
+  });
+
+  it('user_message_key가 있고 t가 주어지면 그 키로 렌더한다(user_message보다 우선)', () => {
+    const t = (key: string) => (key === 'errorConnectionExpired' ? '연결이 만료되었습니다(i18n)' : key);
+    expect(extractBackendErrorMessage({
+      error: { code: 'X', message: 'raw', user_message: '이건 안 쓰인다', user_message_key: 'errorConnectionExpired' },
+    }, t)).toBe('연결이 만료되었습니다(i18n)');
+  });
+
+  it('user_message_key가 있어도 t가 없으면 user_message로 내려간다(옵션 인자 생략 시 회귀 0)', () => {
+    expect(extractBackendErrorMessage({
+      error: { code: 'X', message: 'raw', user_message: '폴백 문장', user_message_key: 'errorConnectionExpired' },
+    })).toBe('폴백 문장');
+  });
+
+  it('detail 쪽(§object 형)에 실려도 동일하게 최우선', () => {
+    expect(extractBackendErrorMessage({
+      detail: { code: 'ANY_CODE', message: 'raw uuid=abc', user_message: '사람이 읽을 문장' },
+    })).toBe('사람이 읽을 문장');
+  });
+
+  it('user_message/user_message_key 둘 다 없으면 기존 allowlist 분기로 그대로 넘어간다(코드 밖=null)', () => {
+    expect(extractBackendErrorMessage({
+      error: { code: 'CODE_WITHOUT_CONTRACT_FIELDS', message: 'raw only' },
+    })).toBeNull();
+  });
+
+  // 뮤테이션 대조 — resolveContractMessage가 조회 안 되면(즉 계약이 무력화되면) 위 첫
+  // 테스트가 반드시 null로 떨어진다는 것을 직접 증명(allowlist에 'SOME_BRAND_NEW_CODE'
+  // 가 없다는 사실 자체로 — 이 코드가 계약 없이는 절대 안전하다고 판단될 수 없다).
+  it('뮤테이션 대조 — SOME_BRAND_NEW_CODE는 allowlist에 없어(계약이 없었다면 이 테스트의 첫 케이스가 반드시 null)', () => {
+    expect(HUMAN_SAFE_ERROR_MESSAGE_CODES.has('SOME_BRAND_NEW_CODE')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/api-error-message.ts
+++ b/apps/web/src/lib/api-error-message.ts
@@ -30,6 +30,16 @@
  * 흐름의 이 code는 안전하다"로 처음 등재했던 게 오판이었다. PR 본문에 코드마다 「raise
  * 자리 수 → 문장 전부」를 표로 남길 것 — "안전해 보인다"가 아니라 "전수 확認했다"가
  * 등재 기준이다.
+ *
+ * story #3615(BE·계약, 페드루 PO 確定 2026-09-07) — 이 allowlist는 "FE가 코드별로
+ * 안전한지 암기"하는 구조라 코드가 늘 때마다(#3605 CHANGES-3처럼) FE도 손으로 따라
+ * 고쳐야 했다. 이 계약이 그 판별을 BE로 옮긴다 — `error.user_message`(BE가 직접 쓴,
+ * 사람에게 그대로 보여도 되는 문장)·`error.user_message_key`(FE i18n 키)가 있으면
+ * **allowlist 조회 없이** 그걸 최우선으로 쓴다(`human_error()`로 채운 자리부터 점진
+ * 전환, `app/core/error_envelope.py` 참고). 아래 allowlist는 아직 human_error()로
+ * 전환 안 된 자리들의 안전망으로 당분간 남는다 — 전환이 끝나(등재 0건 수렴) 이 파일
+ * 자체와 `lint_fe_error_envelope_detail_mismatch.py`를 은퇴시키는 게 이 스토리가 연
+ * 길이다(이 PR에서 즉시 은퇴는 아님 — AC3, "수렴 가능함을 보인다"까지).
  */
 export const HUMAN_SAFE_ERROR_MESSAGE_CODES = new Set<string>([
   // channel_post_comments.py::refresh_publication_comments_endpoint(raise 1곳)
@@ -47,9 +57,41 @@ export const HUMAN_SAFE_ERROR_MESSAGE_CODES = new Set<string>([
   // uuid(connection.id·publication_id)를 그대로 담아 등재 금지(2026-09-07 정정, 페드루 PO).
 ]);
 
-export function extractBackendErrorMessage(body: unknown): string | null {
+interface ErrorLikeShape {
+  code?: unknown;
+  message?: unknown;
+  user_message?: unknown;
+  user_message_key?: unknown;
+}
+
+/**
+ * story #3615 — BE `human_error()` 계약(있으면 allowlist 조회 없이 최우선): (1)
+ * `user_message_key`가 있고 `t`가 주어졌으면 그 키로 렌더 (2) `user_message`가 있으면
+ * 그대로 (3) 둘 다 없으면 `null`(호출부가 코드별 generic 폴백으로 — 이 함수의 기존
+ * allowlist 분기로 계속 넘어간다).
+ */
+function resolveContractMessage(shape: ErrorLikeShape, t?: (key: string) => string): string | null {
+  const key = typeof shape.user_message_key === 'string' ? shape.user_message_key : undefined;
+  if (key && t) return t(key);
+  const userMessage = typeof shape.user_message === 'string' ? shape.user_message : undefined;
+  if (userMessage) return userMessage;
+  return null;
+}
+
+/**
+ * `t`는 선택 — next-intl `useTranslations()`의 반환값(또는 동형 `(key: string) =>
+ * string`)을 넘기면 `user_message_key` 자리도 렌더된다. 생략하면 그 자리는 건너뛰고
+ * `user_message`→allowlist 순으로 그대로 진행(회귀 0, 기존 4개 호출부가 당장 안 바꿔도
+ * 깨지지 않는다).
+ */
+export function extractBackendErrorMessage(body: unknown, t?: (key: string) => string): string | null {
   if (!body || typeof body !== 'object') return null;
-  const b = body as { error?: { code?: unknown; message?: unknown }; detail?: unknown };
+  const b = body as { error?: ErrorLikeShape; detail?: unknown };
+
+  if (b.error && typeof b.error === 'object') {
+    const fromContract = resolveContractMessage(b.error, t);
+    if (fromContract) return fromContract;
+  }
   const errorCode = typeof b.error?.code === 'string' ? b.error.code : undefined;
   if (errorCode && HUMAN_SAFE_ERROR_MESSAGE_CODES.has(errorCode) && typeof b.error?.message === 'string') {
     return b.error.message;
@@ -57,7 +99,9 @@ export function extractBackendErrorMessage(body: unknown): string | null {
   // 순수 문자열 detail — code가 없어 이 gate 밖(위 docstring 참고, story #2647 계약 보존).
   if (typeof b.detail === 'string') return b.detail;
   if (b.detail && typeof b.detail === 'object') {
-    const d = b.detail as { code?: unknown; message?: unknown };
+    const d = b.detail as ErrorLikeShape;
+    const fromContractDetail = resolveContractMessage(d, t);
+    if (fromContractDetail) return fromContractDetail;
     const detailCode = typeof d.code === 'string' ? d.code : undefined;
     if (detailCode && HUMAN_SAFE_ERROR_MESSAGE_CODES.has(detailCode) && typeof d.message === 'string') {
       return d.message;

--- a/backend/app/core/error_envelope.py
+++ b/backend/app/core/error_envelope.py
@@ -1,0 +1,51 @@
+"""story #3615(BE·계약, 페드루 PO 確定 2026-09-07) — 오류 봉투에 `user_message`/
+`user_message_key` additive 계약을 더한다.
+
+그라운딩(develop 실물) — `app/main.py::http_exception_handler`가 dict detail의
+"code"·"message" 외 모든 키를 그대로 `error` 객체로 패스스루한다(:280~284, 새 필드를
+받기 위해 그 핸들러를 바꿀 필요가 이미 없다). 문제는 §object 형(`{code, message}`)
+그 자체다 — `message`는 raise 자리마다 형이 다르다: 어떤 코드(COMMENT_REFRESH_HUMAN_
+ONLY 등 7종, `api-error-message.ts::HUMAN_SAFE_ERROR_MESSAGE_CODES`)는 이미 사람
+문장이고, 어떤 코드(`CHANNEL_CONNECTION_NOT_ACTIVE`의 다수 자리 등)는 uuid·내부
+필드를 그대로 담는다. 지금까지의 처방(#3601·#3957)은 **FE가 코드별로 어느 쪽인지
+암기**하는 allowlist였다 — 코드가 늘 때마다(#3605 CHANGES-3처럼) FE도 손으로
+따라 고쳐야 했다.
+
+이 계약의 판별 — 「값 없을 때 누가 채우나」: **BE**(그 오류를 낸 쪽, 사람 문장인지
+아는 유일한 쪽)가 채운다. FE는 그 오류가 안전한지 다시 판단하지 않는다:
+  - `user_message`가 있으면 그대로 보여준다(내부 식별자·스택·uuid가 섞이지 않게
+    만드는 책임은 이 함수를 호출하는 BE 쪽에 있다 — 원문 message를 그대로
+    넘기지 말 것, 손으로 쓴 문장만 넘길 것).
+  - 없고 `user_message_key`만 있으면 FE i18n 키로 렌더(로케일별 문구는 §22
+    규격을 따르는 FE 쪽 책임).
+  - 둘 다 없으면 FE가 코드별 generic 문구로 폴백(원문 `message`는 화면에 0 —
+    「서버 응답 보기」 details 자리는 예외, 그건 원래 진단용).
+
+전환은 점진적이다(AC 범위 밖 — 모든 raise 자리 일괄 전환 아님) — 이 함수를 아직
+안 쓰는 자리는 지금처럼 `message`만 있고 `user_message`가 없어 FE가 안전하게
+generic으로 떨어진다(회귀 0, 원문 노출도 0 — 3601 allowlist가 그 자리들의 안전망
+으로 당분간 남는다)."""
+from __future__ import annotations
+
+
+def human_error(
+    code: str,
+    message: str,
+    *,
+    user_message: str | None = None,
+    user_message_key: str | None = None,
+    **extra: object,
+) -> dict[str, object]:
+    """FastAPI `HTTPException(detail=...)`에 바로 넣는 dict를 만든다. `message`는
+    지금처럼 진단용 원문(「서버 응답 보기」에서만 노출) — `user_message`/
+    `user_message_key`가 그 자리에서 사람에게 보여도 되는 문장을 아는 경우에만
+    채운다(둘 다 선택, 있으면 사람 화면행·없으면 FE가 코드별 generic 문구로).
+    `extra`는 기존 raise 자리들이 이미 얹던 부가 키(예: retry_after)를 그대로
+    통과시키기 위함 — human_error 도입이 기존 부가 키 계약을 안 깬다."""
+    detail: dict[str, object] = {"code": code, "message": message}
+    if user_message is not None:
+        detail["user_message"] = user_message
+    if user_message_key is not None:
+        detail["user_message_key"] = user_message_key
+    detail.update(extra)
+    return detail

--- a/backend/app/routers/channel_post_comment_replies.py
+++ b/backend/app/routers/channel_post_comment_replies.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.error_envelope import human_error
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.services.channel_post_comment_replies import (
@@ -35,7 +36,10 @@ async def _require_human(db: AsyncSession, auth: AuthContext, org_id: uuid.UUID)
     if resolved.type != "human":
         raise HTTPException(
             status_code=403,
-            detail={"code": "COMMENT_REPLY_HUMAN_ONLY", "message": "이 액션은 휴먼 멤버만 가능합니다."},
+            detail=human_error(
+                "COMMENT_REPLY_HUMAN_ONLY", "이 액션은 휴먼 멤버만 가능합니다.",
+                user_message="이 액션은 휴먼 멤버만 가능합니다.",
+            ),
         )
     return resolved
 
@@ -207,11 +211,11 @@ async def create_comment_reply_draft_endpoint(
     except CommentReplyDraftAlreadyOpenError as exc:
         raise HTTPException(
             status_code=409,
-            detail={
-                "code": "COMMENT_REPLY_DRAFT_ALREADY_OPEN",
-                "message": "안 보낸 초안이 이미 있습니다.",
-                "existing_reply_id": str(exc.existing_reply_id),
-            },
+            detail=human_error(
+                "COMMENT_REPLY_DRAFT_ALREADY_OPEN", "안 보낸 초안이 이미 있습니다.",
+                user_message="안 보낸 초안이 이미 있습니다.",
+                existing_reply_id=str(exc.existing_reply_id),
+            ),
         ) from exc
     return await _reply_view(db, reply, None)
 
@@ -253,12 +257,18 @@ async def submit_comment_reply_endpoint(
     except CommentReplyTargetDeletedError as exc:
         raise HTTPException(
             status_code=409,
-            detail={"code": "COMMENT_REPLY_TARGET_DELETED", "message": "답변 대상 댓글이 삭제되어 상신할 수 없습니다."},
+            detail=human_error(
+                "COMMENT_REPLY_TARGET_DELETED", "답변 대상 댓글이 삭제되어 상신할 수 없습니다.",
+                user_message="답변 대상 댓글이 삭제되어 상신할 수 없습니다.",
+            ),
         ) from exc
     except CommentReplyChannelUnsupportedError as exc:
         raise HTTPException(
             status_code=422,
-            detail={"code": "COMMENT_REPLY_CHANNEL_UNSUPPORTED", "message": "이 채널은 답변 발송을 지원하지 않습니다."},
+            detail=human_error(
+                "COMMENT_REPLY_CHANNEL_UNSUPPORTED", "이 채널은 답변 발송을 지원하지 않습니다.",
+                user_message="이 채널은 답변 발송을 지원하지 않습니다.",
+            ),
         ) from exc
     except CommentNotFoundError as exc:
         # story #3531(2026-09-06) — create 엔드포인트는 이미 이 예외를 404로 잡는데

--- a/backend/app/routers/channel_post_comments.py
+++ b/backend/app/routers/channel_post_comments.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.error_envelope import human_error
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.services.channel_post_comments import (
@@ -30,10 +31,10 @@ async def _require_human(db: AsyncSession, auth: AuthContext, org_id: uuid.UUID)
     if resolved.type != "human":
         raise HTTPException(
             status_code=403,
-            detail={
-                "code": "COMMENT_REFRESH_HUMAN_ONLY",
-                "message": "댓글 재수집은 휴먼 멤버만 가능합니다.",
-            },
+            detail=human_error(
+                "COMMENT_REFRESH_HUMAN_ONLY", "댓글 재수집은 휴먼 멤버만 가능합니다.",
+                user_message="댓글 재수집은 휴먼 멤버만 가능합니다.",
+            ),
         )
     return resolved
 
@@ -245,7 +246,10 @@ async def refresh_publication_comments_endpoint(
     except CommentCollectionUnsupportedError as exc:
         raise HTTPException(
             status_code=422,
-            detail={"code": "COMMENT_COLLECTION_UNSUPPORTED", "message": "이 채널은 댓글 수집을 지원하지 않습니다."},
+            detail=human_error(
+                "COMMENT_COLLECTION_UNSUPPORTED", "이 채널은 댓글 수집을 지원하지 않습니다.",
+                user_message="이 채널은 댓글 수집을 지원하지 않습니다.",
+            ),
         ) from exc
     except CommentFetchError as exc:
         if exc.error_code == "COMMENT_PUBLICATION_NOT_FOUND":

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.error_envelope import human_error
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.channel_post_version import ChannelPostVersion
@@ -110,12 +111,14 @@ async def _require_human(db: AsyncSession, auth: AuthContext, org_id: uuid.UUID)
     엔드포인트와 같은 권한 폭: org 멤버인 휴먼이면 누구나)."""
     resolved = await resolve_member(auth, org_id, db)
     if resolved.type != "human":
+        # story #3615 — 이미 사람 문장(3601 allowlist 등재분)이라 그대로 user_message로.
         raise HTTPException(
             status_code=403,
-            detail={
-                "code": "CHANNEL_POST_PUBLISH_HUMAN_ONLY",
-                "message": "채널 포스트 발행은 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지).",
-            },
+            detail=human_error(
+                "CHANNEL_POST_PUBLISH_HUMAN_ONLY",
+                "채널 포스트 발행은 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지).",
+                user_message="채널 포스트 발행은 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지).",
+            ),
         )
     return resolved
 

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.error_envelope import human_error
 from app.dependencies.auth import get_current_user, get_scope_context, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import Doc
@@ -1612,10 +1613,10 @@ async def transition_gate_endpoint(
         except CommentReplyTargetDeletedError as exc:
             raise HTTPException(
                 status_code=409,
-                detail={
-                    "code": "COMMENT_REPLY_TARGET_DELETED",
-                    "message": "답변 대상 댓글이 삭제되어 승인할 수 없습니다.",
-                },
+                detail=human_error(
+                    "COMMENT_REPLY_TARGET_DELETED", "답변 대상 댓글이 삭제되어 승인할 수 없습니다.",
+                    user_message="답변 대상 댓글이 삭제되어 승인할 수 없습니다.",
+                ),
             ) from exc
     # ⭐S23 RC① + RC#1(방어심층): resolver_id 를 **전 status 무조건 인증 caller 로 강제**(body 무시).
     # body 조작(타인 UUID)으로 SoD(approver≠owner) 우회·confirmed_by_member_id 위조 차단.

--- a/backend/tests/test_3615_human_error_contract.py
+++ b/backend/tests/test_3615_human_error_contract.py
@@ -1,0 +1,98 @@
+"""story #3615(BE·계약, 페드루 PO 確定 2026-09-07) — 오류 봉투 `user_message`/
+`user_message_key` additive 계약(`app/core/error_envelope.py::human_error`) 회귀.
+
+두 축을 고정한다: (1) 헬퍼 자체의 shape(additive·기존 키 불변) (2) AC4 가드 — 지금
+이 저장소에 `human_error(...)`로 채운 모든 `user_message=` 문자열 리터럴이 uuid나
+스택/repr 패턴을 담지 않는다(정적 스캔 — 그 문자열이 애초에 «BE가 손으로 쓴 안전한
+문장»이어야 한다는 이 계약의 전제 자체를 검산). 새 raise 자리가 uuid를 user_message에
+실으면 이 테스트가 바로 잡는다."""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from app.core.error_envelope import human_error
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_APP_ROOT = _REPO_ROOT / "backend" / "app"
+
+_UUID_RE = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+# story #3601 docstring이 실측한 "안전하지 않은" 형(raw exception repr·내부 필드명
+# 그대로) — 이 자체를 문자열 리터럴 안에서 재현할 리는 없지만, f-string 보간 흔적
+# (중괄호)이 있으면 사람이 손으로 안 쓴 조립 문자열일 가능성이 높다는 신호로도 쓴다.
+_FSTRING_INTERPOLATION_RE = re.compile(r"\{[^}]+\}")
+_STACK_HINT_RE = re.compile(r"Traceback|File \"|line \d+, in ")
+
+
+def test_human_error_is_additive_dict():
+    d = human_error("CODE_A", "진단용 원문")
+    assert d == {"code": "CODE_A", "message": "진단용 원문"}
+
+
+def test_human_error_with_user_message():
+    d = human_error("CODE_A", "진단용 원문", user_message="사람 문장")
+    assert d["user_message"] == "사람 문장"
+    assert d["code"] == "CODE_A"
+    assert d["message"] == "진단용 원문"
+    assert "user_message_key" not in d
+
+
+def test_human_error_with_user_message_key():
+    d = human_error("CODE_A", "진단용 원문", user_message_key="errorFoo")
+    assert d["user_message_key"] == "errorFoo"
+    assert "user_message" not in d
+
+
+def test_human_error_extra_kwargs_passthrough():
+    """기존 raise 자리가 부가 키(예: existing_reply_id)를 얹던 계약을 안 깬다."""
+    d = human_error("CODE_A", "m", user_message="u", existing_reply_id="abc-123")
+    assert d["existing_reply_id"] == "abc-123"
+
+
+def _find_user_message_literals(tree: ast.AST) -> list[str]:
+    """`human_error(..., user_message="...")`처럼 키워드 인자로 넘긴 **문자열 리터럴만**
+    수집한다(변수·f-string 보간은 이 정적 스캔의 사각 — verify-no-date-tolocalestring.ts
+    와 동형 한계 승계, 그 경우는 사람이 리뷰에서 직접 본다)."""
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+        if name != "human_error":
+            continue
+        for kw in node.keywords:
+            if kw.arg == "user_message" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                found.append(kw.value.value)
+    return found
+
+
+def test_all_human_error_user_message_literals_are_uuid_and_stack_free():
+    """AC4 — 저장소 전체에서 `human_error(...)`가 채우는 user_message 문자열 리터럴을
+    정적으로 모아 uuid·스택/repr 패턴이 0건임을 확認한다."""
+    violations: list[tuple[str, str]] = []
+    for py_file in _APP_ROOT.rglob("*.py"):
+        content = py_file.read_text(encoding="utf-8")
+        if "human_error(" not in content:
+            continue
+        tree = ast.parse(content, filename=str(py_file))
+        for literal in _find_user_message_literals(tree):
+            if _UUID_RE.search(literal) or _STACK_HINT_RE.search(literal):
+                violations.append((str(py_file.relative_to(_REPO_ROOT)), literal))
+    assert not violations, f"user_message에 uuid/스택 패턴이 실린 자리(0건이어야 함): {violations}"
+
+
+def test_mutation_uuid_literal_would_be_caught():
+    """뮤테이션 대조 — 위 스캐너가 실제로 uuid 패턴을 잡는지, 이 자리에 준비한 가짜
+    소스(문자열, 파일 안 씀)로 직접 증명한다(레포를 더럽히지 않는다)."""
+    fake_source = (
+        'from app.core.error_envelope import human_error\n'
+        'human_error("X", "m", user_message="연결 641adabf-1111-2222-3333-444455556666 실패")\n'
+    )
+    tree = ast.parse(fake_source)
+    literals = _find_user_message_literals(tree)
+    assert literals == ["연결 641adabf-1111-2222-3333-444455556666 실패"]
+    assert _UUID_RE.search(literals[0]) is not None, "스캐너 자체가 uuid를 못 잡으면 본 테스트가 무의미해진다"


### PR DESCRIPTION
## 계약(실물 대조 뒤 확定)
오류 봉투에 `user_message`(BE가 손으로 쓴, 사람에게 그대로 보여도 되는 문장)·`user_message_key`(FE i18n 키) 두 필드를 additive로 더한다. `app/main.py::http_exception_handler`가 이미 dict detail의 `code`/`message` 외 모든 키를 그대로 `error` 객체로 패스스루하므로(:280~284) 그 핸들러는 무변경 — `app/core/error_envelope.py::human_error(code, message, *, user_message=None, user_message_key=None, **extra)` 헬퍼만 신설해 raise 자리가 그걸 채워 넣는다.

판별축(AC 그대로): 「값 없을 때 누가 채우나」 — **BE**(그 오류를 아는 유일한 쪽)가 채운다. FE(`api-error-message.ts::extractBackendErrorMessage`)는 `user_message_key`(t 주어지면 i18n)→`user_message`(그대로)를 **allowlist 조회보다 최우선**으로 본다. `t`는 선택 인자라 기존 4개 호출부가 당장 안 바꿔도 회귀 0 — 이번 PR에서 4곳 다 연결해 계약을 즉시 활성화했다(event-block-card.tsx·delivery-contract-modal.tsx·chat-input.tsx·content/channel-posts/[draftId]/page.tsx).

## population(이번 PR 범위)
3601 allowlist(`HUMAN_SAFE_ERROR_MESSAGE_CODES`)에 이미 등재된 **7코드·8raise자리**를 `human_error()`로 이관 — 이미 전수 검증된 안전한 문장을 그대로 옮기는 것이라 새 안전성 판단이 0이다.

| 코드 | 파일 | 자리 수 |
|---|---|---|
| CHANNEL_POST_PUBLISH_HUMAN_ONLY | channel_posts.py | 1 |
| COMMENT_REFRESH_HUMAN_ONLY | channel_post_comments.py | 1 |
| COMMENT_COLLECTION_UNSUPPORTED | channel_post_comments.py | 1 |
| COMMENT_REPLY_HUMAN_ONLY | channel_post_comment_replies.py | 1 |
| COMMENT_REPLY_DRAFT_ALREADY_OPEN | channel_post_comment_replies.py | 1 |
| COMMENT_REPLY_TARGET_DELETED | channel_post_comment_replies.py·gates.py | 2 |
| COMMENT_REPLY_CHANNEL_UNSUPPORTED | channel_post_comment_replies.py | 1 |

## 스코프 노트 — 3597/3598/3605/3612 코드군
그라운딩 결과 **#3605**(`feat/3605-oauth-connection-kind-generalize`)와 **#3612**(본 세션 PR #3969)는 아직 develop 미병합이다 — 그 그룹이 내는 신규 코드(`CHANNEL_CONNECTION_AUTH_ERROR`·`COMMENT_PUBLICATION_NOT_FOUND`·`INSIGHT_PUBLICATION_NOT_FOUND` 등)는 지금 이 저장소에 존재하지 않아 이번 PR에 없다 — 각자 착지한 뒤 `human_error()`로 채우는 후속 작업.

`CHANNEL_CONNECTION_NOT_ACTIVE`(#3597/#3598이 이미 낸 코드, raise 20곳+ 다수가 uuid를 그대로 담음)의 전수 안전화는 AC 명시 범위 밖 — 지금처럼 `message`만 있고 `user_message`가 없어 FE가 안전하게 코드별 generic 폴백으로 떨어진다(회귀 0, 원문 노출도 0). `InsightFetchError`(insight_snapshots.py)는 어느 라우터도 HTTPException으로 변환하지 않아(내부 스케줄러 전용) 이 계약이 닿지 않는 것도 확認 — populate 대상에서 제외.

`components/content/api-error.ts`(발행 플로우, §22 labelKey 정본)는 의도적으로 손대지 않았다 — 그 파일 자체 docstring이 "서버 message를 그대로 뿌리지 않는다(코드→화면 문구 선택, §22-15 규율)"를 명시해 이 계약과 반대 방향의 기존 정본이 있다(코드마다 FE가 문구를 짓는 설계). 억지로 합치면 §22 규율을 깬다.

3601 allowlist·lint 은퇴(AC3)는 이 PR 범위 밖 — 등재 7건이 그대로 있다(마이그레이션 경로 자체만 이 PR로 입증). 새 raise 자리가 계속 `human_error()`로 채워지면 자연 수렴한다.

## 테스트
- BE `tests/test_3615_human_error_contract.py` 6건 — `human_error()` shape(additive·부가 키 통과)·저장소 전체 `human_error(...)` 호출의 `user_message` 문자열 리터럴 정적 스캔(uuid·스택 패턴 0, AC4)·뮤테이션 대조(실 소스 파일에 uuid 주입 → 스캐너가 실제로 잡음을 확認 후 원복).
- FE `api-error-message.test.ts` 5건 신규 — user_message 우선(allowlist 밖 코드여도)·user_message_key+t 조합·key-without-t 폴백·detail 쪽 동일 우선순위·계약 필드 둘 다 없으면 기존 allowlist 분기. 뮤테이션(`resolveContractMessage` 무력화) → 신규 4건 정확히 RED 확認 후 원복.
- 회귀: comment/reply/gates realdb 61건 + 3601 lint 스크립트 전체 그린. tsc·eslint 그린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG