### PR TITLE
[SID:3616] fix: realtime-gateway 시작 스크립트 멱등화 + readiness 능동 프로브

### DIFF
--- a/backend/app/realtime_main.py
+++ b/backend/app/realtime_main.py
@@ -61,6 +61,8 @@ async def realtime_lifespan(app: FastAPI):
     - outbox_dispatcher_loop — event_broker_outbox_enabled 조합에서 realtime도 관련될 수 있어
       우선 포함(측정 결과로 불필요하면 뺀다).
     - engine.dispose() — 좀비 커넥션 방지, 다른 서비스와 동형으로 필수.
+    - story #3616 — realtime_readiness.run_active_probe_loop(): backplane 무관 항상 기동,
+      /api/v2/ready가 트래픽 의존 신호만으로 무트래픽 구간을 놓치던 사각지대를 닫는다.
     """
     from app.core import shutdown as shutdown_module
     from app.core.database import engine
@@ -98,14 +100,21 @@ async def realtime_lifespan(app: FastAPI):
     if settings.event_broker_outbox_enabled:
         outbox_dispatcher_task = asyncio.create_task(outbox_dispatcher_loop())
 
+    # story #3616 — readiness ③(능동 프로브). backplane 선택(pg/redis)과 무관하게 항상
+    # 띄운다 — ①(listen_task)은 backplane=pg에서만 뜨고 ②(agent API키 인증)는 트래픽
+    # 의존이라, backplane=redis(현재 dev/prod 실값)·무트래픽 조합에서 15시간 감지
+    # 지연을 낸 그 사각지대를 이 태스크가 메운다(realtime_readiness.py 참고).
+    from app.services.realtime_readiness import run_active_probe_loop
+    readiness_probe_task = asyncio.create_task(run_active_probe_loop())
+
     try:
         yield
     finally:
         shutdown_module.shutdown_event.set()
-        for t in (listen_task, redis_shadow_task, outbox_dispatcher_task):
+        for t in (listen_task, redis_shadow_task, outbox_dispatcher_task, readiness_probe_task):
             if t is not None:
                 t.cancel()
-        for t in (listen_task, redis_shadow_task, outbox_dispatcher_task):
+        for t in (listen_task, redis_shadow_task, outbox_dispatcher_task, readiness_probe_task):
             if t is not None:
                 try:
                     await t

--- a/backend/app/services/realtime_readiness.py
+++ b/backend/app/services/realtime_readiness.py
@@ -23,17 +23,31 @@ unhealthy):
    DB 불요라 무관). DB 연결 자체의 실패(예외)만 신호로 잡는다 — 틀린 키(정상 401)는
    readiness와 무관(같이 잡으면 「틀린 키 = 인프라 UNHEALTHY」라는 오판정이 된다).
 
-⚠️못 잡는 것(PO 명시, AC) — 이 신호는 **트래픽 의존**이다. 신규 SSE 연결 시도(agent API키
-경로)가 0인 구간엔 cloud-sql-proxy가 죽어도 ②가 안 나서 `/ready`가 마지막 캐시 상태(또는
-기동 후 첫 시도 前 fail-open 「not_yet_connected」)에 그대로 머문다 — 무트래픽 구간의
-감지 지연. 원 인시던트류(크래시루프)는 fleet 전체의 재연결 폭주가 신호를 계속 만들어
-실용상 잘 잡히지만, 이론상 무트래픽 구간은 이 처방의 사각지대다. 능동 프로브(예: 60s급
-백그라운드 1회 SELECT)는 이번 스코프 밖 — 실 신호(무트래픽 구간에서 놓친 사례)가 나오면
-후속 스토리로.
-"""
+⚠️못 잡는 것(PO 명시, AC, story #2295 원문) — 이 신호는 **트래픽 의존**이다. 신규 SSE
+연결 시도(agent API키 경로)가 0인 구간엔 cloud-sql-proxy가 죽어도 ②가 안 나서 `/ready`가
+마지막 캐시 상태(또는 기동 후 첫 시도 前 fail-open 「not_yet_connected」)에 그대로
+머문다 — 무트래픽 구간의 감지 지연. 원 인시던트류(크래시루프)는 fleet 전체의 재연결
+폭주가 신호를 계속 만들어 실용상 잘 잡히지만, 이론상 무트래픽 구간은 이 처방의
+사각지대다. 능동 프로브(예: 60s급 백그라운드 1회 SELECT)는 그때는 스코프 밖 — "실
+신호(무트래픽 구간에서 놓친 사례)가 나오면 후속 스토리로"라고 명시적으로 미뤄뒀다.
+
+story #3616(2026-09-07, 그 "실 신호") — DB 비밀번호 로테이션 뒤 dev의 backplane은
+redis(①은 아예 안 뜸)라 ②(트래픽 의존)만 유일한 신호원이었는데, 그 창에 SSE 신규
+연결 시도가 뜸해 `/ready`가 마지막 캐시된 "connected"에 15시간 넘게 눌러앉았다 —
+정확히 위 문단이 예견한 그 사각지대다. ③ `run_active_probe_loop()`를 더한다 —
+`ACTIVE_PROBE_INTERVAL_SECONDS`(60s)마다 백그라운드에서 **경량 `SELECT 1`을 딱 한
+커넥션으로** 실행해 같은 `mark_connected`/`mark_disconnected`에 먹인다. 이건 "매
+헬스체크마다 SELECT 1"이 아니다 — 헬스체크 빈도(GCLB 10s 간격 × VM 3대 = 초당
+0.3회)와 무관하게 인스턴스당 60초에 1커넥션·1쿼리로 상한이 고정된다(트래픽·헬스체크
+호출 횟수가 얼마든 이 비용은 안 늘어난다) — /health가 되돌아가려다 만 "체크 빈도에
+비례하는 DB 부하"를 재도입하지 않으면서, ②의 트래픽 의존성만 없앤다."""
 from __future__ import annotations
 
