### PR TITLE
[SID:3640] fix(BE): [sandbox:expire-after-publish] 마커 「영구 지뢰」화 방지 — 1회성으로

### DIFF
--- a/backend/alembic/versions/0350_channel_publication_sandbox_expired_once.py
+++ b/backend/alembic/versions/0350_channel_publication_sandbox_expired_once.py
@@ -1,0 +1,25 @@
+"""story #3640(BE·샌드박스 리그·소형, 페드루 PO 確定 2026-09-07) — `channel_publications`에
+`sandbox_expired_once` additive. `[sandbox:expire-after-publish]` 마커가 media_id에
+영구 접미사를 새겨 댓글 수집이 발행물마다 «매번» 401을 던지던 「영구 지뢰」(dev PO
+Test Org Sandbox Page 1 실사고)를 닫는다 — 이 발행물이 그 401을 이미 한 번 관측했으면
+(양성대조 완료) True, 그 뒤부터 channel_post_comments.py가 접미사를 벗긴 media_id로
+재조회해 200을 받는다."""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0350"
+down_revision = "0349"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE channel_publications ADD COLUMN IF NOT EXISTS sandbox_expired_once "
+        "boolean NOT NULL DEFAULT false"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE channel_publications DROP COLUMN IF EXISTS sandbox_expired_once")

--- a/backend/alembic/versions/0351_channel_publication_sandbox_expired_once.py
+++ b/backend/alembic/versions/0351_channel_publication_sandbox_expired_once.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 from alembic import op
 
-revision = "0350"
-down_revision = "0349"
+revision = "0351"
+down_revision = "0350"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/channel_publication.py
+++ b/backend/app/models/channel_publication.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Text, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -39,6 +39,13 @@ class ChannelPublication(Base):
     error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #3640(BE·샌드박스 리그·소형, 페드루 PO 確定 2026-09-07) — `[sandbox:
+    # expire-after-publish]` 마커가 발행 시 media_id에 영구 접미사를 새겨 fetch_replies가
+    # «매번» 401을 던지던 「영구 지뢰」를 닫는다. 이 발행물에서 그 401을 이미 한 번
+    # 관측했으면(양성대조 완료) True — channel_post_comments.py가 그 뒤부터 접미사를
+    # 벗긴 media_id로 재조회해 200을 받는다(sandbox 어댑터 자체는 결정적·상태 없음 그대로,
+    # 상태는 이 발행물 행에만 산다).
+    sandbox_expired_once: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -146,13 +146,39 @@ async def _fetch_replies_raw(
     if channel in ("sandbox", "instagram_sandbox"):
         if external_id is None:
             raise CommentFetchError(error_code="COMMENT_EXTERNAL_ID_MISSING", message="external_id가 없습니다")
+        # story #3640 — instagram_sandbox의 [sandbox:expire-after-publish] 마커가
+        # media_id에 새긴 영구 접미사를 fetch_replies가 볼 때마다 401을 던지던
+        # 「영구 지뢰」를 닫는다: 이 발행물이 이미 한 번 그 401을 관측했으면
+        # (sandbox_expired_once) 접미사를 벗긴 media_id로 불러 200을 받는다.
+        # sandbox_publish.py(channel="sandbox")엔 이 마커가 없어(그라운딩 확認)
+        # pub 조회 자체를 skip — 새 DB 왕복 0.
+        pub = None
+        effective_external_id = external_id
+        if channel == "instagram_sandbox":
+            from app.services.instagram_sandbox_publish import (
+                _EXPIRE_AFTER_PUBLISH_SUFFIX as _IG_EXPIRE_SUFFIX,
+            )
+
+            if external_id.endswith(_IG_EXPIRE_SUFFIX):
+                from app.models.channel_publication import ChannelPublication
+
+                pub = await db.get(ChannelPublication, publication_id)
+                if pub is not None and pub.sandbox_expired_once:
+                    effective_external_id = external_id[: -len(_IG_EXPIRE_SUFFIX)]
         _publish_client = get_publish_client_module(channel)
         from app.services.threads_publish import ThreadsPublishError
         import httpx
         try:
             async with httpx.AsyncClient() as client:
-                return await _publish_client.fetch_replies(client, access_token="sandbox", media_id=external_id)
+                return await _publish_client.fetch_replies(
+                    client, access_token="sandbox", media_id=effective_external_id,
+                )
         except ThreadsPublishError as exc:
+            # story #3640 — 위에서 접미사를 못 벗겼다(=이번이 첫 401)면 여기서
+            # 「관측했다」로 표시해 다음 틱부터 벗겨진 media_id로 부른다(AC1).
+            if pub is not None and not pub.sandbox_expired_once:
+                pub.sandbox_expired_once = True
+                await db.flush()
             # story #3597 — instagram_sandbox_publish.py::fetch_replies가 새
             # [sandbox:expire-after-publish] 마커로 401을 던지기 전까지는 이 분기가
             # 예외를 낼 일이 없어(sandbox_publish.py는 fetch_replies에서 절대
@@ -207,12 +233,36 @@ async def _fetch_replies_raw(
             error_code="COMMENT_CHANNEL_NOT_IMPLEMENTED", message=f"fetch_replies dispatch가 없습니다: {channel}",
         ) from exc
 
+    # story #3640 — facebook_sandbox의 [sandbox:expire-after-publish] 마커도 ig와
+    # 동형(영구 접미사 → 매 틱 401). 이 공용 블록이 이미 pub를 갖고 있어 sandbox
+    # 분기 재사용 없이 여기서 바로(실 threads/instagram/facebook은 접미사가 애초에
+    # 안 붙으니 이 if가 no-op).
+    effective_external_id = pub.external_id
+    if channel == "facebook_sandbox":
+        from app.services.facebook_sandbox_publish import (
+            _EXPIRE_AFTER_PUBLISH_SUFFIX as _FB_EXPIRE_SUFFIX,
+        )
+
+        if pub.external_id.endswith(_FB_EXPIRE_SUFFIX) and pub.sandbox_expired_once:
+            effective_external_id = pub.external_id[: -len(_FB_EXPIRE_SUFFIX)]
+
     import httpx
     try:
         async with httpx.AsyncClient() as client:
-            return await _publish_client.fetch_replies(client, access_token=access_token, media_id=pub.external_id)
+            return await _publish_client.fetch_replies(
+                client, access_token=access_token, media_id=effective_external_id,
+            )
     except Exception as exc:  # noqa: BLE001 — ThreadsPublishError는 상태코드로 분류(threads/instagram/facebook 공용)
         if isinstance(exc, ThreadsPublishError):
+            # story #3640 — 첫 401(=접미사를 못 벗겼다)이면 관측 기록.
+            if channel == "facebook_sandbox" and not pub.sandbox_expired_once:
+                from app.services.facebook_sandbox_publish import (
+                    _EXPIRE_AFTER_PUBLISH_SUFFIX as _FB_EXPIRE_SUFFIX,
+                )
+
+                if pub.external_id.endswith(_FB_EXPIRE_SUFFIX):
+                    pub.sandbox_expired_once = True
+                    await db.flush()
             # story #3605 — 위 sandbox 분기와 동일하게 classify_graph_error_code로
             # 교체(새 판정 로직 0, 공용 함수 재사용).
             from app.services.graph_api_errors import classify_graph_error_code

--- a/backend/tests/test_3597_ig_fb_connection_status_promote.py
+++ b/backend/tests/test_3597_ig_fb_connection_status_promote.py
@@ -361,3 +361,180 @@ async def test_facebook_sandbox_expire_after_publish_marker_promotes_status_expi
             assert conn.status == "expired"
     finally:
         await engine.dispose()
+
+
+# ─── story #3640(BE·샌드박스 리그·소형, 페드루 PO 確定 2026-09-07) — expire-after-
+# publish 마커의 「영구 지뢰」화 방지: 발행 뒤 첫 수집 1회만 401(위 두 테스트가
+# 고정하는 양성대조), 그 뒤(사람이 「다시 연결」한 뒤 등)는 정상 200·연결 active
+# 유지. dev PO Test Org Sandbox Page 1(641adabf)이 표본이 살아있는 한 영원히
+# 못 쓰던 실사고를 여기서 코드로 고정한다.
+
+
+async def _seed_second_tick(s, *, org_id, publication_id, channel, external_id, due_at):
+    """schedule_comment_collection은 (publication_id, due_at) UNIQUE라 첫 seed와
+    같은 anchor를 재사용하면 충돌한다 — 두 번째 수집 틱은 별도 due_at로 직접
+    삽입(헬퍼 재사용 없이 새 세팅 로직 발명 0, 컬럼은 schedule_comment_collection과
+    동형)."""
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    s.add(CommentCollectionSchedule(
+        id=uuid.uuid4(), org_id=org_id, publication_id=publication_id, channel=channel,
+        external_id=external_id, due_at=due_at, status="pending",
+    ))
+
+
+@pytest.mark.anyio
+async def test_instagram_sandbox_expire_after_publish_marker_second_collection_succeeds_and_stays_active():
+    """AC1 — 첫 수집(위 test_instagram_sandbox_expire_after_publish_marker_
+    promotes_status_expired와 동일 경로)은 401·expired 그대로, 두 번째 수집은
+    200·connection active 유지(사람이 「다시 연결」한 것과 동형 — 재연결 후 다음
+    틱이 또 만료시키던 실사고가 여기서 재현되면 이 테스트가 RED)."""
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+    import app.services.instagram_sandbox_publish as ig_sandbox
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram_sandbox")
+
+            creation_id = await ig_sandbox.create_container(
+                None, access_token="x", threads_user_id="u", text="[sandbox:expire-after-publish]",
+                image_url="https://example.com/i.jpg",
+            )
+            media_id = await ig_sandbox.publish_container(None, access_token="x", threads_user_id="u", creation_id=creation_id)
+
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="instagram_sandbox", external_id=media_id,
+            )
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="instagram_sandbox", external_id=media_id, anchor_at=anchor,
+            )
+            await s.commit()
+
+            counts = await process_due_comment_collections(s)
+            assert counts["failed"] == 1
+            await s.refresh(conn)
+            assert conn.status == "expired"
+
+            # 사람이 「다시 연결」(3613 AC3와 동형 — 여기선 status만 되돌린다, 그
+            # 다시연결 플로우 자체는 이 스토리 스코프 밖).
+            conn.status = "active"
+            await _seed_second_tick(
+                s, org_id=org_id, publication_id=pub.id, channel="instagram_sandbox", external_id=media_id,
+                due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+            )
+            await s.commit()
+
+            counts2 = await process_due_comment_collections(s)
+            assert counts2["failed"] == 0, f"두 번째 수집도 실패로 잡히면 안 된다: {counts2}"
+            assert counts2["captured"] == 1
+
+            await s.refresh(conn)
+            assert conn.status == "active", "두 번째 수집이 다시 연결을 expired로 되돌리면 안 된다(영구 지뢰 재발)"
+
+            await s.refresh(pub)
+            assert pub.sandbox_expired_once is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_facebook_sandbox_expire_after_publish_marker_second_collection_succeeds_and_stays_active():
+    """AC1(facebook_sandbox 짝) — ig와 동형."""
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+    import app.services.facebook_sandbox_publish as fb_sandbox
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook_sandbox")
+
+            creation_id = await fb_sandbox.create_container(
+                None, access_token="x", threads_user_id="u", text="[sandbox:expire-after-publish]",
+            )
+            media_id = await fb_sandbox.publish_container(None, access_token="x", threads_user_id="u", creation_id=creation_id)
+
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook_sandbox", external_id=media_id,
+            )
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox", external_id=media_id, anchor_at=anchor,
+            )
+            await s.commit()
+
+            counts = await process_due_comment_collections(s)
+            assert counts["failed"] == 1
+            await s.refresh(conn)
+            assert conn.status == "expired"
+
+            conn.status = "active"
+            await _seed_second_tick(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox", external_id=media_id,
+                due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+            )
+            await s.commit()
+
+            counts2 = await process_due_comment_collections(s)
+            assert counts2["failed"] == 0, f"두 번째 수집도 실패로 잡히면 안 된다: {counts2}"
+            assert counts2["captured"] == 1
+
+            await s.refresh(conn)
+            assert conn.status == "active"
+
+            await s.refresh(pub)
+            assert pub.sandbox_expired_once is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_instagram_sandbox_expire_marker_without_one_shot_flag_still_401s_mutation():
+    """뮤테이션(AC1) — sandbox_expired_once가 아직 False인 채로(=1회성 로직이
+    없었다면) 두 번째 수집을 돌리면 여전히 401·failed다. 위 성공 테스트가 실제로
+    이 결함을 잡는다는 증거(회귀 가드 자체를 검증) — pub.sandbox_expired_once를
+    다시 False로 되돌려 「관측 기록이 없었다」를 재현."""
+    from app.services.channel_post_comments import process_due_comment_collections, schedule_comment_collection
+    import app.services.instagram_sandbox_publish as ig_sandbox
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="instagram_sandbox")
+
+            creation_id = await ig_sandbox.create_container(
+                None, access_token="x", threads_user_id="u", text="[sandbox:expire-after-publish]",
+                image_url="https://example.com/i.jpg",
+            )
+            media_id = await ig_sandbox.publish_container(None, access_token="x", threads_user_id="u", creation_id=creation_id)
+
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="instagram_sandbox", external_id=media_id,
+            )
+            anchor = datetime.now(timezone.utc) - timedelta(hours=2)
+            await schedule_comment_collection(
+                s, org_id=org_id, publication_id=pub.id, channel="instagram_sandbox", external_id=media_id, anchor_at=anchor,
+            )
+            await s.commit()
+
+            await process_due_comment_collections(s)
+            await s.refresh(pub)
+            assert pub.sandbox_expired_once is True
+
+            # 뮤테이션 — 관측 기록을 되돌려 "1회성 로직이 없었다"를 재현.
+            pub.sandbox_expired_once = False
+            conn.status = "active"
+            await _seed_second_tick(
+                s, org_id=org_id, publication_id=pub.id, channel="instagram_sandbox", external_id=media_id,
+                due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+            )
+            await s.commit()
+
+            counts2 = await process_due_comment_collections(s)
+            assert counts2["failed"] == 1, "sandbox_expired_once 없이는 두 번째도 401(영구 지뢰) — 뮤테이션 RED 확認"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 실물
`instagram_sandbox_publish.py`/`facebook_sandbox_publish.py`의 `[sandbox:expire-after-publish]` 마커가 media_id/creation_id에 영구 접미사(`-expireafterpublish`)를 새기고 `fetch_replies`가 그 접미사만 보고 401을 던지는 구조라, 발행물이 존재하는 한 댓글 수집마다 **매번** 401을 냈다 — 사람이 「다시 연결」해도 다음 수집 틱에 같은 발행물이 또 401을 내 연결이 다시 expired로 떨어졌다(dev PO Test Org Sandbox Page 1 641adabf, 3597 회차 표본 d6c93d8b — 표본이 살아있는 한 그 연결은 영구히 못 쓴다).

## 처방
sandbox 어댑터 함수(`fetch_replies`) 자체는 **결정적·상태 없음** 계약을 그대로 유지한다(다른 sandbox 마커 전부와 동형 — 이 계약을 깨지 않는다). 상태는 `channel_publications.sandbox_expired_once`(migration 0350, additive)에 두고, 호출자(`channel_post_comments.py::_fetch_replies_raw`)가:
1. 이미 한 번 401을 관측했으면(`sandbox_expired_once=true`) media_id에서 접미사를 벗겨 sandbox 함수에 넘긴다 → 정상 200.
2. 처음 401을 맞으면 그 자리에서 true로 세팅.

instagram_sandbox(전용 분기)·facebook_sandbox(공용 DB-lookup 분기, channel gate) 둘 다 적용 — 실 threads/instagram/facebook은 이 신규 분기가 애초에 안 걸린다(channel 이름 gate, 회귀 0).

## AC1 — 테스트
`test_3597_ig_fb_connection_status_promote.py`:
- 첫 수집 401·expired 승격(기존 양성대조 2건, 회귀 0)
- 두 번째 수집 200·connection active 유지(ig/fb 각 1건, 신규)
- 뮤테이션 1건(`sandbox_expired_once`를 다시 false로 → 두 번째도 401)
- 소스 자체를 임시로 되돌리는 수동 뮤테이션(3건 모두 정확한 이유로 RED 확認 후 원복)

## AC2 — 문서
Sprintable doc "Threads 라이브 QA 런북"(05a772ac)에 IG/FB expire-after-publish 마커 절 신설 — 실사고·처방·**결정 지점 7곳(마커 11곳 중) 표**.

## AC3 — 라이브(dev PO Test Org·PO)
Page 1 재연결 뒤 다음 수집 틱에도 active 유지 — PO 라이브 확認 대기.

## AC4 — 표면 변화
0(디자인 판정 불필요).

## Test plan
- [x] 신규 4건 + 회귀 66건 전부 그린(70/70)
- [x] `app.main` import·`alembic upgrade head` 그린
- [ ] 라이브(dev PO Test Org, PO 몫)

🤖 Generated with [Claude Code](https://claude.com/claude-code)