### PR TITLE
[SID:3630] fix: MCP path contract 스캐너가 다중행 데코레이터를 못 읽던 결함

### DIFF
--- a/backend/tests/test_mcp_path_contract_guard.py
+++ b/backend/tests/test_mcp_path_contract_guard.py
@@ -243,3 +243,70 @@ def test_repo_current_state_is_green():
     도는 그 실행과 동일하다(가짜 없음, ref 신선도만 이 테스트 환경에선 git 명령이 있어야 함)."""
     mod = _load()
     assert mod.main() == 0
+
+
+# story #3630(2026-09-07, #3972에서 발견) — load_route_table()의 데코레이터 정규식이 «여는
+# 괄호 직후 같은 줄 문자열»만 읽어 다중행 데코레이터(`@router.post(\n    "...", ...)`)를
+# 통째로 못 봤다(레포 실측 — 채널 포스트 20개 중 19개 등 전체 44개 라우트가 route_table에서
+# 조용히 빠져 있었다, MCP 도구가 그 경로를 안 부르는 동안은 드러나지 않던 잠복 사각지대).
+# 아래는 그 정규식 하나만 고립시켜 검증하는 self-contained positive control — main()류
+# 상위 함수를 안 거치고 load_route_table() 자체를 합성 라우터 파일로 직접 부른다.
+def _write_router(tmp_path: Path, filename: str, body: str) -> Path:
+    routers_dir = tmp_path / "routers"
+    routers_dir.mkdir(exist_ok=True)
+    (routers_dir / filename).write_text(
+        'from fastapi import APIRouter\n\nrouter = APIRouter(prefix="/api/v2/widgets")\n\n' + body
+    )
+    return routers_dir
+
+
+def _write_main(tmp_path: Path, module: str) -> Path:
+    main_py = tmp_path / "main.py"
+    main_py.write_text(f"from app.routers import {module}\n\napp.include_router({module}.router)\n")
+    return main_py
+
+
+def test_load_route_table_reads_multiline_decorator(tmp_path):
+    """⭐양성대조 핵심 — 경로 문자열이 다음 줄에 오는 형(이 스토리가 고치는 그 형 그대로).
+    수정 前(정규식에 `\\s*` 없음)엔 이 테스트가 RED였다(직접 확認, #3630 커밋 로그 참고)."""
+    mod = _load()
+    routers_dir = _write_router(tmp_path, "widgets.py", (
+        '@router.post(\n'
+        '    "/{org_id}/widgets/{widget_id}/archive", response_model=dict,\n'
+        ')\n'
+        "async def archive_widget(org_id, widget_id):\n"
+        "    ...\n"
+    ))
+    main_py = _write_main(tmp_path, "widgets")
+    routes = mod.load_route_table(routers_dir=routers_dir, main_py=main_py)
+    assert ("POST", mod.norm("/api/v2/widgets/{org_id}/widgets/{widget_id}/archive")) in routes
+
+
+def test_load_route_table_reads_single_line_decorator_regression(tmp_path):
+    """회귀가드 — 기존에 이미 작동하던 1줄 형이 계속 잡혀야 한다(다중행 지원 추가가 그
+    형을 깨면 안 된다)."""
+    mod = _load()
+    routers_dir = _write_router(tmp_path, "widgets.py", (
+        '@router.get("/{org_id}/widgets", response_model=list)\n'
+        "async def list_widgets(org_id):\n"
+        "    ...\n"
+    ))
+    main_py = _write_main(tmp_path, "widgets")
+    routes = mod.load_route_table(routers_dir=routers_dir, main_py=main_py)
+    assert ("GET", mod.norm("/api/v2/widgets/{org_id}/widgets")) in routes
+
+
+def test_load_route_table_still_cannot_read_variable_path(tmp_path):
+    """가드가 못 잡는 것 선언(모듈 docstring) — 경로가 리터럴이 아니라 변수/f-string이면
+    여전히 못 읽는다(조용히 빠지되 예외로 죽지는 않는다는 것만 고정 — variable-path
+    라우트 자체를 route_table에 실을 방법이 이 정규식엔 없다는 걸 문서와 일치시킨다)."""
+    mod = _load()
+    routers_dir = _write_router(tmp_path, "widgets.py", (
+        "_ARCHIVE_PATH = \"/{org_id}/widgets/{widget_id}/archive\"\n\n"
+        "@router.post(_ARCHIVE_PATH, response_model=dict)\n"
+        "async def archive_widget(org_id, widget_id):\n"
+        "    ...\n"
+    ))
+    main_py = _write_main(tmp_path, "widgets")
+    routes = mod.load_route_table(routers_dir=routers_dir, main_py=main_py)
+    assert ("POST", mod.norm("/api/v2/widgets/{org_id}/widgets/{widget_id}/archive")) not in routes

--- a/infra/mcp_path_contract_guard.py
+++ b/infra/mcp_path_contract_guard.py
@@ -141,7 +141,26 @@ def check_ref_freshness(repo_root: Path = _REPO_ROOT) -> str | None:
 
 def load_route_table(routers_dir: Path = _ROUTERS_DIR, main_py: Path = _MAIN_PY) -> set[tuple[str, str]]:
     """FastAPI 실제 라우트. prefix가 있는/없는 라우터, include_router(prefix=...) 마운트 시점
-    prefix 세 가지 경우를 모두 읽는다."""
+    prefix 세 가지 경우를 모두 읽는다.
+
+    story #3630(2026-09-07, #3972에서 발견) — 데코레이터 정규식에 `\\s*`를 추가해 «여는
+    괄호와 경로 문자열 사이에 줄바꿈이 있는»(가장 흔한 형: `@router.post(\\n    "...",
+    response_model=...)`) 다중행 데코레이터도 읽는다. 고치기 전 레포 전체 실측(순수 정규식
+    직접 실행) — 전체 라우트 데코레이터 659개 중 이 형 때문에 44개(6곳 이상 파일에 분산,
+    channel_posts.py는 20개 중 19개·site_posts.py 10개 중 7개 등)가 route_table에서 조용히
+    빠져 있었다 — MCP 도구가 그 경로를 하나도 안 불렀던 동안은 드러나지 않던 잠복 사각지대
+    (#3614가 channel_posts.py를 부르는 첫 MCP 도구가 되며 처음 발현). 고친 뒤 재실측 —
+    659개 전부 매칭(누락 0).
+
+    ⛔이 정규식이 여전히 못 읽는 것(자인, 지금 레포에 실례 0건이나 앞으로 생기면 이 스캐너가
+    다시 "M 없이 조용히" 못 본다 — load_mcp_declared()의 unreadable 트래킹과 달리 route_table
+    쪽은 그런 이름-노출 채널이 없다는 게 이 가드 자체의 남은 한계):
+      1. 경로 문자열이 f-string이거나 변수 조립인 경우(`@router.get(f"/{x}")`·`@router.get(
+         PATH_CONST)`) — 리터럴 `"..."` 매칭이라 원천적으로 못 읽는다.
+      2. 경로 문자열 앞에 인라인 주석이 끼어 있는 경우(`@router.post(  # comment\\n    "...")`
+         ) — `\\s*`는 공백/줄바꿈만 건너뛰고 `#...`는 건너뛰지 못한다.
+      3. `@router.post` 대신 `router.add_api_route(...)` 같은 대안 등록 API — 이 정규식은
+         `@router.METHOD(` 데코레이터 형만 본다."""
     routes = set()
     mounted = set()
     mount_prefixes: dict[str, set] = {}
@@ -170,7 +189,7 @@ def load_route_table(routers_dir: Path = _ROUTERS_DIR, main_py: Path = _MAIN_PY)
         if module not in mount_prefixes and decorator_prefix is not None:
             candidate_prefixes.add(decorator_prefix)
 
-        for method, path in re.findall(r'@router\.(get|post|patch|put|delete)\("([^"]*)"', src):
+        for method, path in re.findall(r'@router\.(get|post|patch|put|delete)\(\s*"([^"]*)"', src):
             for prefix in candidate_prefixes:
                 full = (prefix.rstrip("/") + path) if prefix else path
                 routes.add((method.upper(), norm(full)))


### PR DESCRIPTION
## 출처
#3972(3614) CI 실결함 처리 중 발견(2026-09-07 08:15Z) — `test_mcp_path_contract_guard.py::test_repo_current_state_is_green`이 신규 엔드포인트를 「허용목록에 없는 불일치」로 잡았는데 라우트·경로는 정확 일치했다. 원인: `mcp_path_contract_guard.py::load_route_table()`의 데코레이터 정규식 `@router\.(get|...)\("`이 **여는 괄호 직후 같은 줄** 문자열만 매칭해, `@router.post(\n    "...", response_model=...)`형(경로가 다음 줄)은 통째로 못 읽는다.

## 실측(AC3 — 수정 前/後 스캔된 라우트 수)
레포 전체 라우터 데코레이터를 순수 정규식으로 직접 세어 대조:

| | 매칭 | 전체 | 누락 |
|---|---|---|---|
| **수정 前** | 615 | 659 | **44** |
| **수정 後** | 659 | 659 | **0** |

누락 44개가 몰린 파일(6개 이상):
- `channel_posts.py`: 20개 중 19개 누락
- `site_posts.py`: 10개 중 7개
- `channel_connections.py`: 16개 중 6개
- `channel_post_comment_replies.py`: 4개 중 4개(전부)
- `channel_post_comments.py`: 2개 중 2개(전부)
- `conversations.py`/`docs.py`/`events.py`/`gates.py`/`insight_snapshots.py`/`insights_board.py`/`stories.py`: 각 1개씩

이 44개는 그 경로를 부르는 MCP 도구가 하나도 없는 동안은 route_table 누락이 겉으로 드러나지 않던 잠복 사각지대였다 — #3614가 `channel_posts.py`를 부르는 **첫 MCP 도구**가 되며 처음 발현(#3972에서 "허용목록에 없는 신규 불일치"로 오탐).

## 처방
정규식에 `\s*`(공백·줄바꿈 모두 매칭) 하나만 추가. 고친 뒤 실제 가드를 다시 돌려 **불일치 0건**을 확인 — route_table에 항목을 추가만 하므로 기존 MCP 도구 호출의 매칭 결과엔 영향이 없다(AC3의 "새로 드러난 불일치는 목록만"에 해당하는 항목 자체가 0건).

## 셀프테스트(양성대조, AC2)
- 다중행 데코레이터 합성 표본 1건 — **수정 前엔 RED**(뮤테이션으로 정규식을 원복해 직접 재현 확인 후 복구), 수정 後 GREEN.
- 1줄 데코레이터 회귀가드 1건 — 다중행 지원 추가가 기존 형을 안 깬다.
- 변수/f-string 경로 표본 1건 — 여전히 못 읽는 것을 명시 고정(예외로 안 죽고 조용히 빠짐).

모듈 docstring에 남은 한계 3가지 자인(AC1): ①f-string/변수 경로 ②경로 앞 인라인 주석 ③`add_api_route()`류 데코레이터 아닌 등록 방식(현재 레포엔 실례 0건).

## 범위 밖(PO 확定)
- 콘텐츠 전용 toolset 그룹 신설(`_GROUP_KEYWORDS` 부재) — 별건 후보로만 기록, 이 PR에서 안 건드림.
- #3614의 단일행 강제 데코레이터는 그대로 둠(회귀 아님, 이미 옳은 형).

## 검증
- 신규 3테스트 + 기존 18테스트 = 21 passed.
- `mcp/` 관련 전체 108 passed(`CI=1`로 로컬 재현, ref 신선도 체크는 CI에서 스킵되는 설계).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA
