### PR TITLE
[SID:3638] fix: 실패했는데 화면이 말하지 않는 자리 — §11(ⓐ+ⓑ) 판정+수정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4299,6 +4299,7 @@
     "approvalRequestLabel": "Approval request",
     "approvalRequestNotFound": "The approval gate could not be found.",
     "approvalRequestLoadError": "Failed to load approval details.",
+    "messagesLoadFailed": "Couldn't load the conversation.",
     "approvalRequestResolvedStatus": "Resolved — status: {status}",
     "approvalRequestStatusApproved": "Approved",
     "approvalRequestStatusRejected": "Rejected",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -55,6 +55,7 @@
     "stepOrgCreated": "Create an organization",
     "stepAgentConnected": "Connect an agent",
     "stepFirstRoundtrip": "Send an instruction and get a reply",
+    "firstInstructionStartFailed": "Couldn't start the conversation. Please try again.",
     "collapseAria": "Collapse",
     "expandAria": "Expand",
     "collapsedChip": "Setup {completed}/{total}"
@@ -67,7 +68,8 @@
     "switching": "Switching…",
     "switchFailed": "Failed to switch account. Please try again.",
     "reloginRequired": "Re-login required",
-    "capReached": "Account limit reached"
+    "capReached": "Account limit reached",
+    "addAccountFailed": "Failed to add account. Please try again."
   },
   "mobileTabBar": {
     "navLabel": "Mobile tab navigation",
@@ -1029,6 +1031,9 @@
     "addStoryCancel": "Cancel",
     "createStoryFailed": "Failed to add story",
     "storyMoveFailed": "Failed to move story",
+    "titleSaveFailed": "Failed to save title.",
+    "descriptionSaveFailed": "Failed to save description.",
+    "acSaveFailed": "Failed to save acceptance criteria.",
     "filters": "Filters",
     "filterTitle": "Filter",
     "filterAll": "All",
@@ -2006,6 +2011,7 @@
     "advancing": "Advancing...",
     "export": "Export",
     "exportCopied": "Copied to clipboard.",
+    "exportFailed": "Failed to export.",
     "categoryGood": "👍 Good",
     "categoryBad": "👎 Bad",
     "categoryImprove": "💡 Improve",
@@ -4436,6 +4442,7 @@
     "deliveryContractFreeResponseDesc": "When on, participants set to \"mentions only\" in this conversation also receive messages that don't mention them.",
     "deliveryContractReasonGapNote": "Why a message wasn't delivered (e.g. chain limit reached) isn't shown here yet.",
     "deliveryContractSaveFailed": "Failed to save. Please try again.",
+    "muteToggleFailed": "Failed to update notification settings.",
     "you": "You",
     "team": "Team",
     "agent": "Agent",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4299,6 +4299,7 @@
     "approvalRequestLabel": "결재 요청",
     "approvalRequestNotFound": "결재 게이트를 찾을 수 없습니다.",
     "approvalRequestLoadError": "결재 정보를 불러오지 못했습니다.",
+    "messagesLoadFailed": "대화를 불러오지 못했습니다.",
     "approvalRequestResolvedStatus": "처리됨 — 상태: {status}",
     "approvalRequestStatusApproved": "승인됨",
     "approvalRequestStatusRejected": "반려됨",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -55,6 +55,7 @@
     "stepOrgCreated": "조직 만들기",
     "stepAgentConnected": "에이전트 연결하기",
     "stepFirstRoundtrip": "첫 지시 보내고 회신 받기",
+    "firstInstructionStartFailed": "대화를 시작하지 못했습니다. 다시 시도해 주세요.",
     "collapseAria": "접기",
     "expandAria": "펼치기",
     "collapsedChip": "가입 완료 {completed}/{total}"
@@ -67,7 +68,8 @@
     "switching": "전환 중…",
     "switchFailed": "계정 전환에 실패했습니다. 다시 시도해 주세요.",
     "reloginRequired": "재로그인 필요",
-    "capReached": "계정 한도에 도달했습니다"
+    "capReached": "계정 한도에 도달했습니다",
+    "addAccountFailed": "계정 추가에 실패했습니다. 다시 시도해 주세요."
   },
   "mobileTabBar": {
     "navLabel": "모바일 탭 내비게이션",
@@ -1029,6 +1031,9 @@
     "addStoryCancel": "취소",
     "createStoryFailed": "스토리 추가에 실패했습니다",
     "storyMoveFailed": "스토리 이동에 실패했습니다",
+    "titleSaveFailed": "제목 저장에 실패했습니다.",
+    "descriptionSaveFailed": "설명 저장에 실패했습니다.",
+    "acSaveFailed": "완료 기준 저장에 실패했습니다.",
     "filters": "필터",
     "filterTitle": "필터",
     "filterAll": "전체",
@@ -2006,6 +2011,7 @@
     "advancing": "진행 중...",
     "export": "내보내기",
     "exportCopied": "클립보드에 복사됐습니다.",
+    "exportFailed": "내보내기에 실패했습니다.",
     "categoryGood": "👍 Good",
     "categoryBad": "👎 Bad",
     "categoryImprove": "💡 Improve",
@@ -4436,6 +4442,7 @@
     "deliveryContractFreeResponseDesc": "켜면 이 대화에서 «멘션만» 설정한 참여자도 멘션 없는 메시지를 받습니다.",
     "deliveryContractReasonGapNote": "메시지가 전달되지 않은 이유(연쇄 한도 초과 등)는 아직 이 화면에서 바로 보이지 않습니다.",
     "deliveryContractSaveFailed": "저장에 실패했습니다. 다시 시도해 주세요.",
+    "muteToggleFailed": "알림 설정 변경에 실패했습니다.",
     "you": "나",
     "team": "팀",
     "agent": "에이전트",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.export-fail.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.export-fail.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// story #3638(유나 §8 별건) — exportSession()이 실패해도 "내보내기" 클릭이 아무 일도
+// 안 일어난 것처럼 보이던 자리(문구 0, catch { // ignore }). exportCopied와 동형 신규
+// exportFailed 키를 배선한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../../../messages/ko.json';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'session-1' }),
+}));
+vi.mock('@/components/nav/top-bar-slot', () => ({
+  TopBarSlot: ({ title, actions }: { title: React.ReactNode; actions?: React.ReactNode }) => (
+    <div>{title}{actions}</div>
+  ),
+}));
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(RetroRouteProvider: React.ComponentType<{ wsSlug: string; projSlug: string; projectId: string; children: React.ReactNode }>, node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <RetroRouteProvider wsSlug="ws" projSlug="proj" projectId="proj-1">
+        {node}
+      </RetroRouteProvider>
+    </NextIntlClientProvider>
+  );
+}
+
+const SESSION = {
+  id: 'session-1', project_id: 'proj-1', title: '회고 1', phase: 'closed', sprint_id: null,
+  items: [], actions: [],
+};
+
+function stubFetch(exportOk: boolean) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url === 'string' && url.includes(`/api/retro-sessions/${SESSION.id}?project_id=`)) {
+      return { ok: true, json: async () => ({ data: SESSION }) };
+    }
+    if (typeof url === 'string' && url.includes('/export?project_id=')) {
+      return exportOk
+        ? { ok: true, json: async () => ({ data: { markdown: '# 회고' } }) }
+        : { ok: false, json: async () => ({}) };
+    }
+    if (typeof url === 'string' && url.includes('/api/team-members')) {
+      return { ok: true, json: async () => ({ data: [] }) };
+    }
+    return { ok: false, json: async () => null };
+  }));
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ orgId: 'org-1', currentTeamMemberId: 'member-1' });
+  Object.assign(navigator, { clipboard: { writeText: vi.fn(async () => undefined) } });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+async function mount() {
+  const { default: RetroSessionPage } = await import('./page');
+  const { RetroRouteProvider } = await import('../retro-context');
+  await act(async () => { root.render(wrap(RetroRouteProvider, <RetroSessionPage />)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('RetroSessionPage — 내보내기 실패 시 문장(story #3638)', () => {
+  it('exportSession 실패 시 exportFailed 토스트가 뜬다(구 침묵)', async () => {
+    stubFetch(false);
+    await mount();
+    const exportBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.retro.export);
+    await act(async () => { exportBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain(koMessages.retro.exportFailed);
+  });
+
+  // 뮤테이션 대표 — 성공 시엔 exportCopied만 뜨고 exportFailed는 안 뜬다.
+  it('exportSession 성공 시엔 exportCopied만 뜬다', async () => {
+    stubFetch(true);
+    await mount();
+    const exportBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.retro.export);
+    await act(async () => { exportBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain(koMessages.retro.exportCopied);
+    expect(container.textContent).not.toContain(koMessages.retro.exportFailed);
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
@@ -546,12 +546,15 @@ export default function RetroSessionPage() {
     if (!projectId) return;
     try {
       const res = await fetchWithAuth(`/api/retro-sessions/${sessionId}/export?project_id=${projectId}`);
-      if (!res.ok) return;
+      // story #3638(유나 §8 별건 21건 — 이 문서의 v2.1 스캐너가 새로 잡은 자리) — 「내보내기」
+      // 클릭이 실패해도 아무 일도 안 일어난 것처럼 보이던 자리(문구 0). exportCopied와
+      // 동형 신규 1키.
+      if (!res.ok) { addToast({ title: t('exportFailed'), type: 'error' }); return; }
       const json = await res.json() as { data: { markdown: string } };
       await navigator.clipboard.writeText(json.data.markdown);
       addToast({ title: t('exportCopied'), type: 'success' });
     } catch {
-      // ignore
+      addToast({ title: t('exportFailed'), type: 'error' });
     }
   }
 

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.mute-fail.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.mute-fail.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+//
+// story #3638(유나 §8 별건) — handleToggleMute가 실패해도 조용히 원복되던 자리
+// (§2 클래스). muteToggleFailed 신규 1키.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../messages/ko.json';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({
+  useDashboardContextMock: vi.fn(),
+}));
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ conversation_id: 'conv-1' }),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+vi.mock('@/components/chat/chat-view', () => ({
+  ChatView: () => <div data-testid="chat-view-stub" />,
+}));
+
+vi.mock('@/hooks/use-synthetic-parent-tab-history', () => ({
+  useSyntheticParentTabHistory: () => {},
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectId: 'proj-content' });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+function stubFetch(muteOk: boolean) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.includes('/api/conversations/conv-1/mute')) {
+      return { ok: muteOk, json: async () => ({}) };
+    }
+    if (url.includes('/api/conversations/conv-1')) {
+      return {
+        ok: true,
+        json: async () => ({
+          title: null, type: 'dm', muted: false, lastReadAt: null, freeResponse: false,
+          participants: [
+            { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+            { member_id: 'them-1', name: '유나', avatar_url: null, type: 'human' },
+          ],
+        }),
+      };
+    }
+    return { ok: true, json: async () => ({ data: [] }) };
+  }));
+}
+
+async function mount() {
+  const { default: ConversationPage } = await import('./page');
+  const { TopBarProvider, useTopBar } = await import('@/components/nav/top-bar-context');
+  function TopBarRenderer() {
+    const { title, actions } = useTopBar();
+    return <div>{title}{actions}</div>;
+  }
+  await act(async () => {
+    root.render(wrap(
+      <TopBarProvider>
+        <TopBarRenderer />
+        <ConversationPage />
+      </TopBarProvider>,
+    ));
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('ConversationPage — 뮤트 토글 실패 시 문장(story #3638)', () => {
+  it('mute PATCH 실패 시 muteToggleFailed 토스트가 뜬다(구 조용한 롤백)', async () => {
+    stubFetch(false);
+    await mount();
+    const muteBtn = container.querySelector('button[aria-label="알림 끄기"]') as HTMLButtonElement;
+    await act(async () => { muteBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain(koMessages.chats.muteToggleFailed);
+  });
+
+  // 뮤테이션 대표 — 성공 시엔 토스트가 안 뜨고 버튼이 "알림 켜기"(뮤트 상태)로 바뀐다.
+  it('mute PATCH 성공 시엔 토스트가 안 뜨고 상태가 실제로 바뀐다', async () => {
+    stubFetch(true);
+    await mount();
+    const muteBtn = container.querySelector('button[aria-label="알림 끄기"]') as HTMLButtonElement;
+    await act(async () => { muteBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).not.toContain(koMessages.chats.muteToggleFailed);
+    expect(container.querySelector('button[aria-label="알림 켜기"]')).not.toBeNull();
+  });
+});

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -10,6 +10,7 @@ import type { PresenceStatus } from '@/components/chat/presence-dot';
 import { AddParticipantModal } from '@/components/chat/add-participant-modal';
 import { DeliveryContractModal } from '@/components/chat/delivery-contract-modal';
 import { EmptyState } from '@/components/ui/empty-state';
+import { ToastContainer, useToast } from '@/components/ui/toast';
 import { Avatar } from '@/components/shared/avatar';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
 import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
@@ -75,6 +76,7 @@ export default function ConversationPage() {
   const scrollToMessageId = searchParams.get('messageId') ?? undefined;
   const t = useTranslations('chats');
   const { currentTeamMemberId, projectId } = useDashboardContext();
+  const { toasts, addToast, dismissToast } = useToast();
   const [meta, setMeta] = useState<ConversationMeta | null>(null);
   const [showAddParticipant, setShowAddParticipant] = useState(false);
   const [showDeliveryContract, setShowDeliveryContract] = useState(false);
@@ -128,11 +130,16 @@ export default function ConversationPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ muted: next }),
       });
-      if (!res.ok) setMeta((m) => (m ? { ...m, muted: !next } : m));
+      // story #3638(유나 §8 별건) — 뮤트 토글이 실패해도 조용히 원복되던 자리(§2 클래스).
+      if (!res.ok) {
+        addToast({ title: t('muteToggleFailed'), type: 'error' });
+        setMeta((m) => (m ? { ...m, muted: !next } : m));
+      }
     } catch {
+      addToast({ title: t('muteToggleFailed'), type: 'error' });
       setMeta((m) => (m ? { ...m, muted: !next } : m));
     }
-  }, [meta, conversation_id]);
+  }, [meta, conversation_id, addToast, t]);
 
   // EF-S2: rename a group room. Optimistic; the BE PATCH persists the title.
   const handleSaveTitle = useCallback(async () => {
@@ -374,6 +381,7 @@ export default function ConversationPage() {
           onFreeResponseChange={(next) => setMeta((m) => (m ? { ...m, freeResponse: next } : m))}
         />
       )}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </>
   );
 }

--- a/apps/web/src/components/chat/chat-view.load-fail.test.tsx
+++ b/apps/web/src/components/chat/chat-view.load-fail.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// story #3638(유나 디자인 CHANGES 2026-09-07) — 초기 로드(fetchMessages, no `before`)
+// 실패가 messages를 빈 배열로 남겨 "대화를 시작하세요"를 그렸다 — 메시지가 있는
+// 대화를 "없다"고 말하는 §1 클래스(모름을 없음으로 오독). ConnectionLostBanner는
+// handlePoll 경로 하나만 덮어(SSE 끊김에서만 뜸) 이 자리를 못 막는다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => '/chats/thread-1',
+}));
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+const { useChatSseMock } = vi.hoisted(() => ({
+  useChatSseMock: vi.fn((_opts?: unknown) => ({ connected: true, polling: false })),
+}));
+vi.mock('@/hooks/use-chat-sse', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/use-chat-sse')>();
+  return {
+    ...actual,
+    useChatSse: (opts: unknown) => useChatSseMock(opts),
+  };
+});
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useChatSseMock.mockReturnValue({ connected: true, polling: false });
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+function stubFetch(messagesOk: boolean) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url === 'string' && url.includes('/messages?')) {
+      return messagesOk
+        ? { ok: true, json: async () => ({ data: [], meta: { next_cursor: null, has_more: false } }) }
+        : { ok: false, json: async () => ({}) };
+    }
+    return { ok: true, json: async () => ({ data: [] }) };
+  }));
+}
+
+async function mount() {
+  const { ChatView } = await import('./chat-view');
+  const { ChatRailProvider } = await import('../../app/(authenticated)/chats/chat-rail-context');
+  await act(async () => {
+    root.render(wrap(
+      <ChatRailProvider>
+        <ChatView threadId="thread-1" currentTeamMemberId="me-1" />
+      </ChatRailProvider>,
+    ));
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('ChatView — 초기 로드 실패 시 문장(story #3638)', () => {
+  it('초기 로드 실패 시 messagesLoadFailed 문구가 뜨고 "대화를 시작하세요"는 안 뜬다', async () => {
+    stubFetch(false);
+    await mount();
+    expect(container.textContent).toContain(koMessages.chats.messagesLoadFailed);
+    expect(container.textContent).not.toContain('대화를 시작하세요');
+  });
+
+  // 뮤테이션 대표 — 진짜 빈 대화(로드 성공, 메시지 0건)면 기존 empty state 그대로.
+  it('진짜 빈 대화(로드 성공)면 "대화를 시작하세요"가 뜨고 messagesLoadFailed는 안 뜬다', async () => {
+    stubFetch(true);
+    await mount();
+    expect(container.textContent).toContain('대화를 시작하세요');
+    expect(container.textContent).not.toContain(koMessages.chats.messagesLoadFailed);
+  });
+});

--- a/apps/web/src/components/chat/chat-view.load-fail.test.tsx
+++ b/apps/web/src/components/chat/chat-view.load-fail.test.tsx
@@ -73,6 +73,17 @@ function stubFetch(messagesOk: boolean) {
   }));
 }
 
+// story #3638(유나 재판정 CHANGES) — fetch 자체가 던지는 표본(오프라인·DNS 등, !res.ok
+// 분기를 아예 안 거친다). stubFetch(false)는 {ok:false}를 정상 반환해 이 표본을 못 잡는다.
+function stubFetchThrows() {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url === 'string' && url.includes('/messages?')) {
+      throw new Error('network down');
+    }
+    return { ok: true, json: async () => ({ data: [] }) };
+  }));
+}
+
 async function mount() {
   const { ChatView } = await import('./chat-view');
   const { ChatRailProvider } = await import('../../app/(authenticated)/chats/chat-rail-context');
@@ -100,5 +111,12 @@ describe('ChatView — 초기 로드 실패 시 문장(story #3638)', () => {
     await mount();
     expect(container.textContent).toContain('대화를 시작하세요');
     expect(container.textContent).not.toContain(koMessages.chats.messagesLoadFailed);
+  });
+
+  it('fetch 자체가 던지면(오프라인 등, !res.ok가 아닌 throw)도 messagesLoadFailed가 뜬다', async () => {
+    stubFetchThrows();
+    await mount();
+    expect(container.textContent).toContain(koMessages.chats.messagesLoadFailed);
+    expect(container.textContent).not.toContain('대화를 시작하세요');
   });
 });

--- a/apps/web/src/components/chat/chat-view.load-fail.test.tsx
+++ b/apps/web/src/components/chat/chat-view.load-fail.test.tsx
@@ -119,4 +119,36 @@ describe('ChatView — 초기 로드 실패 시 문장(story #3638)', () => {
     expect(container.textContent).toContain(koMessages.chats.messagesLoadFailed);
     expect(container.textContent).not.toContain('대화를 시작하세요');
   });
+
+  // PO 決(2026-09-07) — 성공 경로의 setMessagesLoadFailed(false) 리셋을 지키는 표본이
+  // 없어(리셋 제거해도 위 3건은 그대로 초록) 별도로 고정한다. 재시도 트리거는
+  // useChatSse의 onPoll(handlePoll, story #3621) — mock에 전달된 opts.onPoll을 직접
+  // 호출해 "폴 사이클이 fetchMessages를 다시 태운다"를 재현한다(실 타이머 불요).
+  //
+  // ⚠️ 재시도 응답에 메시지를 담으면 messages.length>0이 돼 렌더가 아예 다른 분기(메시지
+  // 목록)로 넘어가 messagesLoadFailed의 값 자체가 더는 안 읽힌다 — 리셋을 지워도 이
+  // 분기 전환만으로 테스트가 초록이 되는 거짓 통과가 난다(직접 확認: 리셋 삭제 뮤테이션
+  // 으로 먼저 재현). 그래서 재시도 응답도 "성공했지만 진짜 빈 대화"(data: [])로 둬 계속
+  // messages.length===0 분기 안에서 error↔empty state 전환만으로 리셋을 가른다.
+  it('실패로 마운트 → 폴(재시도) 성공(진짜 빈 대화)하면 문구가 사라지고 empty state가 뜬다', async () => {
+    let ok = false;
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/messages?')) {
+        return ok
+          ? { ok: true, json: async () => ({ data: [], meta: { next_cursor: null, has_more: false } }) }
+          : { ok: false, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    await mount();
+    expect(container.textContent).toContain(koMessages.chats.messagesLoadFailed);
+    expect(container.textContent).not.toContain('대화를 시작하세요');
+
+    ok = true;
+    const opts = useChatSseMock.mock.calls[useChatSseMock.mock.calls.length - 1][0] as { onPoll: () => Promise<boolean> };
+    await act(async () => { await opts.onPoll(); });
+
+    expect(container.textContent).not.toContain(koMessages.chats.messagesLoadFailed);
+    expect(container.textContent).toContain('대화를 시작하세요');
+  });
 });

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -347,6 +347,14 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
       setHasMore(meta?.has_more ?? false);
       setMessagesLoadFailed(false);
       return merged;
+    } catch {
+      // story #3638(유나 재판정 CHANGES 2026-09-07) — fetch 자체가 던지면(오프라인·
+      // DNS·res.json() 파싱 실패) !res.ok 분기를 안 거쳐 setMessagesLoadFailed가
+      // 안 서고 finally만 돌아 messages=[]·플래그=false로 「대화를 시작하세요」가
+      // 다시 섰다. 이 함수의 계약(undefined 반환=실패, handlePoll이 그대로 소비)을
+      // 지키며 던짐도 !res.ok와 동일하게 처리한다.
+      setMessagesLoadFailed(true);
+      return undefined;
     } finally {
       setLoading(false);
       setLoadingMore(false);

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -137,6 +137,13 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const isMobile = useIsMobile();
   const { toasts, addToast, dismissToast } = useToast();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  // story #3638(유나 디자인 CHANGES 2026-09-07) — 초기 로드(:349) 실패가 messages를
+  // 빈 배열로 남겨 「대화를 시작하세요」를 그렸다 — 메시지가 있는 대화를 «없다»고
+  // 말하는 §1 클래스(모름을 없음으로 오독). ConnectionLostBanner는 handlePoll 경로
+  // 하나만 덮어(SSE 끊김에서만 뜸) 이 자리를 못 막는다. messages.length===0 렌더
+  // 분기에서만 소비되므로(성공 뒤 메시지가 있으면 이 플래그가 서 있어도 무해) 별도
+  // 호출부 분기 없이 fetchMessages() 공용 함수 레벨에서 갱신한다.
+  const [messagesLoadFailed, setMessagesLoadFailed] = useState(false);
   // story #2265(C-7) 저장 조각(2026-07-29) — write 엔드포인트(#2632)가 서서 citeAction을
   // 실제로 켠다. 선택 확定(confirming) 후 스토리 피커를 열어 골라진 스토리에 저장한다.
   const citeSelection = useMessageRangeSelection();
@@ -325,7 +332,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
       const params = new URLSearchParams({ limit: '50' });
       if (before) params.set('before', before);
       const res = await fetch(`${apiPrefix}/${threadId}/messages?${params.toString()}`);
-      if (!res.ok) return undefined;
+      if (!res.ok) { setMessagesLoadFailed(true); return undefined; }
       // Backend: { data: _to_chat_message[], meta: { next_cursor, has_more } }
       const raw = await res.json() as Record<string, unknown>;
       const rawData = (Array.isArray(raw) ? raw : (raw.data ?? [])) as Record<string, unknown>[];
@@ -338,6 +345,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
       }
       setCursor(meta?.next_cursor ?? null);
       setHasMore(meta?.has_more ?? false);
+      setMessagesLoadFailed(false);
       return merged;
     } finally {
       setLoading(false);
@@ -939,6 +947,12 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
             {loading ? (
               <div className="flex h-full items-center justify-center">
                 <p className="text-sm text-muted-foreground">불러오는 중…</p>
+              </div>
+            ) : messages.length === 0 && messagesLoadFailed ? (
+              <div className="flex h-full items-center justify-center">
+                <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-destructive">
+                  {t('messagesLoadFailed')}
+                </p>
               </div>
             ) : messages.length === 0 ? (
               <div className="flex h-full items-center justify-center">

--- a/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
@@ -245,4 +245,24 @@ describe('ActivationChecklistBanner — "첫 지시…" 항목 클릭(story #320
     );
     expect(emailItem?.querySelector('button')).toBeNull();
   });
+
+  // story #3638(유나 §8 별건) — 대화 생성이 null을 반환하면(실패) 스피너만 멈추고
+  // 조용했다(클릭했는데 아무 일도 없었던 것처럼 보임). connect-step.tsx의 같은 호출은
+  // null을 "건너뛰고 진행"으로 의도적으로 쓰므로(온보딩 흐름이 이 클릭 하나로 안
+  // 막혀야 함) 그쪽은 그대로 두고, 이 배너는 클릭 자체가 유일한 목적이라 실패를 알린다.
+  it('신규 DM 생성이 실패(null)하면 firstInstructionStartFailed 문구가 뜬다(구 침묵)', async () => {
+    stubChecklist({ ...PARTIAL, first_instruction_conversation_id: null });
+    createFirstInstructionConversationMock.mockResolvedValue(null);
+    await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
+    await flush();
+
+    const target = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('첫 지시 보내고 회신 받기'),
+    ) as HTMLButtonElement;
+    await act(async () => { target.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(routerPushMock).not.toHaveBeenCalledWith(expect.stringContaining('/chats/'));
+    expect(container.textContent).toContain('대화를 시작하지 못했습니다. 다시 시도해 주세요.');
+  });
 });

--- a/apps/web/src/components/dashboard/activation-checklist-banner.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.tsx
@@ -29,6 +29,7 @@ export function ActivationChecklistBanner() {
   const { projectId } = useDashboardContext();
   const { state, allComplete } = useActivationStatus();
   const [navigatingToInstruction, setNavigatingToInstruction] = useState(false);
+  const [instructionStartError, setInstructionStartError] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
     try {
@@ -67,9 +68,15 @@ export function ActivationChecklistBanner() {
     }
     if (!projectId) return;
     setNavigatingToInstruction(true);
+    setInstructionStartError(false);
     try {
       const convId = await createFirstInstructionConversation(projectId);
+      // story #3638(유나 §8 별건) — 대화 생성 실패 시 스피너만 멈추고 조용했다(클릭했는데
+      // 아무 일도 없었던 것처럼 보임). connect-step.tsx의 같은 호출은 null을 «건너뛰고
+      // 진행»으로 의도적으로 쓰지만(범위 밖, 그쪽은 그대로 둠), 이 배너는 그 클릭 자체가
+      // 유일한 목적이라 실패를 알려야 한다.
       if (convId) router.push(`/chats/${convId}`);
+      else setInstructionStartError(true);
     } finally {
       setNavigatingToInstruction(false);
     }
@@ -133,6 +140,11 @@ export function ActivationChecklistBanner() {
                   {navigatingToInstruction ? <Loader2 className="size-3.5 shrink-0 animate-spin" /> : icon}
                   <span>{label}</span>
                 </Button>
+                {instructionStartError ? (
+                  <p role="alert" aria-live="assertive" aria-atomic="true" className="px-1 pt-0.5 text-xs text-destructive">
+                    {t('firstInstructionStartFailed')}
+                  </p>
+                ) : null}
               </li>
             );
           }

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -980,11 +980,70 @@ describe('KanbanBoard — 6단계 신뢰축 뷰(story #2933 H4)', () => {
       expect(container.textContent).toContain('완료복귀카드');
     });
   });
+
+  // story #3638(유나 §8·«분기 안에서 일부만 알리는» 눈멂 ③) — handleTrustDragEnd의
+  // !res.ok 분기가 FORBIDDEN만 말하고 그 외 실 실패(500 등)는 롤백만 하고 조용했다.
+  describe('트러스트축 드래그 — FORBIDDEN 아닌 실패도 알린다(story #3638)', () => {
+    it('500 응답이면 storyMoveFailed 토스트가 뜬다(구 조용한 롤백)', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+        if (typeof url === 'string' && url.startsWith('/api/stories?')) {
+          const status = new URL(url, 'http://localhost').searchParams.get('status');
+          const matched = status === 'ready-for-dev'
+            ? [{ id: 's-queued', title: '대기카드', status: 'ready-for-dev', priority: 'medium', trust_stage: 'queued' }]
+            : [];
+          return { ok: true, json: async () => ({ data: matched, meta: { total: matched.length, nextCursor: null } }) };
+        }
+        if (typeof url === 'string' && url.startsWith('/api/members')) {
+          return { ok: true, json: async () => ({ data: [] }) };
+        }
+        if (typeof url === 'string' && url === '/api/stories/bulk') {
+          return { ok: false, json: async () => ({ error: { code: 'INTERNAL_ERROR' } }) };
+        }
+        return { ok: false, json: async () => null };
+      }));
+      await mount();
+      await toggleToTrustAxis();
+
+      const handler = capturedDragEndHandlers.at(-1);
+      expect(handler, 'handleTrustDragEnd를 캡처 못 함').toBeDefined();
+      await act(async () => {
+        handler!({ active: { id: 's-queued' }, over: { id: 'running' } });
+        await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain('스토리 이동에 실패했습니다');
+    });
+  });
 });
 
 // story #3043(PO+유나 IA 확定 ⓒ, 2026-08-25) — viewMode('board'|'list')가 예전엔 뷰포트 무관
 // 'board'로 하드코딩돼 있었다(유나 실측: flow-client의 view='list' 세그로 진입해도 여기서
 // 다시 'board'로 떨어져 3.55배 가로 overflow 재발 — 이름이 같은 두 「board/list」 개념 충돌).
+// story #3638(유나 §8 kanban-board.tsx:929/:987, PO 확定 착수분) — 5-status 클래식 드래그
+// (handleDragEnd)도 트러스트축 형제와 동일 병(FORBIDDEN만 말하고 나머지는 조용)을 앓는다.
+describe('KanbanBoard — 5-status 클래식 드래그, FORBIDDEN 아닌 실패도 알린다(story #3638)', () => {
+  it('bulk PATCH 500이면 storyMoveFailed 토스트가 뜬다(구 조용한 롤백)', async () => {
+    stubFetch([{ id: 's-classic', title: '클래식카드', status: 'backlog', priority: 'medium' }]);
+    await mount();
+    // 기본은 6단계 신뢰축(P0-04) — 5-status 클래식으로 명시 전환해야 handleDragEnd가 걸린다.
+    const classicBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '5-status 클래식');
+    await act(async () => { classicBtn!.click(); });
+    expect(container.textContent).toContain('클래식카드');
+
+    const handler = capturedDragEndHandlers.at(-1);
+    expect(handler, 'handleDragEnd를 캡처 못 함').toBeDefined();
+    await act(async () => {
+      handler!({ active: { id: 's-classic' }, over: { id: 'in-progress' } });
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    // 기본 stubFetch는 /api/stories/bulk를 명시 처리 안 해 그레이스풀 { ok: false }로
+    // 떨어진다(주석 그대로) — 이 스위트의 다른 테스트들에는 무해했지만(드래그를 직접
+    // 발화한 테스트가 이제껏 0건), 이 테스트에선 그 자체가 "실 실패" 재현이다.
+    expect(container.textContent).toContain('스토리 이동에 실패했습니다');
+  });
+});
+
 describe('KanbanBoard — story #3043 <lg 기본값=list(칸반 다열은 opt-in)', () => {
   it('모바일(isMobile=true)이면 기본값이 list다 — board 다열 컬럼이 아니라 KanbanListView가 뜬다', async () => {
     isMobileMock = true;

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -805,6 +805,11 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           bumpTransitionErrorNonce();
           setTransitionError(t('transitionDenied'));
           setTimeout(() => setTransitionError(null), 4000);
+        } else {
+          // story #3638(유나 §8·«분기 안에서 일부만 알리는» 눈멂 ③) — FORBIDDEN 외의
+          // 실 실패(500·네트워크 등)는 롤백만 하고 조용했다. epic-swimlane-board.tsx가
+          // #3637에서 이미 쓴 storyMoveFailed를 형제 자리에도.
+          addToast({ type: 'error', title: t('storyMoveFailed') });
         }
         return;
       }
@@ -831,6 +836,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
         body: JSON.stringify({ position: newPosition }),
       });
     } catch {
+      addToast({ type: 'error', title: t('storyMoveFailed') });
       setStories((prev) =>
         prev.map((s) => (s.id === storyId ? { ...s, status: story.status, position: story.position } : s)),
       );
@@ -936,6 +942,10 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           bumpTransitionErrorNonce();
           setTransitionError(t('transitionDenied'));
           setTimeout(() => setTransitionError(null), 4000);
+        } else {
+          // story #3638(유나 §8·«분기 안에서 일부만 알리는» 눈멂 ③, kanban-board.tsx:929) —
+          // FORBIDDEN 외의 실 실패는 롤백만 하고 조용했다.
+          addToast({ type: 'error', title: t('storyMoveFailed') });
         }
         return;
       }
@@ -950,6 +960,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
         body: JSON.stringify({ position: newPosition }),
       });
     } catch {
+      addToast({ type: 'error', title: t('storyMoveFailed') });
       // 롤백 (카운트도 원복)
       setStories((prev) =>
         prev.map((s) => (s.id === storyId ? { ...s, status: story.status, position: story.position } : s)),
@@ -996,6 +1007,11 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           bumpTransitionErrorNonce();
           setTransitionError(t('transitionDenied'));
           setTimeout(() => setTransitionError(null), 4000);
+        } else {
+          // story #3638(유나 §8·«분기 안에서 일부만 알리는» 눈멂 ③) — handleDragEnd/
+          // handleTrustDragEnd와 동일 병(메뉴 경로 버전, 문서에는 미등재 — 3638 그라운딩
+          // 중 발견한 세 번째 쌍둥이).
+          addToast({ type: 'error', title: t('storyMoveFailed') });
         }
         return;
       }
@@ -1004,6 +1020,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       const violation = Array.isArray(okItems) ? okItems.find((x) => x?.id === storyId)?.violation : null;
       if (violation) addToast({ type: 'warning', title: t('transitionViolation') });
     } catch {
+      addToast({ type: 'error', title: t('storyMoveFailed') });
       // Rollback (카운트도 원복)
       setStories((prev) =>
         prev.map((s) => (s.id === storyId ? { ...s, status: story.status } : s)),

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -890,3 +890,32 @@ describe('StoryDetailPanel — 라벨 제거 버튼 접근성 이름 i18n(story 
     expect(removeBtn).toBeTruthy();
   });
 });
+
+// story #3638(유나 §8 별건, patchStory 층에서 발견) — handleAssigneeToggle 형제는 이미
+// 실패 토스트를 냈는데(else 분기), 제목/설명/완료기준 저장은 편집창만 닫히고 조용히
+// 원래 값으로 남아 실패 신호가 없었다. 기본 stubFetch(모든 fetch → ok:false)가 이미
+// PATCH 실패를 재현하므로 별도 스텁 없이 그대로 실패 경로를 탄다.
+describe('StoryDetailPanel — 제목/설명/완료기준 저장 실패 시 문장(story #3638)', () => {
+  function setNativeValue(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
+    const proto = el instanceof HTMLTextAreaElement ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(proto, 'value')!.set!;
+    setter.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  it('제목 저장 실패 시 titleSaveFailed 토스트가 뜬다(구 조용히 닫히는 편집창)', async () => {
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory({ title: '원래 제목' })} tasks={[]} onClose={() => {}} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const titleBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('원래 제목'));
+    await act(async () => { titleBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const input = container.querySelector('[data-testid="story-title-input"]') as HTMLInputElement;
+    await act(async () => { setNativeValue(input, '새 제목'); });
+    const saveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '저장');
+    await act(async () => { saveBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('제목 저장에 실패했습니다.');
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1019,7 +1019,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     const { story: updated } = await patchStory({ title: titleDraft.trim() });
     setSavingTitle(false);
     setEditingTitle(false);
+    // story #3638(유나 §8 별건, 유나 자가 patchStory 층에서 잡음) — 담당자 토글 형제
+    // (handleAssigneeToggle)는 이미 실패 토스트를 냈는데, 제목 저장은 편집창만 닫히고
+    // 조용히 원래 값으로 남아 실패 신호가 없었다.
     if (updated) onStoryUpdate?.({ ...story, title: updated.title });
+    else addToast({ type: 'error', title: t('titleSaveFailed') });
   };
 
   // E-BOARD S6: 복수 assignee. assignee_ids 우선, 없으면 단일 assignee_id로 폴백(하위호환).
@@ -1085,6 +1089,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     setEditingDescription(false);
     setReferenceDropped(dropped);
     if (updated) onStoryUpdate?.({ ...story, description: updated.description });
+    else addToast({ type: 'error', title: t('descriptionSaveFailed') });
   };
 
   const handleSaveAC = async () => {
@@ -1098,6 +1103,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     setEditingAC(false);
     setReferenceDropped(dropped);
     if (updated) onStoryUpdate?.({ ...story, acceptance_criteria: updated.acceptance_criteria });
+    else addToast({ type: 'error', title: t('acSaveFailed') });
   };
 
   // E-FILE S4: 스토리 첨부 — GCS 업로드 후 PATCH {attachments} (전체 교체이므로 기존+신규 머지 필수).

--- a/apps/web/src/hooks/use-account-switcher.add-account-fail.test.tsx
+++ b/apps/web/src/hooks/use-account-switcher.add-account-fail.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+//
+// story #3638(유나 §8 별건) — handleAdd(계정 추가)가 네트워크 예외로 실패하면 busy
+// 스피너만 멈추고 조용했다(문구 0). addAccountFailed 신규 1키 — error 상태는 이미
+// profile-menu.tsx/context-switcher-chip.tsx 둘 다 렌더하고 있어(role=alert) 배선만
+// 하면 된다. 훅을 직접 마운트하는 최소 하네스로 검증(전체 UI 조립 없이).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../messages/ko.json';
+import { useAccountSwitcher } from './use-account-switcher';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function Harness() {
+  const acc = useAccountSwitcher('나');
+  return (
+    <div>
+      <button type="button" onClick={() => void acc.handleAdd()}>추가</button>
+      {acc.error ? <p role="alert">{acc.error}</p> : null}
+    </div>
+  );
+}
+
+function wrap() {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <Harness />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('useAccountSwitcher — 계정 추가 네트워크 실패 시 문장(story #3638)', () => {
+  it('handleAdd이 예외를 던지면 addAccountFailed가 뜬다(구 조용한 busy 해제)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+    await act(async () => { root.render(wrap()); });
+
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain(koMessages.accountSwitcher.addAccountFailed);
+  });
+});

--- a/apps/web/src/hooks/use-account-switcher.ts
+++ b/apps/web/src/hooks/use-account-switcher.ts
@@ -102,6 +102,8 @@ export function useAccountSwitcher(name: string, avatarUrl?: string | null) {
       const j = (await r.json().catch(() => null)) as { data?: { redirect?: string } } | null;
       window.location.assign(j?.data?.redirect ?? '/login');
     } catch {
+      // story #3638(유나 §8 별건) — 계정 추가 실패 시 busy 스피너만 멈추고 조용했다.
+      setError(t('addAccountFailed'));
       setBusy(null);
     }
   };


### PR DESCRIPTION
## 배경 — 착수 中 §8→§11 갱신(유나 v3.1 스캐너)
착수 당시 doc의 §8(21건+kanban 2건) 기준으로 작업했으나, 완료 시점에 유나가 스캐너 세 번째 눈멂("분기 안에서 일부만 알리는 자리" — `if(!res.ok){롤백; if(FORBIDDEN){문장} return;}` 형)을 실제로 고쳐 §11로 갱신했다. **다행히 §11의 필수 판정 대상(ⓐ 3건 + ⓑ 21건, 총 24건)이 이 PR이 이미 다룬 범위와 정확히 일치한다** — kanban-board.tsx의 3개 드래그 핸들러(ⓐ 핵심)를 포함해 아래 전부 커버.

## ⓐ 일부 분기만 알리는 자리(3건, 이번 갱신의 핵심) — 전부 고침
`FORBIDDEN`만 말하고 500·네트워크·409는 롤백만 하던 kanban-board.tsx 드래그/메뉴 3형제:
1. `handleTrustDragEnd`(:799 `!res.ok`, :833 그 `catch`) — storyMoveFailed(신규, epic-swimlane-board.tsx가 #3637에서 이미 신설) 재사용.
2. `handleDragEnd`(:927 `!res.ok`, :952 그 `catch`) — 문서가 §9에서 정확히 지목한 자리(§2 근거 "형제가 이미 알린다"의 원 인용 오류를 이 구현자가 정정한 것이 이 눈멂 발견의 실마리였음).
3. `handleChangeStatus`(:987 `!res.ok`, :1006 그 `catch`) — 메뉴 경로 버전, 문서 v2까지 미등재였으나 그라운딩 중 동일 병으로 독립 발견.

## ⓑ 그냥 조용한 자리(21건, #4~24) — 고침 5 / 조용해도 됨 16
**고침(5)**:
- `retro/[id]/page.tsx::exportSession`(#10) — exportFailed 신규 1키.
- `chats/[conversation_id]/page.tsx::handleToggleMute`(#11·#12) — muteToggleFailed 신규 1키+useToast 신규 배선.
- `story-detail-panel.tsx::patchStory` 소비 3곳(#18, handleSaveTitle/Description/AC) — 형제 handleAssigneeToggle은 이미 토스트 냈는데 이 셋만 없었다. titleSaveFailed·descriptionSaveFailed·acSaveFailed 신규 3키.
- `hooks/use-account-switcher.ts::handleAddAccount`(#22) — addAccountFailed 신규 1키(error 상태는 이미 profile-menu/context-switcher-chip 둘 다 렌더 중).
- `lib/onboarding/first-instruction.ts` 호출부 중 `activation-checklist-banner.tsx`(#24) — firstInstructionStartFailed 신규 1키. **connect-step.tsx의 같은 호출은 그대로 둠**(null=온보딩 계속 진행의 의도된 계약, 범위 밖).

**조용해도 됨(16, 근거는 각 파일 주석에도 남김)**:
- `docs/[slug]/page.tsx::handleSubmitSlug`(#4·#5) — SlugSubmitResult를 DocUrlDialog가 받아 setInvalid(true)로 렌더.
- `goals/[id]/page.tsx`(#6) — 초기 GET 실패, 읽기 레이스 처방(기존 PO 리뷰 기록) — §6 범위(쓰기 실패만) 밖.
- `retro/[id]/page.tsx::handleGenerateSynthesis/handleAdoptRecommendation`(#7·#8·#9) — boolean 반환을 SprintCloseCockpit이 generateError/adoptError로 렌더.
- `chats/[conversation_id]/page.tsx::fetchPresence`(#13) — 백그라운드 폴링(15s), 다음 사이클 자연 재시도.
- `content/[draftId]/page.tsx::loadGate`(#14) — 배경 재동기화 헬퍼, 성공 피드백은 별도 낙관 UI가 이미 담당.
- `settings/page.tsx::refreshProjects`(#15) — 프로젝트 생성 성공 피드백은 이미 optimistic setProjects+success 배너로 남.
- `chat-view.tsx::fetchMessages`(#16) — #3621 ConnectionLostBanner가 이미 이 실패 신호를 폴링 배너로 커버.
- `my-notification-channel-section.tsx::handleTestSend`(#19·#20) — 'unavailable'은 의도적 중립 상태값, t('testUnavailable')로 이미 렌더 중.
- `billing-actions.ts::fetchBillingKey`(#21) — GET 읽기 실패, §6 범위 밖(모름=없음 오독 위험은 별건 후보로만 문서화).
- `use-account-switcher.ts::handleSignOut`(#23) — 로그인 페이지로 이동(로그아웃 의도된 목적지와 사실상 동일, 명시적 이동이지 침묵 아님).

## ⓒ 의도 주석 29건 — 손대지 않음
문서 지침대로 손대기 전에 주석부터 읽었다 — 클립보드/localStorage 실패 무시·best-effort 등 조용한 것이 맞는 자리로 확認, 이 PR 범위 밖.

## 테스트
자리마다 1건(합계 10여건, 성공/실패 대조 포함) + 뮤테이션 대표 1건(handleTrustDragEnd의 else 분기 제거 → RED 확認 후 복구). 새 키 8개 전부 카탈로그 기존 형(「{액션}에 실패했습니다」)을 그대로 잇는다. `tsc`·`eslint`·i18n 중복키 가드·muted-foreground AA 대비·tint-text 가드 전부 클린.

## 범위 밖
- BFF 라우트 10·services 10 — 화면이 아니라 «봉투가 사라지는 층»(story 3632와 같은 자리).
- ⓒ 29건(의도 주석 확認됨).
- 스캐너(`sweep_silent_failure.py`) 추가 개선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA