### PR TITLE
[SID:3634] fix: 개인 API 키 발급이 members 앵커 없는 휴먼에서 404

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -37,18 +37,40 @@ async def _resolve_current_human_member(
     레거시 경로에서 OrgMember.id를 반환해(shadow 플래그 꺼짐이 기본) member_ssot 캐노니컬
     ``members.id``와 항상 같은 값이라는 보장에 기대지 않는다 — 여기서 직접
     ``Member.user_id == auth.user_id``로 해소(agent API key 경로는 애초에 사용 불가:
-    is_api_key=True면 이 함수를 부르는 라우트 자체가 human_api_key_id 발급 대상이 아님)."""
+    is_api_key=True면 이 함수를 부르는 라우트 자체가 human_api_key_id 발급 대상이 아님).
+
+    story #3634(BE·결함, 페드루 PO 確定 2026-09-07) — member SSOT Phase 0 이후 만들어진
+    org의 휴먼은 org_members 행만 있고 members 앵커 행이 없을 수 있다(migration 0075의
+    ``members.id == org_members.id`` 백필 불변식은 그 마이그 시점 한정 — 이후 신규
+    org_member는 아무도 앵커를 안 만든다, #3627/#3629와 같은 SSOT dual-table 결함
+    클래스). `human_api_keys.member_id`는 `members.id` FK(CASCADE)라 org_members.id로
+    그냥 갈음할 수 없다(conversation_participants류와 달리 FK가 실물로 걸려 있음) —
+    앵커 자체를 멱등 생성해야 한다. `ensure_human_member`(agent_anchor_sync.py, AC3-2c
+    grant write-sync가 이미 쓰는 같은 함수 — 새 판정자 발명 0)로 org_member.id 축에서
+    앵커를 만들고 다시 조회한다."""
     org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
     if not org_id_str:
         raise HTTPException(status_code=400, detail="org_id not resolvable from auth context")
+    org_id = uuid.UUID(org_id_str)
+    user_id = uuid.UUID(auth.user_id)
     member = (await session.execute(
         select(Member).where(
-            Member.user_id == uuid.UUID(auth.user_id),
-            Member.org_id == uuid.UUID(org_id_str),
+            Member.user_id == user_id,
+            Member.org_id == org_id,
             Member.type == "human",
             Member.deleted_at.is_(None),
         )
     )).scalar_one_or_none()
+    if member is None:
+        from app.services.agent_anchor_sync import ensure_human_member
+
+        org_member = (await session.execute(
+            select(OrgMember).where(
+                OrgMember.user_id == user_id, OrgMember.org_id == org_id, OrgMember.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if org_member is not None and await ensure_human_member(session, org_member.id):
+            member = await session.get(Member, org_member.id)
     if member is None:
         raise HTTPException(status_code=404, detail="Member not found")
     return member

--- a/backend/tests/test_1940_human_api_keys.py
+++ b/backend/tests/test_1940_human_api_keys.py
@@ -423,3 +423,85 @@ async def test_router_cannot_revoke_other_humans_key():
             assert ei.value.status_code == 404
     finally:
         await engine.dispose()
+
+
+# ─── story #3634 — org_member만 있고 members 앵커 없는 휴먼도 발급돼야 한다 ─────
+# member SSOT Phase 0 이후 새 org의 휴먼은 org_members 행만 있을 수 있다(dev PO
+# Test Org 실물 모양) — human_api_keys.member_id는 members.id FK(CASCADE)라 앵커가
+# 없으면 발급 자체가 불가능했다(404). ensure_human_member(agent_anchor_sync.py,
+# 이미 다른 SSOT 자리들이 쓰는 같은 함수)로 앵커를 멱등 생성하고 재조회한다.
+
+
+async def _seed_org_member_only_human(session, org_id, user_id, *, role="member"):
+    """team_members/members 앵커가 아예 없는 SSOT-only 휴먼 — org_members 딱 1행만."""
+    from app.models.project import OrgMember
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role)
+    session.add(om)
+    await session.commit()
+    return om.id
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_org_member_only_human_can_create_and_list_api_keys():
+    """org_member만 있는 휴먼도 발급 200 — 이전엔 members 앵커가 없어 404였다."""
+    from app.models.member import Member
+    from app.routers.me import create_my_api_key, list_my_api_keys
+    from app.schemas.human_api_key import CreateHumanApiKeyRequest
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s, email="ssot-only-3634@example.com")
+            om_id = await _seed_org_member_only_human(s, org_id, user_id)
+            auth = _human_auth(user_id, org_id)
+
+            created = await create_my_api_key(
+                CreateHumanApiKeyRequest(name="my key", expires_at=None), session=s, auth=auth,
+            )
+            assert created.api_key.startswith("hu_live_")
+
+            # 0075 불변식(휴먼 members.id == org_members.id)대로 앵커가 멱등 생성됐어야.
+            anchor = await s.get(Member, om_id)
+            assert anchor is not None
+            assert anchor.type == "human"
+
+            listed = await list_my_api_keys(session=s, auth=auth)
+            assert len(listed) == 1
+            assert listed[0].id == created.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_org_member_only_human_without_ensure_human_member_still_404s(monkeypatch):
+    """뮤테이션 — ensure_human_member 호출을 지우면(옛 동작 재현) org_member-only
+    휴먼은 다시 404여야 한다(이 테스트가 실제로 그 경로를 검증한다는 증거)."""
+    import app.routers.me as me_module
+    from fastapi import HTTPException
+    from app.schemas.human_api_key import CreateHumanApiKeyRequest
+
+    async def _never_ensures(session, org_member_id):
+        return False
+
+    monkeypatch.setattr(
+        "app.services.agent_anchor_sync.ensure_human_member", _never_ensures,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s, email="ssot-only-mut-3634@example.com")
+            await _seed_org_member_only_human(s, org_id, user_id)
+            auth = _human_auth(user_id, org_id)
+
+            with pytest.raises(HTTPException) as ei:
+                await me_module.create_my_api_key(
+                    CreateHumanApiKeyRequest(expires_at=None), session=s, auth=auth,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 출처
3629(#3983) 전수 中 범위 밖 발견 — member SSOT Phase 0 이후 만들어진 org의 휴먼은 org_members 행만 있고 members 앵커 행이 없을 수 있다(migration 0075의 `members.id==org_members.id` 백필 불변식은 그 마이그 시점 한정, 이후 신규 org_member는 아무도 앵커를 안 만든다 — #3627/#3629와 같은 SSOT dual-table 결함 클래스). `human_api_keys.member_id`는 `members.id` FK(**CASCADE 실물**)라 `conversation_participants`류와 달리 `org_members.id`로 그냥 갈음할 수 없다 — 앵커 자체가 없으면 발급이 원천 불가능(404).

## AC1 — 원인 확인
`_resolve_current_human_member`가 `Member(user_id, org_id, type='human')`로만 조회해 members 앵커가 없으면 404. FK가 실물이라 "새 판정자로 조회"만으론 못 고친다(#3629의 conversation 계열과 다른 지점) — 앵커를 실제로 만들어야 한다.

## AC2 — 처방
새 판정자 발명 0 — `ensure_human_member`(agent_anchor_sync.py, AC3-2c grant write-sync가 이미 쓰는 같은 함수)를 `_resolve_current_human_member`에서 재사용. `Member` 조회 실패 시 `OrgMember`를 찾아 `ensure_human_member(session, org_member.id)`로 앵커를 멱등 생성(0075 불변식: `members.id == org_members.id`) 후 재조회.

## AC3 — 테스트
- 신규 2건: org_member-only 휴먼 → 발급 200 + 앵커 생성 확인 · legacy 회귀(기존 12건 그대로 그린)
- 뮤테이션 2건: 소스 되돌림(수동) RED 확認 후 원복 · `ensure_human_member` no-op 몽키패치(영구 회귀가드) → 404 재현
- 인접 파일 회귀 확인 — 별건 pre-existing 스키마 드리프트 실패 4건(test_2873/test_3553, `marketing_email_opt_out` NOT NULL 미충족 raw INSERT)은 baseline(변경 stash)에서도 동일 재현 — 이 PR과 무관 확認(재현 커맨드는 커밋 로그 참고)

## AC4 — 라이브(이 PR엔 없음)
dev PO Test Org 실측(sellerking 실제 발급 200)은 이 세션에서 GCP 권한 부재(`gcloud run jobs execute` → `CONSUMER_INVALID`)로 실행 불가 — PO가 직접 확認 필요. `agent_connected` 판정과의 관계도 그때 같이.

## Test plan
- [x] 신규 테스트 2건(발급 200+앵커·legacy 회귀) 그린
- [x] 뮤테이션 2건(수동 되돌림 RED·영구 회귀가드) 확認
- [x] 인접 파일 회귀 — pre-existing 무관 실패만 확認
- [x] app.main import·py_compile 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)