### PR TITLE
[SID:3632] fix: 채널 경로 BE 502가 CF 에지에서 HTML로 바뀌어 화면 침묵

### DIFF
--- a/apps/web/src/components/content/comments-refresh-button.test.tsx
+++ b/apps/web/src/components/content/comments-refresh-button.test.tsx
@@ -91,6 +91,19 @@ describe('CommentsRefreshButton', () => {
     expect(container.querySelector('[data-testid="comments-refresh-error"]')?.textContent).toBe('사람만 다시 수집할 수 있습니다');
   });
 
+  // story #3632(PO 자기정정, 2026-09-07) — 문장 자체는 이미 있었다(BE 4xx user_message
+  // 폴백 체인) — 이 자리의 결함은 접근성 마킹 부재였다. insights-board 등과 동형인
+  // role=alert 배너로 승격(화면 관례 일치).
+  it('generic 오류는 role=alert 배너(Alert variant=destructive)로 선다', async () => {
+    const onRefresh = vi.fn<() => Promise<CommentsRefreshOutcome>>().mockResolvedValue({ ok: false, kind: 'generic', message: '다시 수집하지 못했습니다.' });
+    await mount(<CommentsRefreshButton onRefresh={onRefresh} />);
+    const btn = container.querySelector('[data-testid="comments-refresh-button"]') as HTMLButtonElement;
+    await act(async () => { btn.click(); });
+    const errorEl = container.querySelector('[data-testid="comments-refresh-error"]');
+    expect(errorEl?.getAttribute('role')).toBe('alert');
+    expect(errorEl?.textContent).toBe('다시 수집하지 못했습니다.');
+  });
+
   // story #3517 조각②-b(BE #3876, 유나 16회차 보강, PO 確定 2026-09-06) — 로드
   // 시점에 이미 nextAllowedAt이 미래면 사람이 한 번도 안 눌렀어도 비활성+사유 —
   // 429 응답을 받고서야 아는 게 아니라 로드 시점에 미리 안다. 60초 이상 남으면

--- a/apps/web/src/components/content/comments-refresh-button.tsx
+++ b/apps/web/src/components/content/comments-refresh-button.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 
 // story #3517(BE #3865 조각①, 유나 §22-10③, PO 確定 2026-09-05) — 수동 재수집.
 // 세 갈래를 구분한다(전부 뭉뚱그린 문자열 message 하나로 두면 429/422가 같은 취급을
@@ -159,8 +160,14 @@ export function CommentsRefreshButton({ onRefresh, nextAllowedAt }: CommentsRefr
             : t('commentsRefreshRateLimitedUnknown')}
         </p>
       ) : null}
+      {/* story #3632(PO 자기정정) — 화면 관례(insights-board 등과 동형)로 승격: 무늬만
+          destructive text가 아니라 실제 role=alert 배너라 스크린리더가 뜨는 즉시 읽는다.
+          문장 자체는 이미 있었다(BE 4xx user_message 폴백 체인, api-error-message.ts) —
+          이 자리의 결함은 접근성 마킹 부재였다. */}
       {genericError ? (
-        <p className="text-xs text-destructive" data-testid="comments-refresh-error">{genericError}</p>
+        <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true" data-testid="comments-refresh-error">
+          <AlertDescription>{genericError}</AlertDescription>
+        </Alert>
       ) : null}
     </div>
   );

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -1162,8 +1162,10 @@ async def get_channel_publishing_limit(
                         status_code=409,
                         detail={"code": "CHANNEL_TOKEN_EXPIRED", "message": exc.message},
                     ) from exc
+                # story #3632 — 진짜 상류 실패는 CF가 HTML로 가로채는 502 대신 503으로
+                # (channel_posts.py/channel_post_comments.py의 동일 코드 처리와 동형).
                 raise HTTPException(
-                    status_code=502,
+                    status_code=503,
                     detail={"code": "CHANNEL_PUBLISH_PROVIDER_ERROR", "message": exc.message},
                 ) from exc
     finally:

--- a/backend/app/routers/channel_post_comments.py
+++ b/backend/app/routers/channel_post_comments.py
@@ -266,7 +266,11 @@ async def refresh_publication_comments_endpoint(
             # 채널(Graph API) 자체가 이 호출을 rate-limit한 경우. HTTP 의미상 429 그대로
             # (channel_posts.py 발행 경로의 CHANNEL_RATE_LIMITED 처리와 동형).
             raise HTTPException(
-                status_code=429, detail={"code": exc.error_code, "message": str(exc)},
+                status_code=429,
+                detail=human_error(
+                    exc.error_code, str(exc),
+                    user_message="채널 쪽 호출이 많아 지금은 다시 수집할 수 없습니다 — 잠시 후 다시 시도해 주세요.",
+                ),
             ) from exc
         from app.services.publication_command import classify_failure_kind, FAILURE_KIND_TRANSIENT
 
@@ -275,15 +279,34 @@ async def refresh_publication_comments_endpoint(
             # (SSOT 분류는 publication_command.py, channel_posts.py 발행 경로와 동일
             # 어휘 재사용 — 새 판정 로직 0).
             raise HTTPException(
-                status_code=503, detail={"code": exc.error_code, "message": str(exc)},
+                status_code=503,
+                detail=human_error(
+                    exc.error_code, str(exc),
+                    user_message="채널에서 일시적인 오류가 발생해 다시 수집하지 못했습니다 — 잠시 후 다시 시도해 주세요.",
+                ),
             ) from exc
         # 그 외(CHANNEL_CONNECTION_NOT_ACTIVE·CHANNEL_TOKEN_EXPIRED·CHANNEL_CONNECTION_
         # REVOKED·CHANNEL_CONNECTION_AUTH_ERROR·COMMENT_CHANNEL_NOT_IMPLEMENTED·
         # COMMENT_EXTERNAL_ID_MISSING) — 전부 "우리 상태"(연결·설정·데이터) 문제라 409.
         # CHANNEL_TOKEN_EXPIRED/REVOKED/AUTH_ERROR는 channel_posts.py 발행 경로가 이미
         # 409로 내는 것과 동형(다른 메커니즘은 다른 낱말이되 같은 축은 같은 코드).
+        # story #3615(페드루 PO 정정 2026-09-07) — CHANNEL_CONNECTION_NOT_ACTIVE 등은
+        # `str(exc)`에 connection_id/publication_id uuid가 그대로 담겨(HUMAN_SAFE_ERROR_
+        # MESSAGE_CODES allowlist 등재 금지 사유) FE가 그 원문을 보일 수 없다 — 여기서
+        # human_error()로 안전한 손글 문장을 직접 채운다(그 자리 raise 20곳+ 전수 확認
+        # 대신, 이 엔드포인트가 새로 내는 자리만 사람 문장 보장 — 기존 다른 raise 자리는
+        # 이 스토리 범위 밖).
+        _CONNECTION_STATE_MESSAGES = {
+            "CHANNEL_CONNECTION_NOT_ACTIVE": "연결이 활성 상태가 아니라 댓글을 대조/수집할 수 없습니다 — 연결 화면에서 확인해 주세요.",
+            "CHANNEL_TOKEN_EXPIRED": "채널 연결이 만료되어 댓글을 수집할 수 없습니다 — 연결 화면에서 다시 연결해 주세요.",
+            "CHANNEL_CONNECTION_REVOKED": "채널 연결이 해지되어 댓글을 수집할 수 없습니다 — 연결 화면에서 다시 연결해 주세요.",
+            "CHANNEL_CONNECTION_AUTH_ERROR": "채널 인증에 문제가 있어 댓글을 수집할 수 없습니다 — 연결 화면에서 확인해 주세요.",
+        }
+        user_message = _CONNECTION_STATE_MESSAGES.get(
+            exc.error_code, "지금은 댓글을 다시 수집할 수 없습니다 — 잠시 후 다시 시도해 주세요.",
+        )
         raise HTTPException(
-            status_code=409, detail={"code": exc.error_code, "message": str(exc)},
+            status_code=409, detail=human_error(exc.error_code, str(exc), user_message=user_message),
         ) from exc
 
     return CommentRefreshResponse(

--- a/backend/app/routers/channel_post_comments.py
+++ b/backend/app/routers/channel_post_comments.py
@@ -252,9 +252,39 @@ async def refresh_publication_comments_endpoint(
             ),
         ) from exc
     except CommentFetchError as exc:
+        # story #3632(PO 실측, 2026-09-07) — Cloudflare 에지가 origin의 502/504만 자체
+        # HTML 에러 페이지로 대체한다(Enterprise 미만 플랜, Origin Error Page Pass-thru
+        # 없음) — 봉투(error.code·user_message)가 브라우저에 아예 도달하지 않아 화면이
+        # 침묵했다. 규칙: 「우리 상태」로 인한 거절(연결 비활성·발행 기록 없음·채널
+        # 미구현·필수 데이터 없음)은 CF가 그대로 통과시키는 4xx로, 「진짜 상류 실패」
+        # (채널 API가 실제로 오류/타임아웃 응답)만 503(재시도 의미 있음, CF 통과)으로 —
+        # 502는 이제 이 분기 어디에서도 내지 않는다.
         if exc.error_code == "COMMENT_PUBLICATION_NOT_FOUND":
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        raise HTTPException(status_code=502, detail={"code": exc.error_code, "message": str(exc)}) from exc
+        if exc.error_code == "CHANNEL_RATE_LIMITED":
+            # 우리 쪽 5분 쿨다운(CommentRefreshRateLimitedError, 위)과는 다른 축 —
+            # 채널(Graph API) 자체가 이 호출을 rate-limit한 경우. HTTP 의미상 429 그대로
+            # (channel_posts.py 발행 경로의 CHANNEL_RATE_LIMITED 처리와 동형).
+            raise HTTPException(
+                status_code=429, detail={"code": exc.error_code, "message": str(exc)},
+            ) from exc
+        from app.services.publication_command import classify_failure_kind, FAILURE_KIND_TRANSIENT
+
+        if classify_failure_kind(exc.error_code) == FAILURE_KIND_TRANSIENT:
+            # CHANNEL_PUBLISH_PROVIDER_ERROR류 — 채널 API가 실제로 실패 응답을 준 경우
+            # (SSOT 분류는 publication_command.py, channel_posts.py 발행 경로와 동일
+            # 어휘 재사용 — 새 판정 로직 0).
+            raise HTTPException(
+                status_code=503, detail={"code": exc.error_code, "message": str(exc)},
+            ) from exc
+        # 그 외(CHANNEL_CONNECTION_NOT_ACTIVE·CHANNEL_TOKEN_EXPIRED·CHANNEL_CONNECTION_
+        # REVOKED·CHANNEL_CONNECTION_AUTH_ERROR·COMMENT_CHANNEL_NOT_IMPLEMENTED·
+        # COMMENT_EXTERNAL_ID_MISSING) — 전부 "우리 상태"(연결·설정·데이터) 문제라 409.
+        # CHANNEL_TOKEN_EXPIRED/REVOKED/AUTH_ERROR는 channel_posts.py 발행 경로가 이미
+        # 409로 내는 것과 동형(다른 메커니즘은 다른 낱말이되 같은 축은 같은 코드).
+        raise HTTPException(
+            status_code=409, detail={"code": exc.error_code, "message": str(exc)},
+        ) from exc
 
     return CommentRefreshResponse(
         fetched=result["fetched"], deleted=result["deleted"], captured_at=result["captured_at"].isoformat(),

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -575,7 +575,7 @@ async def post_channel_post_image_upload_url(
             },
         ) from exc
     except ChannelImageUploadFailedError as exc:
-        raise HTTPException(status_code=502, detail={"code": "CHANNEL_IMAGE_UPLOAD_FAILED", "message": str(exc)}) from exc
+        raise HTTPException(status_code=503, detail={"code": "CHANNEL_IMAGE_UPLOAD_FAILED", "message": str(exc)}) from exc
     return ChannelPostImageUploadUrlResponse(**result)
 
 
@@ -629,7 +629,7 @@ async def post_channel_post_video_upload_url(
             },
         ) from exc
     except ChannelVideoUploadFailedError as exc:
-        raise HTTPException(status_code=502, detail={"code": "CHANNEL_VIDEO_UPLOAD_FAILED", "message": str(exc)}) from exc
+        raise HTTPException(status_code=503, detail={"code": "CHANNEL_VIDEO_UPLOAD_FAILED", "message": str(exc)}) from exc
     return ChannelPostVideoUploadUrlResponse(**result)
 
 
@@ -710,7 +710,7 @@ async def post_channel_post_video_confirm(
             },
         ) from exc
     except ChannelVideoUploadFailedError as exc:
-        raise HTTPException(status_code=502, detail={"code": "CHANNEL_VIDEO_UPLOAD_FAILED", "message": str(exc)}) from exc
+        raise HTTPException(status_code=503, detail={"code": "CHANNEL_VIDEO_UPLOAD_FAILED", "message": str(exc)}) from exc
     except ChannelVideoRequiresSingleCoverError as exc:
         raise HTTPException(
             status_code=422, detail={"code": "CHANNEL_VIDEO_REQUIRES_SINGLE_COVER", "message": str(exc)},
@@ -819,7 +819,7 @@ async def post_channel_post_image_confirm(
             },
         ) from exc
     except ChannelImageUploadFailedError as exc:
-        raise HTTPException(status_code=502, detail={"code": "CHANNEL_IMAGE_UPLOAD_FAILED", "message": str(exc)}) from exc
+        raise HTTPException(status_code=503, detail={"code": "CHANNEL_IMAGE_UPLOAD_FAILED", "message": str(exc)}) from exc
     return _image_response(version, image_row)
 
 
@@ -1633,7 +1633,7 @@ async def publish_channel_post_draft_endpoint(
         )
         await db.commit()
         raise HTTPException(
-            status_code=502,
+            status_code=503,
             detail=_with_command_state({"code": "CHANNEL_PUBLISH_PROVIDER_ERROR", "message": str(exc)}),
         ) from exc
     except ChannelPublishInProgressError as exc:
@@ -1659,7 +1659,7 @@ async def publish_channel_post_draft_endpoint(
         )
         await db.commit()
         raise HTTPException(
-            status_code=502,
+            status_code=503,
             detail=_with_command_state({
                 "code": "CHANNEL_IMAGE_CONTAINER_FAILED", "message": str(exc),
                 "container_status": exc.container_status,
@@ -1904,7 +1904,7 @@ async def unpublish_channel_post_endpoint(
         ) from exc
     except ChannelPublishProviderError as exc:
         raise HTTPException(
-            status_code=502,
+            status_code=503,
             detail={"code": "CHANNEL_PUBLISH_PROVIDER_ERROR", "message": str(exc)},
         ) from exc
 

--- a/backend/tests/test_3394_channel_post_list_be_fields.py
+++ b/backend/tests/test_3394_channel_post_list_be_fields.py
@@ -408,7 +408,7 @@ async def test_list_states_partial_success_failed_status_with_container_preserve
             _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
             async with _client_for(app) as client:
                 r_publish = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
-                assert r_publish.status_code == 502, r_publish.text
+                assert r_publish.status_code == 503, r_publish.text  # story #3632 — 진짜 상류 실패는 502 대신 503(CF 통과)
 
         _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
         async with _client_for(app) as client:

--- a/backend/tests/test_3419_cancel_unpublish.py
+++ b/backend/tests/test_3419_cancel_unpublish.py
@@ -636,7 +636,7 @@ async def test_unpublish_twice_second_time_returns_409_not_published():
 
 
 @pytest.mark.anyio
-async def test_unpublish_provider_error_maps_to_502():
+async def test_unpublish_provider_error_maps_to_503():
     from unittest.mock import AsyncMock, patch
     import app.services.threads_publish as tp
     from app.main import app
@@ -666,7 +666,7 @@ async def test_unpublish_provider_error_maps_to_502():
         ):
             async with _client_for(app) as client:
                 r_unpub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/unpublish")
-        assert r_unpub.status_code == 502, r_unpub.text
+        assert r_unpub.status_code == 503, r_unpub.text  # story #3632 — 진짜 상류 실패는 502 대신 503(CF 통과)
         error = r_unpub.json().get("error") or r_unpub.json()
         assert error["code"] == "CHANNEL_PUBLISH_PROVIDER_ERROR"
 

--- a/backend/tests/test_3516_channel_post_comments.py
+++ b/backend/tests/test_3516_channel_post_comments.py
@@ -719,6 +719,73 @@ async def test_api_refresh_allows_human_and_returns_counts(monkeypatch):
         await engine.dispose()
 
 
+# ─── story #3632(PO 실측, 2026-09-07) — Cloudflare가 502/504만 HTML로 가로챈다.
+# 「우리 상태」거절은 4xx로·「진짜 상류 실패」는 503으로 갈라야 CF를 통과한다 ──────
+
+@pytest.mark.anyio
+async def test_api_refresh_connection_not_active_returns_409_not_502():
+    """PO 실측 그대로 재현 — 연결이 만료(expired)된 채 「다시 수집」을 누르면(선검사
+    실패, 상류 호출 자체가 안 감) 이전엔 502였다. CF가 그 502를 HTML로 대체해
+    화면이 침묵했다 — 409(CF 통과)로 정정."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            # sandbox는 access_token="sandbox" 고정이라 연결 상태 선검사 자체를 안 거친다
+            # (channel_post_comments.py::fetch_replies 분기) — 실 채널(facebook)로
+            # 그 분기를 타게 한다(test_3612와 동형 세팅).
+            conn = await _seed_channel_connection(s, org_id, channel="facebook", status="expired")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="facebook", external_id="media-1")
+            human_id = await _seed_human(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                resp = await client.post(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments/refresh")
+        finally:
+            app.dependency_overrides.clear()
+        assert resp.status_code == 409, resp.text
+        assert resp.json()["error"]["code"] == "CHANNEL_CONNECTION_NOT_ACTIVE"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_api_refresh_provider_error_returns_503_not_502(monkeypatch):
+    """진짜 상류 실패(채널 API가 실제로 실패 응답) — 이건 CF를 통과시켜야 하는 503으로
+    분류된다(publication_command.py의 FAILURE_KIND_TRANSIENT SSOT 재사용, 새 판정
+    로직 0)."""
+    from app.main import app
+    import app.services.sandbox_publish as sandbox_publish
+    from app.services.threads_publish import ThreadsPublishError
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+            human_id = await _seed_human(s, org_id)
+
+        async def _fetch_fails(client, *, access_token, media_id):
+            raise ThreadsPublishError("PROVIDER_DOWN", "provider down", status_code=500)
+
+        monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch_fails)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                resp = await client.post(f"/api/v2/organizations/{org_id}/publications/{pub.id}/comments/refresh")
+        finally:
+            app.dependency_overrides.clear()
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["error"]["code"] == "CHANNEL_PUBLISH_PROVIDER_ERROR"
+    finally:
+        await engine.dispose()
+
+
 # ─── insights_board.py::comments_count 배선 ──────────────────────────────────
 
 

--- a/backend/tests/test_3516_channel_post_comments.py
+++ b/backend/tests/test_3516_channel_post_comments.py
@@ -747,7 +747,14 @@ async def test_api_refresh_connection_not_active_returns_409_not_502():
         finally:
             app.dependency_overrides.clear()
         assert resp.status_code == 409, resp.text
-        assert resp.json()["error"]["code"] == "CHANNEL_CONNECTION_NOT_ACTIVE"
+        body = resp.json()
+        assert body["error"]["code"] == "CHANNEL_CONNECTION_NOT_ACTIVE"
+        # story #3615/AC4(2026-09-07 PO 정정) — CHANNEL_CONNECTION_NOT_ACTIVE는 raise
+        # 자리 다수가 uuid를 그대로 담아(api-error-message.ts allowlist 등재 금지 사유)
+        # FE가 원문 message를 못 보인다 — 이 엔드포인트는 human_error()로 안전한 손글
+        # 문장을 직접 채운다. uuid가 안 섞였는지 직접 확認(connection.id 문자열 부재).
+        assert body["error"]["user_message"] == "연결이 활성 상태가 아니라 댓글을 대조/수집할 수 없습니다 — 연결 화면에서 확인해 주세요."
+        assert str(conn.id) not in body["error"]["user_message"]
     finally:
         await engine.dispose()
 
@@ -781,7 +788,9 @@ async def test_api_refresh_provider_error_returns_503_not_502(monkeypatch):
         finally:
             app.dependency_overrides.clear()
         assert resp.status_code == 503, resp.text
-        assert resp.json()["error"]["code"] == "CHANNEL_PUBLISH_PROVIDER_ERROR"
+        body = resp.json()
+        assert body["error"]["code"] == "CHANNEL_PUBLISH_PROVIDER_ERROR"
+        assert body["error"]["user_message"] == "채널에서 일시적인 오류가 발생해 다시 수집하지 못했습니다 — 잠시 후 다시 시도해 주세요."
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_f8f7cb0f_channel_post_publish.py
+++ b/backend/tests/test_f8f7cb0f_channel_post_publish.py
@@ -432,7 +432,7 @@ async def test_partial_success_retry_only_calls_publish_not_create_container():
             _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
             async with _client_for(app) as client:
                 r1 = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
-            assert r1.status_code == 502, r1.text
+            assert r1.status_code == 503, r1.text  # story #3632 — 진짜 상류 실패는 502 대신 503(CF 통과)
             assert r1.json()["error"]["code"] == "CHANNEL_PUBLISH_PROVIDER_ERROR"
 
             async with Session() as s:
@@ -498,7 +498,7 @@ async def test_container_creation_failure_upserts_same_row_not_new_one():
             _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
             async with _client_for(app) as client:
                 r1 = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
-            assert r1.status_code == 502, r1.text
+            assert r1.status_code == 503, r1.text  # story #3632 — 진짜 상류 실패는 502 대신 503(CF 통과)
 
             async with Session() as s:
                 from app.models.channel_publication import ChannelPublication


### PR DESCRIPTION
## 실측(PO, dev-app.sprintable.ai, 2026-09-07)
Sandbox Page 1(연결 expired) 「다시 수집」 클릭 → BE는 봉투(error.code·user_message)를 만들어 502로 반환(0.07s, 상류 호출 자체가 안 감 — 선검사 실패) → Cloudflare 에지가 origin의 502/504만 자체 HTML 에러 페이지로 대체(Enterprise 미만 플랜, Origin Error Page Pass-thru 없음) → 봉투가 브라우저에 도달하지 않아 화면이 침묵. FE 자체엔 이미 비-JSON 본문 폴백(commentsRefreshErrorGeneric)이 있었으나 그 표시 자리(data-testid=comments-refresh-error)에 role=alert 마킹이 없어 접근성으로도 결함(PO 자기정정 — 최초 "문장 0" 관측은 토스트/role=alert만 보고 오독한 것).

## 규칙(PO 確定)
「우리 상태」로 인한 거절(연결 비활성·발행 기록 없음·채널 미구현·필수 데이터 없음)은 CF가 통과시키는 4xx로. 「진짜 상류 실패」(채널 API가 실제로 오류 응답)만 503(재시도 의미 있음, CF 통과)으로. 502는 이 경로들 어디서도 더는 내지 않는다.

## BE
- `channel_post_comments.py::refresh_publication_comments_endpoint` — 「다시 수집」의 정확한 재현 경로. `CommentFetchError` 분기 재구성: `COMMENT_PUBLICATION_NOT_FOUND`(404, 기존)·`CHANNEL_RATE_LIMITED`(429, 채널 자체 rate-limit — 우리 5분 쿨다운과 다른 축)·`publication_command.py::classify_failure_kind()==TRANSIENT`(`CHANNEL_PUBLISH_PROVIDER_ERROR`, 503, channel_posts.py 발행 경로와 SSOT 재사용)·그 외 전부(`CHANNEL_CONNECTION_NOT_ACTIVE`·`CHANNEL_TOKEN_EXPIRED`·`CHANNEL_CONNECTION_REVOKED`·`CHANNEL_CONNECTION_AUTH_ERROR`·`COMMENT_CHANNEL_NOT_IMPLEMENTED`·`COMMENT_EXTERNAL_ID_MISSING`, 409 — channel_posts.py 발행 경로가 이미 같은 코드들을 409로 내는 것과 동형).
- `channel_posts.py`/`channel_connections.py` — 같은 "채널 경로" 도메인의 기존 502 8곳(`CHANNEL_PUBLISH_PROVIDER_ERROR`×3·`CHANNEL_IMAGE_CONTAINER_FAILED`×1·`CHANNEL_IMAGE_UPLOAD_FAILED`×2·`CHANNEL_VIDEO_UPLOAD_FAILED`×2) — 전부 진짜 상류/스토리지 실패라 503으로 통일(이미 `CHANNEL_IMAGE_STORAGE_NOT_CONFIGURED`가 이 파일에서 503 관례를 쓰고 있었다 — 새 판정 도입이 아니라 기존 관례 확장).

## FE
`CommentsRefreshButton`의 `data-testid=comments-refresh-error` 자리를 화면 관례(insights-board 등과 동형인 `<Alert variant="destructive" role="alert" aria-live="assertive">`)로 승격. 문장 자체는 이미 있었다(BE 4xx user_message 폴백 체인) — 이 자리의 결함은 접근성 마킹 부재였다.

## 502 grep 표(전체 32곳 중 이 PR이 손댄 9곳 vs 범위 밖 23곳)
| 파일 | 코드 | 처리 |
|---|---|---|
| channel_post_comments.py×1 | CommentFetchError 분기 전체 | 4xx/503로 재구성 |
| channel_posts.py×7 | CHANNEL_*_UPLOAD/PROVIDER/CONTAINER | 503 |
| channel_connections.py×1 | CHANNEL_PUBLISH_PROVIDER_ERROR | 503 |
| *_sandbox_publish.py×11 | 테스트 마커 시뮬레이션(ThreadsPublishError 발생원, 응답 발신처 아님) | 범위 밖 — 위 라우터들이 소비 시점에 이미 재분류 |
| measurement_connections.py×4 | GA4_TOKEN_REFRESH/LIST_PROPERTIES_FAILED | 범위 밖(GA4 도메인, 채널 발행 아님) |
| billing_keys.py·billing_packs.py·org_subscription_checkout.py×4 | 결제 도메인 | 범위 밖 |
| docs.py·stories.py·conversations.py·attachments.py·assets.py×5 | 범용 업로드/변환 실패 | 범위 밖 |
| gates.py×3 | GitHub 연동 | 범위 밖 |
| retros.py×3 | AI 회고 합성 | 범위 밖 |
| auth_firebase_internal.py×2 | 세션 쿠키 발급 | 범위 밖 |

## 테스트
BE 실DB 신규 2건(`CHANNEL_CONNECTION_NOT_ACTIVE`→409·`CHANNEL_PUBLISH_PROVIDER_ERROR`→503) + 뮤테이션 1건(409→502 되돌림 → RED) 확認 후 복구. 기존 pin 3건(unpublish/publish 502 기대) 503으로 갱신. FE 신규 1건(role=alert) + 뮤테이션 1건(role 제거 → RED) 확認 후 복구. 회귀: destructive 102~132건(comments/publish/unpublish/connection 관련 다수, 실행마다 선택 파일 상이)+비파괴 sandbox 마커 69건 전부 PASS. FE tsc/eslint 클린, 관련 페이지 테스트 224건 PASS.

## 범위 밖
- Cloudflare 플랜/설정 변경(Origin Error Page Pass-thru는 Enterprise 전용).
- 위 표의 채널 도메인 밖 23곳(GA4·결제·범용업로드·GitHub·회고·인증) — 별건.
- 라이브 브라우저(CF 경유 실 호스트)에서 「다시 수집」 눌러 문장+role=alert 확인·CF HTML 0인지는 PO 실측 몫.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA