### PR TITLE
[SID:3627] prod 승격 — 온보딩 왕복·딥링크 휴먼 판정 + 체크리스트 org 스코프 + 개인 API 키 앵커 (3607·3627·3634 cherry-pick)

### DIFF
--- a/backend/app/routers/activation.py
+++ b/backend/app/routers/activation.py
@@ -12,7 +12,7 @@ from jose import JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import decode_email_unsubscribe_token
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id_no_project_gate
 from app.dependencies.database import get_db
 from app.models.user import User
 from app.services.onboarding_activation import get_activation_state, unsubscribe_user
@@ -37,11 +37,17 @@ def _err(code: str, message: str, status: int) -> JSONResponse:
 async def get_checklist(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
 ) -> dict:
+    """story #3607(prod 결함, 선생님 실측 2026-09-07) — `org_id`(요청의 X-Org-Id 헤더/JWT
+    org_id, membership 검증 완료)를 실어 판정 스코프를 "지금 보는 화면의 org"로 맞춘다.
+    이 유저가 그 org의 owner가 아니면 서비스 레이어가 기존 get_owner_org_id로 폴백
+    (resolve_activation_org_id 참고) — 요청 자체는 거부하지 않는다(project-gate 없는
+    org 멤버십만 필요, no_project_gate 변형을 쓰는 이유)."""
     user = await db.get(User, uuid.UUID(auth.user_id))
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    return await get_activation_state(db, user)
+    return await get_activation_state(db, user, requested_org_id=org_id)
 
 
 # unsubscribe는 이메일 링크 클릭이라 pre-auth(브라우저에 세션 없을 수 있음) — 토큰 자체가 인가.

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -37,18 +37,40 @@ async def _resolve_current_human_member(
     레거시 경로에서 OrgMember.id를 반환해(shadow 플래그 꺼짐이 기본) member_ssot 캐노니컬
     ``members.id``와 항상 같은 값이라는 보장에 기대지 않는다 — 여기서 직접
     ``Member.user_id == auth.user_id``로 해소(agent API key 경로는 애초에 사용 불가:
-    is_api_key=True면 이 함수를 부르는 라우트 자체가 human_api_key_id 발급 대상이 아님)."""
+    is_api_key=True면 이 함수를 부르는 라우트 자체가 human_api_key_id 발급 대상이 아님).
+
+    story #3634(BE·결함, 페드루 PO 確定 2026-09-07) — member SSOT Phase 0 이후 만들어진
+    org의 휴먼은 org_members 행만 있고 members 앵커 행이 없을 수 있다(migration 0075의
+    ``members.id == org_members.id`` 백필 불변식은 그 마이그 시점 한정 — 이후 신규
+    org_member는 아무도 앵커를 안 만든다, #3627/#3629와 같은 SSOT dual-table 결함
+    클래스). `human_api_keys.member_id`는 `members.id` FK(CASCADE)라 org_members.id로
+    그냥 갈음할 수 없다(conversation_participants류와 달리 FK가 실물로 걸려 있음) —
+    앵커 자체를 멱등 생성해야 한다. `ensure_human_member`(agent_anchor_sync.py, AC3-2c
+    grant write-sync가 이미 쓰는 같은 함수 — 새 판정자 발명 0)로 org_member.id 축에서
+    앵커를 만들고 다시 조회한다."""
     org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
     if not org_id_str:
         raise HTTPException(status_code=400, detail="org_id not resolvable from auth context")
+    org_id = uuid.UUID(org_id_str)
+    user_id = uuid.UUID(auth.user_id)
     member = (await session.execute(
         select(Member).where(
-            Member.user_id == uuid.UUID(auth.user_id),
-            Member.org_id == uuid.UUID(org_id_str),
+            Member.user_id == user_id,
+            Member.org_id == org_id,
             Member.type == "human",
             Member.deleted_at.is_(None),
         )
     )).scalar_one_or_none()
+    if member is None:
+        from app.services.agent_anchor_sync import ensure_human_member
+
+        org_member = (await session.execute(
+            select(OrgMember).where(
+                OrgMember.user_id == user_id, OrgMember.org_id == org_id, OrgMember.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if org_member is not None and await ensure_human_member(session, org_member.id):
+            member = await session.get(Member, org_member.id)
     if member is None:
         raise HTTPException(status_code=404, detail="Member not found")
     return member

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -41,6 +41,29 @@ async def get_owner_org_id(db: AsyncSession, user_id: uuid.UUID) -> uuid.UUID | 
     )).scalar_one_or_none()
 
 
+async def resolve_activation_org_id(
+    db: AsyncSession, user_id: uuid.UUID, requested_org_id: uuid.UUID | None,
+) -> uuid.UUID | None:
+    """story #3607(prod 결함, 선생님 실측 2026-09-07, 페드루 PO 確定) — 체크리스트/딥링크
+    판정 스코프. `get_owner_org_id`(가장 이른 owner org)는 "현재 화면이 보고 있는 org"와
+    무관해, owner org가 둘 이상인 유저는 배너가 뜬 org와 다른 org 기준으로 판정됐다
+    (dev 실측: sellerking이 moonklabs 화면에서 PO Test Org 기준 판정을 받음).
+
+    `requested_org_id`가 있고 그 org에서 이 유저가 owner이면 그 org를 그대로 쓴다(요청
+    컨텍스트 우선). 없거나(호출자가 컨텍스트를 안 준 리마인드 스윕 cron) 그 org의 owner가
+    아니면(예: 초대받아 참여 중인 org 화면을 보는 중) 기존 `get_owner_org_id`로 폴백 —
+    두 벌 판정자 발명이 아니라 같은 함수의 선택적 우선순위."""
+    if requested_org_id is not None:
+        is_owner_here = (await db.execute(
+            select(OrgMember.org_id).where(
+                OrgMember.user_id == user_id, OrgMember.org_id == requested_org_id, OrgMember.role == "owner",
+            )
+        )).scalar_one_or_none()
+        if is_owner_here is not None:
+            return is_owner_here
+    return await get_owner_org_id(db, user_id)
+
+
 async def is_org_agent_connected(db: AsyncSession, org_id: uuid.UUID) -> bool:
     """org 단위 사실 — 실연결(stdio verify 왕복 완주) 에이전트가 하나라도 있거나, 이미
     첫 왕복(휴먼→에이전트 응답)까지 완주했으면 True.
@@ -104,7 +127,9 @@ async def is_org_first_roundtrip_done(db: AsyncSession, org_id: uuid.UUID) -> bo
     return row is not None
 
 
-async def get_first_instruction_conversation_id(db: AsyncSession, org_id: uuid.UUID) -> uuid.UUID | None:
+async def get_first_instruction_conversation_id(
+    db: AsyncSession, org_id: uuid.UUID, requester_user_id: uuid.UUID,
+) -> uuid.UUID | None:
     """story #3201 — 체크리스트 "첫 지시 보내고 회신 받기" 클릭의 딥링크 타겟.
 
     DM 생성(`POST /api/conversations`)이 의도적으로 always-new라서(EF-S2/db75ecd0,
@@ -115,10 +140,28 @@ async def get_first_instruction_conversation_id(db: AsyncSession, org_id: uuid.U
       ②없으면 org 최초(created_at 가장 이른) agent 참여 DM.
       ③그것도 없으면 None — FE는 None이면 신규 DM 생성 CTA(story #3201 A안)를 그대로
         재사용한다(제3의 경로 발명 금지, PO 지시).
-    """
+
+    story #3607(prod 결함, 선생님 실측 2026-09-07) — ①②는 org 단위로만 골라 «요청 휴먼이
+    실제로 그 대화의 참여자인가»를 안 봤다. agent↔agent DM(요청 휴먼 비참여)도 ②에 걸려
+    골라지면 랜딩 뒤 발신이 403(conversations.py의 (conversation_id, member_id) 비참여자
+    거부와 동형 — 그 403 자체는 옳다, 애초에 링크가 거기로 가면 안 된다). `requester_user_id`
+    의 human TeamMember가 참여자인 대화만 후보로 좁힌다."""
     HumanMsg = aliased(ConversationMessage)
     HumanSender = aliased(TeamMember)
     AgentSender = aliased(TeamMember)
+    RequesterParticipant = aliased(ConversationParticipant)
+    RequesterMember = aliased(TeamMember)
+
+    requester_is_participant = (
+        select(RequesterParticipant.id)
+        .join(RequesterMember, RequesterMember.id == RequesterParticipant.member_id)
+        .where(
+            RequesterParticipant.conversation_id == Conversation.id,
+            RequesterMember.user_id == requester_user_id,
+            RequesterMember.type == "human",
+        )
+        .exists()
+    )
 
     human_before = (
         select(HumanMsg.id)
@@ -138,6 +181,7 @@ async def get_first_instruction_conversation_id(db: AsyncSession, org_id: uuid.U
             Conversation.org_id == org_id,
             AgentSender.type == "agent",
             human_before,
+            requester_is_participant,
         )
         .order_by(ConversationMessage.created_at.asc())
         .limit(1)
@@ -153,21 +197,29 @@ async def get_first_instruction_conversation_id(db: AsyncSession, org_id: uuid.U
             Conversation.org_id == org_id,
             Conversation.type == "dm",
             TeamMember.type == "agent",
+            requester_is_participant,
         )
         .order_by(Conversation.created_at.asc())
         .limit(1)
     )).scalar_one_or_none()
 
 
-async def get_activation_state(db: AsyncSession, user: User) -> dict:
-    """체크리스트/리마인드 공용 — 5단계 완료 여부 + 요약."""
-    org_id = await get_owner_org_id(db, user.id)
+async def get_activation_state(
+    db: AsyncSession, user: User, *, requested_org_id: uuid.UUID | None = None,
+) -> dict:
+    """체크리스트/리마인드 공용 — 5단계 완료 여부 + 요약.
+
+    story #3607(prod 결함, 페드루 PO 確定 2026-09-07) — `requested_org_id`는 HTTP 조회
+    (라우터가 요청의 X-Org-Id/JWT org_id를 검증해 넘긴다)에만 있고, 리마인드 스윕 cron
+    호출(`find_reminder_candidates`)은 안 준다 — 그쪽은 "대상 선별"이 목적이라 기존
+    `get_owner_org_id` 그대로(불변, resolve_activation_org_id의 폴백 분기와 동일값)."""
+    org_id = await resolve_activation_org_id(db, user.id, requested_org_id)
     agent_connected = await is_org_agent_connected(db, org_id) if org_id else False
     roundtrip_done = await is_org_first_roundtrip_done(db, org_id) if org_id else False
     # story #3201 — 체크리스트 "첫 지시…" 항목 클릭 딥링크. org_id 없으면(온보딩 미완주)
     # 애초에 org 스코프 쿼리 자체가 무의미 — None(FE 신규 DM CTA 폴백).
     first_instruction_conv_id = (
-        await get_first_instruction_conversation_id(db, org_id) if org_id else None
+        await get_first_instruction_conversation_id(db, org_id, user.id) if org_id else None
     )
     steps = {
         "signed_up": True,

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -19,7 +19,7 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
@@ -29,6 +29,31 @@ from app.models.team import TeamMember
 from app.models.user import User
 
 logger = logging.getLogger(__name__)
+
+
+def _is_human_member(member_id_col, *, user_id: uuid.UUID | None = None):
+    """story #3627(prod 결함, 페드루 PO 確定 2026-09-07) — 이 member_id가 「휴먼」인지
+    판정하는 유일한 자리(member_resolver.py 첫 줄과 같은 규칙, 새 판정자 발명 0).
+
+    E-MEMBER-SSOT Phase 0부터 JWT 휴먼의 참여자/발신자 id는 `org_members.id`다
+    (org_members 테이블 자체가 휴먼 전용이라 추가 type 조건 불요) — 그런데
+    이 모듈의 왕복·딥링크 판정은 여전히 `team_members(type='human')`로만 이었다.
+    team_members에 그 org의 휴먼 행이 하나도 없으면(SSOT 전환 이후 만들어진
+    org 다수) `human_before`·`requester_is_participant`가 영원히 false로
+    떨어져 "대화 中인데도 미완료·딥링크 null"이 났다(dev PO Test Org 실측).
+
+    둘 다 인정(OR) — legacy team_member(type='human') 행이 남아있는 org도
+    회귀 없이 그대로 통과해야 한다(#3607 기존 테스트가 그 표본).
+    `user_id`를 주면 그 유저 소유 여부까지, 안 주면 "휴먼이기만 하면" 통과."""
+    org_member_conditions = [OrgMember.id == member_id_col, OrgMember.deleted_at.is_(None)]
+    team_member_conditions = [TeamMember.id == member_id_col, TeamMember.type == "human"]
+    if user_id is not None:
+        org_member_conditions.append(OrgMember.user_id == user_id)
+        team_member_conditions.append(TeamMember.user_id == user_id)
+    return or_(
+        select(OrgMember.id).where(*org_member_conditions).exists(),
+        select(TeamMember.id).where(*team_member_conditions).exists(),
+    )
 
 
 async def get_owner_org_id(db: AsyncSession, user_id: uuid.UUID) -> uuid.UUID | None:
@@ -99,15 +124,13 @@ async def is_org_first_roundtrip_done(db: AsyncSession, org_id: uuid.UUID) -> bo
     """휴먼 발신 메시지 "이후"에 온 최초 agent 발신 메시지 존재(같은 conversation 안 순서조건).
     존재만 보면 #3157과 어긋난다(디디 지적) — 반드시 human_msg.created_at < agent_msg.created_at."""
     HumanMsg = aliased(ConversationMessage)
-    HumanSender = aliased(TeamMember)
     AgentSender = aliased(TeamMember)
 
     human_before = (
         select(HumanMsg.id)
-        .join(HumanSender, HumanSender.id == HumanMsg.sender_id)
         .where(
             HumanMsg.conversation_id == ConversationMessage.conversation_id,
-            HumanSender.type == "human",
+            _is_human_member(HumanMsg.sender_id),
             HumanMsg.created_at < ConversationMessage.created_at,
         )
         .exists()
@@ -147,28 +170,23 @@ async def get_first_instruction_conversation_id(
     거부와 동형 — 그 403 자체는 옳다, 애초에 링크가 거기로 가면 안 된다). `requester_user_id`
     의 human TeamMember가 참여자인 대화만 후보로 좁힌다."""
     HumanMsg = aliased(ConversationMessage)
-    HumanSender = aliased(TeamMember)
     AgentSender = aliased(TeamMember)
     RequesterParticipant = aliased(ConversationParticipant)
-    RequesterMember = aliased(TeamMember)
 
     requester_is_participant = (
         select(RequesterParticipant.id)
-        .join(RequesterMember, RequesterMember.id == RequesterParticipant.member_id)
         .where(
             RequesterParticipant.conversation_id == Conversation.id,
-            RequesterMember.user_id == requester_user_id,
-            RequesterMember.type == "human",
+            _is_human_member(RequesterParticipant.member_id, user_id=requester_user_id),
         )
         .exists()
     )
 
     human_before = (
         select(HumanMsg.id)
-        .join(HumanSender, HumanSender.id == HumanMsg.sender_id)
         .where(
             HumanMsg.conversation_id == ConversationMessage.conversation_id,
-            HumanSender.type == "human",
+            _is_human_member(HumanMsg.sender_id),
             HumanMsg.created_at < ConversationMessage.created_at,
         )
         .exists()

--- a/backend/tests/test_1940_human_api_keys.py
+++ b/backend/tests/test_1940_human_api_keys.py
@@ -423,3 +423,85 @@ async def test_router_cannot_revoke_other_humans_key():
             assert ei.value.status_code == 404
     finally:
         await engine.dispose()
+
+
+# ─── story #3634 — org_member만 있고 members 앵커 없는 휴먼도 발급돼야 한다 ─────
+# member SSOT Phase 0 이후 새 org의 휴먼은 org_members 행만 있을 수 있다(dev PO
+# Test Org 실물 모양) — human_api_keys.member_id는 members.id FK(CASCADE)라 앵커가
+# 없으면 발급 자체가 불가능했다(404). ensure_human_member(agent_anchor_sync.py,
+# 이미 다른 SSOT 자리들이 쓰는 같은 함수)로 앵커를 멱등 생성하고 재조회한다.
+
+
+async def _seed_org_member_only_human(session, org_id, user_id, *, role="member"):
+    """team_members/members 앵커가 아예 없는 SSOT-only 휴먼 — org_members 딱 1행만."""
+    from app.models.project import OrgMember
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role)
+    session.add(om)
+    await session.commit()
+    return om.id
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_org_member_only_human_can_create_and_list_api_keys():
+    """org_member만 있는 휴먼도 발급 200 — 이전엔 members 앵커가 없어 404였다."""
+    from app.models.member import Member
+    from app.routers.me import create_my_api_key, list_my_api_keys
+    from app.schemas.human_api_key import CreateHumanApiKeyRequest
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s, email="ssot-only-3634@example.com")
+            om_id = await _seed_org_member_only_human(s, org_id, user_id)
+            auth = _human_auth(user_id, org_id)
+
+            created = await create_my_api_key(
+                CreateHumanApiKeyRequest(name="my key", expires_at=None), session=s, auth=auth,
+            )
+            assert created.api_key.startswith("hu_live_")
+
+            # 0075 불변식(휴먼 members.id == org_members.id)대로 앵커가 멱등 생성됐어야.
+            anchor = await s.get(Member, om_id)
+            assert anchor is not None
+            assert anchor.type == "human"
+
+            listed = await list_my_api_keys(session=s, auth=auth)
+            assert len(listed) == 1
+            assert listed[0].id == created.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_org_member_only_human_without_ensure_human_member_still_404s(monkeypatch):
+    """뮤테이션 — ensure_human_member 호출을 지우면(옛 동작 재현) org_member-only
+    휴먼은 다시 404여야 한다(이 테스트가 실제로 그 경로를 검증한다는 증거)."""
+    import app.routers.me as me_module
+    from fastapi import HTTPException
+    from app.schemas.human_api_key import CreateHumanApiKeyRequest
+
+    async def _never_ensures(session, org_member_id):
+        return False
+
+    monkeypatch.setattr(
+        "app.services.agent_anchor_sync.ensure_human_member", _never_ensures,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s, email="ssot-only-mut-3634@example.com")
+            await _seed_org_member_only_human(s, org_id, user_id)
+            auth = _human_auth(user_id, org_id)
+
+            with pytest.raises(HTTPException) as ei:
+                await me_module.create_my_api_key(
+                    CreateHumanApiKeyRequest(expires_at=None), session=s, auth=auth,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3159_activation_router.py
+++ b/backend/tests/test_3159_activation_router.py
@@ -44,7 +44,7 @@ async def test_get_checklist_404_when_user_missing():
     db.get = AsyncMock(return_value=None)
     auth = type("A", (), {"user_id": str(uuid.uuid4())})()
     with pytest.raises(HTTPException) as ei:
-        await get_checklist(db=db, auth=auth)
+        await get_checklist(db=db, auth=auth, org_id=uuid.uuid4())
     assert ei.value.status_code == 404
 
 
@@ -58,13 +58,17 @@ async def test_get_checklist_returns_state():
     user = object()
     db.get = AsyncMock(return_value=user)
     auth = type("A", (), {"user_id": str(uuid.uuid4())})()
+    org_id = uuid.uuid4()
     state = {"steps": {"email_verified": True}, "completed": 3, "total": 5, "all_complete": False}
-    with patch("app.routers.activation.get_activation_state", AsyncMock(return_value=state)):
-        res = await get_checklist(db=db, auth=auth)
+    with patch("app.routers.activation.get_activation_state", AsyncMock(return_value=state)) as mocked:
+        res = await get_checklist(db=db, auth=auth, org_id=org_id)
     assert isinstance(res, dict)
     assert not hasattr(res, "status_code")  # JSONResponse류 자체래핑이면 이 속성이 있다 — 없어야 정공
     assert res["steps"]["email_verified"] is True
     assert "data" not in res  # {"data": {...}} 이중래핑 재발 방지
+    # story #3607(잔여, 페드루 PO 確定 2026-09-07) — 요청 org 컨텍스트가 서비스로 실제로
+    # 전달되는지(그냥 무시하고 옛 시그니처로 부르지 않는지) 호출 인자로 고정.
+    mocked.assert_awaited_once_with(db, user, requested_org_id=org_id)
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_3159_onboarding_activation_realdb.py
+++ b/backend/tests/test_3159_onboarding_activation_realdb.py
@@ -494,6 +494,128 @@ async def test_is_org_first_roundtrip_order_sensitive():
 
 
 @pytest.mark.anyio
+async def test_is_org_first_roundtrip_done_recognizes_org_member_only_human():
+    """story #3627(prod 결함, 페드루 PO 確定 2026-09-07) — E-MEMBER-SSOT Phase 0부터 JWT
+    휴먼의 sender_id는 `org_members.id`(별개 테이블 PK, `members`/`project_access`/
+    `team_members` 뷰와 겹치지 않는 id 공간)다. 이 휴먼이 `members` 행(따라서 team_members
+    뷰에 잡히는 legacy 행)이 하나도 없는 org(SSOT 전환 이후 만들어진 org 다수의 실제
+    모양, dev PO Test Org 실측과 동형)에서도 왕복 판정이 서야 한다 — org_members만
+    seed(members/project_access 0행)."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            proj = _uuid()
+            human_user = _uuid()
+            om_human = _uuid()
+            agent_member = _uuid()
+            app_id = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','story3159-o','free')"
+            ))
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{human_user}','story3159-ssot@t.test','x','U',true,false,0,false,0)"
+            ))
+            await s.execute(text(
+                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+            ))
+            # 휴먼은 org_members 딱 1행뿐 — members/project_access(따라서 team_members
+            # 뷰)에 이 사람 행이 아예 없다(그라운딩 확인: conversation_participants.
+            # member_id·conversation_messages.sender_id엔 real FK가 없어 org_members.id를
+            # 그대로 써도 무결성 위반 0 — 실물 스키마 확認).
+            await s.execute(text(
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{om_human}','{ORG}','{human_user}','member')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name) VALUES ('{agent_member}','{ORG}','agent','A')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES ('{app_id}','{agent_member}','{proj}')"
+            ))
+            await s.commit()
+
+            now = datetime.now(timezone.utc)
+            t0, t1 = now - timedelta(hours=1), now
+            conv = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{conv}','{ORG}','{proj}','group')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_messages (id,conversation_id,sender_id,content,created_at) VALUES "
+                f"('{_uuid()}','{conv}','{om_human}','hi(org_member만)','{t0.isoformat()}'),"
+                f"('{_uuid()}','{conv}','{agent_member}','hello','{t1.isoformat()}')"
+            ))
+            await s.commit()
+            assert (await svc.is_org_first_roundtrip_done(s, uuid.UUID(ORG))) is True
+        finally:
+            await _wipe(s, ORG)
+            await s.execute(text("DELETE FROM users WHERE email LIKE 'story3159-%'"))
+            await s.commit()
+    await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_first_instruction_conversation_id_org_member_only_human():
+    """story #3627 — 딥링크 축도 마찬가지: 요청 휴먼이 org_members에만 있어도(legacy
+    team_members 행 0) requester_is_participant가 그를 참여자로 인정해야 한다. 원본
+    실증(dev PO Test Org)은 정확히 이 모양이었다(human TeamMember 0행·API 참여자는
+    org_member ecc99eaf)."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            proj = _uuid()
+            human_user = _uuid()
+            om_human = _uuid()
+            agent_member = _uuid()
+            app_id = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','story3159-o','free')"
+            ))
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{human_user}','story3159-ssot2@t.test','x','U',true,false,0,false,0)"
+            ))
+            await s.execute(text(
+                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{om_human}','{ORG}','{human_user}','member')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name) VALUES ('{agent_member}','{ORG}','agent','A')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES ('{app_id}','{agent_member}','{proj}')"
+            ))
+            await s.commit()
+
+            # 대화 0건 — None(①).
+            assert (await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(human_user))) is None
+
+            dm = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type,created_at) VALUES "
+                f"('{dm}','{ORG}','{proj}','dm', now())"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_participants (id,conversation_id,member_id) VALUES "
+                f"('{_uuid()}','{dm}','{om_human}'),('{_uuid()}','{dm}','{agent_member}')"
+            ))
+            await s.commit()
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(human_user))
+            assert str(result) == dm, "org_member만 있는 휴먼도 참여자로 인정돼 딥링크가 나와야 한다(②)"
+        finally:
+            await _wipe(s, ORG)
+            await s.execute(text("DELETE FROM users WHERE email LIKE 'story3159-%'"))
+            await s.commit()
+    await eng.dispose()
+
+
+@pytest.mark.anyio
 async def test_find_reminder_candidates_window_dedup_optout_complete():
     eng, Session = await _engine()
     async with Session() as s:

--- a/backend/tests/test_3159_onboarding_activation_realdb.py
+++ b/backend/tests/test_3159_onboarding_activation_realdb.py
@@ -98,6 +98,59 @@ async def test_get_owner_org_id_only_owner_role():
 
 
 @pytest.mark.anyio
+async def test_resolve_activation_org_id_prefers_requested_context_when_owner_there():
+    """story #3607(prod 결함, 선생님 실측 2026-09-07) — owner org가 둘 이상인 유저가 화면에
+    떠 있는(요청 컨텍스트) org에서 owner이면, 「가장 이른 owner org」가 아니라 그 org로
+    판정한다. 컨텍스트가 없으면(cron 등) 기존 get_owner_org_id 그대로."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            earliest_org, later_org, unrelated_org = ORG, _uuid(), _uuid()
+            owner_user = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan,created_at) VALUES "
+                f"('{earliest_org}','O','story3159-o','free', now() - interval '2 days'),"
+                f"('{later_org}','O2','story3159-o2','free', now())"
+            ))
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{owner_user}','story3159-2owners@t.test','x','U',true,false,0,false,0)"
+            ))
+            await s.execute(text(
+                f"INSERT INTO org_members (id,org_id,user_id,role,created_at) VALUES "
+                f"('{_uuid()}','{earliest_org}','{owner_user}','owner', now() - interval '2 days'),"
+                f"('{_uuid()}','{later_org}','{owner_user}','owner', now())"
+            ))
+            await s.commit()
+
+            # 컨텍스트 없음(cron 등) — 기존 동작: 가장 이른 owner org.
+            no_context = await svc.resolve_activation_org_id(s, uuid.UUID(owner_user), None)
+            assert str(no_context) == earliest_org
+
+            # 요청 컨텍스트=later_org(화면이 지금 보는 org), 그 org의 owner — 그 org로 판정.
+            with_context = await svc.resolve_activation_org_id(s, uuid.UUID(owner_user), uuid.UUID(later_org))
+            assert str(with_context) == later_org
+
+            # 요청 컨텍스트가 이 유저가 owner가 아닌(또는 소속조차 아닌) org면 — 폴백.
+            unrelated_org = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{unrelated_org}','O3','story3159-o3','free')"
+            ))
+            await s.commit()
+            fallback = await svc.resolve_activation_org_id(s, uuid.UUID(owner_user), uuid.UUID(unrelated_org))
+            assert str(fallback) == earliest_org
+        finally:
+            await _wipe(s, ORG)
+            await s.execute(text(f"DELETE FROM organizations WHERE id='{later_org}'"))
+            await s.execute(text(f"DELETE FROM organizations WHERE id='{unrelated_org}'"))
+            await s.execute(text(f"DELETE FROM users WHERE email LIKE 'story3159-%'"))
+            await s.commit()
+    await eng.dispose()
+
+
+@pytest.mark.anyio
 async def test_is_org_agent_connected_requires_real_verify_not_just_member_record():
     """story #3193 근본수정 — 예전엔 agent 멤버 레코드 **존재**만으로 True였다("생성"을
     "연결"로 오판정: 연결 스텝을 건너뛰어도 레코드는 남아 체크리스트가 거짓 완료를 표시
@@ -211,16 +264,28 @@ async def test_get_first_instruction_conversation_id_priority_order():
         try:
             proj = _uuid()
             human_member, agent_member = _uuid(), _uuid()
+            human_user = _uuid()
             app_id = _uuid()
             await s.execute(text(
                 f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','story3159-o','free')"
             ))
             await s.execute(text(
-                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{human_user}','story3159-requester@t.test','x','U',true,false,0,false,0)"
             ))
             await s.execute(text(
-                f"INSERT INTO members (id,org_id,type,name) VALUES "
-                f"('{human_member}','{ORG}','human','H'),('{agent_member}','{ORG}','agent','A')"
+                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+            ))
+            # story #3607(잔여, 페드루 PO 確定 2026-09-07) — human_member에 user_id를 실어야
+            # team_members 뷰(migration 0088)의 user_id가 채워진다 — get_first_instruction_
+            # conversation_id의 새 requester_is_participant 필터가 이 값으로 매치한다.
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name,user_id) VALUES "
+                f"('{human_member}','{ORG}','human','H','{human_user}')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name) VALUES ('{agent_member}','{ORG}','agent','A')"
             ))
             await s.execute(text(
                 f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES ('{app_id}','{agent_member}','{proj}')"
@@ -231,7 +296,7 @@ async def test_get_first_instruction_conversation_id_priority_order():
             await s.commit()
 
             # ① org에 대화 0건 — None.
-            assert (await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG))) is None
+            assert (await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(human_user))) is None
 
             # ② DM 1개 생성(왕복 前) — 그 DM이 반환돼야.
             dm1 = _uuid()
@@ -244,7 +309,7 @@ async def test_get_first_instruction_conversation_id_priority_order():
                 f"('{_uuid()}','{dm1}','{human_member}'),('{_uuid()}','{dm1}','{agent_member}')"
             ))
             await s.commit()
-            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG))
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(human_user))
             assert str(result) == dm1
 
             # ②b DM을 하나 더(더 이른 created_at) 만들면 org 최초(가장 이른) 쪽이 반환돼야.
@@ -258,7 +323,7 @@ async def test_get_first_instruction_conversation_id_priority_order():
                 f"('{_uuid()}','{dm0}','{human_member}'),('{_uuid()}','{dm0}','{agent_member}')"
             ))
             await s.commit()
-            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG))
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(human_user))
             assert str(result) == dm0
 
             # ③ 왕복(휴먼→에이전트 응답) 성사된 대화가 생기면, DM들보다 우선해 그게 반환돼야.
@@ -268,16 +333,99 @@ async def test_get_first_instruction_conversation_id_priority_order():
             await s.execute(text(
                 f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{roundtrip_conv}','{ORG}','{proj}','group')"
             ))
+            # story #3607(잔여) — conversation_participants는 dm뿐 아니라 group도 채워야
+            # 새 requester_is_participant 필터가 이 대화를 인정한다(conversations.py의
+            # (conversation_id, member_id) 매치 0행=비참여자 규칙은 dm/group 공통).
+            await s.execute(text(
+                f"INSERT INTO conversation_participants (id,conversation_id,member_id) VALUES "
+                f"('{_uuid()}','{roundtrip_conv}','{human_member}'),('{_uuid()}','{roundtrip_conv}','{agent_member}')"
+            ))
             await s.execute(text(
                 f"INSERT INTO conversation_messages (id,conversation_id,sender_id,content,created_at) VALUES "
                 f"('{_uuid()}','{roundtrip_conv}','{human_member}','hi','{t0.isoformat()}'),"
                 f"('{_uuid()}','{roundtrip_conv}','{agent_member}','hello','{t1.isoformat()}')"
             ))
             await s.commit()
-            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG))
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(human_user))
             assert str(result) == roundtrip_conv
         finally:
             await _wipe(s, ORG)
+    await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_first_instruction_conversation_id_excludes_dm_requester_not_participant():
+    """story #3607(prod 결함, 선생님 실측 2026-09-07) — agent↔agent DM(요청 휴먼 비참여)은
+    ②에서 절대 고르지 않는다. 요청 휴먼(human_user)이 이 org의 다른 사람이라(participant
+    아님) DM이 있어도 None — 랜딩 뒤 403이 나는 자리로 딥링크가 안 간다."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            proj = _uuid()
+            requester_member, agent1, agent2 = _uuid(), _uuid(), _uuid()
+            requester_user, other_user = _uuid(), _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','story3159-o','free')"
+            ))
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{requester_user}','story3159-req@t.test','x','U',true,false,0,false,0),"
+                f"('{other_user}','story3159-other@t.test','x','U2',true,false,0,false,0)"
+            ))
+            await s.execute(text(
+                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name,user_id) VALUES "
+                f"('{requester_member}','{ORG}','human','Requester','{requester_user}')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name) VALUES "
+                f"('{agent1}','{ORG}','agent','A1'),('{agent2}','{ORG}','agent','A2')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES "
+                f"('{_uuid()}','{agent1}','{proj}'),('{_uuid()}','{agent2}','{proj}')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO project_access (id,project_id,member_id,role) VALUES ('{_uuid()}','{proj}','{requester_member}','member')"
+            ))
+            await s.commit()
+
+            # agent↔agent DM만 있고, 요청 휴먼이 참여하는 대화가 org 안에 하나도 없다.
+            agent_dm = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type,created_at) VALUES "
+                f"('{agent_dm}','{ORG}','{proj}','dm', now() - interval '1 hour')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_participants (id,conversation_id,member_id) VALUES "
+                f"('{_uuid()}','{agent_dm}','{agent1}'),('{_uuid()}','{agent_dm}','{agent2}')"
+            ))
+            await s.commit()
+
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(requester_user))
+            assert result is None, "요청 휴먼이 비참여자인 agent↔agent DM을 골라선 안 된다"
+
+            # 요청 휴먼이 실제로 참여하는 DM이 하나 더 생기면 그건 정상적으로 반환돼야.
+            human_dm = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type,created_at) VALUES "
+                f"('{human_dm}','{ORG}','{proj}','dm', now())"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_participants (id,conversation_id,member_id) VALUES "
+                f"('{_uuid()}','{human_dm}','{requester_member}'),('{_uuid()}','{human_dm}','{agent1}')"
+            ))
+            await s.commit()
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG), uuid.UUID(requester_user))
+            assert str(result) == human_dm
+        finally:
+            await _wipe(s, ORG)
+            await s.execute(text(f"DELETE FROM users WHERE email LIKE 'story3159-%'"))
+            await s.commit()
     await eng.dispose()
 
 


### PR DESCRIPTION
## prod 승격 — 선생님 신고 «온보딩 4/5·대화 中인데 미완료·403» 근본 수정 3건 (cherry-pick만·그 외 develop 변경 미포함)

승인: 선생님 채팅 2026-09-07 10:37Z 「진행 바라는」(결재 카드 674ebfaa 상신 뒤·prod 승격은 명시 허가만).

| develop 커밋 | 스토리 | 내용 |
|---|---|---|
| 59fde2e16 (#3962) | 3607 | 온보딩 체크리스트 org 컨텍스트 무시 + 딥링크 비참여자 agent DM 선택 |
| 51bcf4c5c (#3980) | 3627 | 왕복·딥링크 휴먼 판정이 org_member SSOT 경로를 놓침(휴먼=org_member 또는 legacy team_member) |
| 3d1dc5b4c (#3985) | 3634 | 개인 API 키 발급이 members 앵커 없는 휴먼에서 404 → ensure_human_member 멱등 생성 |

main(fb228908f) 위 cherry-pick 3건 clean(dry-run 확認·6파일 +481/-27). 의존: `ensure_human_member`(agent_anchor_sync)는 main에 이미 존재.

### dev 라이브 실측(배포 48·49 · dev-app·CF 경유)
- 3607 AC2: org 스코프 배너·휴먼 첫 지시 POST 201(배포 48) · PO Test Org 화면 3/5 배너 노출·moonklabs 화면 숨김(scope_is_requested_org).
- 3627: PO Test Org checklist `first_instruction_conversation_id` null(배포 前)→`3d2e8247…`(배포 49) · first_roundtrip=false는 에이전트 미연결이라 정답.
- 3634: **라이브 미실측(지름길 표기)** — apps/web에 개인 API 키 소비자 0이라 BE 직접 호출 필요·테스트 2+뮤테이션 2·코드 경로만. 뿌리(앵커 백필)는 3635(#3987 대기).

### QA(카디르) — 승격 PR도 QA 필수
- 세 커밋의 diff가 develop 원본과 byte-identical(cherry-pick -x)·main 위에서 테스트 초록·main 필수 체크 3종.

### prod 배포 뒤
- GHA Cloud Build(main push) success → prod /api/v2/health 200(읽기만) → 선생님 화면에서 온보딩 4/5·딥링크 재확認(PO는 prod 무접촉).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182uJVpCN88jojW8nH8SBrc
