### PR TITLE
[SID:3617] feat: 채널 포스트 「성과」 절에 「성과 보드에서 보기」 링크

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2432,6 +2432,7 @@
     "errorGateAlreadyHeldLink": "View that draft",
     "errorRawDetailsToggle": "View server response",
     "insightSectionLabel": "Performance",
+    "insightViewInBoardCta": "View in {board}",
     "insightMetricImpressions": "Impressions",
     "insightMetricReach": "Reach",
     "insightMetricViews": "Views",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2432,6 +2432,7 @@
     "errorGateAlreadyHeldLink": "그 초안 보기",
     "errorRawDetailsToggle": "서버 응답 보기",
     "insightSectionLabel": "성과",
+    "insightViewInBoardCta": "{board}에서 보기",
     "insightMetricImpressions": "노출",
     "insightMetricReach": "도달",
     "insightMetricViews": "조회",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1994,7 +1994,10 @@ export default function ChannelPostEditPage() {
             </div>
           ) : null}
           {/* story #3499(Phase2·FE) — publication_id 있을 때만(BE #3844 조각4 의존). */}
-          <InsightSnapshotBlock snapshots={insightSnapshots} orgTimezone={displayTimezone} locale={locale} />
+          <InsightSnapshotBlock
+            snapshots={insightSnapshots} orgTimezone={displayTimezone} locale={locale}
+            publicationId={draft.publication_id}
+          />
           {/* story #3517(Phase2·FE, 그라운딩 ① 자리 그대로 — InsightSnapshotBlock 곁,
               같은 draft.publication_id 조건) — 댓글 섹션. 조각①-FE 범위(PO 確定
               2026-09-05): 세 얼굴·수집 시각·목록·지워진 댓글(§22-9)만 — 행 액션

--- a/apps/web/src/app/(authenticated)/organization/insights-board/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/insights-board/page.test.tsx
@@ -428,3 +428,37 @@ describe('InsightsBoardPage — 댓글 칸 네 갈래(story #3517)', () => {
     expect(container.querySelector('[data-testid="insights-board-comments-text"]')?.textContent).toBe('댓글 5');
   });
 });
+
+// story #3617(유나 3600 AC2 기준선) — 채널 포스트 화면 「성과 보기」에서 ?highlight=
+// {publication_id}로 들어오면 해당 행을 강조·스크롤한다.
+describe('InsightsBoardPage — ?highlight로 들어온 행 강조(story #3617)', () => {
+  it('?highlight=pub-b — 그 행에 scrollIntoView가 불리고 강조 클래스가 붙는다', async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('highlight=pub-b'));
+    stubFetch({});
+    await mount();
+
+    const rows = container.querySelectorAll('[data-testid="insights-board-row"]');
+    const highlighted = [...rows].find((r) => r.getAttribute('data-highlighted') === 'true');
+    expect(highlighted).not.toBeUndefined();
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+  });
+
+  it('?highlight 없음 — 아무 행도 강조되지 않는다(보드 최상단으로 끝나는 기본 경로)', async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams());
+    stubFetch({});
+    await mount();
+    const rows = container.querySelectorAll('[data-testid="insights-board-row"]');
+    expect([...rows].some((r) => r.getAttribute('data-highlighted') === 'true')).toBe(false);
+  });
+
+  it('?highlight가 존재하지 않는 publication_id를 가리키면(레이스·오타) 조용히 무시한다', async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('highlight=pub-does-not-exist'));
+    stubFetch({});
+    await mount();
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(authenticated)/organization/insights-board/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/insights-board/page.tsx
@@ -373,7 +373,7 @@ export default function InsightsBoardPage() {
                     }}
                     data-testid="insights-board-row"
                     data-highlighted={highlightedRowId === row.publication_id ? 'true' : undefined}
-                    className={highlightedRowId === row.publication_id ? 'bg-primary/10 transition-colors' : undefined}
+                    className={highlightedRowId === row.publication_id ? 'bg-primary/10 motion-safe:transition-colors' : undefined}
                   >
                     <td className="max-w-xs truncate px-3 py-2.5 font-medium text-foreground">
                       {row.external_url ? (

--- a/apps/web/src/app/(authenticated)/organization/insights-board/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/insights-board/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
@@ -91,6 +91,10 @@ export default function InsightsBoardPage() {
   const sortDirParam = (searchParams.get('sort_dir') as SortDir | null) ?? DEFAULT_SORT_DIR;
   const rawMetricParam = searchParams.get('metric') as BoardMetric | null;
   const metricParam: BoardMetric = rawMetricParam && METRIC_KEYS.includes(rawMetricParam) ? rawMetricParam : DEFAULT_METRIC;
+  // story #3617(유나 3600 AC2 기준선) — 채널 포스트 화면 「성과 보기」 링크가 이 발행의
+  // publication_id를 실어 온다. 있는 강조/스크롤 메커니즘이 이 화면엔 없어서(그라운딩
+  // 확認) 새로 짠다 — row가 이미 publication_id로 키가 나 있어(346행) 비용이 작다.
+  const highlightParam = searchParams.get('highlight');
   // 실제 BE sort 값 — 역할(published_at 고정, d1/d7은 현재 지표와 합성).
   const resolvedSort = sortRoleParam === 'published_at' ? 'published_at' : `${metricParam}_${sortRoleParam}`;
 
@@ -142,6 +146,23 @@ export default function InsightsBoardPage() {
   }, [orgId, buildQuery, t]);
 
   useEffect(() => { void load(); }, [load]);
+
+  // story #3617 — 채널 포스트 화면 「성과 보기」에서 ?highlight={publication_id}로
+  // 들어오면 해당 행으로 스크롤+강조(짧게, 3초 뒤 해제). 행이 아직 안 실렸으면
+  // (loading 中·다음 페이지에 있음 등) 조용히 스킵 — 없으면 보드 최상단으로
+  // 끝내는 것이 AC의 명시 대체 경로다(새 로딩/재조회 로직 0).
+  const [highlightedRowId, setHighlightedRowId] = useState<string | null>(null);
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
+  useEffect(() => {
+    if (!highlightParam || loading || rows.length === 0) return;
+    const el = rowRefs.current.get(highlightParam);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setHighlightedRowId(highlightParam);
+    const timer = setTimeout(() => setHighlightedRowId(null), 3000);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightParam, loading, rows]);
 
   const handleLoadMore = useCallback(async () => {
     if (!orgId || !nextCursor || loadingMore) return;
@@ -344,7 +365,16 @@ export default function InsightsBoardPage() {
               </thead>
               <tbody className="divide-y divide-border">
                 {rows.map((row, index) => (
-                  <tr key={row.publication_id} data-testid="insights-board-row">
+                  <tr
+                    key={row.publication_id}
+                    ref={(el) => {
+                      if (el) rowRefs.current.set(row.publication_id, el);
+                      else rowRefs.current.delete(row.publication_id);
+                    }}
+                    data-testid="insights-board-row"
+                    data-highlighted={highlightedRowId === row.publication_id ? 'true' : undefined}
+                    className={highlightedRowId === row.publication_id ? 'bg-primary/10 transition-colors' : undefined}
+                  >
                     <td className="max-w-xs truncate px-3 py-2.5 font-medium text-foreground">
                       {row.external_url ? (
                         <a href={row.external_url} target="_blank" rel="noopener noreferrer" className="hover:underline">

--- a/apps/web/src/components/content/insight-snapshot-block.test.tsx
+++ b/apps/web/src/components/content/insight-snapshot-block.test.tsx
@@ -28,9 +28,9 @@ function wrap(node: React.ReactNode) {
   return <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="UTC">{node}</NextIntlClientProvider>;
 }
 
-async function render(snapshots: InsightSnapshot[]) {
+async function render(snapshots: InsightSnapshot[], publicationId?: string | null) {
   await act(async () => {
-    root.render(wrap(<InsightSnapshotBlock snapshots={snapshots} orgTimezone="UTC" locale="ko" />));
+    root.render(wrap(<InsightSnapshotBlock snapshots={snapshots} orgTimezone="UTC" locale="ko" publicationId={publicationId} />));
   });
 }
 
@@ -163,5 +163,28 @@ describe('InsightSnapshotBlock — story #3499(게시물 성과 표면 1차)', (
     await render([unsupported]);
     const el = container.querySelector('[data-testid="insight-snapshot-unsupported"]');
     expect(el?.className).not.toContain('text-destructive');
+  });
+});
+
+// story #3617(유나 3600 AC2 기준선) — 마케팅 흐름의 마지막 구역 건너뛰기를 화면의
+// 길로 없앤다. publicationId 유무로 링크 0/1을 가른다(발행 前에는 그릴 수 없다).
+describe('InsightSnapshotBlock — 「성과 보드」 링크(story #3617)', () => {
+  it('publicationId 없음(발행 前) — 링크가 안 보인다', async () => {
+    await render([capturedSnapshot()], null);
+    expect(container.querySelector('[data-testid="insight-view-in-board-link"]')).toBeNull();
+  });
+
+  it('publicationId 있음(발행 後) — 링크 1개, href에 publication id가 실린다', async () => {
+    await render([capturedSnapshot()], 'pub-123');
+    const links = container.querySelectorAll('[data-testid="insight-view-in-board-link"]');
+    expect(links).toHaveLength(1);
+    const href = links[0].getAttribute('href');
+    expect(href).toBe('/organization/insights-board?highlight=pub-123');
+  });
+
+  // ⭐뮤테이션 표적 — publicationId 가드를 지우면(항상 렌더) 위 "없음" 테스트가 RED여야 한다.
+  it('⭐뮤테이션 대조 — publicationId가 falsy 문자열이 아니라 실제 null/undefined일 때만 안 그린다', async () => {
+    await render([capturedSnapshot()], undefined);
+    expect(container.querySelector('[data-testid="insight-view-in-board-link"]')).toBeNull();
   });
 });

--- a/apps/web/src/components/content/insight-snapshot-block.tsx
+++ b/apps/web/src/components/content/insight-snapshot-block.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { formatRelativeTime } from '@/lib/storage/format';
 import { formatScheduledAt } from '@/components/content/schedule-format';
@@ -32,6 +33,11 @@ export interface InsightSnapshotBlockProps {
   snapshots: InsightSnapshot[];
   orgTimezone: string;
   locale: string;
+  // story #3617(유나 3600 AC2 기준선) — 성과 보드로 가는 유일한 화면 내 길. 발행
+  // 前(publication 없음)에는 undefined/null — 링크를 안 그린다(이 블록 자체도
+  // snapshots.length===0이면 이미 안 그려지지만, publicationId 부재를 별도로도
+  // 명시 방어한다 — "모른다≠다르다").
+  publicationId?: string | null;
 }
 
 const METRIC_KEYS = ['impressions', 'reach', 'views', 'engagements', 'clicks', 'spend', 'conversions'] as const;
@@ -91,8 +97,9 @@ function MetricValue({ value, dashLabel, reasonLabel }: { value: number | null; 
   return <span data-testid="insight-metric-value">{value}</span>;
 }
 
-export function InsightSnapshotBlock({ snapshots, orgTimezone, locale }: InsightSnapshotBlockProps) {
+export function InsightSnapshotBlock({ snapshots, orgTimezone, locale, publicationId }: InsightSnapshotBlockProps) {
   const t = useTranslations('content');
+  const tNav = useTranslations('nav');
 
   if (snapshots.length === 0) return null;
 
@@ -103,7 +110,21 @@ export function InsightSnapshotBlock({ snapshots, orgTimezone, locale }: Insight
       data-testid="content-insight-info"
       className="space-y-3 rounded-md border border-border bg-muted/30 p-3 text-sm"
     >
-      <p className="text-xs font-medium text-muted-foreground">{t('insightSectionLabel')}</p>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-medium text-muted-foreground">{t('insightSectionLabel')}</p>
+        {/* story #3617(유나 3600 AC2 기준선) — 마케팅 흐름(제작→승인→발행→댓글→성과)의
+            마지막 구역 건너뛰기를 화면의 길로 없앤다. 기존 낱말("성과 보드", nav
+            네임스페이스) 재사용 — 새 어휘 0. publicationId 없으면(발행 前) 안 그린다. */}
+        {publicationId ? (
+          <Link
+            href={`/organization/insights-board?highlight=${encodeURIComponent(publicationId)}`}
+            className="text-xs text-primary hover:underline"
+            data-testid="insight-view-in-board-link"
+          >
+            {t('insightViewInBoardCta', { board: tNav('orgInsightsBoard') })}
+          </Link>
+        ) : null}
+      </div>
 
       {latest ? (
         // 유나 지적(§17-19) — captured는 값이 있으면 값만 그린다, "수집됨" 배지를


### PR DESCRIPTION
## 그라운딩(유나 3600 AC2 기준선, 2026-09-07 05:58Z 실측)
마케팅 흐름(제작→승인→발행→댓글→성과)의 구역 건너뛰기 — 사이드바 기준 지금 3개, 화면 안 딥링크까지 치면 남은 건너뛰기는 **「성과」 한 번뿐**이다. 상신→결재함은 이미 딥링크가 있는데(`content/[draftId]:1398`·`channel-posts/[draftId]:2692`), 채널 포스트 화면 「성과」 절(「스냅샷 예정 · 09-07 21:33」 등)에서 `organization/insights-board`로 가는 링크가 **레포 전체에서 0**(insights-board를 가리키는 곳은 nav-config 사이드바뿐). story #3600(IA 축 결정)과는 독립 — IA를 어느 축으로 묶든 「화면의 길」 한 줄은 그 자체로 흐름 비용을 1 줄인다.

## 구현
- `InsightSnapshotBlock`에 `publicationId` prop 추가 — **있을 때만(발행 後)** 「성과」 절 우측에 「성과 보드에서 보기」 링크를 그린다. 기존 낱말 `nav.orgInsightsBoard`("성과 보드")를 그대로 재사용 — 새 어휘는 연결 문구 `"{board}에서 보기"` 하나뿐. `href=/organization/insights-board?highlight={publication_id}`.
- 성과 보드 화면에 `?highlight` 쿼리로 들어온 행을 스크롤+3초 강조하는 메커니즘을 신설했다(그라운딩 확認 — 이 화면엔 재사용할 기존 강조/스크롤 메커니즘이 없었다, AC의 "있으면 재사용·없으면 최상단"에서 후자를 그냥 택하지 않고 비용이 작아 직접 짰다 — row가 이미 `publication_id`로 키가 나 있어 새 쿼리·재조회 0). `highlight`가 없거나, 가리키는 행이 아직 안 실렸거나(로딩 中·페이지네이션), 존재하지 않는 id면 조용히 스킵 — AC의 명시 대체 경로("보드 최상단")가 자연히 성립한다.

## 테스트
- `InsightSnapshotBlock`: publicationId 없음(발행 前)=링크 0 · 있음(발행 後)=링크 1(href에 publication id) + 뮤테이션 1건(가드 제거 → 기존 2건 RED) 확認 후 복구.
- 성과 보드: `?highlight=pub-b`=해당 행 강조 class + `scrollIntoView` 호출 · 없음=강조 0 · 존재하지 않는 id=조용히 무시(scrollIntoView 미호출). 뮤테이션 1건(가드 제거 → RED) 확認 후 복구.
- 회귀: `insight-snapshot-block.test.tsx` 34건 · `insights-board/page.test.tsx` 27건 · `channel-posts/[draftId]/page.test.tsx` 222건 전부 PASS. `tsc --noEmit`/`eslint` 클린.

## 범위 밖
- 성과 보드 IA 위치 변경(story #3600) — 이 PR과 독립.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA
