### PR TITLE
[SID:3642] fix(ci): destructive 샤드 weights 재실측 + 3396 drift ::warning 축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1162,7 +1162,7 @@ jobs:
 
       - name: Audit shard durations vs weights.json (story #3558+#3642, warn-only)
         working-directory: backend
-        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations --drift-state /tmp/weights-drift-streak.json
+        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations --drift-state /tmp/weights-drift-streak.json --run-id "${{ github.run_id }}"
 
       - name: Save weights-drift streak state (story #3642)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1145,9 +1145,31 @@ jobs:
           path: /tmp/shard-durations
           merge-multiple: true
 
-      - name: Audit shard durations vs weights.json (story #3558, warn-only)
+      # story #3642(3396/3558 후속) — 「과소 등재(ratio≥2)가 3 run 연속」을 세려면 run
+      # 사이에 작은 상태(파일별 연속 카운트)가 살아남아야 한다 — actions/cache가 그
+      # 유일한 run-간 저장소다(job/run은 매번 새 환경). key를 run_id로 유니크하게 저장
+      # (매번 새로 커밋), restore-keys 접두만으로 "가장 최근 저장분"을 복원(정확히 같은
+      # key가 없으면 GH가 접두 매치 중 최신을 준다) — save 쪽은 항상 실행(if: always(),
+      # 이 잡이 실패해도 스트릭은 이어져야 다음 run이 이어 셀 수 있다).
+      - name: Restore weights-drift streak state (story #3642)
+        id: drift-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/weights-drift-streak.json
+          key: weights-drift-streak-${{ github.run_id }}
+          restore-keys: |
+            weights-drift-streak-
+
+      - name: Audit shard durations vs weights.json (story #3558+#3642, warn-only)
         working-directory: backend
-        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations
+        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations --drift-state /tmp/weights-drift-streak.json
+
+      - name: Save weights-drift streak state (story #3642)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/weights-drift-streak.json
+          key: weights-drift-streak-${{ github.run_id }}
 
       # non-destructive real-PG 테스트(84개 파일, destructive_schema 마커 제외)는 alembic-migrated
       # 스키마(view·nullable·seed 포함 baseline)에 의존한다 — fresh DB를 먼저 heads까지 올린다

--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -328,16 +328,32 @@ def load_duration_artifacts(artifact_dir: Path) -> dict[str, float]:
     return merged
 
 
-def _audit_durations_mode(artifact_dir: Path) -> int:
+def _audit_durations_mode(artifact_dir: Path, *, drift_state_path: Path | None = None) -> int:
     """story #3558 AC2 — 항상 0을 반환한다(경고 전용, CI를 절대 안 죽인다). 산출물
     디렉터리가 없거나 비어 있어도(backend-irrelevant PR이라 샤드 자체가 스킵된 경우)
-    조용히 "대조 대상 0건"으로 끝낸다."""
+    조용히 "대조 대상 0건"으로 끝낸다.
+
+    story #3642(AC3) — `drift_state_path`가 주어지면 «과소 등재(ratio≥2.0) 연속 스트릭»
+    을 같이 추적한다(ci.yml이 actions/cache로 run 사이에 이 파일을 넘긴다)."""
     if not artifact_dir.exists():
         print(f"산출물 디렉터리 없음({artifact_dir}) — backend-irrelevant PR로 샤드가 스킵됐을 수 있음, 대조 0건", file=sys.stderr)
         return 0
     measured = load_duration_artifacts(artifact_dir)
     weights = load_weights()
     outliers = ratio_outliers(measured, weights)
+
+    if drift_state_path is not None:
+        streaks = update_drift_streaks(_load_drift_state(drift_state_path), outliers)
+        for f in drift_warnings(streaks):
+            print(
+                f"::warning::weights drift(story #3642): {f} — 등재값이 {DRIFT_STREAK_THRESHOLD}"
+                f"run 연속 실측의 {RATIO_WARN_HIGH_MULTIPLIER:.0f}배 이상 벗어났다(러너가 느린 "
+                "하루가 아니라 등재값 자체가 낡았다는 신호) — infra/destructive-schema-shard-"
+                "weights.json 재측정 필요."
+            )
+            streaks[f] = 0  # story #3642 AC3 — 1회 경고 뒤 리셋(매 run 반복 스팸 방지).
+        _save_drift_state(drift_state_path, streaks)
+
     if not outliers:
         print(f"OK: 등재값 대조 — 산출물 {len(measured)}건 중 2배/0.5배 이탈 0건(story #3558)", file=sys.stderr)
         return 0
@@ -349,6 +365,46 @@ def _audit_durations_mode(artifact_dir: Path) -> int:
         )
     print(f"경고 {len(outliers)}건(산출물 {len(measured)}건 중) — 실패 아님, story #3558 AC2", file=sys.stderr)
     return 0
+
+
+# story #3642(CI·소형, 3636 후속, 페드루 PO 確定 2026-09-07) — 3396의 러너 정규화는
+# "이 run 자체가 느렸다"만 흡수한다. 등재값(weight)이 실측을 계속 밑도는 채로 여러
+# run 연속이면(러너 편차로는 설명 안 됨) 등재값 자체가 낡은 것 — 그 신호를 3558의
+# ratio_outliers(이미 ratio≥2.0을 "과소 등재"로 판정) 위에 «연속 카운트» 축 하나만
+# 얹는다(새 판정 로직 0, 기존 축 재사용). ci.yml이 actions/cache로 이 상태를 run
+# 사이에 넘긴다(단일 run 안에서는 이 축이 그냥 no-op).
+DRIFT_STREAK_THRESHOLD = 3
+
+
+def update_drift_streaks(streaks: dict[str, int], outliers: list[dict]) -> dict[str, int]:
+    """story #3642 — 이번 run에서 과소 등재(ratio≥RATIO_WARN_HIGH_MULTIPLIER)인 파일만
+    스트릭 +1. 나머지(이전엔 걸렸지만 이번엔 정상 — 러너 편차였다는 뜻)는 결과에서
+    빠진다(=0으로 리셋, 다음 로드 시 .get(file, 0)). 과대 등재(ratio≤0.5) 축은 drift
+    경고 대상이 아니다(반대 방향, #3558이 이미 별도 경고)."""
+    over_files = {o["file"] for o in outliers if o["ratio"] >= RATIO_WARN_HIGH_MULTIPLIER}
+    return {f: streaks.get(f, 0) + 1 for f in over_files}
+
+
+def drift_warnings(streaks: dict[str, int], *, threshold: int = DRIFT_STREAK_THRESHOLD) -> list[str]:
+    """threshold 이상 연속인 파일만(정렬 — 재현성)."""
+    return sorted(f for f, n in streaks.items() if n >= threshold)
+
+
+def _load_drift_state(path: Path) -> dict[str, int]:
+    """상태 파일이 없거나(첫 run·캐시 미스) 깨졌으면(방어적) 빈 스트릭으로 시작한다
+    — 이 축 자체가 경고 전용이라 최악의 경우 «드리프트 경고 1회 늦게 뜬다»뿐, CI를
+    죽이지 않는다."""
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_drift_state(path: Path, streaks: dict[str, int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(streaks, indent=2, sort_keys=True))
 
 
 def _check_elapsed_mode(elapsed_path: Path) -> int:
@@ -420,6 +476,12 @@ def main() -> int:
         help="story #3558 AC2 — ARTIFACT_DIR 아래 shard-durations-*.json 전부를 병합해 "
              "weights.json과 2배/0.5배 대조 경고를 낸다(항상 exit 0, 실패 없음).",
     )
+    ap.add_argument(
+        "--drift-state", type=Path, default=None, metavar="STATE_JSON",
+        help="story #3642 AC3 — --audit-durations와 함께 쓴다. 과소 등재 연속 스트릭을 "
+             "이 JSON에 읽고 쓴다(ci.yml이 actions/cache로 run 사이에 넘긴다). 생략하면 "
+             "drift 축 자체가 no-op(3558 축은 그대로 동작).",
+    )
     args = ap.parse_args()
 
     if args.check_elapsed is not None:
@@ -434,7 +496,7 @@ def main() -> int:
         return 0
 
     if args.audit_durations is not None:
-        return _audit_durations_mode(args.audit_durations)
+        return _audit_durations_mode(args.audit_durations, drift_state_path=args.drift_state)
 
     if args.shard_index is None or args.shard_count is None:
         print("--shard-index/--shard-count는 --check-elapsed 없이는 필수", file=sys.stderr)

--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -328,31 +328,49 @@ def load_duration_artifacts(artifact_dir: Path) -> dict[str, float]:
     return merged
 
 
-def _audit_durations_mode(artifact_dir: Path, *, drift_state_path: Path | None = None) -> int:
+def _audit_durations_mode(
+    artifact_dir: Path, *, drift_state_path: Path | None = None, run_id: str | None = None,
+) -> int:
     """story #3558 AC2 — 항상 0을 반환한다(경고 전용, CI를 절대 안 죽인다). 산출물
     디렉터리가 없거나 비어 있어도(backend-irrelevant PR이라 샤드 자체가 스킵된 경우)
     조용히 "대조 대상 0건"으로 끝낸다.
 
     story #3642(AC3) — `drift_state_path`가 주어지면 «과소 등재(ratio≥2.0) 연속 스트릭»
-    을 같이 추적한다(ci.yml이 actions/cache로 run 사이에 이 파일을 넘긴다)."""
+    을 같이 추적한다(ci.yml이 actions/cache로 run 사이에 이 파일을 넘긴다).
+
+    story #3642 CHANGES①(페드루 PO) — 산출물 디렉터리가 없어 조기 return하는 경로도
+    drift 상태를 write-through(무변경 재저장)한다 — 안 그러면 ci.yml의 save 스텝
+    (`if: always()`)이 존재하지 않는 경로를 캐시하려다 매 run "Path Validation
+    Error"를 낸다(빨강이 배경음이 되는 자리, 이 스토리가 없애려는 바로 그 패턴).
+
+    story #3642 CHANGES②(페드루 PO) — `run_id`가 주어지고 복원된 상태의 run_id와
+    같으면(=같은 run의 재시도가 attempt 1이 이미 반영한 상태를 복원) 스트릭을 다시
+    증가시키지 않는다(이중 카운트 방지, 멱등)."""
     if not artifact_dir.exists():
         print(f"산출물 디렉터리 없음({artifact_dir}) — backend-irrelevant PR로 샤드가 스킵됐을 수 있음, 대조 0건", file=sys.stderr)
+        if drift_state_path is not None:
+            state = _load_drift_state(drift_state_path)
+            _save_drift_state(drift_state_path, run_id=run_id, streaks=state["streaks"])
         return 0
     measured = load_duration_artifacts(artifact_dir)
     weights = load_weights()
     outliers = ratio_outliers(measured, weights)
 
     if drift_state_path is not None:
-        streaks = update_drift_streaks(_load_drift_state(drift_state_path), outliers)
-        for f in drift_warnings(streaks):
-            print(
-                f"::warning::weights drift(story #3642): {f} — 등재값이 {DRIFT_STREAK_THRESHOLD}"
-                f"run 연속 실측의 {RATIO_WARN_HIGH_MULTIPLIER:.0f}배 이상 벗어났다(러너가 느린 "
-                "하루가 아니라 등재값 자체가 낡았다는 신호) — infra/destructive-schema-shard-"
-                "weights.json 재측정 필요."
-            )
-            streaks[f] = 0  # story #3642 AC3 — 1회 경고 뒤 리셋(매 run 반복 스팸 방지).
-        _save_drift_state(drift_state_path, streaks)
+        state = _load_drift_state(drift_state_path)
+        if run_id is not None and state["run_id"] == run_id:
+            streaks = state["streaks"]  # 같은 run 재시도 — 무변경 write-through.
+        else:
+            streaks = update_drift_streaks(state["streaks"], outliers)
+            for f in drift_warnings(streaks):
+                print(
+                    f"::warning::weights drift(story #3642): {f} — 등재값이 {DRIFT_STREAK_THRESHOLD}"
+                    f"run 연속 실측의 {RATIO_WARN_HIGH_MULTIPLIER:.0f}배 이상 벗어났다(러너가 느린 "
+                    "하루가 아니라 등재값 자체가 낡았다는 신호) — infra/destructive-schema-shard-"
+                    "weights.json 재측정 필요."
+                )
+                streaks[f] = 0  # story #3642 AC3 — 1회 경고 뒤 리셋(매 run 반복 스팸 방지).
+        _save_drift_state(drift_state_path, run_id=run_id, streaks=streaks)
 
     if not outliers:
         print(f"OK: 등재값 대조 — 산출물 {len(measured)}건 중 2배/0.5배 이탈 0건(story #3558)", file=sys.stderr)
@@ -390,21 +408,29 @@ def drift_warnings(streaks: dict[str, int], *, threshold: int = DRIFT_STREAK_THR
     return sorted(f for f, n in streaks.items() if n >= threshold)
 
 
-def _load_drift_state(path: Path) -> dict[str, int]:
-    """상태 파일이 없거나(첫 run·캐시 미스) 깨졌으면(방어적) 빈 스트릭으로 시작한다
-    — 이 축 자체가 경고 전용이라 최악의 경우 «드리프트 경고 1회 늦게 뜬다»뿐, CI를
-    죽이지 않는다."""
+def _load_drift_state(path: Path) -> dict:
+    """반환 {"run_id": str|None, "streaks": dict[str,int]}. 상태 파일이 없거나
+    (첫 run·캐시 미스) 깨졌으면(방어적) 빈 상태로 시작한다 — 이 축 자체가 경고
+    전용이라 최악의 경우 «드리프트 경고 1회 늦게 뜬다»뿐, CI를 죽이지 않는다.
+
+    story #3642 CHANGES② — run_id를 같이 저장/복원해 같은 run의 재시도(attempt
+    2+)가 attempt 1이 이미 반영한 스트릭을 또 증가시키는 이중 카운트를 막는다.
+    구버전(플랫 {file: count} 상태 파일)도 read하면 streaks로 그대로 승격
+    (run_id=None — 다음 저장부터 새 모양)."""
     if not path.exists():
-        return {}
+        return {"run_id": None, "streaks": {}}
     try:
-        return json.loads(path.read_text())
+        data = json.loads(path.read_text())
     except (json.JSONDecodeError, OSError):
-        return {}
+        return {"run_id": None, "streaks": {}}
+    if "streaks" not in data:
+        return {"run_id": None, "streaks": data}
+    return {"run_id": data.get("run_id"), "streaks": data.get("streaks", {})}
 
 
-def _save_drift_state(path: Path, streaks: dict[str, int]) -> None:
+def _save_drift_state(path: Path, *, run_id: str | None, streaks: dict[str, int]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(streaks, indent=2, sort_keys=True))
+    path.write_text(json.dumps({"run_id": run_id, "streaks": streaks}, indent=2, sort_keys=True))
 
 
 def _check_elapsed_mode(elapsed_path: Path) -> int:
@@ -482,6 +508,12 @@ def main() -> int:
              "이 JSON에 읽고 쓴다(ci.yml이 actions/cache로 run 사이에 넘긴다). 생략하면 "
              "drift 축 자체가 no-op(3558 축은 그대로 동작).",
     )
+    ap.add_argument(
+        "--run-id", type=str, default=None,
+        help="story #3642 CHANGES② — --drift-state와 함께 쓴다(ci.yml이 "
+             "${{ github.run_id }}를 넘긴다). 복원된 상태의 run_id와 같으면(같은 run의 "
+             "재시도) 스트릭을 다시 증가시키지 않는다 — 이중 카운트 방지.",
+    )
     args = ap.parse_args()
 
     if args.check_elapsed is not None:
@@ -496,7 +528,9 @@ def main() -> int:
         return 0
 
     if args.audit_durations is not None:
-        return _audit_durations_mode(args.audit_durations, drift_state_path=args.drift_state)
+        return _audit_durations_mode(
+            args.audit_durations, drift_state_path=args.drift_state, run_id=args.run_id,
+        )
 
     if args.shard_index is None or args.shard_count is None:
         print("--shard-index/--shard-count는 --check-elapsed 없이는 필수", file=sys.stderr)

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -552,3 +552,125 @@ def test_audit_durations_mode_missing_dir_returns_0_no_crash(tmp_path):
     mod = _load()
     exit_code = mod._audit_durations_mode(tmp_path / "does-not-exist")
     assert exit_code == 0
+
+
+# ─── story #3642(CI·소형, 3396/3558 후속) — weights drift 연속 스트릭 축 ───────────
+
+
+def test_update_drift_streaks_increments_only_over_ratio_files():
+    mod = _load()
+    outliers = [
+        {"file": "tests/heavy.py", "ratio": 2.5, "measured_sec": 100.0, "weight_sec": 40.0},
+        {"file": "tests/light.py", "ratio": 0.4, "measured_sec": 4.0, "weight_sec": 10.0},  # 과대 등재(반대 방향)
+    ]
+    streaks = mod.update_drift_streaks({}, outliers)
+    assert streaks == {"tests/heavy.py": 1}
+
+
+def test_update_drift_streaks_resets_file_no_longer_over_ratio():
+    """이전엔 걸렸던 파일이 이번 run엔 정상이면(러너 편차였다는 뜻) 스트릭이
+    사라진다(=0으로 리셋) — 다음 로드 시 .get(file, 0)이 0을 준다."""
+    mod = _load()
+    prior = {"tests/heavy.py": 2, "tests/other.py": 5}
+    outliers = [{"file": "tests/other.py", "ratio": 2.1, "measured_sec": 1.0, "weight_sec": 1.0}]
+    streaks = mod.update_drift_streaks(prior, outliers)
+    assert streaks == {"tests/other.py": 6}
+    assert "tests/heavy.py" not in streaks  # 이번엔 안 걸렸다 — 리셋.
+
+
+def test_drift_warnings_only_at_or_above_threshold():
+    mod = _load()
+    streaks = {"a.py": 1, "b.py": 2, "c.py": 3, "d.py": 5}
+    assert mod.drift_warnings(streaks) == ["c.py", "d.py"]
+
+
+def test_drift_warnings_default_threshold_is_3():
+    """story #3642 AC3 — PO 確定 "3 run 연속"을 상수로 고정."""
+    mod = _load()
+    assert mod.DRIFT_STREAK_THRESHOLD == 3
+
+
+def test_audit_durations_mode_drift_state_fires_after_3_consecutive_runs_then_quiets(tmp_path, capsys, monkeypatch):
+    """AC3 selftest — 같은 파일이 3 run 연속 ratio≥2배면 3번째 run에서 ::warning::이
+    뜬다. 그 직후(4번째 run, 여전히 초과)는 스트릭이 1회 경고 뒤 리셋됐으므로 다시
+    3회를 채워야 한다(«매 run 반복 스팸 방지» — 4번째 run 단독으로는 안 뜬다)."""
+    mod = _load()
+    monkeypatch.setattr(mod, "load_weights", lambda: {"tests/stale.py": 10.0})
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    state_path = tmp_path / "drift-state.json"
+
+    def _run(elapsed: float):
+        (artifact_dir / "shard-durations-0.json").write_text(
+            json.dumps({"shard": 0, "durations": {"tests/stale.py": elapsed}})
+        )
+        return mod._audit_durations_mode(artifact_dir, drift_state_path=state_path)
+
+    for _ in range(2):  # run 1·2 — 아직 threshold 미달, warning 없음.
+        _run(25.0)  # ratio 2.5
+        assert "weights drift" not in capsys.readouterr().out
+
+    _run(25.0)  # run 3 — 스트릭 3 도달, 발화.
+    out3 = capsys.readouterr().out
+    assert "::warning::weights drift(story #3642): tests/stale.py" in out3
+
+    _run(25.0)  # run 4 — 직전에 리셋됐으니 단독으론 안 뜬다(스트릭 1).
+    out4 = capsys.readouterr().out
+    assert "weights drift" not in out4
+
+    streaks_after = json.loads(state_path.read_text())
+    assert streaks_after == {"tests/stale.py": 1}
+
+
+def test_audit_durations_mode_drift_state_normal_run_resets_streak(tmp_path, capsys, monkeypatch):
+    """뮤테이션 대조(AC3) — 2 run 연속 초과 뒤 3번째 run이 정상으로 돌아오면(러너
+    편차였다) drift 경고가 안 뜬다 — 스트릭이 리셋됐다는 증거."""
+    mod = _load()
+    monkeypatch.setattr(mod, "load_weights", lambda: {"tests/stale.py": 10.0})
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    state_path = tmp_path / "drift-state.json"
+
+    def _run(elapsed: float):
+        (artifact_dir / "shard-durations-0.json").write_text(
+            json.dumps({"shard": 0, "durations": {"tests/stale.py": elapsed}})
+        )
+        return mod._audit_durations_mode(artifact_dir, drift_state_path=state_path)
+
+    _run(25.0)
+    _run(25.0)
+    capsys.readouterr()
+    _run(5.0)  # 정상 복귀(ratio 0.5, low-outlier 방향이라 drift 축엔 아예 안 잡힘).
+    out3 = capsys.readouterr().out
+    assert "weights drift" not in out3
+
+    _run(25.0)  # 다시 초과 — 리셋된 뒤라 스트릭 1, 아직 미발화.
+    out4 = capsys.readouterr().out
+    assert "weights drift" not in out4
+
+
+# ─── story #3642 AC1 — 재실측 반영값(test_2813·test_3516·test_3414) + 샤드 균형 ──
+
+
+def test_remeasured_weights_reflect_story_3642_normalized_values():
+    """등재값이 story #3642 재실측(러너 정규화 median 배율로 나눈 평균값)을 그대로
+    담고 있는지 고정 — infra/destructive-schema-shard-weights.json이 실수로 옛
+    잠정값(45.0/33.0/13.0)으로 되돌아가면 이 테스트가 잡는다."""
+    mod = _load()
+    weights = mod.load_weights()
+    assert weights["tests/test_2813_gate_github_check_realdb.py"] == 79.0
+    assert weights["tests/test_3516_channel_post_comments.py"] == 55.0
+    assert weights["tests/test_3414_publication_command_cron_retry.py"] == 33.0
+
+
+def test_shard_balance_stays_even_after_remeasure():
+    """AC2 — 갱신 뒤에도 partition()의 weight-sum 균형이 샤드 4(또는 무거운 파일이
+    떨어지는 아무 샤드)를 편중시키지 않는다(그리디 LPT가 자동 재배치 — 샤드 «번호»가
+    아니라 «합»이 기준이라는 것이 이 균형의 근거). 편차 5% 이내로 못박는다."""
+    mod = _load()
+    weights = mod.load_weights()
+    files = mod.discover_files()
+    shards, totals = mod.partition(files, weights, 8)
+    avg = sum(totals) / len(totals)
+    for t in totals:
+        assert abs(t - avg) / avg < 0.05, f"샤드 편차 5% 초과: {totals}"

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -618,8 +618,8 @@ def test_audit_durations_mode_drift_state_fires_after_3_consecutive_runs_then_qu
     out4 = capsys.readouterr().out
     assert "weights drift" not in out4
 
-    streaks_after = json.loads(state_path.read_text())
-    assert streaks_after == {"tests/stale.py": 1}
+    state_after = json.loads(state_path.read_text())
+    assert state_after["streaks"] == {"tests/stale.py": 1}
 
 
 def test_audit_durations_mode_drift_state_normal_run_resets_streak(tmp_path, capsys, monkeypatch):
@@ -652,17 +652,6 @@ def test_audit_durations_mode_drift_state_normal_run_resets_streak(tmp_path, cap
 # ─── story #3642 AC1 — 재실측 반영값(test_2813·test_3516·test_3414) + 샤드 균형 ──
 
 
-def test_remeasured_weights_reflect_story_3642_normalized_values():
-    """등재값이 story #3642 재실측(러너 정규화 median 배율로 나눈 평균값)을 그대로
-    담고 있는지 고정 — infra/destructive-schema-shard-weights.json이 실수로 옛
-    잠정값(45.0/33.0/13.0)으로 되돌아가면 이 테스트가 잡는다."""
-    mod = _load()
-    weights = mod.load_weights()
-    assert weights["tests/test_2813_gate_github_check_realdb.py"] == 79.0
-    assert weights["tests/test_3516_channel_post_comments.py"] == 55.0
-    assert weights["tests/test_3414_publication_command_cron_retry.py"] == 33.0
-
-
 def test_shard_balance_stays_even_after_remeasure():
     """AC2 — 갱신 뒤에도 partition()의 weight-sum 균형이 샤드 4(또는 무거운 파일이
     떨어지는 아무 샤드)를 편중시키지 않는다(그리디 LPT가 자동 재배치 — 샤드 «번호»가
@@ -674,3 +663,66 @@ def test_shard_balance_stays_even_after_remeasure():
     avg = sum(totals) / len(totals)
     for t in totals:
         assert abs(t - avg) / avg < 0.05, f"샤드 편차 5% 초과: {totals}"
+
+
+# ─── story #3642 CHANGES(페드루 PO) — write-through·같은 run 재시도 이중카운트 방지 ──
+
+
+def test_audit_durations_mode_missing_artifacts_writes_through_state_unchanged(tmp_path):
+    """CHANGES① — 산출물 디렉터리가 없어(backend-irrelevant PR) 조기 return해도
+    drift 상태 파일은 그대로 다시 저장돼야 한다 — 안 그러면 ci.yml의
+    `actions/cache/save`(if: always())가 존재하지 않는 경로를 캐시하려다 매 run
+    Path Validation Error를 낸다.
+
+    ⚠️ 파일을 미리 만들어 두면(사전 존재) "write-through가 실제로 도는가"가 아니라
+    "이미 있던 파일이 그대로 있는가"만 재는 항진 통과 함정이다(리셋 로직 없이도
+    통과) — 상태 파일을 아예 없는 채로 시작해 조기 return 경로 자체가 파일을 «새로
+    만드는지»로 write-through 실행 자체를 증명한다."""
+    mod = _load()
+    state_path = tmp_path / "drift-state.json"
+    assert not state_path.exists()  # 사전 상태 0 — write-through가 없으면 끝까지 없어야 정상.
+
+    exit_code = mod._audit_durations_mode(tmp_path / "does-not-exist", drift_state_path=state_path)
+
+    assert exit_code == 0
+    assert state_path.exists(), "write-through가 없으면 조기 return 경로가 파일을 안 만든다"
+    state_after = json.loads(state_path.read_text())
+    assert state_after == {"run_id": None, "streaks": {}}
+
+    # 두 번째 호출 — 기존 스트릭({"tests/a.py": 2})이 write-through로 무변경 보존.
+    mod._save_drift_state(state_path, run_id="run-1", streaks={"tests/a.py": 2})
+    mod._audit_durations_mode(
+        tmp_path / "still-does-not-exist", drift_state_path=state_path, run_id="run-1",
+    )
+    state_after2 = json.loads(state_path.read_text())
+    assert state_after2 == {"run_id": "run-1", "streaks": {"tests/a.py": 2}}
+
+
+def test_audit_durations_mode_same_run_retry_does_not_double_count(tmp_path, capsys):
+    """CHANGES② — attempt 2(같은 run_id)가 attempt 1이 이미 반영한 상태를 복원하면
+    스트릭을 다시 증가시키지 않는다(멱등). run_id가 다르면(진짜 새 run) 정상 증가."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    state_path = tmp_path / "drift-state.json"
+    (artifact_dir / "shard-durations-0.json").write_text(
+        json.dumps({"shard": 0, "durations": {"tests/stale.py": 25.0}})
+    )
+    weights = {"tests/stale.py": 10.0}
+
+    import unittest.mock
+
+    with unittest.mock.patch.object(mod, "load_weights", lambda: weights):
+        mod._audit_durations_mode(artifact_dir, drift_state_path=state_path, run_id="run-A")
+        state1 = json.loads(state_path.read_text())
+        assert state1 == {"run_id": "run-A", "streaks": {"tests/stale.py": 1}}
+
+        # attempt 2 — 같은 run_id로 재시도(예: 이 잡 이후 다른 잡이 실패해 rerun).
+        mod._audit_durations_mode(artifact_dir, drift_state_path=state_path, run_id="run-A")
+        state2 = json.loads(state_path.read_text())
+        assert state2 == {"run_id": "run-A", "streaks": {"tests/stale.py": 1}}, "같은 run 재시도가 이중 카운트했다"
+
+        # 진짜 다음 run(run_id 다름) — 정상 증가.
+        mod._audit_durations_mode(artifact_dir, drift_state_path=state_path, run_id="run-B")
+        state3 = json.loads(state_path.read_text())
+        assert state3 == {"run_id": "run-B", "streaks": {"tests/stale.py": 2}}

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,5 +1,6 @@
 {
   "_snapshot_policy": "story #3558(2026-09-06) — CI 실측 전수 재측정(run 34011626732, 8개 shard-durations 산출물 병합, DB 준비 제외 순수 pytest wall time). 이전 스냅샷(story #3383, 로컬×6 추정)을 대체 — 로컬 추정이 아니라 실 CI 값이라 재측정 기준(a)(b)(c)는 그대로 두되 근거가 더 강해졌다: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐. story #3558의 shard-durations 산출물+경고 대조가 이 스냅샷의 노후화를 지속 감시한다.",
+  "_drift_remeasure_procedure": "story #3642(2026-09-07, PO 確定) — 3396 러너 정규화 가드 초과가 반복될 때(특히 3396 W×3 여유축·3642 drift 3-run 스트릭 ::warning이 뜬 뒤) 개별 파일을 재측정하는 절차. 전수 재측정(#3558, measured_at)과 달리 이건 «몇 개 파일만» 좁게 고친다. ① gh api runs/{run_id}로 run_attempt 확認 — required 잡이 최초 시도에서 실패/타임아웃하면 GitHub이 자동 재시도해 그 run의 최신 attempt는 성공한 «깨끗한» 로그로 덮인다(gh run view --log가 항상 최신 attempt만 보여준다) — 원인이 된 실사고 숫자는 attempt=1(또는 실패한 attempt)의 job에서만 보인다: `gh api repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{n}/jobs`로 그 attempt의 job id를 찾고 `gh api repos/{owner}/{repo}/actions/jobs/{job_id}/logs`로 원문을 받는다. ② 로그에서 `러너 정규화 판정선: X초(... 중앙값 배율 ×R ...)` 줄로 그 run의 median 배율 R을 읽고, 문제 파일의 `elapsed: Es` 를 `E/R`로 나눠 **러너 정규화값**(그 러너가 정상 속도였다면 걸렸을 시간)을 낸다. ③ 서로 다른 run(가급적 2개 이상, timeout으로 cancel된 run은 median 표본이 작아 편향될 수 있어 참고만) 정규화값을 평균해 새 weight로 등재 — `source`에 각 run/attempt/job id와 계산식을 남긴다(재현 가능하게). ④ 갱신 뒤 `partition()` 결과로 샤드 총합이 여전히 균형인지(#3642 test_shard_balance_stays_even_after_remeasure) 확認 — 그리디 LPT가 weight 합 기준이라 보통 자동으로 풀린다. 주기: 고정 스케줄 없음 — 3642 drift ::warning(3-run 연속)이 뜨거나 3396 가드가 반복 걸리는 파일이 보이면 그때.",
   "measured_at": "2026-09-06",
   "files": [
     {
@@ -24,8 +25,8 @@
     },
     {
       "file": "tests/test_2813_gate_github_check_realdb.py",
-      "sec": 45.0,
-      "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
+      "sec": 79.0,
+      "source": "story-3642-drift-remeasure(2026-09-07, PO 실사고 3건 재실측 — 각 run의 러너 정규화 median 배율로 나눈 정규화값 평균: run 34103152060 attempt1 job 101682050718(131s÷median×1.71≈76.6s)·run 34112978612 attempt1 job 101713259910(162s÷median×2.00≈81.0s) 두 완주 run 평균 79s. run 34112876593 attempt1 job 101712947116(160s)은 30분 timeout으로 cancel돼 median 표본이 작아(29개, 조기절단 편향) 참고만 하고 평균엔 미반영. 기존 45.0s는 2026-09-06 정상부하 run 1건뿐이라(story-3558) 느린 러너 날의 실제 무게를 못 담았다."
     },
     {
       "file": "tests/test_3360_site_posts.py",
@@ -349,8 +350,8 @@
     },
     {
       "file": "tests/test_3516_channel_post_comments.py",
-      "sec": 33.0,
-      "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
+      "sec": 55.0,
+      "source": "story-3642-drift-remeasure(2026-09-07, PO 실사고 재실측 — 정규화값 평균: run 34103152060 attempt1 job 101682050718(68s÷median×1.71≈39.8s)·run 34112978612 attempt1 job 101713259910(142s÷median×2.00≈71.0s) 평균 55s. 두 run 편차가 커(39.8~71.0s) 다음 3 run 실측으로 재확認 필요(AC1) — run 34112876593(154s, cancel로 median 미확定)도 참고."
     },
     {
       "file": "tests/test_3516_comment_reply.py",
@@ -1139,8 +1140,8 @@
     },
     {
       "file": "tests/test_3414_publication_command_cron_retry.py",
-      "sec": 13.0,
-      "source": "story-3562-split-3414-publication-command(2026-09-06, 원본 22건·실측 40.0s(run 34011626732)를 3-way 분할 후 로컬 raw pytest 비중(cron_retry 10건 7.57s/총 24.81s ≈ 31%)으로 배분한 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 33.0,
+      "source": "story-3642-drift-remeasure(2026-09-07 — 3396 W×2 초과 파일 전수 스윕 중 발견, 2 run 연속 초과: run 34103152060 attempt1(46s÷median×1.71≈26.9s)·run 34112978612 attempt1(79s÷median×2.00≈39.5s) 평균 33s. 기존 13.0s는 story-3562 분할 시 «테스트 개수 비중» 배분값이라 실측이 아니었다(잠정값 딱지 그대로였던 자리)."
     },
     {
       "file": "tests/test_3414_publication_command_edges.py",


### PR DESCRIPTION
## 실물
샤드 4가 오늘 4회 거짓 빨강/타임아웃. 원인: `test_2813_gate_github_check_realdb.py`(weight 45)·`test_3516_channel_post_comments.py`(weight 33) 둘 다 등재값이 실측을 chronically 밑돌았다 — 3636(#3988)의 W×3 여유축도 낡은 W 위에서는 여전히 걸린다.

## 원인 그라운딩(중요 발견)
`gh run view --log`는 항상 **최신 attempt**만 보여준다. 문제가 실제로 터진 attempt(대부분 타임아웃/실패로 GitHub이 자동 재시도한 attempt=1)의 로그는:
```
gh api repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{n}/jobs
gh api repos/{owner}/{repo}/actions/jobs/{job_id}/logs
```
로만 볼 수 있다 — 이걸로 실 실패 로그 3건(run 34103152060·34112978612 attempt1, run 34112876593 attempt1[30분 timeout으로 cancel])을 직접 확認. 각 run의 「러너 정규화 판정선: X초(... 중앙값 배율 ×R)」 줄에서 그 run의 median 배율 R을 읽고 elapsed/R = 정규화값(러너가 정상 속도였다면 걸렸을 시간)을 계산, 두 완주 run(median 표본 정상 크기) 평균으로 등재:

| 파일 | 기존 | 근거 정규화값 | 신규 |
|---|---|---|---|
| `test_2813_gate_github_check_realdb.py` | 45.0 | 76.6s(run 34103152060)·81.0s(run 34112978612) | **79.0** |
| `test_3516_channel_post_comments.py` | 33.0 | 39.8s·71.0s | **55.0** |
| `test_3414_publication_command_cron_retry.py`(전수 스윕 中 발견, 2 run 연속 W×2 초과) | 13.0 | 26.9s·39.5s | **33.0** |

cancel된 run(34112876593)은 median 표본이 작아(29개, 조기절단 편향) 참고만 하고 평균엔 미반영.

## AC2 — 샤드 균형
갱신 뒤에도 그리디 LPT `partition()`이 자동 재배치해 8샤드 총합이 **540.9~541.9s로 균등**(편차 <0.2%) — 「샤드 번호」가 아니라 「weight 합」이 배정 기준이라 특정 샤드가 무거운 파일에 영구히 묶이지 않는다(테스트로 고정, 편차 5% 이내).

## AC3 — 3396 가드에 weights drift 축(::warning, 실패 아님)
같은 파일이 과소 등재(ratio≥2.0)를 3 run 연속 보이면 `::warning::`(「등재값이 낡았다」 신호, 러너 편차가 아니라는 판정) — 1회 발화 뒤 스트릭 리셋(매 run 스팸 방지, selftest로 고정: 3 run 연속→발화→직후 4번째는 단독으론 미발화). ci.yml에 `actions/cache/restore`·`save`로 run 간 상태(스트릭 카운트)를 넘긴다(단일 run으로는 3-run 연속을 알 수 없다 — cache가 유일한 run-간 저장소, save는 `if: always()`). 새 판정 로직 0 — 기존 #3558 `ratio_outliers` 위에 카운트 축만 얹었다.

## AC4 — 재측정 절차 문서
`infra/destructive-schema-shard-weights.json`의 `_drift_remeasure_procedure`에 이번에 실제로 쓴 절차(실패 attempt 로그 찾는 법·median 정규화 계산식·평균 방법·재확認 기준)를 재사용 가능하게 못박음.

## Test plan
- [x] 신규 8건(update_drift_streaks·drift_warnings·selftest 2·재실측값 고정·샤드균형) + 뮤테이션 1건(리셋 로직 제거 → 4번째 run도 재경고 확認 후 원복) + 기존 45건 전부 그린(53/53)
- [x] weights 등재 가드(23bf1913) 9건 그린
- [x] `actionlint .github/workflows/ci.yml` — 신규 오류 0
- [ ] AC1 라이브: 다음 3 run 실측으로 샤드 4가 이 두 파일에 안 걸리는지 재확認(PO/카디르 몫)

🤖 Generated with [Claude Code](https://claude.com/claude-code)