### PR TITLE
[SID:3633] fix: 재연결 active 복귀 시 last_error_code·last_error_at 잔존

### DIFF
--- a/backend/app/services/channel_connection.py
+++ b/backend/app/services/channel_connection.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel_connection import ChannelConnection
 from app.services.channel_credential_crypto import decrypt_channel_credential, encrypt_channel_credential
+from app.services.graph_api_errors import mark_connection_recovered
 
 # 만료 임박 임계값(cron이 이보다 이내로 남은 active 연결을 갱신 대상으로 본다) — 설정값
 # (story AC 명시, 코드 상수로 시작 — 조직별로 달라질 필요가 생기면 그때 org 설정으로 승격).
@@ -91,8 +92,10 @@ async def upsert_channel_connection(
         existing.token_expires_at = token_expires_at
         existing.refresh_mode = refresh_mode
         existing.scopes = scopes
-        existing.status = "active"
-        existing.last_error = None
+        # story #3633 — status/last_error 3종(last_error_code·last_error_at 포함)
+        # 클리어를 mark_connection_recovered 하나로(graph_api_errors.py, 3605
+        # sticky_connection_status와 같은 모듈).
+        mark_connection_recovered(existing)
         existing.connected_by = connected_by
         existing.secret_hint = secret_hint
         row = existing
@@ -147,8 +150,8 @@ async def replace_channel_connection_credential(
     row.secret_hint = _secret_hint(new_secret)
     if account_label is not None:
         row.account_label = account_label
-    row.status = "active"
-    row.last_error = None
+    # story #3633 — mark_connection_recovered로 status/last_error 3종 통일.
+    mark_connection_recovered(row)
     row.connected_by = updated_by
     # story #3612 — 이 자격 교체도 non-active→active 복귀 경로다(wake_resting_
     # comment_schedules 참고, 단일 깨우는 손).
@@ -197,8 +200,8 @@ async def apply_refresh_result(
     connection.encrypted_access_token = encrypt_channel_credential(new_access_token)
     connection.token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)
     connection.last_refreshed_at = datetime.now(timezone.utc)
-    connection.last_error = None
-    connection.status = "active"
+    # story #3633 — mark_connection_recovered로 status/last_error 3종 통일.
+    mark_connection_recovered(connection)
     # story #3612 — 자동 토큰 갱신 성공도 non-active→active 복귀 경로다(wake_
     # resting_comment_schedules 참고, 단일 깨우는 손).
     from app.services.channel_post_comments import wake_resting_comment_schedules

--- a/backend/app/services/graph_api_errors.py
+++ b/backend/app/services/graph_api_errors.py
@@ -67,6 +67,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import httpx
 
+    from app.models.channel_connection import ChannelConnection
+
 _EXPIRED_SUBCODES = frozenset({463})
 _REVOKED_SUBCODES = frozenset({458, 460, 467, 490})
 
@@ -174,8 +176,9 @@ def sticky_connection_status(current: str, new: str) -> str:
     - current가 "expired" 또는 "revoked"(이미 확정된 구체적 사실)면 new가
       무엇이든 절대 안 바꾼다 — 이 둘은 서로도 안 덮는다. status="active"로
       되돌리는 대입(재연결 upsert·자격 교체·apply_refresh_result)이 전부
-      last_error=None까지 같이 지우므로, 이 얼음은 한 실패 국면 안에서만 서고
-      "지금도 실패하나"는 last_error{code,message,at}가 진다(#3960)."""
+      `mark_connection_recovered`(아래, story #3633) 하나로 last_error·
+      last_error_code·last_error_at 3종까지 같이 지우므로, 이 얼음은 한 실패
+      국면 안에서만 서고 "지금도 실패하나"는 그 3종이 진다(#3960)."""
     if current in ("revoked", "expired"):
         return current
     if current == "error" and new == "error":
@@ -194,6 +197,25 @@ def connection_status_for_error_code(error_code: str | None, *, current_status: 
     않기 규율 자체는 `sticky_connection_status`(공유 단일 지점, CHANGES-2)."""
     new_status = CONNECTION_ERROR_CODE_TO_STATUS.get(error_code, "expired")
     return sticky_connection_status(current_status, new_status)
+
+
+def mark_connection_recovered(connection: "ChannelConnection") -> None:
+    """story #3633(BE·소형·신뢰, 페드루 PO 確定 2026-09-07) — non-active→active 복귀
+    (재연결 upsert·자격 교체·자동 토큰 갱신 성공) 경로 3곳이 각자 `status="active"`·
+    `last_error=None`만 대입하고 3603이 더한 `last_error_code`·`last_error_at`은
+    안 지웠다(dev 실측: Sandbox Page 1 재연결 뒤에도 API가 옛 CHANNEL_CONNECTION_
+    NOT_ACTIVE 코드를 계속 돌려줌 — "활성인데 오류 코드가 붙은" 반쪽 상태, 3605
+    sticky·3612 선검사·FE 칩이 그 옛 코드를 "지금도 실패 中"으로 오독할 수 있다).
+
+    `sticky_connection_status`(위)와 짝 — 그쪽은 "실패로 갈 때 어떤 status를
+    고르나", 이건 "복귀할 때 실패 흔적 4종을 다 지운다"를 한 자리로 고정한다.
+    세 호출부(channel_connection.py::upsert_channel_connection의 재연결 분기·
+    replace_channel_connection_credential·apply_refresh_result)가 전부 이
+    함수 하나로 통일 — 새 판정자 발명 0, 그냥 "지우는 목록"이 넷으로 늘었을 뿐."""
+    connection.status = "active"
+    connection.last_error = None
+    connection.last_error_code = None
+    connection.last_error_at = None
 
 
 def parse_graph_error_envelope(resp: "httpx.Response") -> tuple[int | None, int | None, str | None]:

--- a/backend/tests/test_3603_connection_last_error.py
+++ b/backend/tests/test_3603_connection_last_error.py
@@ -215,3 +215,91 @@ async def test_promote_no_op_keeps_status_but_still_updates_last_error_trio():
             assert refreshed.last_error_at is not None
     finally:
         await engine.dispose()
+
+
+# ─── story #3633 — non-active→active 복귀 3경로가 last_error 3종을 전부 지운다 ───
+# dev 실측(2026-09-07 08:26Z): Sandbox Page 1 재연결 뒤 status=active인데
+# last_error_code=CHANNEL_CONNECTION_NOT_ACTIVE가 그대로 남아 있었다(재연결 경로가
+# last_error 문장만 비우고 code/at은 안 비움) — mark_connection_recovered(graph_
+# api_errors.py, 3605 sticky_connection_status와 같은 모듈)로 세 경로 통일.
+
+
+async def _seed_expired_connection_with_error_trio(session, org_id, *, channel="threads"):
+    conn = await _seed_channel_connection(session, org_id, channel=channel, status="expired")
+    conn.last_error = "old failure"
+    conn.last_error_code = "CHANNEL_CONNECTION_NOT_ACTIVE"
+    conn.last_error_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    await session.commit()
+    return conn
+
+
+@pytest.mark.anyio
+async def test_reconnect_upsert_clears_last_error_trio():
+    """재연결(upsert_channel_connection의 기존 행 upsert 분기)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_connection import upsert_channel_connection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_expired_connection_with_error_trio(s, org_id, channel="threads")
+
+            row = await upsert_channel_connection(
+                s, org_id=org_id, channel="threads", account_id=conn.account_id, account_label=None,
+                credential_kind="oauth", access_token="new-token", refresh_token=None,
+                token_expires_at=None, refresh_mode="reissue_from_access_token", scopes=[],
+                connected_by=uuid.uuid4(),
+            )
+            assert row.id == conn.id
+            assert row.status == "active"
+            assert row.last_error is None
+            assert row.last_error_code is None
+            assert row.last_error_at is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_replace_credential_clears_last_error_trio():
+    """자격 교체(replace_channel_connection_credential)."""
+    from app.services.channel_connection import replace_channel_connection_credential
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_expired_connection_with_error_trio(s, org_id, channel="wordpress")
+
+            row = await replace_channel_connection_credential(
+                s, org_id=org_id, connection_id=conn.id, new_secret="new-secret-value", updated_by=uuid.uuid4(),
+            )
+            assert row.status == "active"
+            assert row.last_error is None
+            assert row.last_error_code is None
+            assert row.last_error_at is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_apply_refresh_result_clears_last_error_trio():
+    """자동 토큰 갱신 성공(apply_refresh_result)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_connection import apply_refresh_result
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_expired_connection_with_error_trio(s, org_id, channel="threads")
+
+            await apply_refresh_result(s, connection=conn, new_access_token="new-token", expires_in_seconds=3600)
+
+            refreshed = await s.get(ChannelConnection, conn.id)
+            assert refreshed.status == "active"
+            assert refreshed.last_error is None
+            assert refreshed.last_error_code is None
+            assert refreshed.last_error_at is None
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 실물(2026-09-07 08:26Z · dev-app · PO Test Org · 3613 AC3 실측 中)
Sandbox Page 1(641adabf) expired → 「다시 연결」 → status active·화면 「연결됨」인데 API `last_error_code`=CHANNEL_CONNECTION_NOT_ACTIVE 그대로(옛 값). `channel_connection.py`의 non-active→active 복귀 경로 3곳이 `status`·`last_error`(문장)만 비우고 3603이 더한 `last_error_code`·`last_error_at`은 안 비웠다 — "활성인데 오류 코드가 붙은" 반쪽 상태. 소비처(3605 sticky·3612 선검사·FE 칩)가 코드를 읽으면 옛 사실을 단정할 수 있다.

## 처방
`graph_api_errors.py`(3605 `sticky_connection_status`와 같은 모듈)에 `mark_connection_recovered()` 신설 — status="active"·last_error·last_error_code·last_error_at 4종을 한 자리에서 클리어. 세 호출부(`upsert_channel_connection`의 재연결 분기·`replace_channel_connection_credential`·`apply_refresh_result`)를 이 헬퍼로 통일(새 판정자 발명 0). `sticky_connection_status`의 docstring도 실물에 맞춰 갱신.

## Test plan
- [x] 경로별 테스트 3건(재연결 upsert·자격 교체·자동 갱신) — expired+코드 있음 → 복귀 → status/last_error/code/at 전부 None
- [x] 뮤테이션(코드/시각 클리어 제거) → 3건 전부 RED 확認 후 원복
- [x] 회귀 66건(test_3603·3373·3492·3612·3597·3598·3605·3523·authz_project_scope) 전부 그린
- [x] app.main import·py_compile 그린

## 범위 밖(본문 기록만)
마커 발행 표본이 재연결마다 다시 만료시키는 "영구 지뢰"(회차 뒤 표본 발행의 수집 종료 수단 부재)는 별건.

## 라이브
dev·PO Test Org에서 Page 1 재연결 뒤 API 3종 None 확認은 배포 뒤 PO 담당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)