### PR TITLE
[SID:3627] fix(prod): 온보딩 왕복·딥링크 휴먼 판정이 org_member SSOT 경로를 놓침

### DIFF
--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -19,7 +19,7 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
@@ -29,6 +29,31 @@ from app.models.team import TeamMember
 from app.models.user import User
 
 logger = logging.getLogger(__name__)
+
+
+def _is_human_member(member_id_col, *, user_id: uuid.UUID | None = None):
+    """story #3627(prod 결함, 페드루 PO 確定 2026-09-07) — 이 member_id가 「휴먼」인지
+    판정하는 유일한 자리(member_resolver.py 첫 줄과 같은 규칙, 새 판정자 발명 0).
+
+    E-MEMBER-SSOT Phase 0부터 JWT 휴먼의 참여자/발신자 id는 `org_members.id`다
+    (org_members 테이블 자체가 휴먼 전용이라 추가 type 조건 불요) — 그런데
+    이 모듈의 왕복·딥링크 판정은 여전히 `team_members(type='human')`로만 이었다.
+    team_members에 그 org의 휴먼 행이 하나도 없으면(SSOT 전환 이후 만들어진
+    org 다수) `human_before`·`requester_is_participant`가 영원히 false로
+    떨어져 "대화 中인데도 미완료·딥링크 null"이 났다(dev PO Test Org 실측).
+
+    둘 다 인정(OR) — legacy team_member(type='human') 행이 남아있는 org도
+    회귀 없이 그대로 통과해야 한다(#3607 기존 테스트가 그 표본).
+    `user_id`를 주면 그 유저 소유 여부까지, 안 주면 "휴먼이기만 하면" 통과."""
+    org_member_conditions = [OrgMember.id == member_id_col, OrgMember.deleted_at.is_(None)]
+    team_member_conditions = [TeamMember.id == member_id_col, TeamMember.type == "human"]
+    if user_id is not None:
+        org_member_conditions.append(OrgMember.user_id == user_id)
+        team_member_conditions.append(TeamMember.user_id == user_id)
+    return or_(
+        select(OrgMember.id).where(*org_member_conditions).exists(),
+        select(TeamMember.id).where(*team_member_conditions).exists(),
+    )
 
 
 async def get_owner_org_id(db: AsyncSession, user_id: uuid.UUID) -> uuid.UUID | None:
@@ -99,15 +124,13 @@ async def is_org_first_roundtrip_done(db: AsyncSession, org_id: uuid.UUID) -> bo
     """휴먼 발신 메시지 "이후"에 온 최초 agent 발신 메시지 존재(같은 conversation 안 순서조건).
     존재만 보면 #3157과 어긋난다(디디 지적) — 반드시 human_msg.created_at < agent_msg.created_at."""
     HumanMsg = aliased(ConversationMessage)
-    HumanSender = aliased(TeamMember)
     AgentSender = aliased(TeamMember)
 
     human_before = (
         select(HumanMsg.id)
-        .join(HumanSender, HumanSender.id == HumanMsg.sender_id)
         .where(
             HumanMsg.conversation_id == ConversationMessage.conversation_id,
-            HumanSender.type == "human",
+            _is_human_member(HumanMsg.sender_id),
             HumanMsg.created_at < ConversationMessage.created_at,
         )
         .exists()
@@ -147,28 +170,23 @@ async def get_first_instruction_conversation_id(
     거부와 동형 — 그 403 자체는 옳다, 애초에 링크가 거기로 가면 안 된다). `requester_user_id`
     의 human TeamMember가 참여자인 대화만 후보로 좁힌다."""
     HumanMsg = aliased(ConversationMessage)
-    HumanSender = aliased(TeamMember)
     AgentSender = aliased(TeamMember)
     RequesterParticipant = aliased(ConversationParticipant)
-    RequesterMember = aliased(TeamMember)
 
     requester_is_participant = (
         select(RequesterParticipant.id)
-        .join(RequesterMember, RequesterMember.id == RequesterParticipant.member_id)
         .where(
             RequesterParticipant.conversation_id == Conversation.id,
-            RequesterMember.user_id == requester_user_id,
-            RequesterMember.type == "human",
+            _is_human_member(RequesterParticipant.member_id, user_id=requester_user_id),
         )
         .exists()
     )
 
     human_before = (
         select(HumanMsg.id)
-        .join(HumanSender, HumanSender.id == HumanMsg.sender_id)
         .where(
             HumanMsg.conversation_id == ConversationMessage.conversation_id,
-            HumanSender.type == "human",
+            _is_human_member(HumanMsg.sender_id),
             HumanMsg.created_at < ConversationMessage.created_at,
         )
         .exists()

--- a/backend/tests/test_3159_onboarding_activation_realdb.py
+++ b/backend/tests/test_3159_onboarding_activation_realdb.py
@@ -541,6 +541,128 @@ async def test_is_org_first_roundtrip_order_sensitive():
 
 
 @pytest.mark.anyio
+async def test_is_org_first_roundtrip_done_recognizes_org_member_only_human():
+    """story #3627(prod 결함, 페드루 PO 確定 2026-09-07) — E-MEMBER-SSOT Phase 0부터 JWT
+    휴먼의 sender_id는 `org_members.id`(별개 테이블 PK, `members`/`project_access`/
+    `team_members` 뷰와 겹치지 않는 id 공간)다. 이 휴먼이 `members` 행(따라서 team_members
+    뷰에 잡히는 legacy 행)이 하나도 없는 org(SSOT 전환 이후 만들어진 org 다수의 실제
+    모양, dev PO Test Org 실측과 동형)에서도 왕복 판정이 서야 한다 — org_members만
+    seed(members/project_access 0행)."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            proj = _uuid()
+            human_user = _uuid()
+            om_human = _uuid()
+            agent_member = _uuid()
+            app_id = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','story3159-o','free')"
+            ))
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{human_user}','story3159-ssot@t.test','x','U',true,false,0,false,0)"
+            ))
+            await s.execute(text(
+                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+            ))
+            # 휴먼은 org_members 딱 1행뿐 — members/project_access(따라서 team_members
+            # 뷰)에 이 사람 행이 아예 없다(그라운딩 확인: conversation_participants.
+            # member_id·conversation_messages.sender_id엔 real FK가 없어 org_members.id를
+            # 그대로 써도 무결성 위반 0 — 실물 스키마 확認).
+            await s.execute(text(
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{om_human}','{ORG}','{human_user}','member')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name) VALUES ('{agent_member}','{ORG}','agent','A')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES ('{app_id}','{agent_member}','{proj}')"
+            ))
+            await s.commit()
+
+            now = datetime.now(timezone.utc)
+            t0, t1 = now - timedelta(hours=1), now
+            conv = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{conv}','{ORG}','{proj}','group')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_messages (id,conversation_id,sender_id,content,created_at) VALUES "
+                f"('{_uuid()}','{conv}','{om_human}','hi(org_member만)','{t0.isoformat()}'),"
+                f"('{_uuid()}','{conv}','{agent_member}','hello','{t1.isoformat()}')"
+            ))
+            await s.commit()
+            assert (await svc.is_org_first_roundtrip_done(s, uuid.UUID(ORG))) is True
+        finally:
+            await _wipe(s, ORG)
+            await s.execute(text("DELETE FROM users WHERE email LIKE 'story3159-%'"))
+            await s.commit()
+    await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_first_instruction_conversation_id_org_member_only_human():
+    """story #3627 — 딥링크 축도 마찬가지: 요청 휴먼이 org_members에만 있어도(legacy
+    team_members 행 0) requester_is_participant가 그를 참여자로 인정해야 한다. 원본
+    실증(dev PO Test Org)은 정확히 이 모양이었다(human TeamMember 0행·API 참여자는
+    org_member ecc99eaf)."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            proj = _uuid()
+            human_user = _uuid()
+            om_human = _uuid()
+            agent_member = _uuid()
+            app_id = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','story3159-o','free')"
+            ))
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{human_user}','story3159-ssot2@t.test','x','U',true,false,0,false,0)"
+            ))
+            await s.execute(text(
+                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{om_human}','{ORG}','{human_user}','member')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name) VALUES ('{agent_member}','{ORG}','agent','A')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES ('{app_id}','{agent_member}','{proj}')"
+            ))
+            await s.commit()
+
+            # 대화 0건 — None(①).
+            assert (await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(human_user))) is None
+
+            dm = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type,created_at) VALUES "
+                f"('{dm}','{ORG}','{proj}','dm', now())"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_participants (id,conversation_id,member_id) VALUES "
+                f"('{_uuid()}','{dm}','{om_human}'),('{_uuid()}','{dm}','{agent_member}')"
+            ))
+            await s.commit()
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(human_user))
+            assert str(result) == dm, "org_member만 있는 휴먼도 참여자로 인정돼 딥링크가 나와야 한다(②)"
+        finally:
+            await _wipe(s, ORG)
+            await s.execute(text("DELETE FROM users WHERE email LIKE 'story3159-%'"))
+            await s.commit()
+    await eng.dispose()
+
+
+@pytest.mark.anyio
 async def test_find_reminder_candidates_window_dedup_optout_complete():
     eng, Session = await _engine()
     async with Session() as s:


### PR DESCRIPTION
## 실물(2026-09-07 07:39Z · dev 배포 48 · 디디 DB 진단+PO 코드 대조)
`GET /api/activation/checklist`(sellerking·X-Org-Id=PO Test Org db474a4e·owner) → `first_roundtrip:false`·`first_instruction_conversation_id:null`. DM `3d2e8247`은 API 참여자에 sellerking(human ecc99eaf)+probe-agent가 있는데도 — DB 진단: org db474a4e에 sellerking(user d3ed4ed8)의 team_members human 행 0건·ecc99eaf는 team_members에 없음(=org_members id).

## 원인
`member_resolver.py`(E-MEMBER-SSOT Phase 0) 이후 JWT 휴먼의 참여자/발신자 id는 `org_members.id`다. 그런데 `onboarding_activation.py::is_org_first_roundtrip_done`/`get_first_instruction_conversation_id`는 여전히 `team_members(type='human')`로만 휴먼을 이었다 — SSOT 전환 이후 생성된 org(legacy team_members human 행이 0건)에서는 두 판정이 영원히 false/null로 떨어진다. 선생님 prod 증상 ①("대화 中인데 4/5 미완료")의 진짜 뿌리 후보. #3607(#3962)은 org 스코프만 고쳤고 이 결합은 남아있었다(그 QA 표본이 legacy team_member 휴먼이라 통과했을 뿐).

## 처방
새 판정자를 발명하지 않고 `member_resolver.py`와 같은 규칙으로 `_is_human_member()` 헬퍼 하나 신설 — `org_members`(SSOT) 또는 legacy `team_members(type='human')` 둘 중 하나면 휴먼으로 인정(OR). 두 함수의 human_before·requester_is_participant 조건을 이 헬퍼로 교체(`is_org_agent_connected`는 `is_org_first_roundtrip_done`을 호출하므로 전이적으로 같이 고쳐짐 — AC2 확인, 갈린 헬퍼 0).

그라운딩: `conversation_participants.member_id`·`conversation_messages.sender_id`는 실 스키마에 FK 제약 자체가 없음을 실측 확認(org_members.id를 그대로 써도 무결성 위반 0).

## Test plan
- [x] 신규 2건: org_member만 있는 휴먼(SSOT 전용 org) — 왕복 완료 true·딥링크 해소
- [x] 기존 9건(legacy team_member 휴먼 org·agent↔agent DM 배제) 회귀 그린
- [x] 뮤테이션: org_member 분기 제거 → 신규 2건 RED 확認 후 원복
- [x] mock 기반 activation 라우터/이메일 로케일 테스트 13건 그린(쿼리 재구조화가 mock 체인을 안 깸)
- [x] app.main import 그린

## 범위 밖
member SSOT Phase 1(team_members 휴먼 행 폐기) 자체 · 리마인드 스윕 org 선택. dev 배포 뒤 라이브 실측(`first_instruction_conversation_id`=3d2e8247 반환)은 PO 담당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)