### PR TITLE
[SID:3645] feat(BE): evidence 소재 계보(asset_sha256s) + hook_key 분석 라벨

### DIFF
--- a/backend/alembic/versions/0353_channel_post_versions_hook_key.py
+++ b/backend/alembic/versions/0353_channel_post_versions_hook_key.py
@@ -1,0 +1,26 @@
+"""story #3645(Phase2·BE, 페드루 PO 確定 2026-09-07 — 3pt·BE만·#3987 뒤) —
+`channel_post_versions`에 `hook_key` additive. 훅(캡션 도입부) A/B 태깅용 순수 분석
+라벨 — 봉인 축(body_sha256/image_sha256)엔 안 들어간다(값이 바뀌어도 재승인 사유가
+아니다). 발행 시점에 evidence payload로 값을 복사해 두므로, 발행 뒤 이 컬럼을 고쳐도
+이미 기록된 evidence는 안 바뀐다.
+
+down_revision을 0352(#3987/#3635)로 고정 — 그 슬롯이 먼저 develop에 착지한다는
+PO 사전 지정(순서: 3649 > #3987 > 3645 > 3646). 로컬 head가 아직 0351이면 #3987이
+착지하기 前이라는 뜻 — 착지 뒤 rebase로 자연히 이어진다(이 세션의 기존 재넘버 관례
+그대로)."""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0353"
+down_revision = "0352"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE channel_post_versions ADD COLUMN IF NOT EXISTS hook_key text")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE channel_post_versions DROP COLUMN IF EXISTS hook_key")

--- a/backend/alembic/versions/0353_channel_post_versions_hook_key.py
+++ b/backend/alembic/versions/0353_channel_post_versions_hook_key.py
@@ -4,16 +4,15 @@
 아니다). 발행 시점에 evidence payload로 값을 복사해 두므로, 발행 뒤 이 컬럼을 고쳐도
 이미 기록된 evidence는 안 바뀐다.
 
-down_revision을 0352(#3987/#3635)로 고정 — 그 슬롯이 먼저 develop에 착지한다는
-PO 사전 지정(순서: 3649 > #3987 > 3645 > 3646). 로컬 head가 아직 0351이면 #3987이
-착지하기 前이라는 뜻 — 착지 뒤 rebase로 자연히 이어진다(이 세션의 기존 재넘버 관례
-그대로)."""
+down_revision=0351(develop 현재 head) — 페드루 PO CHANGES(2026-09-07): PR#3987이
+qa:changes로 길어져 이 PR이 그걸 기다리지 않게 순서를 바꿨다. #3987의 0352는 이 PR
+착지 뒤 0354(down_revision=0353)로 재번호된다(그쪽 PR 몫)."""
 from __future__ import annotations
 
 from alembic import op
 
 revision = "0353"
-down_revision = "0352"
+down_revision = "0351"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/channel_post_version.py
+++ b/backend/app/models/channel_post_version.py
@@ -39,6 +39,13 @@ class ChannelPostVersion(Base):
     link_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     body_sha256: Mapped[str] = mapped_column(Text, nullable=False)
     image_sha256: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #3645(Phase2·BE, 페드루 PO 確定 2026-09-07) — 훅(캡션 도입부) A/B 태깅용
+    # 분석 라벨. **봉인 축에 안 넣는다**(위 image_sha256/body_sha256 분리 논리와 같은
+    # 이유로 더 강하게 — 이건 내용도 아니고 순수 분석 메타라 값이 바뀌어도 재승인 사유가
+    # 생길 이유가 아예 없다). 발행 시점에 evidence payload로 값을 복사해 두므로(§
+    # insight_snapshots.py::_record_insight_evidence), 발행 뒤 이 컬럼을 고쳐도 이미
+    # 기록된 evidence는 안 바뀐다(카피가 그 시점의 스냅샷이므로).
+    hook_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     author_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     author_kind: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -2,6 +2,7 @@
 API. `app/routers/site_posts.py`(story #3365) 형태를 그대로 미러 — 새 패턴 발명 0."""
 from __future__ import annotations
 
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -151,6 +152,10 @@ async def _require_owner_or_admin(db: AsyncSession, auth: AuthContext, org_id: u
     return resolved
 
 
+# story #3645(Phase2·BE, 페드루 PO 確定 2026-09-07).
+_HOOK_KEY_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
+
+
 class CreateChannelPostDraftVersionRequest(BaseModel):
     work_item_id: uuid.UUID
     connection_id: uuid.UUID
@@ -172,6 +177,20 @@ class CreateChannelPostDraftVersionRequest(BaseModel):
     # 시에만 반영, 편집(기존 draft) 호출은 무시된다(서비스 계층 docstring 참고).
     source_content_item_id: uuid.UUID | None = None
 
+    # story #3645(Phase2·BE, 페드루 PO 確定 2026-09-07) — 훅(캡션 도입부) A/B 태깅용
+    # 분석 라벨. link_url과 동형(캐리포워드 없음, 이 요청의 값이 현재 값). 생략/null=
+    # 라벨 없음.
+    hook_key: str | None = None
+
+    @field_validator("hook_key")
+    @classmethod
+    def _hook_key_format(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if len(v) > 64 or not _HOOK_KEY_PATTERN.fullmatch(v):
+            raise ValueError("hook_key는 64자 이하의 영문·숫자·-·_ 조합이어야 합니다")
+        return v
+
 
 class ChannelPostDraftVersionResponse(BaseModel):
     draft_id: uuid.UUID
@@ -186,6 +205,8 @@ class ChannelPostDraftVersionResponse(BaseModel):
     # 빈 배열=위반 없음(지어내지 않는다 — organization이 규칙을 아예 안 정했으면 항상
     # 빈 배열).
     violations: list[dict] = []
+    # story #3645(Phase2·BE, 페드루 PO 確定 2026-09-07).
+    hook_key: str | None = None
 
 
 class ChannelPostVideoMeta(BaseModel):
@@ -494,7 +515,7 @@ async def post_channel_post_draft_version(
         version, channel, violations = await create_channel_post_draft_version(
             db, org_id=org_id, work_item_id=body.work_item_id, connection_id=body.connection_id,
             text=body.text, link_url=body.link_url, author_member_id=member_id, author_kind=actor_type,
-            source_content_item_id=body.source_content_item_id,
+            source_content_item_id=body.source_content_item_id, hook_key=body.hook_key,
         )
     except ChannelPostSourceContentItemNotFoundError as exc:
         raise HTTPException(
@@ -528,6 +549,7 @@ async def post_channel_post_draft_version(
         draft_id=version.draft_id, version_id=version.id, version=version.version,
         author_kind=version.author_kind, body_sha256=version.body_sha256,
         tagged_link_preview=tagged_link_preview, violations=violations,
+        hook_key=version.hook_key,
     )
 
 

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -454,6 +454,7 @@ async def create_channel_post_draft_version(
     author_kind: str,
     image_sha256: str | None = _IMAGE_SHA256_CARRY_FORWARD,  # type: ignore[assignment]
     source_content_item_id: uuid.UUID | None = None,
+    hook_key: str | None = None,
 ) -> tuple[ChannelPostVersion, str, list[dict]]:
     """초안을 (org, work_item, connection_id)로 upsert하고 새 불변 버전을 추가한다 —
     site_posts.create_site_post_draft_version과 1:1 대응(AC1).
@@ -474,7 +475,13 @@ async def create_channel_post_draft_version(
     story #3437(AC2, 페드루 PO 確定 2026-09-04) — `source_content_item_id`는 **초안
     생성 시에만** 반영한다(channel이 connection_id의 파생값으로 생성 시에만 고정되는
     것과 동형 축 — 편집마다 다시 보내는 text/link_url과는 다른 종류의 필드). org
-    불일치·존재하지 않는 원문은 `ChannelPostSourceContentItemNotFoundError`(422)."""
+    불일치·존재하지 않는 원문은 `ChannelPostSourceContentItemNotFoundError`(422).
+
+    story #3645(Phase2·BE, 페드루 PO 確定 2026-09-07) — `hook_key`는 `link_url`과
+    동형(캐리포워드 없음, 매 호출이 현재 값을 명시) — image_sha256과 달리 「빈손
+    발행」류 결함 소지가 없는 순수 분석 라벨이라 캐리포워드 sentinel을 얹는 복잡도가
+    안 남는다. 형식 검사(≤64자·`[A-Za-z0-9_-]`)는 라우터 요청 모델(422)에서 이미
+    끝낸 값만 여기로 들어온다."""
     connection = await _get_active_connection(db, org_id=org_id, connection_id=connection_id)
     _validate_text_length(channel=connection.channel, text=text)
 
@@ -535,7 +542,7 @@ async def create_channel_post_draft_version(
         id=uuid.uuid4(), draft_id=draft.id, version=next_version,
         text=text, link_url=link_url,
         body_sha256=compute_channel_post_hash(text=text, link_url=link_url),
-        image_sha256=resolved_image_sha256,
+        image_sha256=resolved_image_sha256, hook_key=hook_key,
         author_member_id=author_member_id, author_kind=author_kind,
     )
     db.add(version)

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -17,6 +17,10 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.channel_post_image import ChannelPostImage
+from app.models.channel_post_version import ChannelPostVersion
+from app.models.channel_post_video import ChannelPostVideo
+from app.models.channel_publication import ChannelPublication
 from app.models.insight_snapshot import InsightSnapshot
 from app.services.facebook_publish import _GRAPH_BASE as _FACEBOOK_GRAPH_BASE
 from app.services.instagram_publish import _GRAPH_BASE as _INSTAGRAM_GRAPH_BASE
@@ -769,6 +773,50 @@ async def _maybe_enrich_with_ga4_inflow(db: AsyncSession, snapshot: InsightSnaps
         snapshot.normalized.update(inflow)
 
 
+async def _resolve_channel_publication_asset_evidence(
+    db: AsyncSession, snapshot: InsightSnapshot,
+) -> tuple[list[str] | None, str | None]:
+    """story #3645(Phase2·BE, 페드루 PO 確定 2026-09-07 — 그라운딩 정정: asset_master
+    개념은 코드 0건, 블루프린트 «처분»을 «착지»로 읽은 PO 오독이었다) — 이 스냅샷이
+    가리키는 발행물이 실제로 내보낸 소재(이미지/영상)의 sha256을 position 순으로,
+    그리고 그 버전에 걸린 `hook_key`를 함께(`(asset_sha256s, hook_key)`) — 같은
+    `ChannelPublication`→`ChannelPostVersion` 조회를 한 번만 태운다.
+
+    `publication_kind == "site_post"`(hosted_site)는 이미지/영상·hook_key 개념
+    자체가 없어 `(None, None)`(있는 걸 지어내지 않는다). `channel_publication`만
+    `ChannelPublication.version_id`를 거쳐 찾는다 — 릴스(`ChannelPostVideo`, story
+    #3554)면 영상+커버(position=0 이미지) 순으로 2건, 아니면 `ChannelPostImage`를
+    position 순으로(캐러셀 N장 또는 단일 1장). 이미지도 영상도 없으면(텍스트만)
+    asset_sha256s는 None. hook_key는 이 시점의 `ChannelPostVersion.hook_key` 값을
+    그대로 카피 — 발행 뒤 그 컬럼을 고쳐도 이미 기록된 이 evidence는 안 바뀐다."""
+    if snapshot.publication_kind != "channel_publication":
+        return None, None
+
+    publication = await db.get(ChannelPublication, snapshot.publication_id)
+    if publication is None:
+        return None, None
+
+    version = await db.get(ChannelPostVersion, publication.version_id)
+    hook_key = version.hook_key if version is not None else None
+
+    video = (await db.execute(
+        select(ChannelPostVideo).where(ChannelPostVideo.version_id == publication.version_id)
+    )).scalar_one_or_none()
+
+    images = (await db.execute(
+        select(ChannelPostImage)
+        .where(ChannelPostImage.version_id == publication.version_id)
+        .order_by(ChannelPostImage.position.asc())
+    )).scalars().all()
+
+    sha256s: list[str] = []
+    if video is not None:
+        sha256s.append(video.original_sha256)
+    sha256s.extend(image.original_sha256 for image in images)
+
+    return sha256s or None, hook_key
+
+
 async def _record_insight_evidence(db: AsyncSession, snapshot: InsightSnapshot) -> None:
     """story #3497 그라운딩①(페드루 決定 반영) — evidence.payload(JSONB)에 구조화
     데이터를, note에는 사람용 한 줄만. Evidence(...) 직접 construct(evidence_service.py
@@ -786,6 +834,11 @@ async def _record_insight_evidence(db: AsyncSession, snapshot: InsightSnapshot) 
     parts = [f"{k}={v}" for k, v in n.items() if v is not None]
     note = f"{', '.join(parts)} · captured {snapshot.captured_at.strftime('%m-%d %H:%MZ')}" if snapshot.captured_at else ", ".join(parts)
 
+    # story #3645 — 이 evidence 시점의 소재 계보·hook_key를 고정한다(publish 뒤 draft
+    # 쪽 이미지나 hook_key가 바뀌어도 이미 기록된 이 evidence는 안 바뀐다 — 카피지
+    # 참조가 아니다).
+    asset_sha256s, hook_key = await _resolve_channel_publication_asset_evidence(db, snapshot)
+
     db.add(Evidence(
         id=uuid.uuid4(), org_id=snapshot.org_id, work_item_id=snapshot.work_item_id,
         work_item_type="story", type="metric", ref=str(snapshot.id), source=snapshot.channel,
@@ -793,5 +846,6 @@ async def _record_insight_evidence(db: AsyncSession, snapshot: InsightSnapshot) 
         payload={
             **n, "captured_at": snapshot.captured_at.isoformat() if snapshot.captured_at else None,
             "source": snapshot.channel, "snapshot_id": str(snapshot.id), "recorded_by": "platform",
+            "asset_sha256s": asset_sha256s, "hook_key": hook_key,
         },
     ))

--- a/backend/tests/test_3645_evidence_asset_hook_keys.py
+++ b/backend/tests/test_3645_evidence_asset_hook_keys.py
@@ -1,0 +1,496 @@
+"""story #3645(Phase2·BE, 페드루 PO 確定 2026-09-07 — 그라운딩 정정 후 3pt·BE만·#3987
+뒤): evidence에 소재(asset) 계보 + hook_key 라벨.
+
+그라운딩에서 정정된 두 가지(본문·코드 둘 다 근거):
+① asset_master 개념은 코드 0건 — 블루프린트 "처분"을 "착지"로 읽은 PO 오독이었다.
+   원장 개념을 새로 만들지 않는다. `channel_post_images.original_sha256`을 그대로
+   소재 키로 쓴다.
+② `verification_sheet` Evidence kind는 story #3561로 이미 존재 — 이 스토리 범위
+   밖(③ 채택 안 함).
+
+이 파일의 관심사:
+1. `insight_snapshots.py::_resolve_channel_publication_asset_evidence`의 정규화
+   (캐러셀 N장·릴스 영상+커버 2건·단일 이미지 1건·텍스트만 null·site_post kind는
+   애초에 이미지 개념이 없어 null).
+2. `channel_post_versions.hook_key` — 서버 형식 검사(≤64자·`[A-Za-z0-9_-]`, 422)·
+   발행 뒤 편집이 이미 기록된 evidence에 영향 없음(카피지 참조가 아니다).
+
+세팅 헬퍼는 test_620beefc_channel_post_image_upload.py(draft/이미지/연결)·
+test_3497_insight_snapshots.py(스냅샷 스케줄/처리) 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_620beefc_channel_post_image_upload import (
+    _client_for,
+    _create_draft,
+    _seed_connection,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _seed_image(session, *, org_id, draft_id, version_id, position, sha256=None):
+    from app.models.channel_post_image import ChannelPostImage
+
+    image = ChannelPostImage(
+        id=uuid.uuid4(), org_id=org_id, draft_id=draft_id, version_id=version_id, position=position,
+        original_object_path=f"org/{org_id}/img-{uuid.uuid4().hex[:8]}.jpg",
+        original_sha256=sha256 or uuid.uuid4().hex,
+        original_content_type="image/jpeg", original_bytes=1234,
+        original_width=1080, original_height=1080, created_by=uuid.uuid4(),
+    )
+    session.add(image)
+    await session.commit()
+    return image
+
+
+async def _seed_video(session, *, org_id, draft_id, version_id, sha256=None):
+    from app.models.channel_post_video import ChannelPostVideo
+
+    video = ChannelPostVideo(
+        id=uuid.uuid4(), org_id=org_id, draft_id=draft_id, version_id=version_id,
+        original_object_path=f"org/{org_id}/vid-{uuid.uuid4().hex[:8]}.mp4",
+        original_sha256=sha256 or uuid.uuid4().hex,
+        original_content_type="video/mp4", original_bytes=999999,
+        duration_seconds=12.0, width=1080, height=1920, codec="avc1", created_by=uuid.uuid4(),
+    )
+    session.add(video)
+    await session.commit()
+    return video
+
+
+async def _seed_channel_publication(session, *, org_id, connection_id, channel, version_id, external_id="media-1"):
+    from app.models.channel_publication import ChannelPublication
+
+    pub = ChannelPublication(
+        id=uuid.uuid4(), org_id=org_id, gate_id=uuid.uuid4(), version_id=version_id,
+        connection_id=connection_id, channel=channel, status="published",
+        external_id=external_id, published_at=datetime.now(timezone.utc),
+    )
+    session.add(pub)
+    await session.commit()
+    return pub
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    """test_3497_insight_snapshots.py의 dict 직접 주입 선례와 동형 — sandbox insight
+    캡처 경로가 이 어댑터 등재를 요구한다."""
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=10,
+        insight_metrics=("impressions", "reach", "views", "engagements", "clicks", "spend", "conversions"),
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+async def _capture_and_get_evidence(session, *, org_id, work_item_id, publication_id, publication_kind, channel="sandbox"):
+    from app.models.evidence import Evidence
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    due_soon = datetime.now(timezone.utc) - timedelta(minutes=1)
+    await schedule_insight_snapshots(
+        session, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+        publication_kind=publication_kind, channel=channel, external_id=None,
+        anchor_at=due_soon - timedelta(days=1),
+    )
+    await session.commit()
+    counts = await process_due_insight_snapshots(session)
+    assert counts["captured"] == 1, counts
+
+    evidence = (await session.execute(
+        select(Evidence).where(Evidence.work_item_id == work_item_id, Evidence.source == channel)
+    )).scalar_one()
+    return evidence
+
+
+# ─── ①-normalize — asset_sha256s ──────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_asset_sha256s_carousel_two_images_position_ordered():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+            draft_id = uuid.uuid4()
+            version_id = uuid.uuid4()
+            img0 = await _seed_image(s, org_id=org_id, draft_id=draft_id, version_id=version_id, position=0)
+            img1 = await _seed_image(s, org_id=org_id, draft_id=draft_id, version_id=version_id, position=1)
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn_id, channel="sandbox", version_id=version_id)
+
+            evidence = await _capture_and_get_evidence(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), publication_id=pub.id,
+                publication_kind="channel_publication",
+            )
+            assert evidence.payload["asset_sha256s"] == [img0.original_sha256, img1.original_sha256]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_asset_sha256s_reels_video_then_cover():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+            draft_id = uuid.uuid4()
+            version_id = uuid.uuid4()
+            video = await _seed_video(s, org_id=org_id, draft_id=draft_id, version_id=version_id)
+            cover = await _seed_image(s, org_id=org_id, draft_id=draft_id, version_id=version_id, position=0)
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn_id, channel="sandbox", version_id=version_id)
+
+            evidence = await _capture_and_get_evidence(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), publication_id=pub.id,
+                publication_kind="channel_publication",
+            )
+            assert evidence.payload["asset_sha256s"] == [video.original_sha256, cover.original_sha256]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_asset_sha256s_single_image():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+            draft_id = uuid.uuid4()
+            version_id = uuid.uuid4()
+            img = await _seed_image(s, org_id=org_id, draft_id=draft_id, version_id=version_id, position=0)
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn_id, channel="sandbox", version_id=version_id)
+
+            evidence = await _capture_and_get_evidence(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), publication_id=pub.id,
+                publication_kind="channel_publication",
+            )
+            assert evidence.payload["asset_sha256s"] == [img.original_sha256]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_asset_sha256s_text_only_null():
+    """이미지도 영상도 없는(텍스트만) 버전 — 있는 걸 지어내지 않는다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+            version_id = uuid.uuid4()
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn_id, channel="sandbox", version_id=version_id)
+
+            evidence = await _capture_and_get_evidence(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), publication_id=pub.id,
+                publication_kind="channel_publication",
+            )
+            assert evidence.payload["asset_sha256s"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_asset_sha256s_null_for_site_post_kind():
+    """publication_kind="site_post"(hosted_site)는 이미지/영상 개념 자체가 없다 —
+    channel_publication 축 조회를 아예 안 타는지 확認(기존 #3497 site_post 경로
+    회귀 0)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+
+            evidence = await _capture_and_get_evidence(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), publication_id=uuid.uuid4(),
+                publication_kind="site_post",
+            )
+            assert evidence.payload["asset_sha256s"] is None
+            assert evidence.payload["hook_key"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_removing_asset_resolver_call_loses_asset_sha256s_key(monkeypatch):
+    """뮤테이션 — evidence 기록에서 소재 계보 조회를 없애면 캐러셀 스냅샷의
+    asset_sha256s가 None으로 무너진다(이 정규화가 실제로 그 결함을 잡는다는 증거)."""
+    import app.services.insight_snapshots as insight_snapshots_module
+
+    async def _never_resolves(db, snapshot):
+        return None, None
+
+    monkeypatch.setattr(
+        insight_snapshots_module, "_resolve_channel_publication_asset_evidence", _never_resolves,
+    )
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+            draft_id = uuid.uuid4()
+            version_id = uuid.uuid4()
+            await _seed_image(s, org_id=org_id, draft_id=draft_id, version_id=version_id, position=0)
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn_id, channel="sandbox", version_id=version_id)
+
+            evidence = await _capture_and_get_evidence(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), publication_id=pub.id,
+                publication_kind="channel_publication",
+            )
+            assert evidence.payload["asset_sha256s"] is None, "뮤테이션이 걸리지 않았다"
+    finally:
+        await engine.dispose()
+
+
+# ─── ②-hook_key — 형식 검사·post-publish 편집 격리 ─────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_hook_key_valid_persists_on_version():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id = await _seed_human(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+
+        app.dependency_overrides.clear()
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        try:
+            async with _client_for(app) as c:
+                r = await c.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(conn_id),
+                        "text": "훅 테스트", "hook_key": "hook-A_1",
+                    },
+                )
+                assert r.status_code == 201, r.text
+                assert r.json()["hook_key"] == "hook-A_1"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hook_key_too_long_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id = await _seed_human(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+
+        app.dependency_overrides.clear()
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        try:
+            async with _client_for(app) as c:
+                r = await c.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(conn_id),
+                        "text": "훅 테스트", "hook_key": "x" * 65,
+                    },
+                )
+                assert r.status_code == 422, r.text
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hook_key_invalid_characters_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id = await _seed_human(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+
+        app.dependency_overrides.clear()
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        try:
+            async with _client_for(app) as c:
+                r = await c.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(conn_id),
+                        "text": "훅 테스트", "hook_key": "hook key!",
+                    },
+                )
+                assert r.status_code == 422, r.text
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hook_key_edit_after_publish_does_not_change_recorded_evidence():
+    """발행 뒤 draft를 다시 편집(새 버전, hook_key 다른 값)해도 이미 기록된 evidence의
+    hook_key는 안 바뀐다 — evidence가 그 시점(publication.version_id 고정)의 버전을
+    카피했기 때문(참조 조회가 아니다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id = await _seed_human(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+
+        app.dependency_overrides.clear()
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        try:
+            async with _client_for(app) as c:
+                r1 = await c.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(conn_id),
+                        "text": "훅 v1", "hook_key": "hook-v1",
+                    },
+                )
+                assert r1.status_code == 201, r1.text
+                published_version_id = uuid.UUID(r1.json()["version_id"])
+
+                # 발행(그 버전을 가리키는 channel_publication)은 이 시점의 버전을 고정.
+                async with Session() as s:
+                    pub = await _seed_channel_publication(
+                        s, org_id=org_id, connection_id=conn_id, channel="sandbox",
+                        version_id=published_version_id,
+                    )
+                    evidence = await _capture_and_get_evidence(
+                        s, org_id=org_id, work_item_id=story_id, publication_id=pub.id,
+                        publication_kind="channel_publication",
+                    )
+                    assert evidence.payload["hook_key"] == "hook-v1"
+
+                # 발행 뒤 편집(같은 draft, 새 버전) — hook_key를 다른 값으로.
+                r2 = await c.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(conn_id),
+                        "text": "훅 v2", "hook_key": "hook-v2",
+                    },
+                )
+                assert r2.status_code == 201, r2.text
+                assert r2.json()["version_id"] != str(published_version_id)
+
+                # 이미 기록된 evidence는 v1 그대로.
+                async with Session() as s:
+                    from sqlalchemy import select
+                    from app.models.evidence import Evidence
+                    reloaded = (await s.execute(
+                        select(Evidence).where(Evidence.id == evidence.id)
+                    )).scalar_one()
+                    assert reloaded.payload["hook_key"] == "hook-v1", "발행 뒤 편집이 옛 evidence를 조용히 바꿨다"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_removing_hook_key_pass_through_loses_hook_key_in_evidence(monkeypatch):
+    """뮤테이션 — 라우터가 hook_key를 서비스로 안 넘기면(누락) 발행물의 hook_key가
+    항상 None으로 무너진다."""
+    from app.main import app
+    import app.routers.channel_posts as channel_posts_router_module
+
+    original = channel_posts_router_module.create_channel_post_draft_version
+
+    async def _drop_hook_key(*args, **kwargs):
+        kwargs.pop("hook_key", None)
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(channel_posts_router_module, "create_channel_post_draft_version", _drop_hook_key)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id = await _seed_human(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            conn_id = await _seed_connection(s, org_id, channel="sandbox")
+
+        app.dependency_overrides.clear()
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        try:
+            async with _client_for(app) as c:
+                r = await c.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(conn_id),
+                        "text": "훅 테스트", "hook_key": "hook-A",
+                    },
+                )
+                assert r.status_code == 201, r.text
+                assert r.json()["hook_key"] is None, "뮤테이션이 걸리지 않았다"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3645_evidence_asset_hook_keys.py
+++ b/backend/tests/test_3645_evidence_asset_hook_keys.py
@@ -390,9 +390,14 @@ async def test_hook_key_invalid_characters_rejected_422():
 
 @pytest.mark.anyio
 async def test_hook_key_edit_after_publish_does_not_change_recorded_evidence():
-    """발행 뒤 draft를 다시 편집(새 버전, hook_key 다른 값)해도 이미 기록된 evidence의
-    hook_key는 안 바뀐다 — evidence가 그 시점(publication.version_id 고정)의 버전을
-    카피했기 때문(참조 조회가 아니다)."""
+    """AC3 — evidence 고정의 근거는 「version 행 불변」 하나뿐(편집=새 version 행을
+    추가할 뿐, publication.version_id가 가리키는 옛 행을 제자리 갱신하지 않는다).
+    이 구조를 실제 시간 순서(발행 → 편집(새 version) → +1d 스냅샷 캡처) 그대로
+    밟아 증명한다 — 스냅샷 캡처가 편집보다 **나중에** 일어나도, resolver가
+    publication.version_id로 조회하는 건 여전히 발행 시점의 그 옛 행이라 옛 값을
+    낸다. 잃는 것(PR 본문에도 명시): 편집이 같은 version 행을 「제자리」로 고치는
+    경로가 생기는 순간 이 구조가 깨진다 — 지금 head엔 그런 `.hook_key =` 갱신이
+    0건이라 참."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -407,6 +412,9 @@ async def test_hook_key_edit_after_publish_does_not_change_recorded_evidence():
         _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
         try:
             async with _client_for(app) as c:
+                # ① 발행 — v1(hook_key=hook-v1)을 만들고, 그 버전을 가리키는
+                # channel_publication을 심는다(실 발행 오케스트레이션은 다른 파일이
+                # 이미 잰다 — 이 테스트의 관심사는 「그 뒤」 축뿐).
                 r1 = await c.post(
                     f"/api/v2/organizations/{org_id}/channel-posts/drafts",
                     json={
@@ -417,19 +425,14 @@ async def test_hook_key_edit_after_publish_does_not_change_recorded_evidence():
                 assert r1.status_code == 201, r1.text
                 published_version_id = uuid.UUID(r1.json()["version_id"])
 
-                # 발행(그 버전을 가리키는 channel_publication)은 이 시점의 버전을 고정.
                 async with Session() as s:
                     pub = await _seed_channel_publication(
                         s, org_id=org_id, connection_id=conn_id, channel="sandbox",
                         version_id=published_version_id,
                     )
-                    evidence = await _capture_and_get_evidence(
-                        s, org_id=org_id, work_item_id=story_id, publication_id=pub.id,
-                        publication_kind="channel_publication",
-                    )
-                    assert evidence.payload["hook_key"] == "hook-v1"
 
-                # 발행 뒤 편집(같은 draft, 새 버전) — hook_key를 다른 값으로.
+                # ② 발행 뒤 편집(같은 draft, 새 버전 v2) — hook_key를 다른 값으로.
+                # 이 시점엔 아직 스냅샷을 한 번도 캡처하지 않았다(+1d 스냅샷은 뒤에).
                 r2 = await c.post(
                     f"/api/v2/organizations/{org_id}/channel-posts/drafts",
                     json={
@@ -440,14 +443,18 @@ async def test_hook_key_edit_after_publish_does_not_change_recorded_evidence():
                 assert r2.status_code == 201, r2.text
                 assert r2.json()["version_id"] != str(published_version_id)
 
-                # 이미 기록된 evidence는 v1 그대로.
+                # ③ +1d 스냅샷 캡처 — v2 편집 「뒤」에 일어난다. publication.version_id는
+                # 여전히 v1을 가리키므로(발행이 v2를 다시 가리키게 옮기는 경로가 없다),
+                # resolver가 읽는 ChannelPostVersion.hook_key도 v1의 값 그대로다.
                 async with Session() as s:
-                    from sqlalchemy import select
-                    from app.models.evidence import Evidence
-                    reloaded = (await s.execute(
-                        select(Evidence).where(Evidence.id == evidence.id)
-                    )).scalar_one()
-                    assert reloaded.payload["hook_key"] == "hook-v1", "발행 뒤 편집이 옛 evidence를 조용히 바꿨다"
+                    evidence = await _capture_and_get_evidence(
+                        s, org_id=org_id, work_item_id=story_id, publication_id=pub.id,
+                        publication_kind="channel_publication",
+                    )
+                    assert evidence.payload["hook_key"] == "hook-v1", (
+                        "편집(v2) 뒤에 캡처한 스냅샷인데도 발행 시점(v1) 값이 아니다 — "
+                        "publication.version_id가 편집으로 옮겨갔거나, v1 행이 제자리로 고쳐졌다는 뜻"
+                    )
         finally:
             app.dependency_overrides.clear()
     finally:

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1507,6 +1507,11 @@
       "file": "tests/test_3629_member_ssot_notification_command_center_realdb.py",
       "sec": 20.0,
       "source": "story-3629-member-ssot-notification-command-center(PR 개설 前 선제 등재, 페드루 PO CHANGES — app.main 전역 엔진+실 HTTP 클라이언트 경유라 destructive_schema 짝 요구. 로컬 raw pytest 3건 3.02s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3645_evidence_asset_hook_keys.py",
+      "sec": 41.0,
+      "source": "story-3645-evidence-asset-hook-keys(PR #4002 CI 가드 발견 — 로컬 raw pytest 11건 6.81s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 41s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
스토리 id 96852bb9-c973-4b69-b3ba-5dcde7ae5e64. 그라운딩(디디, 코드 X) 뒤 PO 재확定 — 3pt·BE만·#3987(migration 0352) 뒤.

## 그라운딩 정정(채택)
- asset_master 개념은 코드 0건 — 블루프린트 "처분"을 "착지"로 읽은 PO 오독이었다(원 배경 서술 정정). 새 원장을 안 만들고 `channel_post_images.original_sha256`을 그대로 소재 키로 쓴다.
- `verification_sheet` Evidence kind는 story #3561로 이미 존재 — 이 스토리 범위 밖(③ 채택 안 함).

## ① asset_sha256s
`insight_snapshots.py::_resolve_channel_publication_asset_evidence` — 스냅샷의 `publication_id`→`ChannelPublication.version_id`를 거쳐 실제로 내보낸 소재를 position 순으로 모은다:
- 캐러셀 N장(`ChannelPostImage`)
- 릴스는 영상+커버 2건(`ChannelPostVideo` 우선, story #3554)
- 단일 이미지 1건
- 텍스트만이면 `None`(있는 걸 지어내지 않는다)
- `publication_kind="site_post"`(hosted_site)는 이미지 개념 자체가 없어 애초에 조회를 안 탄다.

## ② hook_key
`channel_post_versions.hook_key`(nullable, migration 0353) — 훅(캡션 도입부) A/B 태깅용 순수 분석 라벨.

**봉인 축(body_sha256/image_sha256)엔 안 넣는다** — 값이 바뀌어도 재승인 사유가 아니다. `link_url`과 동형(캐리포워드 없음) — `image_sha256`과 달리 「빈손 발행」류 결함 소지가 없는 라벨이라 캐리포워드 sentinel 복잡도가 안 남는다. 라우터 요청 모델에서 형식 검사(≤64자·`[A-Za-z0-9_-]`, 422).

발행 시점에 evidence payload로 값을 복사해 두므로, 발행 뒤 이 컬럼을 고쳐도 이미 기록된 evidence는 안 바뀐다(카피지 참조가 아니다 — 실경로 테스트로 증명).

**AC3(확認, PO 대조)** — 실제로는 「발행 시점」이 아니라 「+1d/+7d 스냅샷 캡처 시점」에 `ChannelPostVersion.hook_key`를 읽는 구조다. 이게 AC3(발행 시점 값 고정)를 만족하는 근거는 **「version 행 불변」 하나뿐** — 편집은 항상 새 `ChannelPostVersion` 행을 추가할 뿐, `channel_publication.version_id`가 가리키는 옛 행을 제자리로 고치지 않는다. head엔 `.hook_key =` 같은 제자리 갱신 경로가 0건이라 지금은 참이지만, **잃는 것**: 그런 경로가 새로 생기는 순간 이 구조가 깨진다. 테스트를 실제 시간순(발행 → 편집(새 version) → +1d 캡처)으로 재구성해 증명했다(캡처가 편집보다 나중이어도 옛 값을 낸다).

## Test plan
- [x] 정규화 5건(캐러셀 2·릴스 2·단일 1·텍스트 null·site_post kind null)
- [x] hook_key 형식 검사 422 2건(길이·문자)+정상 값 persist 1건
- [x] post-publish hook_key 편집이 이미 기록된 evidence에 무영향 1건(실경로 HTTP)
- [x] 뮤테이션 2(소재 조회 제거·hook_key 전달 누락) — 정확한 이유로 RED 확認 후 원복
- [x] 기존 회귀(insight_snapshots·이미지 업로드·캐러셀·릴스·발행) 104/104 그린
- [x] `app.main` import 그린

## 라이브
dev 착지 뒤 PO(캐러셀·텍스트전용 발행) — 그라운딩⑤ 그대로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