+import asyncio
+import logging
 from datetime import UTC, datetime
+
+_logger = logging.getLogger(__name__)
 
 # AC4(카디르 제안, 근거): listen_loop()의 재연결 backoff는 1s→2s→4s→8s→16s→30s(cap)로
 # 자란다. 유예시간을 그 backoff 자체의 수렴값(30s)으로 맞추면 — 연결이 끊긴 순간부터
@@ -42,6 +56,13 @@ from datetime import UTC, datetime
 # 뜻이 된다. 임의 숫자가 아니라 기존 재시도 스케줄 자체를 유예 기준으로 재사용한 것 — 새
 # 임계값 체계를 따로 발명하지 않는다.
 UNHEALTHY_GRACE_SECONDS = 30.0
+
+# story #3616 — ③ 능동 프로브 주기. UNHEALTHY_GRACE_SECONDS(30s)보다 짧으면 무트래픽
+# 구간에서도 최소 1회는 그 유예 창 안에 들어와 flapping 오탐 없이 정상적으로 unhealthy
+# 로 전이한다(60s를 골랐다고 실제 감지가 60s+30s=최대 90s까지 걸릴 수 있다는 뜻 — 그래도
+# 기존 인시던트의 15시간에 비하면 실용적으로 충분하고, 이보다 짧게 잡을 근거[분당 비용
+# 상한]는 없다는 판단. 더 빠른 감지가 필요해지면 여기 숫자만 낮추면 된다).
+ACTIVE_PROBE_INTERVAL_SECONDS = 60.0
 
 _connected: bool = False
 _disconnected_since: datetime | None = None
@@ -94,3 +115,30 @@ def is_ready() -> tuple[bool, dict]:
         "disconnected_for_seconds": round(elapsed, 1),
         "last_error": _last_error,
     }
+
+
+async def run_active_probe_loop(interval_seconds: float = ACTIVE_PROBE_INTERVAL_SECONDS) -> None:
+    """story #3616 — ③ 능동 프로브. ①(backplane=pg 전용)·②(트래픽 의존) 둘 다 신호를
+    못 내는 조합(backplane=redis·무트래픽)에서 15시간 감지 지연을 낸 그 사각지대를
+    닫는다. `app.core.database.engine`으로 매 주기 딱 한 커넥션·`SELECT 1` 하나만 쓰고
+    바로 반환(연결 보유 0 — 커넥션 풀에 상주하지 않는다) — 실패해도 예외를 삼키고
+    `mark_disconnected()`만 호출한다(이 루프 자체가 죽으면 ③ 신호가 영구 소실되므로,
+    한 번의 DB 장애로 루프가 죽는 것이 최악의 결과 — 절대 raise하지 않는다).
+
+    realtime_main.py::realtime_lifespan이 backplane 선택과 무관하게(pg든 redis든) 항상
+    이 태스크를 띄운다 — ③은 ①의 대체가 아니라 추가 신호원(OR 집합에 합류)."""
+    from sqlalchemy import text
+
+    from app.core.database import engine
+
+    while True:
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+            mark_connected()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — 위 docstring: 절대 루프를 죽이지 않는다.
+            mark_disconnected(f"active_probe: {type(exc).__name__}: {exc}")
+            _logger.warning("realtime_readiness 능동 프로브 실패(다음 주기에 재시도): %s", exc)
+        await asyncio.sleep(interval_seconds)

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -481,6 +481,17 @@ trap 'rm -f "${STARTUP_SCRIPT_FILE}"' EXIT
     echo '#   소켓 dir을 world-writable로 — 프록시(생성)·앱(소켓 접속) 양쪽 UID 무관하게 통과.'
     echo "chmod 777 ${_HOST_SOCKET_DIR}"
     echo 'docker rm -f cloud-sql-proxy 2>/dev/null || true'
+    # story #3616(라이브 결함, 2026-09-06~07 DB 비밀번호 로테이션 뒤 15시간 503) — 이
+    # startup-script는 `rolling-action restart`(재부팅)에서도 그대로 재실행된다(위 주석
+    # "재부팅마다 재실행" 그대로)는데, `/mnt/stateful_partition`은 stateful(디스크 보존)
+    # 이라 이전 부팅의 소켓 파일(`${SQL_INSTANCE_CONN}/.s.PGSQL.5432`)이 재부팅 뒤에도
+    # 그대로 남아 있었다 — 새 cloud-sql-proxy 컨테이너가 그 자리에 bind하려다
+    # "Unable to mount socket: listen unix ...: bind: address already in use"로 죽어
+    # 크래시루프(`replace`=디스크 자체를 새로 만들어 우연히 피해갔을 뿐, `restart`=고장
+    # 그대로 재현). 컨테이너를 지운 뒤(위 줄) 그 잔존 소켓 서브dir을 지워 매 부팅을
+    # 항상 「빈 소켓 dir에서 새로 붙는」 것과 동일하게 만든다 — restart와 replace가
+    # 이제 이 실패축에서 동등해진다(AC1).
+    echo "rm -rf \"${_HOST_SOCKET_DIR}/${SQL_INSTANCE_CONN}\""
     echo 'docker run -d --name cloud-sql-proxy --restart=always \'
     echo "  -v ${_HOST_SOCKET_DIR}:/cloudsql \\"
     echo "  gcr.io/cloud-sql-connectors/cloud-sql-proxy:2 \\"
@@ -622,6 +633,9 @@ if [ "${DRY_RUN}" = "1" ]; then
     # story #3071 — 같은 관례: 시크릿 배치 fetch 로직(embedded fetch-secrets.sh + 재조립
     # 루프)이 실제로 생성된 그대로를 노출한다(요약 변수가 아니라 산출물 자체).
     _GENERATED_FETCH_SECRETS_BLOCK_B64="$(sed -n '/^cat > \/tmp\/fetch-secrets\.sh/,/^# story #3071 fetch-secrets block end/p' "${STARTUP_SCRIPT_FILE}" | base64 | tr -d '\n')"
+    # story #3616 — cloud-sql-proxy 재기동 블록(잔존 소켓 정리 순서 검증용, 같은 관례:
+    # 요약이 아니라 산출물 자체를 노출).
+    _GENERATED_CLOUDSQL_PROXY_BLOCK_B64="$(sed -n '/^docker rm -f cloud-sql-proxy/,/^# 소켓 파일이 실제로 나타날 때까지/p' "${STARTUP_SCRIPT_FILE}" | base64 | tr -d '\n')"
     cat <<EOF
 ENV=${ENV}
 MIG_NAME=${MIG_NAME}
@@ -639,6 +653,7 @@ GENERATED_PLAIN_ENV_FILE_B64=${_GENERATED_PLAIN_ENV_FILE_B64}
 UVICORN_APP_MODULE=${UVICORN_APP_MODULE}
 GENERATED_UVICORN_CMD_LINE=${_GENERATED_UVICORN_CMD_LINE}
 GENERATED_FETCH_SECRETS_BLOCK_B64=${_GENERATED_FETCH_SECRETS_BLOCK_B64}
+GENERATED_CLOUDSQL_PROXY_BLOCK_B64=${_GENERATED_CLOUDSQL_PROXY_BLOCK_B64}
 EOF
     exit 0
 fi

--- a/backend/tests/test_deploy_realtime_gce_stale_socket_cleanup.py
+++ b/backend/tests/test_deploy_realtime_gce_stale_socket_cleanup.py
@@ -1,0 +1,90 @@
+"""story #3616(라이브 결함, 2026-09-06~07) — realtime-gateway GCE startup-script의
+cloud-sql-proxy 재기동 순서 회귀가드.
+
+배경: DB 비밀번호 로테이션 뒤 `rolling-action restart`(재부팅)가 15시간 동안 3대 전부
+`cloud-sql-proxy … Unable to mount socket: listen unix /cloudsql/…: bind: address
+already in use`로 크래시루프였다. `/mnt/stateful_partition`은 stateful(재부팅에도
+보존)이라 이전 부팅의 소켓 파일이 그대로 남아 새 프록시 컨테이너가 그 자리에 bind하지
+못했다 — `rolling-action replace`(디스크 재생성)로만 우연히 피해갔을 뿐, startup-script
+자체는 restart에 대해 멱등하지 않았다.
+
+이 파일은 생성된 startup-script(DRY_RUN 산출물, `deploy_realtime_gce.sh`의 기존
+`GENERATED_*_B64` 관례와 동형)가 실제로 잔존 소켓을 지우는지, 그리고 그 위치가
+"컨테이너 제거 후·새 프록시 기동 전"인지(순서가 어긋나면 새 컨테이너가 뜬 뒤에
+지워 그 컨테이너 자신의 소켓을 지우는 자기파괴가 됨)를 실 bash 서브프로세스로
+검증한다(요약이 아니라 생성된 코드 그 자체)."""
+from __future__ import annotations
+
+import base64
+import os
+import re
+import subprocess
+
+_SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts")
+_DEPLOY_GCE = os.path.join(_SCRIPTS, "deploy_realtime_gce.sh")
+
+
+def _resolve(env: str = "dev") -> dict[str, str]:
+    proc = subprocess.run(
+        ["bash", _DEPLOY_GCE, env],
+        capture_output=True, text=True, env={**os.environ, "DRY_RUN": "1"}, check=True,
+    )
+    cfg: dict[str, str] = {}
+    for line in proc.stdout.strip().splitlines():
+        if "=" in line:
+            k, _, v = line.partition("=")
+            cfg[k.strip()] = v.strip()
+    return cfg
+
+
+def _cloudsql_proxy_block(env: str = "dev") -> str:
+    cfg = _resolve(env)
+    return base64.b64decode(cfg["GENERATED_CLOUDSQL_PROXY_BLOCK_B64"]).decode()
+
+
+def test_stale_socket_dir_removed_before_new_proxy_container_starts():
+    """AC1 — 순서: docker rm(옛 컨테이너 제거) → rm -rf(잔존 소켓 정리) → docker run
+    (새 컨테이너). 순서가 어긋나면(예: run이 rm -rf보다 먼저) 새로 만든 소켓을 지우는
+    자기파괴가 되거나, 여전히 옛 소켓에 막혀 이번 인시던트가 재현된다."""
+    block = _cloudsql_proxy_block()
+    lines = [ln for ln in block.splitlines() if ln.strip()]
+
+    idx_docker_rm = next(i for i, ln in enumerate(lines) if ln.startswith("docker rm -f cloud-sql-proxy"))
+    idx_rm_rf = next(i for i, ln in enumerate(lines) if ln.startswith("rm -rf ") and "cloudsql" in ln)
+    idx_docker_run = next(i for i, ln in enumerate(lines) if ln.startswith("docker run -d --name cloud-sql-proxy"))
+
+    assert idx_docker_rm < idx_rm_rf < idx_docker_run, (
+        f"순서 위반(회귀) — docker rm={idx_docker_rm}, rm -rf={idx_rm_rf}, "
+        f"docker run={idx_docker_run}: {lines}"
+    )
+
+
+def test_stale_socket_cleanup_targets_the_connection_scoped_subdir_not_whole_host_dir():
+    """호스트 소켓 dir 전체(`_HOST_SOCKET_DIR`)가 아니라 그 안의 connection-scoped
+    서브dir만 지운다 — 전체를 지우면(다른 무관한 상태가 그 자리에 있을 경우) 과도한
+    파괴가 될 수 있다. 정확한 경로 형태(`<HOST_DIR>/<SQL_INSTANCE_CONN>`)를 고정한다."""
+    cfg = _resolve()
+    conn = cfg["SQL_INSTANCE_CONN"]
+    block = _cloudsql_proxy_block()
+
+    m = re.search(r'^rm -rf "([^"]+)"$', block, re.MULTILINE)
+    assert m, f"rm -rf 라인을 못 찾음: {block}"
+    removed_path = m.group(1)
+    assert removed_path.endswith(f"/{conn}"), f"connection-scoped 서브dir이 아님: {removed_path}"
+    assert removed_path != "/mnt/stateful_partition/cloudsql", "호스트 dir 전체를 지우면 과도한 파괴"
+
+
+def test_mutation_reordered_rm_rf_after_docker_run_would_fail_the_order_test():
+    """뮤테이션 대조 — 위 순서 검사 로직 자체가 실제로 순서 위반을 잡는지, 준비한 가짜
+    라인 목록으로 직접 증명한다(레포를 더럽히지 않는다)."""
+    fake_lines_wrong_order = [
+        "docker rm -f cloud-sql-proxy 2>/dev/null || true",
+        "docker run -d --name cloud-sql-proxy --restart=always \\",
+        'rm -rf "/mnt/stateful_partition/cloudsql/proj:region:db"',
+    ]
+    idx_docker_rm = next(i for i, ln in enumerate(fake_lines_wrong_order) if ln.startswith("docker rm -f cloud-sql-proxy"))
+    idx_rm_rf = next(i for i, ln in enumerate(fake_lines_wrong_order) if ln.startswith("rm -rf "))
+    idx_docker_run = next(i for i, ln in enumerate(fake_lines_wrong_order) if ln.startswith("docker run -d --name cloud-sql-proxy"))
+    assert not (idx_docker_rm < idx_rm_rf < idx_docker_run), (
+        "이 가짜 순서는 위반이어야 하는데 통과함 — 순서 검사 로직 자체가 무력화됨"
+    )

--- a/backend/tests/test_realtime_main_lifespan_shutdown_order.py
+++ b/backend/tests/test_realtime_main_lifespan_shutdown_order.py
@@ -98,10 +98,41 @@ async def test_all_three_background_tasks_are_referenced_and_awaited():
          patch("app.services.event_broker.redis_consume_loop", side_effect=_tracked_loop("redis_shadow")), \
          patch("app.core.config.settings.event_broker_outbox_enabled", True), \
          patch("app.services.event_broker.outbox_dispatcher_loop", side_effect=_tracked_loop("outbox")), \
+         patch("app.services.realtime_readiness.run_active_probe_loop", side_effect=_tracked_loop("readiness_probe")), \
          patch("app.core.database.engine", new=_FakeEngine()):
         async with rm.realtime_lifespan(rm.app):
             await asyncio.sleep(0)
 
-    assert cancelled == {"listen", "redis_shadow", "outbox"}, (
+    assert cancelled == {"listen", "redis_shadow", "outbox", "readiness_probe"}, (
         f"일부 백그라운드 루프가 취소되지 않음(GC 조기수거 위험) — cancelled={cancelled}"
     )
+
+
+async def test_readiness_probe_task_always_starts_regardless_of_backplane():
+    """story #3616 — readiness_probe_task는 backplane 선택(pg/redis)과 무관하게 항상
+    떠야 한다(①listen_task는 backplane=pg에서만 뜨는 것과 대조적으로, ③은 그 조합
+    무관 상시 신호원이어야 무트래픽·backplane=redis 사각지대를 닫는다는 게 이 스토리의
+    존재 이유). backplane=redis(dev/prod 실값)로 명시 재현."""
+    import app.realtime_main as rm
+
+    probe_started = asyncio.Event()
+
+    async def _fake_probe_loop():
+        probe_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise
+
+    async def _fake_redis_consume_loop():
+        await asyncio.Event().wait()
+
+    with patch("app.services.event_broker.resolve_backplane", return_value="redis"), \
+         patch("app.core.config.settings.event_broker_redis_dual_publish_enabled", True), \
+         patch("app.core.config.settings.event_broker_redis_consume_enabled", True), \
+         patch("app.services.event_broker.redis_consume_loop", side_effect=_fake_redis_consume_loop), \
+         patch("app.services.event_broker.check_outbox_dual_publish_config", return_value=None), \
+         patch("app.services.realtime_readiness.run_active_probe_loop", side_effect=_fake_probe_loop), \
+         patch("app.core.database.engine", new=_FakeEngine()):
+        async with rm.realtime_lifespan(rm.app):
+            await asyncio.wait_for(probe_started.wait(), timeout=1.0)

--- a/backend/tests/test_realtime_readiness.py
+++ b/backend/tests/test_realtime_readiness.py
@@ -1,7 +1,17 @@
 """story #2295 — realtime_readiness 모듈 단위 테스트. 순수 상태기계, DB/네트워크 0."""
+import asyncio
 import time
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
 
 import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
 
 
 @pytest.fixture(autouse=True)
@@ -76,3 +86,102 @@ def test_reconnect_after_disconnect_clears_state():
     assert healthy is True
     assert detail["pg_listen"] == "connected"
     assert rr._disconnected_since is None
+
+
+# ─── story #3616 — run_active_probe_loop(): ③ 능동 프로브(트래픽·backplane 무관 신호원) ──
+
+class _FakeConn:
+    def __init__(self, *, fail: bool = False):
+        self._fail = fail
+
+    async def execute(self, *args, **kwargs):
+        if self._fail:
+            raise ConnectionRefusedError("probe: simulated DB down")
+
+
+class _FakeEngine:
+    def __init__(self, *, fail: bool = False):
+        self._fail = fail
+
+    @asynccontextmanager
+    async def connect(self):
+        yield _FakeConn(fail=self._fail)
+
+
+async def _run_one_iteration_then_cancel(interval_seconds: float = 999.0):
+    """루프 첫 반복(engine.connect→execute→mark_*)이 끝나고 asyncio.sleep에 진입하는
+    순간을 asyncio.sleep을 스파이해서 잡는다 — 그 시점에 태스크를 취소해 정확히
+    "1회 반복"만 관측한다(sleep 값 자체는 크게 둬서 자연 만료로 테스트가 오염되지 않게)."""
+    from app.services import realtime_readiness as rr
+
+    entered_sleep = asyncio.Event()
+    real_sleep = asyncio.sleep
+
+    async def _spy_sleep(seconds):
+        entered_sleep.set()
+        await real_sleep(seconds)
+
+    task = asyncio.create_task(rr.run_active_probe_loop(interval_seconds))
+    with patch("asyncio.sleep", side_effect=_spy_sleep):
+        await asyncio.wait_for(entered_sleep.wait(), timeout=1.0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+async def test_active_probe_success_marks_connected():
+    from app.services import realtime_readiness as rr
+
+    with patch("app.core.database.engine", new=_FakeEngine(fail=False)):
+        await _run_one_iteration_then_cancel()
+
+    assert rr._connected is True
+
+
+async def test_active_probe_failure_marks_disconnected_without_crashing_loop():
+    """AC — DB 왕복 실패해도 예외가 루프를 죽이면 안 된다(그러면 ③ 신호가 영구
+    소실돼 반쪽 처방이 된다) — mark_disconnected만 호출되고 태스크는 다음 sleep으로
+    넘어가 살아있어야 한다(취소 전까지 CancelledError 외엔 절대 안 죽음)."""
+    from app.services import realtime_readiness as rr
+
+    with patch("app.core.database.engine", new=_FakeEngine(fail=True)):
+        await _run_one_iteration_then_cancel()
+
+    assert rr._connected is False
+    assert rr._last_error is not None and "ConnectionRefusedError" in rr._last_error
+
+
+async def test_active_probe_cancellation_is_not_swallowed():
+    """루프 자체가 CancelledError를 삼키면 lifespan finally의 await가 영원히 안
+    끝난다(다른 세 태스크와 동형 계약) — 취소가 정상적으로 전파돼야 한다. 실 DB
+    엔진에 기대지 않도록(reachability에 따라 flaky해지는 것 방지) 성공 스텁으로 고정."""
+    from app.services import realtime_readiness as rr
+
+    with patch("app.core.database.engine", new=_FakeEngine(fail=False)):
+        task = asyncio.create_task(rr.run_active_probe_loop(999.0))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_active_probe_uses_short_lived_connection_not_persistent():
+    """engine.connect()가 매 반복 새로 호출되는지(커넥션을 계속 들고 있지 않는지) —
+    async with 블록을 벗어나면 연결이 반환된다는 것을 스파이로 확인."""
+    from app.services import realtime_readiness as rr
+
+    connect_call_count = 0
+    real_connect = _FakeEngine.connect
+
+    class _CountingEngine(_FakeEngine):
+        def connect(self):
+            nonlocal connect_call_count
+            connect_call_count += 1
+            return real_connect(self)
+
+    with patch("app.core.database.engine", new=_CountingEngine(fail=False)):
+        await _run_one_iteration_then_cancel()
+
+    assert connect_call_count == 1, "1회 반복에 connect()가 정확히 1번만 불려야 한다(상주 연결 금지)"

--- a/docs/infra-realtime-gateway-boot-once-secrets-and-topology.md
+++ b/docs/infra-realtime-gateway-boot-once-secrets-and-topology.md
@@ -1,0 +1,101 @@
+# realtime-gateway(GCE MIG) — 부팅 1회형 시크릿 소비자·이중 구조 판정
+
+story #3616(2026-09-07, 라이브 결함) 후속 문서. 배경: `DATABASE_URL_DEV` 로테이션
+(2026-09-06T14:27:40Z, v17) 뒤 GCE MIG `sprintable-realtime-gateway-dev`가 15시간
+동안 옛 비밀번호를 컨테이너 env에 굳힌 채 503을 냈다(부팅 때 시크릿을 1회만 읽고
+디스크에 기록하지 않는 설계 — `backend/scripts/deploy_realtime_gce.sh` — 라 로테이션
+사본 목록·감시 대상에서 이 소비자가 빠져 있었다). 원인·처방 코드는 PR 본문 참고
+(`backend/scripts/deploy_realtime_gce.sh`의 잔존 소켓 정리, `app/services/
+realtime_readiness.py::run_active_probe_loop`).
+
+## AC3 — 「부팅 1회형」 시크릿 소비자 목록(로테이션 런북 체크리스트)
+
+시크릿을 **부팅 시점에 1회만 읽고 디스크/env에 그대로 굳히는** 소비자는 일반적인
+"시크릿 갱신 → 다음 배포가 자동으로 새 값을 받는다" 가정이 깨진다. 로테이션 PR/절차는
+아래 목록을 체크리스트로 삼아, 로테이션 대상 시크릿을 쓰는 소비자가 이 표에 있으면
+**그 소비자의 재부팅/재배포를 로테이션과 같은 변경 세트에 명시적으로 포함**해야 한다.
+
+| 소비자 | 시크릿 소비 방식 | 로테이션 후 필요한 조치 |
+|---|---|---|
+| GCE MIG `sprintable-realtime-gateway-dev`/`-prod` | startup-script가 `gcloud secrets versions access latest`를 **부팅 때 1회**만 호출해 컨테이너 `-e` 인자로 굳힘(`deploy_realtime_gce.sh`) — 디스크 미기록(보안 설계 그대로 유지, 바꾸지 않음) | `gcloud compute instance-groups managed rolling-action replace <MIG> --project=<proj> --zone=<zone>`(지역 MIG는 `--region`+`--max-unavailable=<zone 수 이상>`) — **`restart`가 아니라 `replace`**를 써야 새 시크릿을 읽는다(restart는 같은 디스크·같은 env로 컨테이너만 재기동, 값이 안 바뀜). `deploy_realtime_gce.sh`를 develop HEAD로 재실행해도 동일 효과(cloudbuild.yaml의 `deploy-realtime-gce` 스텝이 develop 푸시마다 이미 자동 수행 — 로테이션이 코드 변경과 별도로 일어난 창에서만 수동 개입 필요). |
+
+체크리스트 항목(로테이션 실행 PR/절차에 추가할 것):
+1. 로테이션 대상 시크릿 이름을 위 표의 "시크릿 소비 방식" 열과 대조 — 겹치면 해당 소비자를
+   같은 변경 세트에 포함.
+2. GCE MIG가 겹치면 로테이션 직후(같은 절차 안에서) `rolling-action replace` 실행 —
+   **사후 대응이 아니라 로테이션 자체의 마지막 스텝**으로 취급한다(이번 인시던트는 이
+   스텝이 절차에 아예 없어 15시간 방치됐다).
+3. `replace` 뒤 각 VM의 `/api/v2/health`(DB 포함)가 `db: ok`인지 확認 — `/api/v2/ready`
+   만으로는 부족하다(트래픽 의존·능동 프로브 주기 지연 가능, 아래 판정 참고).
+
+이 목록은 "새로 발견되는 대로 추가"하는 살아있는 문서다 — Cloud Run 서비스(backend-dev/
+realtime-dev 등)는 `--update-secrets`로 재배포마다 최신 값을 받아 이 클래스에 안 걸린다
+(GCE MIG처럼 "값을 굳히는" 축이 없음).
+
+## AC1/AC2 코드 처방 요약(실물은 코드 참고)
+
+- **시작 스크립트 멱등화**: `docker rm -f cloud-sql-proxy` 뒤 `rm -rf
+  "${_HOST_SOCKET_DIR}/${SQL_INSTANCE_CONN}"`를 추가 — `/mnt/stateful_partition`은
+  stateful(재부팅에도 보존)이라 이전 부팅의 소켓 파일이 남아 새 프록시가
+  "address already in use"로 죽던 것을 막는다. 이제 `restart`(재부팅)만으로도
+  `replace`(디스크 재생성)와 동등하게 복구된다.
+- **LB 헬스체크가 DB까지 보게**: `/api/v2/ready`에 새 신호원 ③(`run_active_probe_loop`,
+  `realtime_readiness.py`)을 추가 — 60초 주기 백그라운드 `SELECT 1` 1커넥션(헬스체크
+  호출 빈도와 무관한 고정 비용, 기존 `/health`가 겪은 "체크마다 DB 부하" 문제를
+  재도입하지 않음). backplane=redis(dev/prod 실값)·무트래픽 구간에서 기존 신호원
+  (①pg_pubsub 재연결·②agent API키 인증)이 둘 다 못 내던 신호를 이 능동 프로브가
+  대신 낸다 — 이번 인시던트가 정확히 그 사각지대였다(story #2295 원문이 "실 신호가
+  나오면 후속 스토리로" 미뤄뒀던 그 자리).
+
+## AC4 — Cloud Run `sprintable-realtime-dev` vs GCE MIG 게이트웨이 이중 구조 판정
+
+**둘 다 `/api/v2/events/stream`을 마운트하지만 실제로는 서로 다른 역할이다(단순 중복
+아님) — cloudbuild.yaml의 `realtime_url` output(:326~354 이력 주석) 실물 대조 결과:**
+
+- **GCE MIG `sprintable-realtime-gateway-dev`(GCLB 뒤, `dev-realtime.sprintable.ai`)**
+  = **정본(primary)**. story #2185(2026-07-27)가 FE `REALTIME_URL`을 이 스택으로
+  durable 전환했다 — 실 브라우저 SSE 트래픽이 여기로 붙는다(GCLB 로그 실측: `/api/v2/
+  events/stream` 다건, 콜드스타트 없는 상시 2~3노드).
+- **Cloud Run `sprintable-realtime-dev`** = FE가 더는 직접 안 붙지만(REALTIME_URL이
+  GCE를 가리킨 뒤로 신규 연결 0에 가까움) **폐기되지 않았다** — story #3198(2026-08-28)
+  이 이 서비스를 Redis backplane의 **consume+dispatch 노드**로 계속 쓴다(`backend_
+  redis_consume_enabled=true`·`dispatch_enabled=true`, cloudbuild.yaml). backend-dev
+  (API 쓰기 경로)가 Redis 채널에 발행한 이벤트를 GCE MIG 인스턴스들이 구독해 실제
+  SSE로 내보내는데, 그 크로스인스턴스 팬아웃 배관의 소비측이 바로 이 Cloud Run
+  서비스다 — **같은 `/api/v2/events/stream` 라우트를 갖고 있어도 실질 소비처가 다르다**
+  (Cloud Run=Redis 구독·팬아웃 백플레인 / GCE=사람이 붙는 프런트 게이트웨이).
+
+**판정: 하나로 수렴 불가 — 별도 스토리 제안 안 함.** 두 서비스가 "같은 라우트를
+제공"하는 것처럼 보이지만 실제로는 **레이어가 다르다**(하나는 팬아웃 백플레인,
+하나는 엣지 게이트웨이) — 이건 이중 구조가 아니라 **의도된 2계층 구조**다. `event_
+broker.py::resolve_backplane()`이 redis일 때 이 2계층이 정확히 필요(Cloud Run이
+없으면 Redis pub/sub을 구독해 GCE 인스턴스들에 팬아웃할 주체가 없어진다). 굳이 하나로
+합친다면 GCE MIG 컨테이너 안에 Redis consume+dispatch 로직을 흡수시켜야 하는데,
+그러면 (a) 상시 3대 각각이 독립적으로 같은 Redis 채널을 구독·중복 배달 방지 로직을
+새로 설계해야 하고 (b) `realtime_main.py`가 이미 이 로직을 갖고 있어(`redis_consume_
+loop`) 재사용이 아니라 재작성이 된다 — 이번 스토리(AC4 "판정과 제안까지")의 스코프를
+넘는 별도 아키텍처 변경. 현재 2계층 유지를 권고.
+
+## AC5 — 알림(제안, 실행은 PO 확인 후)
+
+이번 인시던트에서 "관측 구멍"으로 지목된 것: `/api/event-stream`(FE BFF) 5xx 루프가
+10분 60~90회씩 발생했는데 사람이 보는 알림이 0이었다(선생님이 직접 신고해서야 발견).
+아래는 Cloud Monitoring 알림 정책 제안이다 — **실행(정책 생성)은 PO 확인 후 진행**
+(인프라 조치 lane 규율).
+
+```bash
+# 제안 — dev-realtime GCLB 백엔드 헬스 실패율 알림(실행 전 PO 확인)
+gcloud alpha monitoring policies create \
+  --project=sprintable-494803 \
+  --display-name="dev-realtime GCLB backend UNHEALTHY" \
+  --condition-display-name="realtime-gateway-dev-backend health check failing" \
+  --condition-filter='resource.type="https_lb_rule" AND resource.labels.backend_target_name="realtime-gateway-dev-backend" AND metric.type="loadbalancing.googleapis.com/https/backend_request_count" AND metric.labels.response_code_class="500"' \
+  --condition-threshold-value=10 \
+  --condition-threshold-duration=300s \
+  --notification-channels=<PO가 지정할 채널>
+```
+
+임계값(5분 내 500 10건)은 실측(10분 60~90회) 대비 보수적으로 낮게 잡아 — 이 정책이
+실 사고보다 먼저(60~90회에 도달하기 전) 울리게 하는 것이 목적. 정확한 채널(Slack/
+PagerDuty/이메일 등)과 임계값 튜닝은 PO 판단 — 이 커맨드는 「신호가 있어야 한다」는
+요구를 채우는 최소 제안이다.


### PR DESCRIPTION
## 라이브 실물(2026-09-07, 선생님 신고 05:45Z)
`REALTIME_URL` → LB `realtime-gateway-dev-backend` → GCE MIG `sprintable-realtime-gateway-dev`(VM 3대) health 503 `db: InvalidPasswordError` — `DATABASE_URL_DEV` 로테이션(09-06 14:27Z) 뒤 15시간 방치. 복구 시도 중 발견한 2차 결함: `rolling-action restart` 뒤 3대 전부 `cloud-sql-proxy … bind: address already in use`로 크래시루프(`replace`로만 회복).

## AC1 — 시작 스크립트 멱등화
`/mnt/stateful_partition`(호스트 소켓 dir)은 stateful — 재부팅에도 보존된다. `docker rm -f cloud-sql-proxy`는 컨테이너만 지우고 호스트 소켓 파일은 그대로 남아, 새 프록시가 그 자리에 bind 못 해 죽었다. `docker rm` 직후·`docker run` 직전에 `rm -rf "<HOST_SOCKET_DIR>/<SQL_INSTANCE_CONN>"` 추가 — restart와 replace가 이제 이 실패축에서 동등.

## AC2 — LB 헬스체크가 DB까지 보게(원문 재도입 없이)
`/api/v2/ready`(story #2295)는 **의도적으로** DB를 직접 조회하지 않는다 — 매 체크마다 SELECT 1을 날리면 그 자체가 DB 부하이고 부분장애를 전면장애로 증폭시킨다는 것이 그 설계의 근거(문서 원문·`/health` 원복 안 함). 대신 신호원 2개(①pg_pubsub 재연결 상태=backplane=pg 전용, ②agent API키 인증 DB 왕복=트래픽 의존)의 캐시된 사실만 읽는다.

dev의 실 backplane은 **redis**(①은 아예 안 뜸)라 ②만 유일한 신호였는데, 로테이션 직후 무트래픽 구간에 `/ready`가 마지막 캐시된 "connected"에 15시간 눌러앉았다 — story #2295 원문이 "실 신호가 나오면 후속 스토리로" 명시적으로 미뤄뒀던 그 사각지대(이번이 그 실 신호).

**처방**: `realtime_readiness.py::run_active_probe_loop()`(③ 신규) — 60초 주기·인스턴스당 딱 1커넥션·`SELECT 1` 하나로 같은 `mark_connected`/`mark_disconnected`에 합류. 헬스체크 호출 빈도(GCLB 10s×VM 3대=초당 0.3회)와 무관하게 비용이 고정돼(`/health`가 겪던 "체크 빈도에 비례하는 DB 부하" 재도입 없음), ②의 트래픽 의존성만 없앤다. `realtime_main.py::realtime_lifespan`이 backplane 선택과 무관하게 항상 이 태스크를 띄운다.

## AC3/AC4/AC5 — 문서(`docs/infra-realtime-gateway-boot-once-secrets-and-topology.md`)
- **AC3** 로테이션 런북 체크리스트: GCE MIG는 부팅 1회형 시크릿 소비자 — `rolling-action replace`만 새 값을 읽는다(`restart`는 무효, 이번 인시던트가 증명).
- **AC4** 이중 구조 판정: Cloud Run `sprintable-realtime-dev`(Redis consume+dispatch 백플레인, story #3198)와 GCE MIG(엣지 게이트웨이, story #2185)는 같은 라우트를 가져도 레이어가 다른 **의도된 2계층**이다(팬아웃 백플레인 vs 프런트 게이트웨이) — 수렴 비권고, 근거는 문서 본문.
- **AC5** Cloud Monitoring 알림 정책 gcloud 커맨드 제안 — **실행은 PO 확인 후**.

## 실행 lane 경계
이 PR은 코드·문서만이다. 실제 `rolling-action replace` 실행·알림 정책 생성은 인프라 조치 lane(PO)로 남겨둔다. prod는 AC 명시 범위 밖 — dev와 같은 startup-script를 공유해 AC1 코드 fix는 prod 배포 시에도 자동 적용되지만, 실행(replace)은 별도 확인 필요.

## 테스트
신규 3파일: stale-socket 순서 회귀 3건(실 DRY_RUN 산출물 대상, 뮤테이션 1) · readiness 능동 프로브 4건(성공/실패/취소전파/커넥션비상주, 뮤테이션 1) · lifespan 4번째 태스크(readiness_probe) 취소·backplane 무관 기동 검증 2건. 회귀(realtime_readiness·realtime_main·health·GCE 배포 스크립트 전체) 86건 그린. 뮤테이션 2건(순서 뒤바꿈·try/except 제거) 실 소스 대상 RED 확認 후 원복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mwUQtXsAJJ75pYg2UP1eG