### PR TITLE
[SID:3647] fix: QA Review Gate가 verdict의 codex exec 세션 표식을 검사한다

### DIFF
--- a/.github/actions/qa-verdict-codex-session-check/action.yml
+++ b/.github/actions/qa-verdict-codex-session-check/action.yml
@@ -1,0 +1,53 @@
+name: QA verdict codex session check
+description: >
+  story #3647(CI·QA 관문·소형·긴급, 페드루 PO 確定 2026-09-07, 선생님 12:17Z 지시) —
+  qa:pass의 근거가 되는 최신 「## QA verdict: approved (qa:pass)」 코멘트 본문에
+  `codex session: <uuid>`·`model: <이름>` 두 줄이 있는지 검사한다. 2026-04 선생님-
+  카디르 합의(QA 판정=Claude 대화 + codex exec 실제 실행, Claude 단독 approve 금지)를
+  기계로 강제하는 첫 관문 — 09-01~02·09-05~07 두 창에서 codex 미사용 verdict가
+  ~300건 나간 실사고(선생님 실측) 재발 방지.
+
+  ⚠️잃는 것(선언, AC3) — 이 관문은 **형식만** 본다. GitHub 러너는 이 머신의
+  `~/.codex/sessions` 로그를 볼 수 없어(다른 프로세스·다른 장비) 코멘트에 적힌
+  세션 id가 실재하는지·그 PR을 정말 그 세션으로 리뷰했는지는 검증 못 한다 —
+  UUID 모양의 문자열 아무거나 적으면 통과한다. 실재 검증은 PO 재출근 점검(세션
+  로그와 verdict 대조)이 사람 축으로 메운다(story 본문 범위 밖 — 후속 후보:
+  세션 id를 sprintable 서버에 등록).
+
+  verdict-head-check(같은 디렉터리 위)와 별도 액션으로 둔 이유도 그 액션 자체의
+  ⛔주석과 동형 — head-check는 qa/design 둘 다 쓰는 공용 로직(코멘트 규약이 리뷰어
+  마다 다름)이고, 이 축은 qa:pass 전용(codex exec 규율은 카디르 QA에만 적용, 유나
+  design 리뷰엔 없다) — 억지로 한 액션에 파라미터로 합치면 design 쪽에도 이 검사가
+  새서 무관한 요구가 강제된다.
+
+  코멘트를 찾는 것(gh api·jq)만 이 자리(bash)에서 하고, 문자열 판정 자체는
+  `infra/qa_verdict_codex_session_check.py`로 뺐다(pytest로 selftest+뮤테이션이
+  스토리 AC라 순수 함수로 분리 — verdict-head-check의 인라인-bash-only 전례를
+  그대로 안 따른 유일한 이유).
+
+inputs:
+  gh-token:
+    description: gh api 호출용 토큰.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        # qa-review-gate.yml의 verdict-head-check 호출과 같은 header-regex(그 스텝이
+        # "찾았다"고 판정한 바로 그 코멘트를 이 축도 다시 본다 — 새 판정 로직 0, 같은
+        # 코멘트를 두 번째 잣대로만 잰다).
+        LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+          | jq -r '.[] | select(.body | test("^## QA verdict: approved \\(qa:pass\\)")) | [.created_at, .body] | @tsv' \
+          | sort | tail -1 | cut -f2-)"
+        if [ -z "${LATEST_VERDICT_BODY}" ]; then
+          echo "::error title=qa:pass verdict comment not found::codex 세션 검사 대상 코멘트를 못 찾았다 — verdict-head-check 스텝이 먼저 잡았어야 한다(fail-closed, 방어적 재확認)."
+          exit 1
+        fi
+
+        printf '%s' "${LATEST_VERDICT_BODY}" | python3 "${GITHUB_WORKSPACE}/infra/qa_verdict_codex_session_check.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,23 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_model_registration_completeness.py
 
+  # story #3647(CI·QA 관문·소형·긴급, 페드루 PO 確定 2026-09-07) — qa-review-gate.yml의
+  # qa-verdict-codex-session-check 액션이 부르는 판정 로직(infra/qa_verdict_codex_
+  # session_check.py::missing_codex_session_lines)이 순수 함수라 pytest 없이도 자기
+  # 자신에 --selftest로 픽스처를 심었다(story #3592 verify-no-new-repeated-row-action-
+  # names의 --selftest 관례 그대로, 새 테스트 러너 배선 0). 이 job은 그 판정 로직
+  # 자체의 회귀를 매 PR에서 잡는다 — qa-review-gate.yml 자신은 이 로직을 "실제 qa:pass
+  # PR"에만 태우므로 회귀가 나도 그 순간까지 조용할 수 있다.
+  qa-verdict-codex-session-check-selftest:
+    name: QA verdict codex session check selftest (guard, story #3647)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run codex session/model line check selftest fixtures
+        run: python3 infra/qa_verdict_codex_session_check.py --selftest
+
   alembic-no-autocommit-block:
     name: Alembic migrations — no autocommit_block() (guard)
     runs-on: ubuntu-latest

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -207,6 +207,15 @@ jobs:
           head-extract-regex: '\*\*Head:\*\*[^0-9a-f]*[0-9a-f]{7,40}'
           gh-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # story #3647(2026-09-07, 선생님 12:17Z 지시) — «codex exec 위임 없이 낸 approved»
+      # 재발 방지. 위 head-check와 별도 액션(그 자체 ⛔주석 참고 — qa 전용 규율을
+      # design과 공유하는 액션에 억지로 얹지 않는다). 형식 검사만(잃는 것은 액션 자체
+      # docstring에 선언).
+      - name: Enforce qa:pass verdict comment has codex exec session line
+        uses: ./.github/actions/qa-verdict-codex-session-check
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+
       # story #2676 AC2 — PR#3088 실사고 ③: 최초 qa:pass 승인이 Backend pytest가 아직
       # in_progress이던 도중(job 95074664724, 21:49~21:59) 21:54에 나갔다 — 리뷰 코멘트가
       # "CI green"이라 썼지만 그 시점 실제로는 «아직 안 나온 결과»였다(까디르 자기 정정).

--- a/infra/qa_verdict_codex_session_check.py
+++ b/infra/qa_verdict_codex_session_check.py
@@ -21,11 +21,17 @@ from __future__ import annotations
 import re
 import sys
 
+# story #3647 CHANGES(카디르 codex 발견, 2026-09-07) — `\s`는 개행도 먹는다(re.DOTALL
+# 없이도 `\s` 클래스 자체가 `\n`을 포함). 그래서 "model:"이 그 줄에서 값 없이 끝나고
+# 다음 줄에 아무 낱말이나 있어도(완전히 무관한 문장의 일부라도) `\s*\S+`가 그 낱말을
+# "model:"의 값으로 잘못 집어 통과시켰다(python 재현 済 — 실사고는 아니고 카디르가
+# 검사 중 직접 발견). 줄바꿈은 절대 건너뛰면 안 되는 경계라 `[ \t]*`(스페이스·탭만)
+# 로 좁힌다 — 두 정규식 다 같은 결함이라 같이 고친다.
 _SESSION_RE = re.compile(
-    r"codex session:\s*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    r"codex session:[ \t]*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
     re.IGNORECASE,
 )
-_MODEL_RE = re.compile(r"model:\s*\S+", re.IGNORECASE)
+_MODEL_RE = re.compile(r"model:[ \t]*\S+", re.IGNORECASE)
 
 
 def missing_codex_session_lines(body: str) -> list[str]:
@@ -88,6 +94,11 @@ _SELFTEST_CASES: list[tuple[str, str, bool]] = [
     (
         "model 줄만 없음(session은 정상) → 실패",
         "## QA verdict: approved (qa:pass)\ncodex session: 5b6f1a2c-9d3e-4f10-8a7b-1c2d3e4f5a6b\n",
+        False,
+    ),
+    (
+        "카디르 발견(2026-09-07) — model: 값 없이 줄이 끝나고 다음 줄에 무관한 낱말이 와도 실패해야 한다(개행을 건너뛰면 안 됨)",
+        "## QA verdict: approved (qa:pass)\ncodex session: 5b6f1a2c-9d3e-4f10-8a7b-1c2d3e4f5a6b\nmodel:\n어떤 텍스트가 다음 줄에 있음\n",
         False,
     ),
 ]

--- a/infra/qa_verdict_codex_session_check.py
+++ b/infra/qa_verdict_codex_session_check.py
@@ -59,5 +59,57 @@ def main() -> int:
     return 0
 
 
+# story #3647 AC2 — selftest 3(있음→통과·없음→실패·형식 틀림→실패) + PO 지시 v7 표본.
+# 이 repo-root 스크립트는 backend/ 패키지 밖이라 pytest 수집 경로에 안 잡힌다(conftest
+# 없음) — `ci.yml`의 기존 관례(`verify-no-new-repeated-row-action-names -- --selftest`)
+# 를 그대로 따라 스크립트 자신에 --selftest 플래그로 픽스처를 심는다(새 테스트 러너
+# 배선 0).
+_SELFTEST_CASES: list[tuple[str, str, bool]] = [
+    (
+        "session+model 둘 다 있음(v4) → 통과",
+        "## QA verdict: approved (qa:pass)\n**Head:** `abc1234`\ncodex session: 5b6f1a2c-9d3e-4f10-8a7b-1c2d3e4f5a6b\nmodel: gpt-6-astra\n",
+        True,
+    ),
+    (
+        "session+model 둘 다 있음(v7, 페드루 PO 지시 예시) → 통과",
+        "## QA verdict: approved (qa:pass)\n**Head:** `abc1234`\ncodex session: 01a07be9-cad1-7b10-aaa1-91a7d0c1efe6\nmodel: gpt-6-astra\n",
+        True,
+    ),
+    (
+        "둘 다 없음(구형 verdict) → 실패",
+        "## QA verdict: approved (qa:pass)\n**Head:** `abc1234`\nAPPROVE — 로그인 흐름 확認.\n",
+        False,
+    ),
+    (
+        "session 줄이 있지만 UUID 형식이 틀림(짧은 hex) → 실패",
+        "## QA verdict: approved (qa:pass)\ncodex session: abc123\nmodel: gpt-6-astra\n",
+        False,
+    ),
+    (
+        "model 줄만 없음(session은 정상) → 실패",
+        "## QA verdict: approved (qa:pass)\ncodex session: 5b6f1a2c-9d3e-4f10-8a7b-1c2d3e4f5a6b\n",
+        False,
+    ),
+]
+
+
+def _run_selftest() -> int:
+    failures = 0
+    for label, body, expect_ok in _SELFTEST_CASES:
+        missing = missing_codex_session_lines(body)
+        actual_ok = not missing
+        status = "OK" if actual_ok == expect_ok else "FAIL"
+        if status == "FAIL":
+            failures += 1
+        print(f"[{status}] {label} — missing={missing!r}")
+    if failures:
+        print(f"selftest: {failures}/{len(_SELFTEST_CASES)} 실패")
+        return 1
+    print(f"selftest: {len(_SELFTEST_CASES)}/{len(_SELFTEST_CASES)} 통과")
+    return 0
+
+
 if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        raise SystemExit(_run_selftest())
     raise SystemExit(main())

--- a/infra/qa_verdict_codex_session_check.py
+++ b/infra/qa_verdict_codex_session_check.py
@@ -1,0 +1,63 @@
+"""story #3647(CI·QA 관문·소형·긴급, 페드루 PO 確定 2026-09-07, 선생님 12:17Z 지시) —
+qa:pass 근거가 되는 최신 「## QA verdict: approved (qa:pass)」 코멘트 본문에
+`codex session: <uuid>`·`model: <이름>` 두 줄이 있는지 형식만 검사한다. 2026-04
+선생님-카디르 합의(QA 판정=Claude 대화 + codex exec 실제 실행, Claude 단독 approve
+금지)를 기계로 강제하는 첫 관문 — 09-01~02·09-05~07 두 창에서 codex 미사용 verdict가
+~300건 나간 실사고(선생님 실측) 재발 방지.
+
+⚠️잃는 것(선언) — 형식만 본다. GitHub 러너는 이 머신의 `~/.codex/sessions` 로그를
+볼 수 없어(다른 프로세스·다른 장비) 세션 id가 실재하는지는 검증 못 한다 — UUID
+모양의 문자열 아무거나 적으면 통과한다. 실재 검증은 PO 재출근 점검(세션 로그와
+verdict 대조)이 사람 축으로 메운다(범위 밖 — 후속 후보: 세션 id를 sprintable
+서버에 등록).
+
+`.github/actions/qa-verdict-codex-session-check/action.yml`이 이 스크립트를
+stdin(최신 approved verdict 코멘트 본문)으로 호출한다 — gh api/jq로 코멘트를
+찾는 것은 그 액션(bash)이 맡고, 이 스크립트는 순수 문자열 판정만(pytest로
+검산 가능하게 분리, verdict-head-check의 인라인-bash-only 전례와 달리 이
+축은 selftest+뮤테이션이 스토리 AC라 별도 함수로 뺐다)."""
+from __future__ import annotations
+
+import re
+import sys
+
+_SESSION_RE = re.compile(
+    r"codex session:\s*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+_MODEL_RE = re.compile(r"model:\s*\S+", re.IGNORECASE)
+
+
+def missing_codex_session_lines(body: str) -> list[str]:
+    """빠진 표식의 사람용 라벨 목록(둘 다 있으면 빈 리스트) — codex session은 UUID
+    모양(8-4-4-4-12 hex)까지 요구하고(형식 검사, AC3 선언대로 실재는 안 봄), model은
+    "model:" 뒤에 공백 아닌 토큰이 하나라도 있으면 통과(이름 자체를 화이트리스트로
+    제한하지 않는다 — 모델명이 바뀌어도 이 가드가 안 깨지게)."""
+    missing: list[str] = []
+    if not _SESSION_RE.search(body):
+        missing.append("codex session: <uuid>")
+    if not _MODEL_RE.search(body):
+        missing.append("model: <이름>")
+    return missing
+
+
+def main() -> int:
+    body = sys.stdin.read()
+    missing = missing_codex_session_lines(body)
+    if missing:
+        print(
+            "::error title=qa:pass verdict missing codex exec session line::"
+            "codex exec 세션 id 없음 — 위임 실행 없이 낸 verdict는 관문을 통과할 수 "
+            f"없다(2026-04 선생님-카디르 합의). 최신 approved verdict 코멘트에 빠진 줄: "
+            f"{', '.join(missing)}"
+        )
+        return 1
+    print(
+        "codex session·model 두 줄 확認 — QA verdict가 codex exec 위임 표식을 갖고 있다.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
디디군 WIP(`f0cf14f9d`, composite action+workflow 배선·actionlint 그린)을 이어받아 완결 — 나머지는 selftest·뮤테이션·CI 배선.

## 배경
2026-04 선생님-카디르 합의(QA 판정=Claude 대화 + codex exec 실제 실행, Claude 단독 approve 금지)를 QA Review Gate가 기계로 강제하지 않고 있었다 — verdict 코멘트의 "approved" 문자열만 보고 codex 실행 여부는 안 본다. 선생님 실측(2026-09-07 12:17Z): 카디르 QA가 codex 미사용으로 낸 verdict ~300건·머지 203건(두 창: 09-01~02·09-05~07).

## 완료(이어받은 것 확認)
- `.github/actions/qa-verdict-codex-session-check/action.yml` — 기존 `verdict-head-check`와 같은 header-regex로 최신 approved 코멘트를 찾고, `infra/qa_verdict_codex_session_check.py::missing_codex_session_lines`(순수 함수)로 `codex session: <uuid>`·`model: <이름>` 두 줄을 검사한다. UUID 정규식(8-4-4-4-12 hex)이 버전 니블을 안 봐 v4/v7 둘 다 자동으로 통과(별도 분기 불요 — PO 지시 v7 표본으로 확認).
- `qa-review-gate.yml`에 head-check 바로 뒤로 스텝 배선.
- "잃는 것" 선언 — 액션 description·스크립트 docstring 양쪽에 이미 명시(형식만 검사, 세션 실재는 GitHub 러너가 이 머신 로그를 못 봐 원리적으로 불가 — PO 재출근 점검이 사람 축으로 메운다).

## 이번 판 추가
- `--selftest` 플래그(story #3592 `verify-no-new-repeated-row-action-names`의 관례 그대로 — `infra/`는 backend/ 패키지 밖이라 pytest 수집 경로 밖, 새 테스트 러너 배선 0) — 픽스처 5개: session+model 있음(v4/v7 각 1)→통과, 둘 다 없음→실패, session UUID 형식 오류→실패, model만 없음→실패.
- `ci.yml`에 신규 job(`qa-verdict-codex-session-check-selftest`) — 기존 lint-guard job들과 동형 관례(checkout+단일 python3 호출)로 이 판정 로직 자체의 회귀를 매 PR에서 잡는다(`qa-review-gate.yml` 자신은 실제 qa:pass PR에만 이 로직을 태우므로 회귀가 나도 그 순간까지 조용할 수 있다).
- 뮤테이션 1건(session/model 검사 두 줄 제거 → 5개 중 3개 RED 확認 후 복구) — actionlint·YAML 파싱 재확認.

## 잃는 것(재확認, 스토리 AC3)
형식 검사만. GitHub 러너는 이 머신의 `~/.codex/sessions` 로그를 못 봐 세션 id 실재·그 PR을 정말 그 세션으로 리뷰했는지는 검증 불가 — UUID 모양 문자열이면 통과한다. 실재 검증은 PO 재출근 점검(사람 축, 범위 밖 — 후속 후보: 세션 id를 sprintable 서버에 등록).

## 라이브(AC4, 착지 후)
카디르 다음 verdict 1건에서 새 형식(codex session+model 두 줄)으로 QRG 통과 확認 · 세션 id 없는 옛 형식 verdict로 재현해 1회 실패 확認 — 카디르 QA 표본 필요(코드 착지 뒤 별도 확認).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA