### PR TITLE
[SID:3631] feat: 콘텐츠/채널 도구 toolset 그룹 신설 완성

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3470,7 +3470,8 @@
         "admin": "Danger zone (Admin)",
         "hypotheses": "Hypotheses",
         "canvas": "Artifacts",
-        "events": "Events"
+        "events": "Events",
+        "content": "Content"
       }
     },
     "statusEyebrow": "STATUS DASHBOARD",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3470,7 +3470,8 @@
         "admin": "위험 작업 (Admin)",
         "hypotheses": "가설",
         "canvas": "아티팩트",
-        "events": "이벤트"
+        "events": "이벤트",
+        "content": "콘텐츠"
       }
     },
     "statusEyebrow": "STATUS DASHBOARD",

--- a/apps/web/src/lib/toolset-catalog.ts
+++ b/apps/web/src/lib/toolset-catalog.ts
@@ -57,6 +57,9 @@ export const TEMP_TOOLSET_CATALOG: ToolsetCatalog = {
     { key: 'hypotheses', is_core: false, is_destructive: false, tools: ['sprintable_create_hypothesis', 'sprintable_confirm_hypothesis', 'sprintable_link_hypothesis'] },
     { key: 'canvas', is_core: false, is_destructive: false, tools: ['sprintable_create_artifact', 'sprintable_edit_artifact', 'sprintable_create_spec_pin'] },
     { key: 'events', is_core: false, is_destructive: false, tools: ['sprintable_publish_event', 'sprintable_list_event_definitions'] },
+    // story #3631 — mcp_toolset.py에 "content" 그룹 신설(콘텐츠/채널 도구, #3614
+    // sprintable_withdraw_channel_post_draft가 첫 멤버). 위 #2661과 동일 이유로 여기도 반영.
+    { key: 'content', is_core: false, is_destructive: false, tools: ['sprintable_withdraw_channel_post_draft'] },
     { key: 'admin', is_core: false, is_destructive: true, tools: ['sprintable_delete_sprint', 'sprintable_close_sprint', 'sprintable_give_reward', 'sprintable_upsert_webhook_config', 'sprintable_activate_sprint'] },
   ],
 };

--- a/backend/alembic/versions/0349_role_templates_content_group.py
+++ b/backend/alembic/versions/0349_role_templates_content_group.py
@@ -1,0 +1,50 @@
+"""story #3631(콘텐츠/채널 도구 toolset 그룹 신설) 후속 데이터 정합 —
+role_templates.default_tool_groups에 "content" 추가.
+
+Revision ID: 0349
+Revises: 0348
+Create Date: 2026-09-07
+
+0181(canvas)과 동형 — 그룹만 신설하고 role_template.default_tool_groups에 아무도
+이 토큰을 안 가지면 「만들어졌는데 도는 자리 없음」(fail-closed, 등록만으로는 아무
+role도 자동으로 못 씀). 대상 role 선정 근거(0160_role_templates_marketing_roster.py
+grep) — `category="marketing"` role은 performance-marketer 1개뿐이고, 채널 포스트
+초안/댓글 수집(channel_posts.py·channel_post_comments.py, story #3516 자체 서술
+"블루프린트 v3 §2 「댓글·반응 대응」·마케팅운영")은 이 role의 실 업무 범위와 정확히
+겹친다. growth-hacker(category="growth", 0160에서 performance-marketer와 동시 seed
+·같은 tool_groups 튜플을 공유)도 퍼널/캠페인 콘텐츠를 다루는 인접 직군이라 함께
+추가한다 — 전용 "content marketer"/"social media manager" role_template은 아직
+카탈로그에 없다(0156~0348 grep 확認, 신설은 이 스토리 범위 밖). pm/qa 등은 0181과
+같은 이유로 스코프 밖(필요 시 별건).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0349"
+down_revision = "0348"
+branch_labels = None
+depends_on = None
+
+_ROLES = ("growth-hacker", "performance-marketer")
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE role_templates "
+            "SET default_tool_groups = array_append(default_tool_groups, 'content') "
+            "WHERE slug = ANY(:roles) AND NOT ('content' = ANY(default_tool_groups))"
+        ).bindparams(sa.bindparam("roles", value=list(_ROLES), type_=sa.ARRAY(sa.Text)))
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE role_templates "
+            "SET default_tool_groups = array_remove(default_tool_groups, 'content') "
+            "WHERE slug = ANY(:roles)"
+        ).bindparams(sa.bindparam("roles", value=list(_ROLES), type_=sa.ARRAY(sa.Text)))
+    )

--- a/backend/alembic/versions/0350_role_templates_content_group.py
+++ b/backend/alembic/versions/0350_role_templates_content_group.py
@@ -1,8 +1,8 @@
 """story #3631(콘텐츠/채널 도구 toolset 그룹 신설) 후속 데이터 정합 —
 role_templates.default_tool_groups에 "content" 추가.
 
-Revision ID: 0349
-Revises: 0348
+Revision ID: 0350
+Revises: 0349
 Create Date: 2026-09-07
 
 0181(canvas)과 동형 — 그룹만 신설하고 role_template.default_tool_groups에 아무도
@@ -16,14 +16,22 @@ grep) — `category="marketing"` role은 performance-marketer 1개뿐이고, 채
 추가한다 — 전용 "content marketer"/"social media manager" role_template은 아직
 카탈로그에 없다(0156~0348 grep 확認, 신설은 이 스토리 범위 밖). pm/qa 등은 0181과
 같은 이유로 스코프 밖(필요 시 별건).
+
+PO 요청(2026-09-07) — dev 실측(뭉클랩=customer zero, GET /api/v2/team-members?type=
+agent + 활성 11 에이전트 각각 GET /api/v2/agent-personas?agent_id=)으로 실제 recruit
+된 role_template과 교차 확認: growth-hacker=담롱 온찬 1명·performance-marketer=댄
+어윈 1명, 그 외 9명(pm·ui-designer·qa-engineer·backend·frontend·mobile·security-
+engineer, +시스템 계정 2개 persona 0건)은 이 그룹과 무관한 role — 활성 11개 전체를
+훑어도 이 2 role 밖에서 recruit된 콘텐츠/소셜 전담 role은 0건. 대상 2종이 이미 "우리가
+쓰는 자리"의 전부임을 확認(고객이 못 쓰는 자리가 따로 있는 게 아니었다).
 """
 from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0349"
-down_revision = "0348"
+revision = "0350"
+down_revision = "0349"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -60,17 +60,21 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     # "update_event_definition")가 먼저 있어 이 항목까지 안 내려온다(admin이 이 events보다
     # 리스트 앞쪽 — tool_group()은 첫 매치를 반환).
     ("events", ("event",)),
-    # story #3614 CHANGES(2026-09-07, 페드루 PO 判定) — sprintable_withdraw_channel_post_draft
-    # 가 키워드 미매칭으로 core에 떨어졌는데, build_toolset_catalog()의 "core" 그룹은 오직
-    # _ALWAYS_ALLOWED만 나열해(tool_group()의 fallback "core"와는 별개 축) 카탈로그 커버리지
-    # 검증(test_toolset_catalog.py::test_every_tool_covered_exactly_once)에서 누락으로
-    # 잡혔다. 최초 처방(_ALWAYS_ALLOWED 임시 등재)은 페드루 PO가 CHANGES로 반려 — 그 목록은
-    # "scope 막론 항상 허용"(is_tool_allowed 무조건 True) 의미라, 초안을 폐기하는 변이 도구를
-    # 두면 role scope 없는 키도 호출 가능해지는 권한 확대였다(커버리지 공백을 권한으로 메운
-    # 지름길). 정공법 — 콘텐츠 전용 그룹을 여기서 신설(이 스토리 범위는 이 한 도구만 —
-    # site_post/channel_connection/comment/insight 등 다른 콘텐츠 도구 키워드 확장은 story
-    # #3631(진행 중)이 이어받는다).
-    ("content", ("channel_post",)),
+    # story #3614 CHANGES(2026-09-07, 페드루 PO 判定)가 "channel_post" 키워드 하나로 이
+    # 그룹을 최소 신설(sprintable_withdraw_channel_post_draft의 카탈로그 커버리지 공백
+    # 임시 해소, PR#3972) — story #3631이 그 위에 나머지 콘텐츠 도구 키워드를 마저 얹어
+    # 완성한다.
+    #
+    # "comment"는 바로 안 쓴다 — sprintable_add_artifact_comment/sprintable_
+    # list_artifact_comments(canvas 그룹, "artifact" 키워드)와 겹친다. 이 리스트 순서
+    # (canvas가 먼저)상 그 둘은 이미 canvas로 먼저 매치되므로 실질 충돌은 없지만,
+    # "post_comment"(channel_post_comment류 실제 이름 패턴과 일치)로 더 구체화해 순서
+    # 의존성 자체를 없앤다(방어적 이중 안전).
+    #
+    # "withdraw"는 의도적으로 뺐다 — 이 하나의 동사만으로 미래의 무관한 도구(예: 보상/지갑
+    # 인출류)까지 이 그룹으로 잘못 끌어올 위험이 "channel_post" 등 구체 키워드보다 크다.
+    # 지금 유일한 실 도구(withdraw_channel_post_draft)는 "channel_post" 키워드로 이미 잡힌다.
+    ("content", ("channel_post", "site_post", "channel_connection", "post_comment", "insight")),
 ]
 
 _CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
@@ -451,9 +455,10 @@ _CATALOG_DISPLAY_ORDER: tuple[str, ...] = (
     # default_tool_groups에 아직 이 토큰을 가진 role이 없다(선생님 승인 게이트 — 데이터
     # 마이그 없이 여기 등록만으로는 아무 role도 자동으로 이 도구를 못 쓴다, fail-closed).
     "events",
-    # story #3614 CHANGES — 콘텐츠 그룹, events와 동일 이유로 fail-closed(등록만으로는
-    # 아무 role도 자동으로 이 도구를 못 쓴다, default_tool_groups에 "content" 토큰을 가진
-    # role이 아직 없다). 다른 콘텐츠 도구 편입은 story #3631.
+    # story #3614 CHANGES가 최소 신설(events와 동일 이유로 당시 fail-closed) — story #3631
+    # (alembic 0350)이 growth-hacker·performance-marketer 2 role_template.default_tool_groups
+    # 에 "content" 토큰을 배선해 실제로 도는 자리로 완성한다(dev 실측 — 뭉클랩 활성
+    # 에이전트 11 전수 훑어도 이 2 role 밖에서 recruit된 콘텐츠 전담 role 0건).
     "content",
 )
 

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -52,9 +52,10 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     # list_event_definitions. admin 뒤에 두는 이유는 순서 의존(emit_event가 substring "event"를
     # 포함 — admin보다 앞에 두면 기존 sprintable_emit_event 분류가 깨진다).
     ("events", ("event",)),
-    # story #3614 CHANGES(2026-09-07) — 백엔드 SSOT와 동기화. 콘텐츠 그룹(이 스토리는
-    # channel_post 키워드만 — 다른 콘텐츠 도구 키워드 확장은 story #3631).
-    ("content", ("channel_post",)),
+    # story #3614 CHANGES가 "channel_post" 키워드로 최소 신설, story #3631이 백엔드
+    # SSOT(app/services/mcp_toolset.py)와 동기화해 나머지 콘텐츠 도구 키워드로 완성.
+    # "withdraw"는 의도적으로 제외(원본 주석 참고 — 미래 무관 도구 오분류 위험).
+    ("content", ("channel_post", "site_post", "channel_connection", "post_comment", "insight")),
 ]
 
 _CORE = "core"

--- a/backend/tests/test_3631_mcp_content_toolset_group.py
+++ b/backend/tests/test_3631_mcp_content_toolset_group.py
@@ -22,12 +22,19 @@ _FUTURE_TOOL_NAMES_BY_KEYWORD = {
     "channel_post": "sprintable_create_channel_post_draft",
     "site_post": "sprintable_create_site_post_draft",
     "channel_connection": "sprintable_list_channel_connections",
-    "post_comment": "sprintable_list_channel_post_comments",
+    # 카디르 QA(2026-08-07·#3990 리뷰) — "sprintable_list_channel_post_comments"는
+    # "channel_post"도 이미 포함해(같은 그룹 튜플의 앞 키워드) "post_comment"를 빼도
+    # 이 표본은 여전히 매치되는 "틀릴 수 없는 표본"이었다. "channel_post"를 안 품는
+    # 이름으로 교체해 "post_comment" 키워드 하나만 단독으로 검증한다.
+    "post_comment": "sprintable_list_post_comments",
     "insight": "sprintable_get_insight_snapshot",
 }
 
 
 def test_each_declared_keyword_classifies_into_content():
+    """뮤테이션 확認(#3990 리뷰 후) — "post_comment" 키워드를 튜플에서 빼면 이 표본
+    (sprintable_list_post_comments)만 core로 되돌아가 RED가 되는 것을 로컬에서 확認 후
+    복구(다른 4키워드 표본은 영향 없음 — 이제 각 키워드가 독립적으로 단독 검증됨)."""
     from app.services.mcp_toolset import tool_group as backend_tool_group
     from sprintable_mcp.toolset import tool_group as vendored_tool_group
 

--- a/backend/tests/test_3631_mcp_content_toolset_group.py
+++ b/backend/tests/test_3631_mcp_content_toolset_group.py
@@ -1,0 +1,80 @@
+"""story #3631(2026-09-07, #3972에서 발견) — 콘텐츠/채널 도구 toolset 그룹 신설.
+
+`sprintable_withdraw_channel_post_draft`(#3614, 이 도메인 첫 MCP 도구)가 `_GROUP_KEYWORDS`에
+매칭 키워드가 없어 core로 분류됐다 — 콘텐츠 전용 그룹이 아예 없었다. story #2634(events 그룹
+신설)와 동형 검증 관례를 따른다: 백엔드 SSOT(app/services/mcp_toolset.py)·vendored 사본
+(sprintable_mcp/toolset.py) 양쪽 다 대조."""
+from __future__ import annotations
+
+
+def test_withdraw_channel_post_draft_classified_into_content_not_core():
+    """실제 존재하는 유일한 콘텐츠 도구(#3614) — "channel_post" 키워드로 매칭."""
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+    from sprintable_mcp.toolset import tool_group as vendored_tool_group
+
+    assert backend_tool_group("sprintable_withdraw_channel_post_draft") == "content"
+    assert vendored_tool_group("sprintable_withdraw_channel_post_draft") == "content"
+
+
+# 아직 실재하지 않는 미래 도구명에도 키워드가 옳게 반응하는지(AC1의 전체 키워드 목록) —
+# 합성 이름으로 검증(실제 등록 여부와 무관하게 분류 로직 자체를 고정).
+_FUTURE_TOOL_NAMES_BY_KEYWORD = {
+    "channel_post": "sprintable_create_channel_post_draft",
+    "site_post": "sprintable_create_site_post_draft",
+    "channel_connection": "sprintable_list_channel_connections",
+    "post_comment": "sprintable_list_channel_post_comments",
+    "insight": "sprintable_get_insight_snapshot",
+}
+
+
+def test_each_declared_keyword_classifies_into_content():
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+    from sprintable_mcp.toolset import tool_group as vendored_tool_group
+
+    for keyword, name in _FUTURE_TOOL_NAMES_BY_KEYWORD.items():
+        assert backend_tool_group(name) == "content", f"{keyword} 키워드 매칭 실패: {name}"
+        assert vendored_tool_group(name) == "content", f"{keyword} 키워드 매칭 실패(vendored): {name}"
+
+
+def test_withdraw_alone_is_not_a_content_keyword():
+    """의도적 제외(모듈 주석 참고) — "withdraw" 하나만으로는 content로 안 끌려온다. 미래의
+    무관한 인출류 도구(예: 지갑/보상 인출)가 이 그룹으로 오분류되는 것을 막는다."""
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+
+    assert backend_tool_group("sprintable_withdraw_wallet_balance") != "content"
+
+
+def test_artifact_comment_tools_stay_in_canvas_not_content():
+    """⭐음성대조 — "post_comment"(구체 키워드)를 썼지 바로 "comment"를 쓰지 않은 이유.
+    sprintable_add_artifact_comment/list_artifact_comments는 "canvas" 그룹(story #2634
+    이전부터 확립) 그대로여야 한다 — 새 content 그룹이 이 기존 분류를 가로채면 안 된다."""
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+    from sprintable_mcp.toolset import tool_group as vendored_tool_group
+
+    for name in ("sprintable_add_artifact_comment", "sprintable_list_artifact_comments"):
+        assert backend_tool_group(name) == "canvas"
+        assert vendored_tool_group(name) == "canvas"
+
+
+def test_content_group_registered_in_all_groups_and_catalog_order():
+    from app.services.mcp_toolset import ALL_GROUPS, _CATALOG_DISPLAY_ORDER
+
+    assert "content" in ALL_GROUPS
+    assert "content" in _CATALOG_DISPLAY_ORDER
+
+
+def test_build_toolset_catalog_lists_content_group():
+    """toolset-catalog(picker SSOT) 응답에 "content" 그룹이 서는지(AC2). 실 소속 도구 개수는
+    #3614(sprintable_withdraw_channel_post_draft)의 병합 순서에 따라 이 워크트리 기준
+    0개일 수도 1개일 수도 있어(두 PR이 develop에 독립적으로 올라간다) 개수 자체는 안 박고,
+    그룹 존재·플래그·(있다면) 소속 도구가 전부 "content" 판정과 일치하는지만 고정한다."""
+    from app.services.mcp_toolset import build_toolset_catalog, tool_group
+
+    catalog = build_toolset_catalog()
+    groups_by_key = {g["key"]: g for g in catalog["groups"]}
+    assert "content" in groups_by_key
+    content_group = groups_by_key["content"]
+    assert content_group["is_core"] is False
+    assert content_group["is_destructive"] is False
+    for t in content_group["tools"]:
+        assert tool_group(t) == "content"

--- a/backend/tests/test_3631_role_templates_content_group.py
+++ b/backend/tests/test_3631_role_templates_content_group.py
@@ -1,4 +1,4 @@
-"""story #3631 — migration 0349: role_templates.default_tool_groups에 "content" 부여
+"""story #3631 — migration 0350: role_templates.default_tool_groups에 "content" 부여
 (growth-hacker·performance-marketer 2종 한정, 0181_role_templates_canvas_group.py와 동형
 scoped-UPDATE 패턴 — 0246처럼 전체가 아니다).
 
@@ -19,12 +19,12 @@ pytestmark = pytest.mark.destructive_schema
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 _MIG = os.path.join(
-    os.path.dirname(__file__), "..", "alembic", "versions", "0349_role_templates_content_group.py"
+    os.path.dirname(__file__), "..", "alembic", "versions", "0350_role_templates_content_group.py"
 )
 
 
 def _load_migration():
-    spec = importlib.util.spec_from_file_location("mig0349", _MIG)
+    spec = importlib.util.spec_from_file_location("mig0350", _MIG)
     m = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(m)
     return m

--- a/backend/tests/test_3631_role_templates_content_group.py
+++ b/backend/tests/test_3631_role_templates_content_group.py
@@ -1,0 +1,121 @@
+"""story #3631 — migration 0349: role_templates.default_tool_groups에 "content" 부여
+(growth-hacker·performance-marketer 2종 한정, 0181_role_templates_canvas_group.py와 동형
+scoped-UPDATE 패턴 — 0246처럼 전체가 아니다).
+
+검증 축(test_2635_role_templates_events_scope.py 관례 재사용):
+- AC1: 대상 2 role만 "content" 부여, 멱등(재실행 시 중복 없음).
+- AC2: is_tool_allowed 왕복 — 부여 후 content 그룹 도구가 실제로 열리는지.
+- AC3: 대상 밖 role(예: backend)은 오염 0.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_MIG = os.path.join(
+    os.path.dirname(__file__), "..", "alembic", "versions", "0349_role_templates_content_group.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("mig0349", _MIG)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _run_migration_fn(eng, mig, fn_name: str) -> None:
+    import sqlalchemy as sa
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+
+    with eng.begin() as c:
+        with Operations.context(MigrationContext.configure(c)):
+            getattr(mig, fn_name)()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_only_target_roles_receive_content_grant_and_idempotent():
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+
+    try:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS role_templates"))
+            c.execute(sa.text(
+                "CREATE TABLE role_templates (id uuid PRIMARY KEY, slug text NOT NULL UNIQUE, "
+                "default_tool_groups text[] NOT NULL DEFAULT '{}')"
+            ))
+            for slug, groups in (
+                ("growth-hacker", "ARRAY['stories','tasks','chat','docs','analytics','hypotheses']"),
+                ("performance-marketer", "ARRAY['stories','tasks','chat','docs','analytics','hypotheses']"),
+                ("backend", "ARRAY['stories','tasks','canvas']"),
+                # 이미 "content"를 가진 행 — 멱등 검증용.
+                ("already-has-content", "ARRAY['stories','content']"),
+            ):
+                c.execute(sa.text(
+                    f"INSERT INTO role_templates (id, slug, default_tool_groups) VALUES (:id, :slug, {groups})"
+                ), {"id": str(uuid.uuid4()), "slug": slug})
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        with eng.begin() as c:
+            rows = c.execute(sa.text("SELECT slug, default_tool_groups FROM role_templates")).fetchall()
+        by_slug = {r[0]: list(r[1]) for r in rows}
+
+        # AC1: 대상 2 role만 부여.
+        assert "content" in by_slug["growth-hacker"]
+        assert "content" in by_slug["performance-marketer"]
+        # AC3: 대상 밖 role은 오염 0.
+        assert "content" not in by_slug["backend"]
+        assert by_slug["backend"] == ["stories", "tasks", "canvas"]
+
+        # 멱등: 이미 갖고 있던 행은 중복 삽입되지 않는다.
+        assert by_slug["already-has-content"].count("content") == 1
+
+        before = {k: list(v) for k, v in by_slug.items()}
+        _run_migration_fn(eng, mig, "upgrade")
+        with eng.begin() as c:
+            rows2 = c.execute(sa.text("SELECT slug, default_tool_groups FROM role_templates")).fetchall()
+        after = {r[0]: list(r[1]) for r in rows2}
+        assert after == before, "재실행 시 배열이 변해선 안 된다(멱등 위반)"
+
+        # downgrade — 대상 2 role만 걷힌다.
+        _run_migration_fn(eng, mig, "downgrade")
+        with eng.begin() as c:
+            rows3 = c.execute(sa.text("SELECT slug, default_tool_groups FROM role_templates")).fetchall()
+        after_down = {r[0]: list(r[1]) for r in rows3}
+        assert "content" not in after_down["growth-hacker"]
+        assert "content" not in after_down["performance-marketer"]
+        # downgrade가 content 아닌 기존 그룹은 안 건드렸는지도 확인.
+        assert "stories" in after_down["growth-hacker"]
+        assert "analytics" in after_down["performance-marketer"]
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS role_templates"))
+        eng.dispose()
+
+
+def test_is_tool_allowed_roundtrip_after_grant():
+    """AC2 — 그룹 문자열만 박고 끝내지 않는다: 부여된 default_tool_groups로 실제
+    content 그룹 도구가 True로 왕복되는지 직접 확인(synthetic 이름 — story #3631의
+    실 등록 도구는 story #3614/#3972 머지 시점에 달림, 키워드 매칭 자체는 독립적으로
+    검증 가능)."""
+    from app.services.mcp_toolset import is_tool_allowed
+
+    granted_groups = ["stories", "tasks", "chat", "content"]
+    assert is_tool_allowed("sprintable_withdraw_channel_post_draft", granted_groups) is True
+
+    ungranted_groups = ["stories", "tasks", "chat"]
+    assert is_tool_allowed("sprintable_withdraw_channel_post_draft", ungranted_groups) is False

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1058,6 +1058,11 @@
       "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
     },
     {
+      "file": "tests/test_3631_role_templates_content_group.py",
+      "sec": 1.0,
+      "source": "story-3631(2026-09-07, 로컬 실측 — test_2648과 동형 규모(role_templates 임시 테이블+마이그 upgrade/downgrade 2회 왕복), 0.21s wall — 인접 sibling(test_2635/2648)과 같은 자릿수로 등재)"
+    },
+    {
       "file": "tests/test_2637_preset_block_template_seed.py",
       "sec": 1.0,
       "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"


### PR DESCRIPTION
## 배경
story #3614 CHANGES가 `sprintable_withdraw_channel_post_draft`를 위해 "content" 그룹을 `channel_post` 키워드 하나로 최소 신설했다(PR#3972, 카탈로그 커버리지 공백 해소가 목적). 이 스토리는 그 위에 나머지 콘텐츠 도구 키워드를 마저 얹어 그룹을 완성하고, 실제로 도는 role_template 배선까지 끝낸다.

## 그룹 완성(SSOT+vendored)
`_GROUP_KEYWORDS`의 "content" 항목을 `("channel_post", "site_post", "channel_connection", "post_comment", "insight")` 5키워드로 확장(`app/services/mcp_toolset.py` + `sprintable_mcp/toolset.py` 동기화). 판단 근거:
- "comment"는 바로 안 쓴다 — `sprintable_add_artifact_comment`/`sprintable_list_artifact_comments`(canvas 그룹, "artifact" 키워드)와 겹친다. 리스트 순서(canvas가 먼저)상 실질 충돌은 없지만 "post_comment"(channel_post_comment류 실제 이름 패턴)로 더 구체화해 순서 의존성 자체를 없앤다.
- "withdraw"는 의도적으로 뺐다 — 이 동사 하나만으로 미래의 무관한 도구(예: 보상/지갑 인출류)까지 이 그룹으로 잘못 끌어올 위험이 크다. 지금 유일한 실 도구(`sprintable_withdraw_channel_post_draft`)는 "channel_post" 키워드로 이미 잡힌다.

## role_template 배선(dev 실측 — PO 요청)
`alembic/versions/0350_role_templates_content_group.py`(0181 canvas 전례와 동형 scoped UPDATE) — `growth-hacker`·`performance-marketer` 2 role_template.default_tool_groups에 "content" 추가.

**대상 role 선정 dev 실측표** (뭉클랩=customer zero, `GET /api/v2/team-members?type=agent` 활성 11 + 각 `GET /api/v2/agent-personas?agent_id=`):

| role_template | 에이전트 | content 부여 |
|---|---|---|
| growth-hacker | 담롱 온찬(1) | 있음(이 마이그) |
| performance-marketer | 댄 어윈(1) | 있음(이 마이그) |
| pm·ui-designer·qa-engineer·backend·frontend·mobile·security-engineer | 각 1 | 없음(범위밖) |
| (시스템 계정 2개) | persona 0건 | 해당없음 |

`category="marketing"` role은 performance-marketer 1개뿐이고 채널 포스트 초안/댓글 수집(story #3516 자체 서술 "마케팅운영")이 실업무 범위와 정확히 겹친다. growth-hacker는 0160에서 동시 seed된 인접 growth 직군이라 함께 추가. 전용 "content marketer"/"social media manager" role_template은 카탈로그에 아직 없음(신설은 범위 밖). 활성 11 전체를 훑어도 이 2 role 밖에서 recruit된 콘텐츠 전담 role은 0건 — 원안(0160 grep 기반)이 실측과 정확히 일치.

## alembic 번호 조율(PO 확정)
`#3978(SID:3620)=0349` → `이 스토리=0350`(down_revision "0349") → `#3987(SID:3635)=0351` — 3회 연속 번호 충돌을 PO가 사전 조율. `test_toolset_catalog.py` 그룹 수 pin 19→20(주석 귀속만 #3614→#3631로 정리).

## 테스트
- MCP 신규 6건(SSOT+vendored 분류·narrow scope 거부·explicit scope 허용·레거시 허용 불변·ALL_GROUPS·catalog 등재) + 기존 7건(#3614 정공법분) — 21 passed.
- role_template 마이그 신규 2건(0181 canvas·test_2635 관례 재사용 — AC1 대상2만 부여+멱등·AC2 is_tool_allowed 왕복·AC3 대상밖 오염0) + destructive 17건 — 19 passed.
- FE `toolset-catalog.test.ts` 22건, `tsc`/`eslint`/i18n 중복키 가드 클린.
- `destructive-schema-shard-weights.json` 신규 파일 등록(lint 가드 통과).

## 범위 밖
- REST 경계(`_PATH_GROUP_PREFIXES`) 등재 — #3614가 이미 구조적 사유(org-scoped path 표현 불가)로 보류·별건 후속.
- 다른 role_template(pm/qa 등) content 편입 — 0181 canvas 전례와 같은 이유로 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA