### PR TITLE
[SID:3636] fix(ci): edited 트리거 산 run 취소 + 러너 정규화 가드 거짓 빨강 2건

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,29 @@ on:
     # base 재타겟도 새 런을 튼다 — required 3잡(alembic-fresh-db·backend-test·ci)엔
     # changes.base skip-필터를 걸지 않는다(그 잡들의 기존 `if: always()`가 스킵-캐스케이드
     # 방지용이라, skip 조건을 더하면 그 방지를 무력화한다 — [[ci-stuck-c-d-remedy-design-20260822]]
-    # landmine 참고). title/body 편집에도 전체 재실행되지만 PR#3324의 concurrency그룹이
-    # 연속 편집 시 구run을 자동취소해 낭비를 완화한다.
+    # landmine 참고). title/body 편집에도 전체 재실행된다 — 이건 story #3636이 아래
+    # concurrency.group에서 별도 격리한다(낭비는 있지만 산 run을 더는 안 죽인다).
     types: [opened, synchronize, reopened, edited]
     branches: [main, develop]
   push:
     branches: [main, develop]
 
+# story #3636(CI·소형, 페드루 PO 確定 2026-09-07) — #3972 실사고: `edited`가 PR **본문/
+# 제목만** 편집해도 발화해(GitHub이 base 재타겟과 구분 안 함) 같은 head에 새 run이 하나
+# 더 생기고, 이 concurrency 그룹이 같아 cancel-in-progress가 **아직 돌고 있던 산 run의
+# 잡**을 즉시 죽였다(PO가 새 run을 pending 중복으로 오인해 취소 → 산 run 0 → 재가동
+# ≈15분 손실). job-level `if:`로는 이 취소 자체를 못 막는다(취소는 새 run이 이 그룹에
+# 큐잉되는 순간 발화 — job의 if 평가보다 먼저다). 그래서 group 자체를 조건부로: `edited`
+# 이벤트인데 `changes.base`가 없으면(=base 안 바뀐 본문/제목 편집) 그 run만 run_id로
+# 격리된 자기 그룹에 넣어 — 옛(진짜) run과 아예 안 겹쳐 취소가 안 걸린다. base가 실제로
+# 바뀐 재타겟(#2912/#3317 의도)·opened/synchronize/reopened·push는 전부 그대로 안정
+# 그룹을 공유해 기존 취소 동작을 그대로 유지한다.
+# ⚠️낭비 축(선언) — 본문/제목만 편집한 그 throwaway run은 격리된 자기 그룹에서 required
+# 3잡을 「전량」 돈다(job/step skip 없음 — story #2555/22436b87의 "skip=required 체크
+# 애매" landmine을 그대로 피한다). 즉 같은 head SHA를 두 번 완주하는 CI 낭비(연속 편집마다
+# 반복될 수 있다)는 그대로 남는다 — 정확성(산 run이 안 죽는다)과 맞바꾼 것.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.base == null) && format('-edited-only-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -190,17 +190,55 @@ def normalized_slow_threshold_sec(ratios: list[float], *, base_seconds: float = 
     return statistics.median(ratios) * base_seconds
 
 
+# story #3636(CI·소형, 페드루 PO 確定 2026-09-07) — 위 threshold는 **run 전체에 대한
+# 하나의 flat 값**이라, 그 파일 자신의 등재 weight와 무관하게 모든 weighted 파일에
+# 똑같이 적용된다. test_2813_gate_github_check_realdb.py(weight 45.0s, 실제로는 25개
+# realdb 테스트가 매번 전체 스키마 create_all을 다시 태우는 무거운 파일)가 2026-09-07
+# 하루에 두 번 거짓 빨강(72s>66.0s·131s>102.9s)을 냈다 — 그 파일 자신의 elapsed/weight
+# 배율은 1.6·2.91로 평범한 편차인데, weight가 60s 근방/이상인 파일은 애초에 그
+# 배율만으로도 flat 임계값을 밥먹듯 넘는 구조다(weight 자체가 threshold의 분모에
+# 전혀 반영 안 됨). 이 축은 그 구조적 갭을 메운다: 파일 자신의 weight × 배수(3.0) 밑에
+# 있으면 flat 임계값을 넘었어도 FAIL이 아니라 WARN으로 낮춘다(무거운 파일에 «자기
+# 무게만큼의» 여유를 준다 — flat 임계값 자체를 못 믿는 게 아니라 무거운 파일에게만
+# 추가 여유축을 얹는 것, AC6이 거부한 "배율 자체의 상한"과는 다른 축).
+#
+# ⚠️ 이 가드가 이제 놓치는 것(선언, story #3636 AC2): 등재 weight W인 파일이 flat
+# 임계값은 넘되 W × 3.0 밑으로만 느려지면(예: test_2813 weight 45 → elapsed ≤135) FAIL이
+# 아니라 WARN이다 — «무거운 파일이 자기 weight의 3배 이내로 느려지는」 회귀는 이제
+# 잡지 못한다(WARN으로만 보임). weight가 가벼운 파일(예: 5.0)의 20배 회귀(test_
+# genuinely_heavy_file_still_caught_when_runner_is_normal, 100.0s)는 5.0×3.0=15.0을
+# 훨씬 넘어 여전히 FAIL — 이 축은 무거운 파일에만 좁게 적용된다.
+HEAVY_FILE_OWN_WEIGHT_FAIL_MULTIPLIER = 3.0
+
+
 def slow_files_normalized(
     elapsed_by_file: dict[str, float], weights: dict[str, float], *, base_seconds: float = 60.0,
 ) -> tuple[list[str], float, int]:
     """story #3396 — weighted 파일만 대상으로 러너 정규화 60초 가드를 판정한다.
     반환: (초과한 파일 목록·정렬, 실제로 쓴 판정선(초), 배율 표본 크기). unweighted
     파일은 대상에서 아예 빠진다(#3392가 별도로 담당 — 두 가드가 같은 파일을 다른
-    기준으로 두 번 재는 혼선을 막는다)."""
+    기준으로 두 번 재는 혼선을 막는다).
+
+    story #3636 — FAIL 판정은 flat threshold 초과 **AND** 그 파일 자신의 weight ×
+    HEAVY_FILE_OWN_WEIGHT_FAIL_MULTIPLIER도 초과할 때만(무거운 파일 전용 여유축,
+    위 상수 docstring 참고)."""
     ratios = weighted_ratios(elapsed_by_file, weights)
     threshold = normalized_slow_threshold_sec(ratios, base_seconds=base_seconds)
-    slow = [f for f, elapsed in elapsed_by_file.items() if f in weights and elapsed > threshold]
+    slow = [
+        f for f, elapsed in elapsed_by_file.items()
+        if f in weights and elapsed > threshold
+        and elapsed > weights[f] * HEAVY_FILE_OWN_WEIGHT_FAIL_MULTIPLIER
+    ]
     return sorted(slow), threshold, len(ratios)
+
+
+def warned_only_files_normalized(
+    elapsed_by_file: dict[str, float], weights: dict[str, float], threshold: float, slow: list[str],
+) -> list[str]:
+    """story #3636 — flat threshold는 넘었지만 자기 weight×3.0 여유축에 막혀 FAIL에서
+    빠진 파일(가시성용 — 실패 0, story #3558의 ratio_outliers와 동형으로 경고만)."""
+    over_threshold = {f for f, elapsed in elapsed_by_file.items() if f in weights and elapsed > threshold}
+    return sorted(over_threshold - set(slow))
 
 
 def partition(files: list[str], weights: dict[str, float], shard_count: int) -> tuple[list[list[str]], list[float]]:
@@ -320,6 +358,15 @@ def _check_elapsed_mode(elapsed_path: Path) -> int:
     elapsed_by_file = _parse_elapsed_file(elapsed_path)
     weights = load_weights()
     slow, threshold, sample_size = slow_files_normalized(elapsed_by_file, weights)
+
+    # story #3636 — weight×3.0 여유축에 막혀 FAIL에서 빠진 파일도 조용히 넘기지 않고
+    # WARN으로 남긴다(가시성 — story #3558 ratio_outliers와 동형 관례).
+    for f in warned_only_files_normalized(elapsed_by_file, weights, threshold, slow):
+        print(
+            f"::warning::러너 정규화 가드 — {f} 임계값({threshold:.1f}s) 초과했지만 자기 weight"
+            f"({weights[f]:.1f}s)×{HEAVY_FILE_OWN_WEIGHT_FAIL_MULTIPLIER:.1f} 이내라 WARN만(story #3636): "
+            f"{elapsed_by_file[f]:.0f}s"
+        )
 
     if sample_size < MIN_RATIO_SAMPLE:
         print(

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -334,6 +334,81 @@ def test_genuinely_heavy_file_still_caught_when_runner_is_normal():
     assert threshold == 60.0  # 정상 러너(배율 1.0) — 사실상 절대 60초와 같은 값, 100s는 그 위
 
 
+# ── story #3636(CI 후속) — 무거운 파일의 flat 임계값 거짓 빨강(2026-09-07 실사고 2건) ──
+#
+# test_2813_gate_github_check_realdb.py(weight 45.0s — 25개 realdb 테스트, 매번 전체
+# schema create_all을 다시 태우는 무거운 파일)가 오늘 두 번: run 34099865987에서
+# 72s>66.0s, run 34103152060에서 131s>102.9s. 둘 다 그 파일과 무관한 PR이고 다음 run은
+# 초록이었다(3396의 정규화 자체는 맞게 동작 — "그 run이 전반적으로 느렸다"는 판정까지는
+# 맞았다. 문제는 threshold가 파일 자신의 weight와 무관한 flat 값이라 weight 45.0처럼
+# 60s 근방인 파일은 median_ratio가 1.0만 넘어도 밥먹듯 걸리는 구조였다는 것).
+_INCIDENT1_ELAPSED = {
+    "tests/normal_a.py": 11.0, "tests/normal_b.py": 11.0, "tests/normal_c.py": 11.0,
+    "tests/test_2813_gate_github_check_realdb.py": 72.0,
+}
+_INCIDENT1_WEIGHTS = {
+    "tests/normal_a.py": 10.0, "tests/normal_b.py": 10.0, "tests/normal_c.py": 10.0,
+    "tests/test_2813_gate_github_check_realdb.py": 45.0,
+}  # median_ratio = 1.1 → threshold = 66.0(실사고와 동일)
+
+_INCIDENT2_ELAPSED = {
+    "tests/normal_a.py": 17.15, "tests/normal_b.py": 17.15, "tests/normal_c.py": 17.15,
+    "tests/test_2813_gate_github_check_realdb.py": 131.0,
+}
+_INCIDENT2_WEIGHTS = {
+    "tests/normal_a.py": 10.0, "tests/normal_b.py": 10.0, "tests/normal_c.py": 10.0,
+    "tests/test_2813_gate_github_check_realdb.py": 45.0,
+}  # median_ratio = 1.715 → threshold ≈ 102.9(실사고와 동일)
+
+
+def test_incident1_2026_09_07_run_34099865987_no_longer_flags_test_2813():
+    """⭐story #3636 핵심(실사고 1) — weight×3.0 여유축 적용 후 test_2813(72s)이
+    더는 FAIL이 아니어야 한다(정규화 자체는 맞다 — threshold 66.0도 실사고와 일치)."""
+    mod = _load()
+    slow, threshold, sample_size = mod.slow_files_normalized(_INCIDENT1_ELAPSED, _INCIDENT1_WEIGHTS)
+    assert threshold == pytest.approx(66.0)
+    assert slow == [], f"weight×3.0 여유축이 있는데도 여전히 걸림: {slow}"
+
+
+def test_incident2_2026_09_07_run_34103152060_no_longer_flags_test_2813():
+    """⭐story #3636 핵심(실사고 2) — 131s>102.9s도 마찬가지로 더는 FAIL이 아니다."""
+    mod = _load()
+    slow, threshold, sample_size = mod.slow_files_normalized(_INCIDENT2_ELAPSED, _INCIDENT2_WEIGHTS)
+    assert threshold == pytest.approx(102.9, abs=0.1)
+    assert slow == [], f"weight×3.0 여유축이 있는데도 여전히 걸림: {slow}"
+
+
+def test_incident1_without_own_weight_cap_axis_would_still_fail_mutation():
+    """뮤테이션(AC4) — weight×3.0 여유축 없이(구 로직 그대로) 판정하면 실사고 1이
+    다시 FAIL로 재현돼야 한다. slow_files_normalized() 내부 두 번째 AND 조건을
+    걷어낸 구식 판정을 직접 재현(이 assert가 표현하는 조건으로 되돌아간다는 뜻)."""
+    mod = _load()
+    ratios = mod.weighted_ratios(_INCIDENT1_ELAPSED, _INCIDENT1_WEIGHTS)
+    threshold = mod.normalized_slow_threshold_sec(ratios)
+    old_slow = sorted(f for f, e in _INCIDENT1_ELAPSED.items() if f in _INCIDENT1_WEIGHTS and e > threshold)
+    assert old_slow == ["tests/test_2813_gate_github_check_realdb.py"]
+
+
+def test_warned_only_files_normalized_surfaces_the_spared_file():
+    """story #3636 — FAIL에서 빠졌다고 조용히 넘어가지 않는다. warned_only에 잡혀야
+    한다(가시성, story #3558 ratio_outliers와 동형)."""
+    mod = _load()
+    slow, threshold, _ = mod.slow_files_normalized(_INCIDENT1_ELAPSED, _INCIDENT1_WEIGHTS)
+    warned = mod.warned_only_files_normalized(_INCIDENT1_ELAPSED, _INCIDENT1_WEIGHTS, threshold, slow)
+    assert warned == ["tests/test_2813_gate_github_check_realdb.py"]
+
+
+def test_heavy_file_own_weight_cap_still_fails_past_3x_boundary():
+    """경계 — test_2813 weight 45.0이라도 자기 weight의 3배(135.0s)를 넘게 느려지면
+    (진짜 회귀) 여전히 FAIL이어야 한다 — 이 축이 «무거운 파일은 뭘 해도 안 걸린다»로
+    변질되면 안 된다(story #3636 AC2 선언과 짝)."""
+    mod = _load()
+    elapsed = dict(_INCIDENT1_ELAPSED)
+    elapsed["tests/test_2813_gate_github_check_realdb.py"] = 140.0  # > 45.0*3.0
+    slow, threshold, _ = mod.slow_files_normalized(elapsed, _INCIDENT1_WEIGHTS)
+    assert slow == ["tests/test_2813_gate_github_check_realdb.py"]
+
+
 def test_check_elapsed_mode_exit_code_matches_slow_files(tmp_path, capsys, monkeypatch):
     """_check_elapsed_mode()를 통째로 돌려 오늘 실사고 표본이 exit 0(정상 판정)이
     되는지 e2e로 확인한다(파일 파싱·가중치 로딩·판정 전체 경로). 이 픽스처는 PR


### PR DESCRIPTION
## ① `pull_request: edited` 트리거가 본문 편집에도 산 run을 죽인다(#3972 실사고)

`edited`(story #2912, base 재타겟 재트리거 목적)가 PR 본문/제목만 편집해도 발화 — 같은 head에 새 run이 생기고 concurrency 그룹이 같아 `cancel-in-progress`가 아직 돌고 있던 산 run의 잡을 즉시 죽였다.

job-level `if:`(1차 제안)는 채택 안 함 — 취소는 새 run이 concurrency 그룹에 큐잉되는 순간 발화, job의 if 평가보다 먼저다(PO 대조 확認). **처방** — `concurrency.group`을 조건부로: `edited`인데 `changes.base`가 없으면(본문/제목만 편집) 그 run만 `run_id`로 격리된 자기 그룹에 — 옛 run과 안 겹쳐 취소가 안 걸린다. base 재타겟·opened/synchronize/reopened·push는 기존 안정 그룹 그대로.

⚠️ **낭비 축(선언)**: 격리된 throwaway run은 required 3잡을 전량 돈다(skip 없음, story #2555/22436b87 landmine 회피) — 같은 head SHA 두 번 완주하는 CI 낭비는 남는다. 정확성과 맞바꾼 것.

**검증(이 PR 자체로 실측)**: 이 PR 본문을 편집해 재현 — 로그는 아래 갱신.

## ② 러너 정규화 60초 가드 거짓 빨강(story #3396, 2026-09-07 2회)

`test_2813_gate_github_check_realdb.py`(weight 45.0s — 25개 realdb 테스트, 매번 전체 schema create_all)가 오늘 2회: 72s>66.0s(run 34099865987)·131s>102.9s(run 34103152060). 정규화 자체는 맞다(두 threshold 모두 실사고와 정확히 일치) — 문제는 threshold가 run 전체 flat 값이라 파일 자신의 weight와 무관하다는 것. weight가 60s 근방/이상인 파일은 median_ratio가 1.0만 넘어도 flat 임계값을 밥먹듯 넘는 구조.

**처방(옵션 c의 weight-scaled 정밀판)**: FAIL 판정에 `elapsed > 자기 weight × 3.0` AND 조건 추가. 순수 절대초 상한(180s 등)은 안 씀 — 기존 회귀 테스트(가벼운 파일 20배 회귀, weight 5.0→100.0s)가 그 상한 밑으로 들어와 깨지기 때문. weight-scaled라야 무거운 파일에만 좁게 적용되고 가벼운 파일의 진짜 회귀는 그대로 잡힌다.

⚠️ **가드가 이제 놓치는 것(선언)**: weight W 파일이 flat threshold는 넘고 W×3.0 밑으로만 느려지는 회귀(test_2813 → elapsed ≤135)는 이제 FAIL 아니라 WARN. W×3.0을 넘는 진짜 회귀는 여전히 FAIL(`test_heavy_file_own_weight_cap_still_fails_past_3x_boundary`가 못박음). 가벼운 파일(weight 5.0)의 20배 회귀도 여전히 FAIL(기존 회귀 테스트 그대로 살아있음).

## Test plan
- [x] `test_shard_destructive_tests.py` 45/45 그린(신규 5 + 기존 40) — 실사고 2건 정확 재현(threshold 66.0/102.9 실측값과 일치) + 뮤테이션(AND 조건 되돌림 → RED 확認 후 원복) + 경계(3x 초과는 여전히 FAIL)
- [x] `actionlint .github/workflows/ci.yml` — 신규 오류 0(사전 존재 무관 shellcheck 경고 1건만)
- [ ] ①의 실 PR 시나리오 검증(본문 편집 후 로그 갱신 — 아래)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### 라이브 검증 로그(①, 시나리오 1 — 본문만 편집)
- 2026-09-07T09:37:50Z 이 줄을 추가하며 본문만 편집(edited 이벤트, base 미변경) — 아래 재확認 결과 기록 예정.
