### PR TITLE
[SID:3650] fix: 채널 연결 화면 막다른 길 둘 — 재연결 대상 불일치·sandbox dead-end

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2168,6 +2168,8 @@
     "channelSandboxConnectionBadge": "Test connection",
     "channelDisconnectAction": "Disconnect",
     "channelReauthAction": "Reconnect",
+    "channelReauthMismatchNote": "The {updated} connection was refreshed — you approved a different account, so {intended} is unchanged.",
+    "channelSandboxReauthUnavailableNote": "Test connections can't be reconnected — use \"Create {channel} connection\" to make a new one.",
     "channelTestAction": "Test connection",
     "channelRowActionAriaLabel": "{label} — connection {n}",
     "channelTestOk": "OK · {account}",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2168,6 +2168,8 @@
     "channelSandboxConnectionBadge": "테스트용 연결",
     "channelDisconnectAction": "해제",
     "channelReauthAction": "다시 연결",
+    "channelReauthMismatchNote": "승인한 계정이 달라 {updated} 연결이 갱신됐습니다 — {intended} 연결은 그대로입니다.",
+    "channelSandboxReauthUnavailableNote": "테스트용 연결은 다시 연결할 수 없습니다 — 「{channel} 연결 만들기」로 새로 만들어 주세요.",
     "channelTestAction": "연결 시험",
     "channelRowActionAriaLabel": "{n}번째 연결 {label}",
     "channelTestOk": "정상 · {account}",

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -328,6 +328,59 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
     const headerChip = chips.find((c) => c.getAttribute('data-status-chip') !== 'connected');
     expect(headerChip?.getAttribute('data-status-chip')).toBe('reauth_required');
   });
+
+  // story #3650(PO Test Org 실측 2026-09-07) — 「다시 연결」이 어느 행을 재인증하려는
+  // 것인지 authorize 쿼리에 실려야 콜백이 대상을 안다.
+  it('재인증 필요 행의 「다시 연결」 링크에 connection_id가 그 행의 id로 실린다', async () => {
+    stubFetch({
+      connections: [{ ...CONNECTION_ACTIVE, id: 'conn-needs-reauth', status: 'revoked' }],
+    });
+    await mount('owner');
+    const reauthLink = [...container.querySelectorAll('a')].find((a) => a.textContent === '다시 연결') as HTMLAnchorElement;
+    expect(reauthLink).not.toBeUndefined();
+    const href = reauthLink.getAttribute('href')!;
+    expect(href).toContain('connection_id=conn-needs-reauth');
+    expect(href).toContain('channel=threads');
+  });
+
+  // story #3650 — credential_kind='none'(예: instagram_sandbox) 행은 OAuth authorize
+  // 자체가 그 채널을 지원 안 해 「다시 연결」이 구조적 막다른 길이다. 버튼 대신 문장.
+  it('테스트용 연결(credential_kind=none)이 재인증 필요면 「다시 연결」 버튼 대신 문장이 뜬다', async () => {
+    stubFetch({
+      availableChannels: [
+        { channel: 'instagram_sandbox', display_name: 'Instagram Sandbox', credential_kind: 'none', kind: 'social' },
+      ],
+      connections: [{
+        ...CONNECTION_ACTIVE, id: 'conn-ig-sandbox', channel: 'instagram_sandbox',
+        credential_kind: 'none', status: 'revoked',
+      }],
+    });
+    await mount('owner');
+    const reauthLink = [...container.querySelectorAll('a')].find((a) => a.textContent === '다시 연결');
+    expect(reauthLink).toBeUndefined();
+    const note = container.querySelector('[data-testid="channel-sandbox-reauth-unavailable"]');
+    expect(note).not.toBeNull();
+    expect(note?.textContent).toContain('테스트용 연결은 다시 연결할 수 없습니다');
+  });
+
+  // story #3650 — dev 실측 재현: 재연결 대상과 콜백이 실제로 갱신한 행이 다르면
+  // ?connected=&mismatch=&updated= 세 쿼리가 함께 온다. 화면이 두 id를 이미 불러온
+  // connections에서 라벨로 바꿔 한 문장으로 보인다(침묵 0).
+  it('?mismatch=&updated= 쿼리가 있으면 일반 성공 배너 대신 대상 불일치 문장이 뜬다', async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('connected=threads&mismatch=conn-page2&updated=conn-page1'));
+    stubFetch({
+      connections: [
+        { ...CONNECTION_ACTIVE, id: 'conn-page1', account_label: 'Page 1', status: 'active' },
+        { ...CONNECTION_ACTIVE, id: 'conn-page2', account_label: 'Page 2', status: 'revoked' },
+      ],
+    });
+    await mount('owner');
+    const note = container.querySelector('[data-testid="channel-reauth-mismatch-note"]');
+    expect(note).not.toBeNull();
+    expect(note?.textContent).toContain('Page 1');
+    expect(note?.textContent).toContain('Page 2');
+    expect(container.textContent).not.toContain(koMessages.channelConnect.channelConnectSuccess.replace('{channel}', 'Threads'));
+  });
 });
 
 // story #3436 묶음10(유나 §17-21⑧⑨, PO 確定 2026-09-06) — oauth 갈래 「{channel}

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -542,10 +542,19 @@ function ConnectionRow({
         </Button>
         {/* story #3504 — 재인증·해제는 owner 전용(_require_owner). §5-2 "그려진
             컨트롤은 「할 수 있다」는 단정" — admin에게 넓게 그리고 403으로 막지
-            않는다: 안 그리고 사유 한 줄만. */}
+            않는다: 안 그리고 사유 한 줄만.
+            story #3650(PO Test Org 실측 2026-09-07) — credential_kind==='none'
+            채널(예: instagram_sandbox)은 OAuth authorize 분기 자체가 이 채널을
+            지원 안 해(app 자격도 등록될 수 없음) 「다시 연결」이 구조적 막다른
+            길이다("테스트용 연결" 배지와 같은 판별축 — sandboxConnectionBadge
+            참고). 버튼 대신 문장, 처방은 「새로 만들기」. */}
         {derived.status === 'reauth_required' ? (
-          isOwnerStrict ? (
-            <a href={`/api/oauth-channel/authorize?org=${orgId}&channel=${conn.channel}`}>
+          conn.credential_kind === 'none' ? (
+            <p className="text-xs text-muted-foreground" data-testid="channel-sandbox-reauth-unavailable">
+              {t('channelSandboxReauthUnavailableNote', { channel: channelLabel(conn.channel, t) })}
+            </p>
+          ) : isOwnerStrict ? (
+            <a href={`/api/oauth-channel/authorize?org=${orgId}&channel=${conn.channel}&connection_id=${conn.id}`}>
               <Button
                 size="sm" variant="outline"
                 aria-label={t('channelRowActionAriaLabel', { n: index + 1, label: t('channelReauthAction') })}
@@ -861,6 +870,13 @@ export default function OrganizationChannelsPage() {
 
   const connected = searchParams.get('connected');
   const connectError = searchParams.get('connect_error');
+  // story #3650(PO Test Org 실측 2026-09-07) — 재연결 대상 행과 콜백이 실제로 갱신한
+  // 행이 다를 때(다른 계정을 승인) BFF가 함께 싣는 두 id. 라벨은 이 화면이 이미
+  // 불러온 connections에서 붙인다(콜백 라우트는 opaque 릴레이 그대로 유지).
+  const mismatchTargetId = searchParams.get('mismatch');
+  const mismatchUpdatedId = searchParams.get('updated');
+  const mismatchTargetConn = connections.find((c) => c.id === mismatchTargetId);
+  const mismatchUpdatedConn = connections.find((c) => c.id === mismatchUpdatedId);
 
   // story #3549(§13-8②, 3547 계약) — 콜백 BFF(api/oauth-channel/callback/[channel])가
   // 2개 이상 페이지를 찾으면 `?select_pending={channel}&pending_id=...&candidates=...`
@@ -887,7 +903,16 @@ export default function OrganizationChannelsPage() {
         <p className="text-sm text-muted-foreground">{t('pageDescription')}</p>
       </div>
 
-      {connected ? (
+      {connected && mismatchTargetId && mismatchUpdatedId ? (
+        <Alert variant="info" role="status" aria-live="polite" aria-atomic="true" data-testid="channel-reauth-mismatch-note">
+          <AlertDescription>
+            {t('channelReauthMismatchNote', {
+              updated: mismatchUpdatedConn?.account_label ?? mismatchUpdatedConn?.account_id ?? mismatchUpdatedId,
+              intended: mismatchTargetConn?.account_label ?? mismatchTargetConn?.account_id ?? mismatchTargetId,
+            })}
+          </AlertDescription>
+        </Alert>
+      ) : connected ? (
         <Alert variant="success" role="status" aria-live="polite" aria-atomic="true">
           <AlertDescription>{t('channelConnectSuccess', { channel: channelLabel(connected, t) })}</AlertDescription>
         </Alert>

--- a/apps/web/src/app/api/oauth-channel/authorize/route.test.ts
+++ b/apps/web/src/app/api/oauth-channel/authorize/route.test.ts
@@ -58,10 +58,31 @@ describe('GET /api/oauth-channel/authorize (story #3376)', () => {
     const res = await GET(makeRequest({ org: 'org-1', channel: 'threads' }));
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/organizations/org-1/channel-connections/threads/authorize'),
-      expect.objectContaining({ method: 'POST', headers: { Authorization: 'Bearer sp-at-token' } }),
+      expect.objectContaining({
+        method: 'POST',
+        headers: { Authorization: 'Bearer sp-at-token', 'Content-Type': 'application/json' },
+      }),
     );
     expect(h.cookiesSetMock).toHaveBeenCalledWith('oauth_channel_org_threads', 'org-1', expect.any(Object));
     expect(res.headers.get('location')).toBe('https://threads.net/oauth/authorize?x=1');
+  });
+
+  // story #3650(PO Test Org 실측 2026-09-07) — 「다시 연결」 대상 행. BE authorize가
+  // state에 실어 콜백까지 왕복시키는 값 — 이 라우트는 쿼리에서 받아 body로 릴레이만.
+  it('connection_id 쿼리가 있으면 BE 요청 body에 target_connection_id로 실려 간다', async () => {
+    h.cookiesGetMock.mockReturnValue({ value: 'sp-at-token' });
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ url: 'https://threads.net/oauth/authorize?x=1', state: 's' }) });
+    await GET(makeRequest({ org: 'org-1', channel: 'threads', connection_id: 'conn-42' }));
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ target_connection_id: 'conn-42' });
+  });
+
+  it('connection_id 쿼리가 없으면(신규 연결) target_connection_id가 undefined로 실린다', async () => {
+    h.cookiesGetMock.mockReturnValue({ value: 'sp-at-token' });
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ url: 'https://threads.net/oauth/authorize?x=1', state: 's' }) });
+    await GET(makeRequest({ org: 'org-1', channel: 'threads' }));
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({});
   });
 
   // story #3613 — instagram/facebook/facebook_sandbox도 같은 라우트를 공유한다(채널명만

--- a/apps/web/src/app/api/oauth-channel/authorize/route.ts
+++ b/apps/web/src/app/api/oauth-channel/authorize/route.ts
@@ -15,6 +15,9 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const orgId = searchParams.get('org');
   const channel = searchParams.get('channel');
+  // story #3650(PO Test Org 실측 2026-09-07) — 「다시 연결」 대상 행. 없으면(신규
+  // 연결) 기존 동작 그대로 — BE authorize가 body 없이도 받는다.
+  const connectionId = searchParams.get('connection_id');
   const origin = resolveAppUrl(null);
 
   if (!orgId || !channel) {
@@ -29,7 +32,11 @@ export async function GET(request: Request) {
 
   const res = await fetch(
     `${FASTAPI_BASE}/api/v2/organizations/${orgId}/channel-connections/${channel}/authorize`,
-    { method: 'POST', headers: { Authorization: `Bearer ${spAt}` } },
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${spAt}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target_connection_id: connectionId ?? undefined }),
+    },
   ).catch(() => null);
 
   if (!res?.ok) {

--- a/apps/web/src/app/api/oauth-channel/callback/[channel]/route.test.ts
+++ b/apps/web/src/app/api/oauth-channel/callback/[channel]/route.test.ts
@@ -168,4 +168,30 @@ describe('GET /api/oauth-channel/callback/[channel] — Facebook 「선택 대�
     const res = await GET(facebookRequest({ code: 'c', state: 's' }), facebookRouteParams());
     expect(res.headers.get('location')).toBe('http://localhost:3108/organization/channels?connected=facebook');
   });
+
+  // story #3650(PO Test Org 실측 2026-09-07) — BE가 reconnect_mismatch_target_id를
+  // 실으면(재연결 대상≠실제 갱신 행) 이 라우트는 그대로 릴레이만 한다(opaque —
+  // 라벨 조립은 /organization/channels 몫).
+  it('BE가 reconnect_mismatch_target_id를 실으면 mismatch·updated 쿼리로 릴레이한다', async () => {
+    stubFacebookCookies();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'updated-row-id', channel: 'facebook', reconnect_mismatch_target_id: 'target-row-id' }),
+    });
+    const res = await GET(facebookRequest({ code: 'c', state: 's' }), facebookRouteParams());
+    const location = new URL(res.headers.get('location')!);
+    expect(location.searchParams.get('connected')).toBe('facebook');
+    expect(location.searchParams.get('mismatch')).toBe('target-row-id');
+    expect(location.searchParams.get('updated')).toBe('updated-row-id');
+  });
+
+  it('reconnect_mismatch_target_id가 null이면(정상 재인증) 기존 ?connected=로', async () => {
+    stubFacebookCookies();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'c1', channel: 'facebook', reconnect_mismatch_target_id: null }),
+    });
+    const res = await GET(facebookRequest({ code: 'c', state: 's' }), facebookRouteParams());
+    expect(res.headers.get('location')).toBe('http://localhost:3108/organization/channels?connected=facebook');
+  });
 });

--- a/apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts
+++ b/apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts
@@ -81,6 +81,7 @@ export async function GET(request: Request, { params }: RouteParams) {
   // "미리보기 없음" 규율과 같은 이유로 원래도 가벼운 데이터).
   const successBody = await res.json().catch(() => null) as {
     kind?: string; pending_id?: string; candidates?: { page_id: string; name: string }[]; expires_at?: string;
+    id?: string; reconnect_mismatch_target_id?: string | null;
   } | null;
   if (successBody?.kind === 'pending_selection' && successBody.pending_id) {
     const params = new URLSearchParams({
@@ -89,6 +90,19 @@ export async function GET(request: Request, { params }: RouteParams) {
       candidates: JSON.stringify(successBody.candidates ?? []),
     });
     if (successBody.expires_at) params.set('expires_at', successBody.expires_at);
+    return NextResponse.redirect(`${origin}/organization/channels?${params.toString()}`);
+  }
+
+  // story #3650(PO Test Org 실측 2026-09-07) — 재연결 대상 행과 콜백이 실제로 갱신한
+  // 행이 다르면(다른 계정을 승인했다는 뜻) 갱신 사실은 그대로 두되 화면이 침묵하지
+  // 않게 두 id를 싣는다. `/organization/channels`가 이미 불러온 목록에서 라벨을
+  // 붙인다(여기서 미리 조립하지 않는다 — 이 라우트는 org_id 이후로는 opaque 릴레이).
+  if (successBody?.reconnect_mismatch_target_id && successBody.id) {
+    const params = new URLSearchParams({
+      connected: channel,
+      mismatch: successBody.reconnect_mismatch_target_id,
+      updated: successBody.id,
+    });
     return NextResponse.redirect(`${origin}/organization/channels?${params.toString()}`);
   }
 

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -169,9 +169,14 @@ class ChannelConnectionResponse(BaseModel):
     # 대기"(PendingSelectionResponse) 둘 중 하나일 수 있어(Facebook Page만 해당) FE가
     # 판별자로 가른다. additive 기본값이라 기존 threads/instagram 응답·소비자는 무변.
     kind: Literal["connected"] = "connected"
+    # story #3650(PO Test Org 실측 2026-09-07) — additive. authorize state가 실은
+    # target_connection_id가 이 콜백이 실제로 갱신한 행(id)과 다르면 채워진다(다른
+    # 계정을 골랐다는 뜻 — 갱신 자체은 사실대로 진행, 화면이 어느 행이 실제로
+    # 갱신됐는지 침묵하지 않게 하는 신호일 뿐). 일치·state 없음(신규 연결)이면 null.
+    reconnect_mismatch_target_id: uuid.UUID | None = None
 
 
-def _to_response(row) -> ChannelConnectionResponse:
+def _to_response(row, *, reconnect_mismatch_target_id: uuid.UUID | None = None) -> ChannelConnectionResponse:
     adapter = get_channel_adapter(row.channel)
     max_text_length = adapter.max_text_length if adapter is not None and adapter.max_text_length > 0 else None
     supports_unpublish = adapter is not None and adapter.supports_unpublish
@@ -213,7 +218,14 @@ def _to_response(row) -> ChannelConnectionResponse:
         video_aspect_tolerance=adapter.video_aspect_tolerance if adapter is not None else 0.0,
         video_codecs=list(adapter.video_codecs) if adapter is not None else [],
         secret_hint=row.secret_hint,
+        reconnect_mismatch_target_id=reconnect_mismatch_target_id,
     )
+
+
+class AuthorizeRequest(BaseModel):
+    # story #3650(PO Test Org 실측 2026-09-07) — 「다시 연결」 대상 행을 authorize
+    # 단계에서 state에 실어 콜백까지 왕복시킨다. 생략(신규 연결)이면 기존 동작 그대로.
+    target_connection_id: uuid.UUID | None = None
 
 
 class AuthorizeResponse(BaseModel):
@@ -404,6 +416,7 @@ async def list_available_channels_endpoint(
 async def authorize_channel_connection(
     org_id: uuid.UUID,
     channel: str,
+    body: AuthorizeRequest = AuthorizeRequest(),
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
@@ -415,6 +428,16 @@ async def authorize_channel_connection(
     adapter = get_channel_adapter(channel)
     if adapter is None:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
+
+    # story #3650 — target_connection_id가 실려 오면 이 org·채널 소유가 맞는지 먼저
+    # 검증한다(IDOR 방지 — 콜백 mismatch 판정이 믿는 값이 여기서부터 정직해야 한다).
+    if body.target_connection_id is not None:
+        target_conn = await get_channel_connection(db, org_id=org_id, connection_id=body.target_connection_id)
+        if target_conn is None or target_conn.channel != channel:
+            raise HTTPException(
+                status_code=404,
+                detail={"code": "CHANNEL_CONNECTION_NOT_FOUND", "message": "재연결 대상 연결을 찾을 수 없습니다."},
+            )
 
     # 선생님 지적·페드루 PO 정정(2026-09-03 08:29Z) — 조직이 자기 채널 앱 자격을 등록 안
     # 했으면(플랫폼 기본값도 없으면) authorize 진입 자체를 여기서 막는다. Meta 호출 0건.
@@ -434,6 +457,7 @@ async def authorize_channel_connection(
     try:
         state = sign_channel_oauth_state(
             org_id=org_id, requester_member_id=resolved.id, channel=channel, code_verifier=code_verifier,
+            connection_id=body.target_connection_id,
         )
     except ChannelOAuthStateNotConfigured as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
@@ -510,7 +534,7 @@ async def channel_connection_callback(
     if channel in ("facebook", "facebook_sandbox"):
         return await _facebook_channel_connection_callback(
             db, org_id=org_id, channel=channel, code=body.code, app_id=app_id, app_secret=app_secret,
-            requester_member_id=resolved.id,
+            requester_member_id=resolved.id, target_connection_id=oauth_state.connection_id,
         )
 
     # story #3320 — instagram_oauth.InstagramOAuthError는 ThreadsOAuthError와 같은
@@ -563,12 +587,20 @@ async def channel_connection_callback(
         token_expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in),
         refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(","), connected_by=resolved.id,
     )
-    return _to_response(row)
+    # story #3650 — 대상 행(재연결 의도)과 실제 갱신된 행이 다르면(provider가 다른
+    # 계정을 돌려줬다는 뜻 — 다른 계정으로 로그인/선택) 갱신은 그대로 진행하되
+    # 화면에 알릴 신호를 싣는다. 일치·state에 target 자체가 없으면(신규 연결) null.
+    mismatch_target_id = (
+        oauth_state.connection_id
+        if oauth_state.connection_id is not None and oauth_state.connection_id != row.id
+        else None
+    )
+    return _to_response(row, reconnect_mismatch_target_id=mismatch_target_id)
 
 
 async def _facebook_channel_connection_callback(
     db: AsyncSession, *, org_id: uuid.UUID, channel: str, code: str, app_id: str, app_secret: str,
-    requester_member_id: uuid.UUID,
+    requester_member_id: uuid.UUID, target_connection_id: uuid.UUID | None = None,
 ) -> ChannelConnectionResponse | PendingSelectionResponse:
     """story #3547(페드루 PO 確定 2026-09-06) — Facebook Page는 페이지 개수에 따라
     갈래가 셋(0/1/2+)이다. `_redirect_uri`는 threads/instagram과 같은 채널별 콜백
@@ -611,7 +643,14 @@ async def _facebook_channel_connection_callback(
             token_expires_at=None,  # 페이지 토큰은 장기 유저 토큰에서 파생 — 별도 만료 불명(⚠️미확認).
             refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(","), connected_by=requester_member_id,
         )
-        return _to_response(row)
+        # story #3650(PO Test Org 실측 2026-09-07) — facebook_sandbox는 고정 계정 1개라
+        # 어느 행에서 「다시 연결」을 눌러도 이 단일-페이지 갈래가 항상 그 고정 계정으로
+        # upsert한다. target_connection_id(재연결 의도 행)와 실제 갱신된 행(row.id)이
+        # 다르면 갱신 자체는 사실대로 두되 화면에 신호를 싣는다.
+        mismatch_target_id = (
+            target_connection_id if target_connection_id is not None and target_connection_id != row.id else None
+        )
+        return _to_response(row, reconnect_mismatch_target_id=mismatch_target_id)
 
     now = datetime.now(timezone.utc)
     candidates = [{"page_id": p["page_id"], "name": p["name"]} for p in pages]

--- a/backend/tests/test_3373_channel_connections_auth.py
+++ b/backend/tests/test_3373_channel_connections_auth.py
@@ -534,3 +534,225 @@ async def test_owner_disconnect_revokes_and_wipes_tokens():
         await engine.dispose()
 
 
+# ─── story #3650 — 재연결 대상 행≠콜백 계정 mismatch 신호 ───────────────────
+
+@pytest.mark.anyio
+async def test_authorize_with_foreign_org_target_connection_id_rejected_404():
+    """IDOR 방지 — target_connection_id가 이 org 소유가 아니면 authorize 자체를 막는다
+    (콜백 mismatch 판정이 믿는 값이 여기서부터 정직해야 한다)."""
+    from app.main import app
+    from app.models.channel_connection import ChannelConnection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a_id, _ = await _seed_org(s, slug="org-a-3650")
+            org_b_id, _ = await _seed_org(s, slug="org-b-3650")
+            owner_a_id = await _seed_human(s, org_a_id, role="owner")
+            other_org_row = ChannelConnection(
+                id=uuid.uuid4(), org_id=org_b_id, channel="threads", account_id="acc-b",
+                account_label="b", credential_kind="oauth", refresh_mode="reissue_from_access_token",
+                status="needs_reauth", connected_by=owner_a_id,
+            )
+            s.add(other_org_row)
+            await s.commit()
+            foreign_connection_id = other_org_row.id
+        _setup_org_scoped_app(app, Session, org_a_id, user_id=owner_a_id)
+
+        async with _client_for(app) as client:
+            r_auth = await client.post(
+                f"/api/v2/organizations/{org_a_id}/channel-connections/threads/authorize",
+                json={"target_connection_id": str(foreign_connection_id)},
+            )
+        assert r_auth.status_code == 404, r_auth.text
+        assert r_auth.json()["error"]["code"] == "CHANNEL_CONNECTION_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconnect_target_matches_callback_account_no_mismatch():
+    """재연결 대상 행과 콜백이 돌려준 계정이 같으면(정상 재인증) mismatch 신호가 없다."""
+    from app.main import app
+    from app.models.channel_connection import ChannelConnection
+    import app.services.threads_oauth as ccr
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            row = ChannelConnection(
+                id=uuid.uuid4(), org_id=org_id, channel="threads", account_id="ext-account-1",
+                account_label="page1", credential_kind="oauth", refresh_mode="reissue_from_access_token",
+                status="needs_reauth", connected_by=owner_id,
+            )
+            s.add(row)
+            await s.commit()
+            target_id = row.id
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r_auth = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/threads/authorize",
+                json={"target_connection_id": str(target_id)},
+            )
+        assert r_auth.status_code == 200, r_auth.text
+        state = r_auth.json()["state"]
+
+        with patch.object(
+            ccr, "exchange_code_for_short_lived_token", AsyncMock(return_value=("sl", "ext-account-1")),
+        ), patch.object(
+            ccr, "exchange_for_long_lived_token", AsyncMock(return_value=("ll", 5184000)),
+        ), patch.object(
+            ccr, "test_connection", AsyncMock(return_value={"id": "ext-account-1", "username": "page1"}),
+        ):
+            async with _client_for(app) as client:
+                r_cb = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-connections/threads/callback",
+                    json={"code": "c", "state": state},
+                )
+        assert r_cb.status_code == 200, r_cb.text
+        payload = r_cb.json()
+        assert payload["id"] == str(target_id)
+        assert payload["reconnect_mismatch_target_id"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconnect_target_differs_from_callback_account_mismatch_signaled():
+    """dev 실측 재현(threads 축) — Page 2 행에서 「다시 연결」을 눌렀는데 콜백이 다른
+    계정(Page 1에 해당하는 ext-account-1)을 돌려주면, 그 계정이 실제로 매핑되는 행이
+    갱신되고(사실 유지) 응답에 mismatch_target_id=Page 2 행 id가 실린다. 뮤테이션
+    대상 — mismatch 판정 줄을 지우면 이 단언이 RED."""
+    from app.main import app
+    from app.models.channel_connection import ChannelConnection
+    import app.services.threads_oauth as ccr
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            page1_row = ChannelConnection(
+                id=uuid.uuid4(), org_id=org_id, channel="threads", account_id="ext-account-1",
+                account_label="page1", credential_kind="oauth", refresh_mode="reissue_from_access_token",
+                status="active", connected_by=owner_id,
+            )
+            page2_row = ChannelConnection(
+                id=uuid.uuid4(), org_id=org_id, channel="threads", account_id="ext-account-2",
+                account_label="page2", credential_kind="oauth", refresh_mode="reissue_from_access_token",
+                status="needs_reauth", connected_by=owner_id,
+            )
+            s.add_all([page1_row, page2_row])
+            await s.commit()
+            page1_id, page2_id = page1_row.id, page2_row.id
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        # Page 2 행에서 "다시 연결"을 누른다(target=page2) — 그런데 브라우저가 돌아온
+        # 계정은 ext-account-1(Page 1)이다(dev 실측: 사용자가 Meta 다이얼로그에서
+        # 다른 계정을 골랐거나, sandbox처럼 고정 계정인 경우).
+        async with _client_for(app) as client:
+            r_auth = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/threads/authorize",
+                json={"target_connection_id": str(page2_id)},
+            )
+        state = r_auth.json()["state"]
+
+        with patch.object(
+            ccr, "exchange_code_for_short_lived_token", AsyncMock(return_value=("sl", "ext-account-1")),
+        ), patch.object(
+            ccr, "exchange_for_long_lived_token", AsyncMock(return_value=("ll", 5184000)),
+        ), patch.object(
+            ccr, "test_connection", AsyncMock(return_value={"id": "ext-account-1", "username": "page1"}),
+        ):
+            async with _client_for(app) as client:
+                r_cb = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-connections/threads/callback",
+                    json={"code": "c", "state": state},
+                )
+        assert r_cb.status_code == 200, r_cb.text
+        payload = r_cb.json()
+        # 갱신 사실은 그대로 — ext-account-1에 매핑되는 page1_row가 갱신됐다(정직).
+        assert payload["id"] == str(page1_id)
+        assert payload["status"] == "active"
+        # 화면이 침묵하지 않게 하는 신호 — 의도한 대상(page2)을 알린다.
+        assert payload["reconnect_mismatch_target_id"] == str(page2_id)
+
+        async with Session() as s:
+            from sqlalchemy import select
+            fresh_page2 = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == page2_id))).scalar_one()
+        assert fresh_page2.status == "needs_reauth", "의도한 행(page2)은 갱신되지 않고 그대로 남아야 한다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_facebook_sandbox_single_page_reconnect_mismatch_signaled():
+    """dev 실측 그대로(facebook_sandbox 축) — sandbox는 고정 계정 1개라 어느 행에서
+    「다시 연결」을 눌러도 그 고정 계정으로 upsert된다. Page 2 행 target으로 authorize
+    했는데 sandbox 모듈이 항상 Page 1 계정을 돌려주면 mismatch가 실린다."""
+    from app.main import app
+    from app.models.channel_connection import ChannelConnection
+    import app.services.facebook_sandbox_oauth as fbs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            # facebook_sandbox는 platform_settings 공용 앱 fallback 컬럼이 없다
+            # (_PLATFORM_SETTINGS_COLUMNS 미등재) — org 자체 등록이 유일한 경로.
+            from app.services.channel_app_credentials import upsert_channel_app_credentials
+            await upsert_channel_app_credentials(
+                s, org_id=org_id, channel="facebook_sandbox", app_id="org-fb-app-id",
+                app_secret="org-fb-app-secret", updated_by=owner_id,
+            )
+            page1_row = ChannelConnection(
+                id=uuid.uuid4(), org_id=org_id, channel="facebook_sandbox", account_id="fb-page-1",
+                account_label="Page 1", credential_kind="oauth", refresh_mode="reissue_from_access_token",
+                status="active", connected_by=owner_id,
+            )
+            page2_row = ChannelConnection(
+                id=uuid.uuid4(), org_id=org_id, channel="facebook_sandbox", account_id="fb-page-2",
+                account_label="Page 2", credential_kind="oauth", refresh_mode="reissue_from_access_token",
+                status="needs_reauth", connected_by=owner_id,
+            )
+            s.add_all([page1_row, page2_row])
+            await s.commit()
+            page1_id, page2_id = page1_row.id, page2_row.id
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r_auth = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook_sandbox/authorize",
+                json={"target_connection_id": str(page2_id)},
+            )
+        assert r_auth.status_code == 200, r_auth.text
+        state = r_auth.json()["state"]
+
+        with patch.object(
+            fbs, "exchange_code_for_short_lived_token", AsyncMock(return_value=("sl", None)),
+        ), patch.object(
+            fbs, "exchange_for_long_lived_token", AsyncMock(return_value=("ll", 5184000)),
+        ), patch.object(
+            fbs, "list_pages", AsyncMock(return_value=[{"page_id": "fb-page-1", "name": "Page 1", "access_token": "pt"}]),
+        ):
+            async with _client_for(app) as client:
+                r_cb = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-connections/facebook_sandbox/callback",
+                    json={"code": "c", "state": state},
+                )
+        assert r_cb.status_code == 200, r_cb.text
+        payload = r_cb.json()
+        assert payload["id"] == str(page1_id)
+        assert payload["reconnect_mismatch_target_id"] == str(page2_id)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+


### PR DESCRIPTION
## ① 재연결 대상 행≠콜백 계정이면 조용히 다른 행이 갱신됨
dev 실측(PO Test Org, 2026-09-07): Sandbox Page 2 행에서 「다시 연결」 → 콜백이 고정 계정(Page 1)을 돌려줘 Page 1 행이 갱신되고 Page 2는 그대로 「재인증 필요」로 남는데 화면은 아무 말도 안 했다. 사용자는 「눌렀는데 안 풀렸다」로 읽는다.

`ChannelOAuthState.connection_id` 필드가 스키마엔 이미 있었으나(story #3373) authorize/callback 어디서도 채우거나 쓰지 않았다.

### BE
- `AuthorizeRequest.target_connection_id`(신규, 전부 default 옵셔널이라 기존 무-body 호출 그대로) — authorize 시점에 이 org·채널 소유가 맞는지 검증(IDOR 방지) 후 `sign_channel_oauth_state(connection_id=...)`로 state에 싣는다.
- `ChannelConnectionResponse.reconnect_mismatch_target_id`(additive, 새 판별자 `kind`와 동형 관례) — 콜백(threads/instagram 공용 경로 + `_facebook_channel_connection_callback`의 단일-페이지 경로, sandbox가 타는 바로 그 갈래)이 대상≠실제 갱신 행이면 채운다. 갱신 자체는 사실대로 진행(정직) — 신호만 추가.

### FE
- 「다시 연결」 href에 `connection_id={conn.id}` 추가(BFF `oauth-channel/authorize`가 body로 릴레이) → 콜백 BFF가 `mismatch`·`updated` 쿼리로 릴레이 → `/organization/channels`가 이미 불러온 connections에서 두 라벨을 붙여 한 문장(`channelReauthMismatchNote`, 유나 낱말 확定) — 일반 성공 배너를 대체.

## ② 앱 자격 없는 sandbox 행의 「다시 연결」 dead-end
`instagram_sandbox`는 `credential_kind='none'`이라 OAuth authorize 분기 자체가 이 채널을 지원 안 한다(app 자격도 등록될 수 없음) — 「다시 연결」을 누르면 `CHANNEL_APP_CREDENTIALS_MISSING`으로 구조적 막다른 길(3646 ④ 실측). `conn.credential_kind === 'none'` 판별(기존 "테스트용 연결" 배지와 같은 축)로 버튼 대신 문장(`channelSandboxReauthUnavailableNote`, 「{channel} 연결 만들기」 재사용 유도, 유나 낱말 확定).

## 테스트
BE 신규 5(IDOR 거부·일치=null·threads 불일치·facebook_sandbox 단일-페이지 불일치 — dev 실측 그대로 재현) + 뮤테이션 2(양쪽 mismatch 판정 줄 제거 → 각 RED). FE 신규 7(authorize body 릴레이 2·callback mismatch 릴레이 2·connection_id href·sandbox dead-end 문장·mismatch 배너) + 뮤테이션 3. 새 키 2(`channelReauthMismatchNote`·`channelSandboxReauthUnavailableNote`, 유나 확定). BE 123건·FE 113건 회귀 0. i18n 가드 3종·contrast·tint 가드 전부 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA