### PR TITLE
[SID:3639] fix: 초안 폐기가 재시도 대기 中인 발행 command를 취소하지 않는다

### DIFF
--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -1908,6 +1908,28 @@ async def withdraw_channel_post_draft(
         if published is not None:
             raise ChannelPostDraftAlreadyPublishedError(draft_id)
 
+        # story #3639(3614 후속, 페드루 PO 確定 2026-09-07) — dev 실측: 승인된 초안을
+        # 발행 시도했다가 503(provider-error)로 pending·next_retry_at이 잡힌 채 withdraw
+        # 하면(게이트는 이미 approved라 위 "gate.status == pending" 분기가 안 닿는다)
+        # command가 살아서 재시도를 계속했다. 마커 표본은 영원히 실패하지만 진짜 일시
+        # 실패(네트워크·rate limit)였다면 다음 재시도가 성공해 "작성자가 폐기한 초안이
+        # 외부에 발행"된다 — 3614의 "닫는다"가 command 층까지 안 닿는 반쪽이었다.
+        # cancel_scheduled_publication(story #3419 AC1)과 동일 조건/전이(새 상태기계
+        # 0) — pending·blocked·dead_letter만 취소, in_progress/completed/voided/이미
+        # cancelled는 손 안 댐(레이스로 그 사이 워커가 이미 집었다면 그대로 진행되게
+        # 둔다 — 이 스토리는 "죽은 채 재시도만 남은" 경로를 닫는 것이지 진행 중인 발행을
+        # 가로채는 게 아니다).
+        command = (await db.execute(
+            select(PublicationCommand)
+            .where(PublicationCommand.gate_id == gate.id)
+            .order_by(PublicationCommand.created_at.desc())
+            .limit(1)
+            .with_for_update()
+        )).scalar_one_or_none()
+        if command is not None and command.status in _CANCELLABLE_COMMAND_STATUSES:
+            command.status = "cancelled"
+            command.reason_code = "CANCELLED_BY_HUMAN"
+
         if gate.status == "pending":
             from app.services.gate_service import transition_gate
 

--- a/backend/tests/test_3614_channel_post_draft_withdraw.py
+++ b/backend/tests/test_3614_channel_post_draft_withdraw.py
@@ -15,6 +15,7 @@ from tests.test_3414_publication_command_core import (
     _seed_org, _seed_agent, _seed_human, _seed_default_role, _seed_connection, _seed_story,
     _session_factory, _setup_org_scoped_app, _client_for, _draft_body,
 )
+from app.services.publication_command import process_due_publication_commands
 
 pytestmark = [pytest.mark.destructive_schema]
 
@@ -362,5 +363,141 @@ async def test_list_excludes_withdrawn_by_default_includes_with_flag():
             r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
             assert r_detail.status_code == 200, r_detail.text
             assert r_detail.json()["draft_status"] == "withdrawn"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_withdraw_cancels_pending_retry_command():
+    """story #3639(3614 후속) — dev 실측 재현: 승인된 초안을 발행 시도했다가 503으로
+    command_status=pending·next_attempt_at이 미래로 잡힌 채 withdraw하면(게이트는 이미
+    approved라 "gate.status == pending" 분기는 안 닿는다), command가 cancelled로
+    종결돼 워커 due 조회(process_due_publication_commands)에서 더는 안 집힌다. 마커
+    표본이 아니라 진짜 일시 실패였다면 다음 재시도가 성공해 "작성자가 폐기한 초안이
+    외부에 발행"되는 반쪽을 막는다."""
+    from app.main import app
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.models.publication_command import PublicationCommand
+    from datetime import datetime, timedelta, timezone
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r_submit = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={})
+            gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+        from tests.test_3414_publication_command_core import _approve_gate_directly
+
+        command_id = uuid.uuid4()
+        async with Session() as s:
+            await _approve_gate_directly(s, gate_id)
+            v = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalars().first()
+            # dev 실측 그대로 — 503(provider-error 마커) 뒤 워커가 남긴 pending·재시도
+            # 대기 command를 직접 심는다(이 테스트의 관심사는 withdraw의 취소 가드지
+            # 발행 파이프라인 자체가 아니다).
+            command = PublicationCommand(
+                id=command_id, org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=v.id, operation="publish", content_kind="channel_post",
+                status="pending", attempt_count=1,
+                next_attempt_at=datetime.now(timezone.utc) - timedelta(seconds=1),  # 이미 도래(due)
+                requested_by_member_id=human_id,
+            )
+            s.add(command)
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/withdraw")
+        assert r.status_code == 200, r.text
+
+        async with Session() as s:
+            refreshed = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == command_id)
+            )).scalar_one()
+            assert refreshed.status == "cancelled"
+            assert refreshed.reason_code == "CANCELLED_BY_HUMAN"
+
+        # AC1 — 워커 due 조회에서 실제로 빠지는지 직접 증명(단언만이 아니라 실제 워커
+        # 진입점을 태워 0건 처리됨을 확認).
+        async with Session() as s:
+            result = await process_due_publication_commands(s)
+            assert sum(result.values()) == 0, f"취소된 command가 워커에 집혔다: {result}"
+            refreshed = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == command_id)
+            )).scalar_one()
+            assert refreshed.status == "cancelled", "워커가 취소된 command를 다시 집으면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_withdraw_cancel_mutation_removing_guard_leaves_command_due():
+    """뮤테이션 대조 — cancel 로직을 제거하면(withdraw_channel_post_draft에서 command
+    상태를 안 건드리면) 위 테스트가 RED로 돌아가는지는 소스 코드 리뷰로 확認(로컬에서
+    수동 확認 후 복구) — 여기서는 그 반대(정상 동작에서 command가 실제로 due 조회에
+    안 걸림)를 별도 직접 쿼리로 한 번 더 고정한다(process_due_publication_commands
+    내부의 SKIP LOCKED 배치 크기·격리와 무관하게, 순수 WHERE 조건만으로도 재검증)."""
+    from app.main import app
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.models.publication_command import PublicationCommand
+    from datetime import datetime, timedelta, timezone
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r_submit = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={})
+            gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+        from tests.test_3414_publication_command_core import _approve_gate_directly
+
+        command_id = uuid.uuid4()
+        async with Session() as s:
+            await _approve_gate_directly(s, gate_id)
+            v = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalars().first()
+            command = PublicationCommand(
+                id=command_id, org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=v.id, operation="publish", content_kind="channel_post",
+                status="pending", attempt_count=1,
+                next_attempt_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+                requested_by_member_id=human_id,
+            )
+            s.add(command)
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/withdraw")
+        assert r.status_code == 200, r.text
+
+        async with Session() as s:
+            due = (await s.execute(
+                select(PublicationCommand).where(
+                    PublicationCommand.id == command_id,
+                    PublicationCommand.status == "pending",
+                )
+            )).scalar_one_or_none()
+            assert due is None, "취소됐다면 status='pending' 조건에 더는 안 걸려야 한다(due 배제 SSOT)"
     finally:
         await engine.dispose()


### PR DESCRIPTION
## 실측(PO Test Org, 2026-09-07 10:35Z)
3632 503 표본으로 IG 초안(16b95b7a)을 승인·발행 → provider-error 마커라 503(`command_status=pending`·`next_retry_at` 잡힘) → `POST drafts/{id}/withdraw` 200 → 초안은 `withdrawn`인데 발행 command는 살아서 재시도를 계속했다(게이트가 이미 `approved`라 기존 `gate.status == pending` 분기가 안 닿는다). 마커 표본은 영원히 실패하지만 진짜 일시 실패(네트워크·rate limit)였다면 다음 재시도가 성공해 **작성자가 폐기한 초안이 외부에 발행**된다 — story #3614의 "닫는다"가 command 층까지 안 닿는 반쪽이었다.

## 처방
`withdraw_channel_post_draft()`에 story #3419 AC1의 `cancel_scheduled_publication()`과 동일 조건/전이(새 상태기계 0) 추가 — 게이트에 걸린 최신 `publication_command`가 pending·blocked·dead_letter면 `cancelled`(`reason_code=CANCELLED_BY_HUMAN`)로 종결한다. in_progress/completed/voided/이미 cancelled는 손 안 댐(레이스로 그 사이 워커가 이미 집었다면 그대로 진행되게 둔다 — "죽은 채 재시도만 남은" 경로만 닫는 것이지 진행 중인 발행을 가로채는 게 아니다). 이미 published면 기존 409(`ChannelPostDraftAlreadyPublishedError`) 그대로 — 그 체크가 먼저이므로 published 초안의 command를 잘못 취소할 일은 없다.

AC2(승인된 게이트를 rejected로 뒤집지 않음·FE 「폐기」 버튼이 failed-publish 초안에서도 서는지)는 코드 확認만 — 기존 로직이 이미 이 두 조건을 만족한다(`gate.status=="pending"` 분기는 approved 게이트를 건드리지 않고, `can_withdraw` 계산은 `published_pub is None`만 본다).

## 테스트
pending command 있는 초안 withdraw → command cancelled·워커 due 조회(`process_due_publication_commands`)에서 실제로 0건 처리됨을 직접 증명 1건 + 뮤테이션 대표 1건(cancel 로직 제거 → due 조회에 그대로 남음 RED 확認 후 복구). published 초안 409 불변(기존 테스트 무변경 확認). destructive 61건(withdraw 13+unpublish 12+publication_command core+list+publish) 전부 PASS.

## 범위 밖
- 마커 표본 "영구 지뢰"(재연결마다 재만료) — 별건 그대로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA