### PR TITLE
[SID:3651] feat: hosted MCP 도구 sprintable_get_publication_insights 신설

### DIFF
--- a/backend/app/routers/insight_snapshots.py
+++ b/backend/app/routers/insight_snapshots.py
@@ -15,7 +15,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import get_current_user
 from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
-from app.services.insight_snapshots import list_insight_snapshots_for_publication
+from app.services.insight_snapshots import (
+    label_snapshot_offset,
+    list_insight_snapshots_for_publication,
+    resolve_publication_published_at,
+)
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["insight-snapshots"])
 
@@ -29,6 +33,12 @@ class InsightSnapshotView(BaseModel):
     normalized: dict[str, int | None] | None
     source: str | None
     error_code: str | None
+    # story #3651 CHANGES(카디르 발견, PR#4003, 2026-09-07) — insights_board.py가 이미
+    # 쓰던 「due_at−«지금» published_at」 라벨링을 소비부(MCP 도구)가 각자 인덱스로
+    # 흉내 내다 재발행(같은 publication_id, published_at 갱신 + 새 due_at 2행 추가)
+    # 사례에서 오라벨했다. 서버가 정본 라벨을 낸다 — null=옛 발행 사이클의 잔존
+    # 스냅샷(그 due_at이 «지금» published_at의 +1일/+7일 어느 쪽도 아님).
+    offset_label: str | None = None
 
 
 @router.get(
@@ -49,10 +59,22 @@ async def list_publication_insights_endpoint(
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
     rows = await list_insight_snapshots_for_publication(db, org_id=org_id, publication_id=publication_id)
+    # story #3651 CHANGES — 이 publication의 «지금» published_at 1회 조회(행마다 반복
+    # 조회 0, 어차피 폴리모픽 publication_id 하나당 kind는 하나다 — rows[0]에서 그대로
+    # 읽는다). 스냅샷이 없으면 조회 자체를 스킵(빈 목록 반환은 그대로 유지).
+    published_at = None
+    if rows:
+        published_at = await resolve_publication_published_at(
+            db, publication_kind=rows[0].publication_kind, publication_id=publication_id,
+        )
     return [
         InsightSnapshotView(
             id=r.id, channel=r.channel, due_at=r.due_at, captured_at=r.captured_at,
             status=r.status, normalized=r.normalized, source=r.source, error_code=r.error_code,
+            offset_label=(
+                label_snapshot_offset(due_at=r.due_at, published_at=published_at)
+                if published_at is not None else None
+            ),
         )
         for r in rows
     ]

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -95,6 +95,38 @@ async def list_insight_snapshots_for_publication(
     return list(rows)
 
 
+async def resolve_publication_published_at(
+    db: AsyncSession, *, publication_kind: str, publication_id: uuid.UUID,
+) -> datetime | None:
+    """publication_kind별 «지금」 published_at 해석 — insights_board.py의 rows_cte가
+    kind별로 이미 푸는 자리와 같은 소스(SitePost.published_at·ChannelPublication.
+    published_at). 존재하지 않는 publication_id는 None(지어내지 않는다)."""
+    from app.models.channel_publication import ChannelPublication
+    from app.models.site_post import SitePost
+
+    model = SitePost if publication_kind == "site_post" else ChannelPublication
+    return (await db.execute(
+        select(model.published_at).where(model.id == publication_id)
+    )).scalar_one_or_none()
+
+
+def label_snapshot_offset(*, due_at: datetime, published_at: datetime) -> str | None:
+    """due_at이 «지금» published_at 기준 +1일/+7일 버킷 중 어디인지 — insights_board.py
+    관찰 그대로(round()로 부동소수 잡음 완충, `.days`는 0을 향해 버려 경계값이 밀릴
+    수 있다). 매치 안 되면 None — 카디르 발견(PR#4003, 2026-09-07): hosted_site 재발행은
+    같은 publication_id를 유지한 채 published_at을 갱신하고, `schedule_insight_
+    snapshots`가 새 due_at 2행을 더 연다(UNIQUE(publication_id, due_at)는 «새» due_at을
+    안 막는다) — 원래 있던 인덱스 기반 라벨링("idx0=1d·나머지=7d")은 이 옛 발행 사이클의
+    잔존 스냅샷을 «7d»로 오라벨했다. None은 "옛 사이클 잔존"의 정직한 신호 — 호출자가
+    델타 계산에서 빼고 개수만 알린다(3651 MCP 도구의 superseded_snapshots)."""
+    offset = round((due_at - published_at).total_seconds() / 86400)
+    if offset == 1:
+        return "1d"
+    if offset == 7:
+        return "7d"
+    return None
+
+
 async def get_latest_insight_snapshot(db: AsyncSession, *, publication_id: uuid.UUID) -> InsightSnapshot | None:
     """story #3497 조각3 — get_*_publication 응답에 얹는 `latest_insight` 1건(그라운딩
     確定④). "최신"은 captured_at 내림차순 — 아직 아무것도 안 잡힌 발행은 None(지어

--- a/backend/app/services/insights_board.py
+++ b/backend/app/services/insights_board.py
@@ -41,7 +41,7 @@ from app.models.gate import Gate
 from app.models.insight_snapshot import InsightSnapshot
 from app.models.pm import Story
 from app.models.site_post import SitePost
-from app.services.insight_snapshots import NORMALIZED_KEYS
+from app.services.insight_snapshots import NORMALIZED_KEYS, label_snapshot_offset
 
 _WINDOW_DAYS = {"7d": 7, "30d": 30, "90d": 90}  # story 確定(e) — 3475(7d·30d)에 90d 신규 편입.
 _SNAPSHOT_OFFSET_DAYS = {"d1": 1, "d7": 7}
@@ -252,15 +252,15 @@ async def list_insights_board(
     for r in page:
         # due_at은 anchor_at(=published_at) + offset로 스케줄됐다(schedule_insight_
         # snapshots) — published_at과의 일수 차이로 +1일/+7일 버킷을 되짚는다.
-        # 페드루 PO 기록③(PR#3849 리뷰) — `.days`는 0을 향해 버림(예: 6.999일→6)이라
-        # 초 단위 미세 오차(타임존 변환 왕복 등)에서 경계값이 밀릴 수 있다 —
-        # round()로 완충(整수 offset만 유효하므로 반올림이 잘림보다 항상 안전).
+        # label_snapshot_offset(insight_snapshots.py) 공유 헬퍼로 뺐다(카디르 발견,
+        # PR#4003 — MCP 3651이 이 자리와 별개로 인덱스 기반 라벨링을 갖고 있어 재발행
+        # 스냅샷을 오라벨했다, 같은 규칙 한 자리).
         d1 = d7 = None
         for snap in snapshots_by_pub.get(r.publication_id, []):
-            offset = round((snap.due_at - r.published_at).total_seconds() / 86400)
-            if offset == 1:
+            label = label_snapshot_offset(due_at=snap.due_at, published_at=r.published_at)
+            if label == "1d":
                 d1 = snap
-            elif offset == 7:
+            elif label == "7d":
                 d7 = snap
         is_channel_pub = r.kind == "channel_publication"
         adapter = CHANNEL_ADAPTERS.get(r.channel) if is_channel_pub else None

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -439,6 +439,9 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     # 콘텐츠 전용 그룹이 아직 없다는 기존 갭(REST _PATH_GROUP_PREFIXES에도 channel-posts
     # 미등록, 동일 갭)의 연장선. 새 그룹 신설은 이 스토리 범위 밖 — 후속 스토리 후보로 남긴다.
     "sprintable_withdraw_channel_post_draft",
+    # 발행물 인사이트(story #3651) — 이름에 "insight"가 있어 _GROUP_KEYWORDS의 "content"
+    # 그룹(3631 신설)이 이미 커버한다(위 withdraw와 달리 새 갭이 아니다).
+    "sprintable_get_publication_insights",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -36,7 +36,10 @@ from .toolset import is_tool_allowed
 from .tools.a2a import (
     LinkGateToTaskInput, ListAgentCardsInput, link_gate_to_task, list_agent_cards,
 )
-from .tools.channel_posts import WithdrawChannelPostDraftInput, withdraw_channel_post_draft
+from .tools.channel_posts import (
+    GetPublicationInsightsInput, WithdrawChannelPostDraftInput,
+    get_publication_insights, withdraw_channel_post_draft,
+)
 from .tools.decisions import RequestDecisionInput, request_decision
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.judgments import AddJudgmentInput, ListJudgmentsInput, add_judgment, list_judgments
@@ -985,6 +988,16 @@ _TOOL_DEFS: list[tuple] = [
      "게이트는 사유 「작성자가 폐기」로 rejected 종결, 이미 발행된 초안은 409(발행 취소는 "
      "별도 unpublish 경로). 이미 폐기된 초안 재호출은 멱등.",
      WithdrawChannelPostDraftInput, withdraw_channel_post_draft),
+    # 발행물 1일·7일 인사이트 — story #3651(2026-09-07). 블루프린트 §7 Phase 2 AC
+    # 「1일·7일 성과를 비교해 후속 스토리를 만든다」의 에이전트 몫(스토리 생성 자체는
+    # 기존 sprintable_add_story).
+    ("sprintable_get_publication_insights",
+     "[일감] 발행물의 1일·7일 인사이트 스냅샷 목록 + 둘 사이 키별 델타(v7-v1)를 준다 — "
+     "publication_id 직접 지정 또는 draft_id로 「마지막 발행」을 대신 찾음(초안 미발행 "
+     "시 그 사실을 알림). delta_1d_to_7d는 두 스냅샷 모두 captured일 때만 채워지고, "
+     "미도래(pending)·실패(failed)면 null+사유. 한쪽이라도 미제공(null)인 지표는 델타도 "
+     "null(0과 섞지 않음). 후속 스토리는 이 도구가 대신 안 만든다 — sprintable_add_story를 쓸 것.",
+     GetPublicationInsightsInput, get_publication_insights),
 ]
 
 for _name, _doc, _cls, _fn in _TOOL_DEFS:

--- a/backend/sprintable_mcp/tools/channel_posts.py
+++ b/backend/sprintable_mcp/tools/channel_posts.py
@@ -33,3 +33,89 @@ async def withdraw_channel_post_draft(args: WithdrawChannelPostDraftInput) -> li
         return ok(result)
     except Exception as exc:
         return err(str(exc))
+
+
+# story #3651(Phase2·MCP·소형, 페드루 PO 確定 2026-09-07) — 블루프린트 v3 §7 Phase 2 AC
+# 「1일·7일 성과를 비교해 후속 스토리를 만든다」의 에이전트 몫. 원장(story #3497/#3571)·
+# REST 조회(insight_snapshots.py:34, `/publications/{publication_id}/insights`)는 이미
+# 완비돼 있었으나 hosted MCP엔 insight류 도구가 0(휴먼 표면=insights-board만 있고 에이전트
+# 표면이 없던 자리) — 「만들어졌는데 쓰는 자리 없음」 클래스. 후속 스토리 생성 자체는
+# 새로 안 짓는다 — 기존 sprintable_add_story를 그대로 쓴다(이 도구는 «비교할 재료»만 준다).
+class GetPublicationInsightsInput(SprintableInput):
+    # 원한다면(권장) publication_id를 직접, 모르면 draft_id로 최신 발행을 찾아 준다 —
+    # 최저 지능 에이전트가 초안 id만 알아도 되게 하는 편의 축(선택, 스토리 처방③).
+    publication_id: str | None = None
+    draft_id: str | None = None
+
+
+# story #3497 서비스(insight_snapshots.py)의 NORMALIZED_KEYS와 같은 계약(정규화 7키+
+# GA4 유입 3키)을 이 MCP 프로세스는 직접 import 못 한다(별도 패키지, REST 경계 너머) —
+# 여기서 키 목록을 재선언하지 않고 응답에 실제로 있는 키의 합집합으로 델타를 낸다(BE가
+# 키를 늘려도 이 축이 안 깨진다, 새 계약 문서 동기화 불요).
+def _label_snapshots_and_compute_delta(
+    snapshots: list[dict],
+) -> tuple[list[dict], dict[str, int | None] | None, str | None]:
+    """due_at 오름차순 정렬 뒤 offset_label(1d|7d)을 매기고, 둘 다 captured일 때만
+    키별 v7−v1 델타를 낸다. 페드루 決定(3321 원칙) — 0과 null(미제공)을 섞지 않는다:
+    두 값 중 하나라도 None이면 그 키의 델타는 None(0으로 대체하지 않는다)."""
+    sorted_snapshots = sorted(snapshots, key=lambda s: s["due_at"])
+    labeled = [
+        {**snap, "offset_label": "1d" if idx == 0 else "7d"}
+        for idx, snap in enumerate(sorted_snapshots)
+    ]
+    snapshot_1d = next((s for s in labeled if s["offset_label"] == "1d"), None)
+    snapshot_7d = next((s for s in labeled if s["offset_label"] == "7d"), None)
+    if snapshot_1d is None or snapshot_7d is None:
+        return labeled, None, "스냅샷이 2건 미만 — 1일·7일 두 스냅샷이 모두 등록돼야 델타를 계산합니다."
+    if snapshot_1d["status"] != "captured":
+        return labeled, None, f"1일 스냅샷 미도달(status={snapshot_1d['status']})"
+    if snapshot_7d["status"] != "captured":
+        return labeled, None, f"7일 스냅샷 미도달(status={snapshot_7d['status']})"
+
+    normalized_1d = snapshot_1d.get("normalized") or {}
+    normalized_7d = snapshot_7d.get("normalized") or {}
+    delta: dict[str, int | None] = {}
+    for key in sorted(set(normalized_1d) | set(normalized_7d)):
+        v1, v7 = normalized_1d.get(key), normalized_7d.get(key)
+        delta[key] = (v7 - v1) if isinstance(v1, int) and isinstance(v7, int) else None
+    return labeled, delta, None
+
+
+async def get_publication_insights(args: GetPublicationInsightsInput) -> list[TextContent]:
+    """발행물의 1일·7일 인사이트 스냅샷 목록과 둘 사이 키별 델타를 준다 — 에이전트가
+    「어제 낸 글 성과가 어땠는지」를 스스로 읽고 후속 스토리를 판단할 재료(스토리는
+    이 도구가 대신 안 만든다 — sprintable_add_story를 쓸 것).
+
+    publication_id를 모르면 draft_id로 그 초안의 「마지막 발행」 publication_id를 찾아
+    대신 조회한다(초안이 발행된 적 없으면 그 사실을 알린다). delta_1d_to_7d는 두
+    스냅샷 모두 status=captured일 때만 채워진다 — 7일이 아직 안 왔거나(pending) 수집이
+    실패했으면(failed) null+delta_unavailable_reason으로 사유를 알린다. 각 키는 두
+    스냅샷 모두 값이 있을 때만 계산되고, 한쪽이라도 미제공(null)이면 그 키도 null —
+    0(선언했고 실제로 0)과 null(그 채널이 그 지표를 아예 선언 안 함)을 섞지 않는다."""
+    try:
+        publication_id = args.publication_id
+        if not publication_id:
+            if not args.draft_id:
+                return err("publication_id 또는 draft_id 중 하나는 필요합니다.")
+            draft = await client.get(
+                f"/api/v2/organizations/{client.org_id}/channel-posts/drafts/{args.draft_id}",
+            )
+            publication_id = draft.get("publication_id")
+            if not publication_id:
+                return err(
+                    "이 초안은 아직 발행된 적이 없습니다(publication_id 없음) — "
+                    "발행 후 다시 조회해 주세요.",
+                )
+
+        snapshots = await client.get(
+            f"/api/v2/organizations/{client.org_id}/publications/{publication_id}/insights",
+        )
+        labeled, delta, reason = _label_snapshots_and_compute_delta(snapshots)
+        return ok({
+            "publication_id": publication_id,
+            "snapshots": labeled,
+            "delta_1d_to_7d": delta,
+            "delta_unavailable_reason": reason,
+        })
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/tools/channel_posts.py
+++ b/backend/sprintable_mcp/tools/channel_posts.py
@@ -52,12 +52,27 @@ class GetPublicationInsightsInput(SprintableInput):
 # GA4 유입 3키)을 이 MCP 프로세스는 직접 import 못 한다(별도 패키지, REST 경계 너머) —
 # 여기서 키 목록을 재선언하지 않고 응답에 실제로 있는 키의 합집합으로 델타를 낸다(BE가
 # 키를 늘려도 이 축이 안 깨진다, 새 계약 문서 동기화 불요).
+def _is_numeric(v: object) -> bool:
+    """bool은 int의 서브클래스라(`isinstance(True, int) is True`) 명시로 뺀다 — 정규화
+    값에 boolean이 올 계약은 없지만, 있다면 델타로 계산되면 안 되는 종류다."""
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
 def _label_snapshots_and_compute_delta(
     snapshots: list[dict],
-) -> tuple[list[dict], dict[str, int | None] | None, str | None]:
+) -> tuple[list[dict], dict[str, int | float | None] | None, str | None]:
     """due_at 오름차순 정렬 뒤 offset_label(1d|7d)을 매기고, 둘 다 captured일 때만
     키별 v7−v1 델타를 낸다. 페드루 決定(3321 원칙) — 0과 null(미제공)을 섞지 않는다:
-    두 값 중 하나라도 None이면 그 키의 델타는 None(0으로 대체하지 않는다)."""
+    두 값 중 하나라도 None이면 그 키의 델타는 None(0으로 대체하지 않는다). 값은
+    int뿐 아니라 float도 허용(spend·GA4 유입 파생값 등 실수로 올 수 있는 지표가
+    조용히 null 처리되면 «제공된 값»을 «미제공」으로 오판하는 것이라 — 페드루 CHANGES
+    2026-09-07, PR#4003).
+
+    ⚠️전제(관찰, 페드루 CHANGES 동시 지적) — 라벨은 idx 0=1d·나머지 전부=7d다. 원장
+    (`_SNAPSHOT_OFFSETS`, insight_snapshots.py)이 지금 오프셋 2개(1d·7d)만 등록해
+    한 publication_id·채널 조합엔 스냅샷이 정확히 2건뿐이라 안전하지만, 재시도 등으로
+    3건 이상이 생기면 셋째부터도 "7d"로 잘못 찍힌다 — 이 스토리 범위 밖(원장에
+    오프셋이 늘어나면 그때 이 함수도 같이 고칠 자리)."""
     sorted_snapshots = sorted(snapshots, key=lambda s: s["due_at"])
     labeled = [
         {**snap, "offset_label": "1d" if idx == 0 else "7d"}
@@ -74,10 +89,10 @@ def _label_snapshots_and_compute_delta(
 
     normalized_1d = snapshot_1d.get("normalized") or {}
     normalized_7d = snapshot_7d.get("normalized") or {}
-    delta: dict[str, int | None] = {}
+    delta: dict[str, int | float | None] = {}
     for key in sorted(set(normalized_1d) | set(normalized_7d)):
         v1, v7 = normalized_1d.get(key), normalized_7d.get(key)
-        delta[key] = (v7 - v1) if isinstance(v1, int) and isinstance(v7, int) else None
+        delta[key] = (v7 - v1) if _is_numeric(v1) and _is_numeric(v7) else None
     return labeled, delta, None
 
 

--- a/backend/sprintable_mcp/tools/channel_posts.py
+++ b/backend/sprintable_mcp/tools/channel_posts.py
@@ -60,32 +60,32 @@ def _is_numeric(v: object) -> bool:
 
 def _label_snapshots_and_compute_delta(
     snapshots: list[dict],
-) -> tuple[list[dict], dict[str, int | float | None] | None, str | None]:
-    """due_at 오름차순 정렬 뒤 offset_label(1d|7d)을 매기고, 둘 다 captured일 때만
-    키별 v7−v1 델타를 낸다. 페드루 決定(3321 원칙) — 0과 null(미제공)을 섞지 않는다:
-    두 값 중 하나라도 None이면 그 키의 델타는 None(0으로 대체하지 않는다). 값은
-    int뿐 아니라 float도 허용(spend·GA4 유입 파생값 등 실수로 올 수 있는 지표가
-    조용히 null 처리되면 «제공된 값»을 «미제공」으로 오판하는 것이라 — 페드루 CHANGES
-    2026-09-07, PR#4003).
+) -> tuple[dict[str, int | float | None] | None, str | None, int]:
+    """서버(insight_snapshots.py 라우터)가 이미 매긴 offset_label(1d|7d|null)을 그대로
+    읽는다 — 둘 다 captured일 때만 키별 v7−v1 델타를 낸다. 페드루 決定(3321 원칙) —
+    0과 null(미제공)을 섞지 않는다: 두 값 중 하나라도 None이면 그 키의 델타는 None
+    (0으로 대체하지 않는다). 값은 int뿐 아니라 float도 허용(spend·GA4 유입 파생값
+    등 실수로 올 수 있는 지표가 조용히 null 처리되면 «제공된 값»을 «미제공」으로
+    오판하는 것이라 — 페드루 CHANGES 2026-09-07, PR#4003).
 
-    ⚠️전제(관찰, 페드루 CHANGES 동시 지적) — 라벨은 idx 0=1d·나머지 전부=7d다. 원장
-    (`_SNAPSHOT_OFFSETS`, insight_snapshots.py)이 지금 오프셋 2개(1d·7d)만 등록해
-    한 publication_id·채널 조합엔 스냅샷이 정확히 2건뿐이라 안전하지만, 재시도 등으로
-    3건 이상이 생기면 셋째부터도 "7d"로 잘못 찍힌다 — 이 스토리 범위 밖(원장에
-    오프셋이 늘어나면 그때 이 함수도 같이 고칠 자리)."""
-    sorted_snapshots = sorted(snapshots, key=lambda s: s["due_at"])
-    labeled = [
-        {**snap, "offset_label": "1d" if idx == 0 else "7d"}
-        for idx, snap in enumerate(sorted_snapshots)
-    ]
-    snapshot_1d = next((s for s in labeled if s["offset_label"] == "1d"), None)
-    snapshot_7d = next((s for s in labeled if s["offset_label"] == "7d"), None)
+    카디르 발견(PR#4003, 2026-09-07) — 예전엔 이 함수가 직접 「idx0=1d·나머지=7d」로
+    라벨을 매겼는데, hosted_site 재발행이 같은 publication_id를 유지한 채 published_at
+    을 갱신하고 새 due_at 2행을 더 열어(UNIQUE는 «새» due_at을 안 막는다) 4건 이상이
+    흔했다 — 옛 사이클의 잔존 스냅샷이 "7d"로 오라벨돼 에러 없이 틀린 델타가 나갔다.
+    처방(근본) — 인덱스 라벨링을 버리고 서버가 「due_at−«지금» published_at」으로
+    낸 정본 라벨만 읽는다(insights_board.py와 같은 헬퍼 `label_snapshot_offset`).
+    null 라벨(옛 사이클 잔존)은 델타 계산에서 빼고 개수만 3번째 반환값(superseded_
+    snapshots)으로 알린다 — 지어내지 않고 사실 그대로("이 발행 뒤로 안 쓰는 스냅샷이
+    n건 더 있었다")."""
+    superseded = [s for s in snapshots if s.get("offset_label") is None]
+    snapshot_1d = next((s for s in snapshots if s.get("offset_label") == "1d"), None)
+    snapshot_7d = next((s for s in snapshots if s.get("offset_label") == "7d"), None)
     if snapshot_1d is None or snapshot_7d is None:
-        return labeled, None, "스냅샷이 2건 미만 — 1일·7일 두 스냅샷이 모두 등록돼야 델타를 계산합니다."
+        return None, "스냅샷이 2건 미만 — 1일·7일 두 스냅샷이 모두 등록돼야 델타를 계산합니다.", len(superseded)
     if snapshot_1d["status"] != "captured":
-        return labeled, None, f"1일 스냅샷 미도달(status={snapshot_1d['status']})"
+        return None, f"1일 스냅샷 미도달(status={snapshot_1d['status']})", len(superseded)
     if snapshot_7d["status"] != "captured":
-        return labeled, None, f"7일 스냅샷 미도달(status={snapshot_7d['status']})"
+        return None, f"7일 스냅샷 미도달(status={snapshot_7d['status']})", len(superseded)
 
     normalized_1d = snapshot_1d.get("normalized") or {}
     normalized_7d = snapshot_7d.get("normalized") or {}
@@ -93,7 +93,7 @@ def _label_snapshots_and_compute_delta(
     for key in sorted(set(normalized_1d) | set(normalized_7d)):
         v1, v7 = normalized_1d.get(key), normalized_7d.get(key)
         delta[key] = (v7 - v1) if _is_numeric(v1) and _is_numeric(v7) else None
-    return labeled, delta, None
+    return delta, None, len(superseded)
 
 
 async def get_publication_insights(args: GetPublicationInsightsInput) -> list[TextContent]:
@@ -106,7 +106,11 @@ async def get_publication_insights(args: GetPublicationInsightsInput) -> list[Te
     스냅샷 모두 status=captured일 때만 채워진다 — 7일이 아직 안 왔거나(pending) 수집이
     실패했으면(failed) null+delta_unavailable_reason으로 사유를 알린다. 각 키는 두
     스냅샷 모두 값이 있을 때만 계산되고, 한쪽이라도 미제공(null)이면 그 키도 null —
-    0(선언했고 실제로 0)과 null(그 채널이 그 지표를 아예 선언 안 함)을 섞지 않는다."""
+    0(선언했고 실제로 0)과 null(그 채널이 그 지표를 아예 선언 안 함)을 섞지 않는다.
+
+    각 스냅샷의 offset_label(1d|7d|null)은 서버가 매긴 정본 — null은 재발행 등으로
+    옛 발행 사이클에 속한 잔존 스냅샷(카디르 발견, PR#4003)이라 델타 계산에서 빠지고,
+    그 개수가 superseded_snapshots에 실린다(0이면 잔존 없음)."""
     try:
         publication_id = args.publication_id
         if not publication_id:
@@ -125,12 +129,13 @@ async def get_publication_insights(args: GetPublicationInsightsInput) -> list[Te
         snapshots = await client.get(
             f"/api/v2/organizations/{client.org_id}/publications/{publication_id}/insights",
         )
-        labeled, delta, reason = _label_snapshots_and_compute_delta(snapshots)
+        delta, reason, superseded_count = _label_snapshots_and_compute_delta(snapshots)
         return ok({
             "publication_id": publication_id,
-            "snapshots": labeled,
+            "snapshots": snapshots,
             "delta_1d_to_7d": delta,
             "delta_unavailable_reason": reason,
+            "superseded_snapshots": superseded_count,
         })
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -119,6 +119,8 @@ EXPECTED_TOOLS = {
     # channel post drafts (1) — story #3614: 이 도메인의 첫 MCP 도구(withdraw). org-scoped URL을
     # client.org_id로 수동 구성하는 첫 사례(server.py 참고).
     "sprintable_withdraw_channel_post_draft",
+    # 발행물 인사이트 (1) — story #3651: 1일·7일 스냅샷 조회 + 델타. 이 도메인 둘째 도구.
+    "sprintable_get_publication_insights",
     # smoke
     "ping",
 }
@@ -146,8 +148,9 @@ def test_total_tool_count():
     # story #2709: sprintable_request_decision 1종 신설(AskUserQuestion 블로킹 대체) — 122→123.
     # story #3331: sprintable_list_conversations 1종 신설(내 참여 방 목록 — 알림 미도달 백스톱) — 124→125.
     # story #3614: sprintable_withdraw_channel_post_draft 1종 신설(채널 글 초안 폐기 — 이 도메인
-    # 첫 MCP 도구) — 125→126.
-    assert len(_TOOLS) == 126  # story b6b9c52d(#2707 부수): sprintable_import_image_artifact 신설 123→124
+    # 첫 MCP 도구) — 125→126. story #3651: sprintable_get_publication_insights 1종 신설(발행물
+    # 1일·7일 인사이트 스냅샷+델타 — 이 도메인 둘째 도구) — 126→127.
+    assert len(_TOOLS) == 127  # story b6b9c52d(#2707 부수): sprintable_import_image_artifact 신설 123→124
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -82,12 +82,13 @@ def test_all_registered_tools_share_the_same_lockdown():
     sprintable_submit_for_approval 추가로 121→122. story #2709: sprintable_request_decision
     추가로 122→123. story b6b9c52d(#2707 부수): sprintable_import_image_artifact 추가로
     123→124. story #3331: sprintable_list_conversations 추가로 124→125. story #3614:
-    sprintable_withdraw_channel_post_draft 추가로 125→126) 전부 arg_model이
+    sprintable_withdraw_channel_post_draft 추가로 125→126. story #3651:
+    sprintable_get_publication_insights 추가로 126→127) 전부 arg_model이
     extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 126
+    assert len(tools) == 127
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_3497_insight_snapshots.py
+++ b/backend/tests/test_3497_insight_snapshots.py
@@ -602,6 +602,81 @@ async def test_insights_list_endpoint_org_mismatch_403():
 
 
 @pytest.mark.anyio
+async def test_insights_list_endpoint_offset_label_nulls_out_superseded_snapshots_after_republish():
+    """카디르 발견(PR#4003, 2026-09-07) — hosted_site 재발행은 같은 publication_id를
+    유지한 채 published_at을 갱신하고 새 due_at 2행을 더 연다(UNIQUE(publication_id,
+    due_at)는 «새» due_at을 안 막는다). offset_label은 due_at을 «지금» published_at
+    기준으로 재해석해야 한다 — 옛 사이클의 due_at은 더 이상 +1일/+7일 어느 쪽도
+    아니게 되어 null, 재발행 사이클의 두 행만 1d/7d로 라벨돼야 한다(인덱스 기반
+    라벨링이던 시절은 이 값이 서버에 없었다 — 지금은 소비부가 대신 흉내 낼 필요가
+    없다는 것 자체가 이 계약의 요점)."""
+    from app.main import app
+    from app.models.site_post import SitePost
+    from app.services.insight_snapshots import schedule_insight_snapshots
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+            work_item_id = uuid.uuid4()
+
+            first_published_at = datetime.now(timezone.utc) - timedelta(days=20)
+            post = SitePost(
+                id=uuid.uuid4(), org_id=org_id, lang="ko", slug="republish-post", title="제목",
+                summary="요약", tags=[], body_md="본문", published_at=first_published_at,
+                source_story_id=work_item_id, gate_id=uuid.uuid4(),
+            )
+            s.add(post)
+            await s.commit()
+
+            # 최초 발행 사이클 — 이 두 due_at은 재발행 뒤 더 이상 유효한 1d/7d가 아니다.
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=post.id,
+                publication_kind="site_post", channel="hosted_site", external_id=None,
+                anchor_at=first_published_at,
+            )
+            await s.commit()
+
+            # 재발행 — published_at 갱신 + 새 due_at 2행(다른 anchor_at이라 UNIQUE 충돌 없음).
+            republish_at = datetime.now(timezone.utc) - timedelta(days=5)
+            post.published_at = republish_at
+            await s.commit()
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=post.id,
+                publication_kind="site_post", channel="hosted_site", external_id=None,
+                anchor_at=republish_at,
+            )
+            await s.commit()
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/publications/{post.id}/insights")
+        assert r.status_code == 200, r.text
+        rows = r.json()
+        assert len(rows) == 4, "최초 사이클 2행 + 재발행 사이클 2행"
+
+        by_label: dict[str | None, int] = {}
+        for row in rows:
+            by_label[row["offset_label"]] = by_label.get(row["offset_label"], 0) + 1
+        assert by_label == {None: 2, "1d": 1, "7d": 1}, by_label
+
+        # 카운트만으론 부족 — «어느 사이클»의 due_at이 1d/7d로 라벨됐는지 직접 확認한다
+        # (뮤테이션 대상: rows[0].due_at 기준 역산 같은 우회는 이 표본에서 우연히 같은
+        # 카운트 분포를 낼 수 있다 — 실제 republish_at 앵커와 정확히 일치해야 한다).
+        labeled_by_due_at = {row["due_at"]: row["offset_label"] for row in rows}
+        expected_1d_due = (republish_at + timedelta(days=1)).isoformat().replace("+00:00", "Z")
+        expected_7d_due = (republish_at + timedelta(days=7)).isoformat().replace("+00:00", "Z")
+        matched_1d = [due for due, label in labeled_by_due_at.items() if label == "1d"]
+        matched_7d = [due for due, label in labeled_by_due_at.items() if label == "7d"]
+        assert len(matched_1d) == 1 and matched_1d[0].startswith(expected_1d_due[:19])
+        assert len(matched_7d) == 1 and matched_7d[0].startswith(expected_7d_due[:19])
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_compute_insight_snapshot_counts_tallies_by_status_within_window():
     """확定⑤ — 3475 접합용 카운트 함수(이 PR에선 호출부 미배선, 함수만). created_at
     기준 window 밖 행은 안 세고, pending 행도 안 센다(3종만)."""

--- a/backend/tests/test_3651_mcp_get_publication_insights.py
+++ b/backend/tests/test_3651_mcp_get_publication_insights.py
@@ -105,6 +105,29 @@ async def test_unprovided_metric_stays_null_not_zero(monkeypatch):
     assert body["delta_1d_to_7d"]["conversions"] == 7
 
 
+async def test_float_metrics_get_real_delta_not_null(monkeypatch):
+    """페드루 CHANGES(2026-09-07, PR#4003) — 정규화 값이 float으로 와도(spend·GA4 유입
+    파생값 등) «제공된 값」으로 취급해 실수 델타를 낸다. 이전 버전은 isinstance(v, int)만
+    허용해 float 쌍이 조용히 null이 됐다(제공된 값을 미제공으로 오판). 한쪽만 float이고
+    한쪽이 null이면(진짜 미제공) 여전히 null."""
+    from sprintable_mcp.tools import channel_posts
+
+    snapshots = [
+        _snapshot(due_at="2026-09-08T00:00:00Z", normalized={"spend": 12.5, "ctr": None}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", normalized={"spend": 30.25, "ctr": 0.042}),
+    ]
+    monkeypatch.setattr(channel_posts.client, "get", _RecordingGet([snapshots]))
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(publication_id="pub-1"),
+    )
+    body = jsonlib.loads(result[0].text)
+
+    assert body["delta_1d_to_7d"]["spend"] == pytest.approx(17.75)
+    assert body["delta_1d_to_7d"]["ctr"] is None  # 1일값이 null(미제공)이라 여전히 null
+
+
 async def test_draft_id_without_publication_surfaces_be_error_as_text(monkeypatch):
     """다른 org의 draft_id(또는 존재하지 않는 draft_id)를 주면 draft 상세 조회 자체가
     BE에서 404로 거부된다 — SprintableApiError를 삼키지 않고 그대로 err()로 낸다(3651

--- a/backend/tests/test_3651_mcp_get_publication_insights.py
+++ b/backend/tests/test_3651_mcp_get_publication_insights.py
@@ -18,11 +18,17 @@ pytestmark = pytest.mark.anyio
 
 
 def _snapshot(
-    *, due_at: str, status: str = "captured", normalized: dict | None = None, channel: str = "facebook_sandbox",
+    *, due_at: str, offset_label: str | None, status: str = "captured", normalized: dict | None = None,
+    channel: str = "facebook_sandbox",
 ) -> dict:
+    """카디르 CHANGES(PR#4003) — offset_label은 이제 서버(insight_snapshots.py 라우터)
+    가 정본을 매겨 보낸다. 이 MCP 계층은 더 이상 인덱스로 라벨링하지 않으므로, 이
+    fixture가 서버 응답을 흉내 낼 때 명시적으로 값을 실어야 한다(암묵적 "첫째=1d"
+    가정 재도입 금지 — 그게 이 버그의 원인이었다)."""
     return {
         "id": f"snap-{due_at}", "channel": channel, "due_at": due_at, "captured_at": due_at,
         "status": status, "normalized": normalized, "source": "facebook_sandbox", "error_code": None,
+        "offset_label": offset_label,
     }
 
 
@@ -44,8 +50,8 @@ async def test_positive_delta_both_captured(monkeypatch):
     from sprintable_mcp.tools import channel_posts
 
     snapshots = [
-        _snapshot(due_at="2026-09-08T00:00:00Z", normalized={"impressions": 100, "clicks": 10, "spend": None}),
-        _snapshot(due_at="2026-09-14T00:00:00Z", normalized={"impressions": 250, "clicks": 40, "spend": None}),
+        _snapshot(due_at="2026-09-08T00:00:00Z", offset_label="1d", normalized={"impressions": 100, "clicks": 10, "spend": None}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", offset_label="7d", normalized={"impressions": 250, "clicks": 40, "spend": None}),
     ]
     recorder = _RecordingGet([snapshots])
     monkeypatch.setattr(channel_posts.client, "get", recorder)
@@ -68,8 +74,8 @@ async def test_7d_pending_yields_null_delta_with_reason(monkeypatch):
     from sprintable_mcp.tools import channel_posts
 
     snapshots = [
-        _snapshot(due_at="2026-09-08T00:00:00Z", normalized={"impressions": 100}),
-        _snapshot(due_at="2026-09-14T00:00:00Z", status="pending", normalized=None),
+        _snapshot(due_at="2026-09-08T00:00:00Z", offset_label="1d", normalized={"impressions": 100}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", offset_label="7d", status="pending", normalized=None),
     ]
     monkeypatch.setattr(channel_posts.client, "get", _RecordingGet([snapshots]))
     monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
@@ -90,8 +96,8 @@ async def test_unprovided_metric_stays_null_not_zero(monkeypatch):
     from sprintable_mcp.tools import channel_posts
 
     snapshots = [
-        _snapshot(due_at="2026-09-08T00:00:00Z", normalized={"spend": None, "conversions": 5}),
-        _snapshot(due_at="2026-09-14T00:00:00Z", normalized={"spend": None, "conversions": 12}),
+        _snapshot(due_at="2026-09-08T00:00:00Z", offset_label="1d", normalized={"spend": None, "conversions": 5}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", offset_label="7d", normalized={"spend": None, "conversions": 12}),
     ]
     monkeypatch.setattr(channel_posts.client, "get", _RecordingGet([snapshots]))
     monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
@@ -113,8 +119,8 @@ async def test_float_metrics_get_real_delta_not_null(monkeypatch):
     from sprintable_mcp.tools import channel_posts
 
     snapshots = [
-        _snapshot(due_at="2026-09-08T00:00:00Z", normalized={"spend": 12.5, "ctr": None}),
-        _snapshot(due_at="2026-09-14T00:00:00Z", normalized={"spend": 30.25, "ctr": 0.042}),
+        _snapshot(due_at="2026-09-08T00:00:00Z", offset_label="1d", normalized={"spend": 12.5, "ctr": None}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", offset_label="7d", normalized={"spend": 30.25, "ctr": 0.042}),
     ]
     monkeypatch.setattr(channel_posts.client, "get", _RecordingGet([snapshots]))
     monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
@@ -155,7 +161,7 @@ async def test_draft_id_resolves_publication_id_then_fetches_insights(monkeypatc
     from sprintable_mcp.tools import channel_posts
 
     draft = {"id": "draft-1", "publication_id": "pub-9"}
-    snapshots = [_snapshot(due_at="2026-09-08T00:00:00Z", normalized={"impressions": 5})]
+    snapshots = [_snapshot(due_at="2026-09-08T00:00:00Z", offset_label="1d", normalized={"impressions": 5})]
     recorder = _RecordingGet([draft, snapshots])
     monkeypatch.setattr(channel_posts.client, "get", recorder)
     monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
@@ -187,6 +193,38 @@ async def test_draft_never_published_reports_no_publication(monkeypatch):
     assert result[0].text.startswith("Error:")
     assert "발행된 적이 없습니다" in result[0].text
     assert len(recorder.calls) == 1  # insights 조회는 안 나감
+
+
+async def test_republish_superseded_snapshots_excluded_from_delta(monkeypatch):
+    """카디르 발견(PR#4003, 2026-09-07) — hosted_site 재발행은 같은 publication_id를
+    유지한 채 published_at을 갱신하고 새 due_at 2행을 더 연다(UNIQUE(publication_id,
+    due_at)는 «새» due_at을 안 막는다). 4건(최초 1d/7d + 재발행 1d/7d) 표본에서 옛
+    인덱스 라벨링("idx0=1d·나머지=7d")은 최초 사이클의 due_at 순번을 오라벨했다 —
+    이제 서버가 매긴 offset_label을 그대로 읽으므로, null 라벨(최초 사이클 잔존
+    2건)은 델타에서 빠지고 재발행 짝(1d/7d)만으로 델타가 나며 superseded_snapshots
+    =2로 알려야 한다."""
+    from sprintable_mcp.tools import channel_posts
+
+    snapshots = [
+        # 최초 발행 사이클 — 재발행으로 due_at이 더 이상 «지금» published_at의
+        # +1일/+7일 어느 쪽도 아니게 된 잔존 스냅샷(서버가 null로 라벨).
+        _snapshot(due_at="2026-09-01T00:00:00Z", offset_label=None, normalized={"impressions": 10}),
+        _snapshot(due_at="2026-09-07T00:00:00Z", offset_label=None, normalized={"impressions": 20}),
+        # 재발행 사이클 — 이 둘만 «지금» published_at 기준 유효한 1d/7d.
+        _snapshot(due_at="2026-09-08T00:00:00Z", offset_label="1d", normalized={"impressions": 100}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", offset_label="7d", normalized={"impressions": 250}),
+    ]
+    monkeypatch.setattr(channel_posts.client, "get", _RecordingGet([snapshots]))
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(publication_id="pub-1"),
+    )
+    body = jsonlib.loads(result[0].text)
+
+    assert body["delta_1d_to_7d"] == {"impressions": 150}  # 250-100(재발행 짝), 20-10(최초)이 아니다
+    assert body["delta_unavailable_reason"] is None
+    assert body["superseded_snapshots"] == 2
 
 
 async def test_neither_id_given_rejected_before_any_http_call(monkeypatch):

--- a/backend/tests/test_3651_mcp_get_publication_insights.py
+++ b/backend/tests/test_3651_mcp_get_publication_insights.py
@@ -1,0 +1,178 @@
+"""story #3651(Phase2·MCP·소형, 페드루 PO 確定 2026-09-07) — sprintable_get_publication_
+insights 도구. 블루프린트 §7 Phase 2 AC 「1일·7일 성과를 비교해 후속 스토리를 만든다」의
+에이전트 몫 — REST `/publications/{publication_id}/insights`(insight_snapshots.py:34)를
+그대로 래핑하고, due_at 오름차순으로 offset_label(1d|7d)을 매겨 둘 사이 키별 델타를 낸다.
+
+test_3614_mcp_withdraw_channel_post_draft.py의 monkeypatch 관례(client.get/post 교체 +
+client.org_id property override)를 그대로 재사용(새 mock 패턴 발명 0)."""
+from __future__ import annotations
+
+import json as jsonlib
+import sys
+
+import pytest
+
+sys.path.insert(0, ".")
+
+pytestmark = pytest.mark.anyio
+
+
+def _snapshot(
+    *, due_at: str, status: str = "captured", normalized: dict | None = None, channel: str = "facebook_sandbox",
+) -> dict:
+    return {
+        "id": f"snap-{due_at}", "channel": channel, "due_at": due_at, "captured_at": due_at,
+        "status": status, "normalized": normalized, "source": "facebook_sandbox", "error_code": None,
+    }
+
+
+class _RecordingGet:
+    """호출 순서대로 미리 등록한 응답을 반환(draft 조회 → insights 조회 2단 호출 검증용).
+    단일 응답만 필요하면 responses=[그 값 하나]로."""
+
+    def __init__(self, responses: list):
+        self._responses = list(responses)
+        self.calls: list[str] = []
+
+    async def __call__(self, path: str, **_kwargs):
+        self.calls.append(path)
+        return self._responses.pop(0)
+
+
+async def test_positive_delta_both_captured(monkeypatch):
+    """양성 — 1일·7일 둘 다 captured면 키별 v7-v1 델타가 나온다(3651 AC1)."""
+    from sprintable_mcp.tools import channel_posts
+
+    snapshots = [
+        _snapshot(due_at="2026-09-08T00:00:00Z", normalized={"impressions": 100, "clicks": 10, "spend": None}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", normalized={"impressions": 250, "clicks": 40, "spend": None}),
+    ]
+    recorder = _RecordingGet([snapshots])
+    monkeypatch.setattr(channel_posts.client, "get", recorder)
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(publication_id="pub-1"),
+    )
+    body = jsonlib.loads(result[0].text)
+
+    assert recorder.calls == ["/api/v2/organizations/org-1/publications/pub-1/insights"]
+    assert body["snapshots"][0]["offset_label"] == "1d"
+    assert body["snapshots"][1]["offset_label"] == "7d"
+    assert body["delta_1d_to_7d"] == {"impressions": 150, "clicks": 30, "spend": None}
+    assert body["delta_unavailable_reason"] is None
+
+
+async def test_7d_pending_yields_null_delta_with_reason(monkeypatch):
+    """7일이 아직 안 도래(pending)하면 델타는 null+사유(3651 AC1)."""
+    from sprintable_mcp.tools import channel_posts
+
+    snapshots = [
+        _snapshot(due_at="2026-09-08T00:00:00Z", normalized={"impressions": 100}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", status="pending", normalized=None),
+    ]
+    monkeypatch.setattr(channel_posts.client, "get", _RecordingGet([snapshots]))
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(publication_id="pub-1"),
+    )
+    body = jsonlib.loads(result[0].text)
+
+    assert body["delta_1d_to_7d"] is None
+    assert "7일" in body["delta_unavailable_reason"]
+    assert "pending" in body["delta_unavailable_reason"]
+
+
+async def test_unprovided_metric_stays_null_not_zero(monkeypatch):
+    """미제공(null) 지표는 델타도 null — 0으로 기록하지 않는다(3321 원칙, 3651 AC1 「미제공
+    null 유지」). 뮤테이션 대상: 0으로 오기록하면 이 테스트가 RED가 돼야 한다."""
+    from sprintable_mcp.tools import channel_posts
+
+    snapshots = [
+        _snapshot(due_at="2026-09-08T00:00:00Z", normalized={"spend": None, "conversions": 5}),
+        _snapshot(due_at="2026-09-14T00:00:00Z", normalized={"spend": None, "conversions": 12}),
+    ]
+    monkeypatch.setattr(channel_posts.client, "get", _RecordingGet([snapshots]))
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(publication_id="pub-1"),
+    )
+    body = jsonlib.loads(result[0].text)
+
+    assert body["delta_1d_to_7d"]["spend"] is None
+    assert body["delta_1d_to_7d"]["conversions"] == 7
+
+
+async def test_draft_id_without_publication_surfaces_be_error_as_text(monkeypatch):
+    """다른 org의 draft_id(또는 존재하지 않는 draft_id)를 주면 draft 상세 조회 자체가
+    BE에서 404로 거부된다 — SprintableApiError를 삼키지 않고 그대로 err()로 낸다(3651
+    AC1 「다른 org publication → 404/403」의 실제 발생 지점: publication_id 직접 조회는
+    org WHERE절 불일치가 빈 목록으로 떨어지는 기존 설계라, 거부는 draft_id 경로에서 난다)."""
+    from sprintable_mcp.tools import channel_posts
+    from sprintable_mcp.api_client import SprintableApiError
+
+    async def _raise(path: str, **_kwargs):
+        raise SprintableApiError(404, "draft를 찾을 수 없습니다: draft-foreign", None)
+
+    monkeypatch.setattr(channel_posts.client, "get", _raise)
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(draft_id="draft-foreign"),
+    )
+    assert result[0].text.startswith("Error:")
+    assert "찾을 수 없습니다" in result[0].text
+
+
+async def test_draft_id_resolves_publication_id_then_fetches_insights(monkeypatch):
+    """draft_id만 주면 초안 상세에서 publication_id를 읽어 그 값으로 insights를 다시
+    조회한다(3651 처방③ — draft_id 편의 축). 2단 호출 순서를 직접 검증."""
+    from sprintable_mcp.tools import channel_posts
+
+    draft = {"id": "draft-1", "publication_id": "pub-9"}
+    snapshots = [_snapshot(due_at="2026-09-08T00:00:00Z", normalized={"impressions": 5})]
+    recorder = _RecordingGet([draft, snapshots])
+    monkeypatch.setattr(channel_posts.client, "get", recorder)
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(draft_id="draft-1"),
+    )
+    body = jsonlib.loads(result[0].text)
+
+    assert recorder.calls == [
+        "/api/v2/organizations/org-1/channel-posts/drafts/draft-1",
+        "/api/v2/organizations/org-1/publications/pub-9/insights",
+    ]
+    assert body["publication_id"] == "pub-9"
+
+
+async def test_draft_never_published_reports_no_publication(monkeypatch):
+    """publication_id가 null인 초안(발행된 적 없음)은 insights를 조회하지 않고 그 사실을
+    알린다(불필요 호출 0)."""
+    from sprintable_mcp.tools import channel_posts
+
+    recorder = _RecordingGet([{"id": "draft-1", "publication_id": None}])
+    monkeypatch.setattr(channel_posts.client, "get", recorder)
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(draft_id="draft-1"),
+    )
+    assert result[0].text.startswith("Error:")
+    assert "발행된 적이 없습니다" in result[0].text
+    assert len(recorder.calls) == 1  # insights 조회는 안 나감
+
+
+async def test_neither_id_given_rejected_before_any_http_call(monkeypatch):
+    from sprintable_mcp.tools import channel_posts
+
+    recorder = _RecordingGet([])
+    monkeypatch.setattr(channel_posts.client, "get", recorder)
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(channel_posts.GetPublicationInsightsInput())
+    assert result[0].text.startswith("Error:")
+    assert recorder.calls == []

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -83,6 +83,7 @@ def test_tool_names_and_param_models_untouched():
     부수): sprintable_import_image_artifact 1종 신설(base64 원콜 이미지 임포트) — 122→123.
     story #3331: sprintable_list_conversations 1종 신설(내 참여 방 목록 — 알림 미도달
     백스톱) — 123→124. story #3614: sprintable_withdraw_channel_post_draft 1종 신설(채널 글
-    초안 폐기, [일감] 축 — 콘텐츠 초안도 작업 단위 work item) — 124→125."""
-    assert len(_TOOL_DEFS) == 125
+    초안 폐기, [일감] 축 — 콘텐츠 초안도 작업 단위 work item) — 124→125. story #3651:
+    sprintable_get_publication_insights 1종 신설(발행물 1일·7일 인사이트) — 125→126."""
+    assert len(_TOOL_DEFS) == 126
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
블루프린트 v3 §7 Phase 2 AC 「1일·7일 성과를 비교해 후속 스토리를 만든다」의 에이전트 몫. 스냅샷 원장(story #3497/#3571)·REST 조회(`insight_snapshots.py:34`, `GET /publications/{publication_id}/insights`)는 이미 완비돼 있었으나 hosted MCP엔 insight류 도구가 0(휴먼 표면=insights-board만 있고 에이전트 표면이 없던 자리) — 「만들어졌는데 쓰는 자리 없음」 클래스.

## 구현
- `sprintable_get_publication_insights(publication_id?, draft_id?)` — REST 조회를 그대로 래핑. due_at 오름차순으로 `offset_label`(1d|7d)을 매기고, 둘 다 `status=captured`일 때만 키별 델타(v7−v1)를 낸다. 한쪽이라도 미제공(null)이면 그 키의 델타도 null — 0과 null을 섞지 않는다(3321 원칙, 델타 판정 자체를 순수 함수 `_label_snapshots_and_compute_delta`로 분리해 뮤테이션 검증 가능하게 함).
- `draft_id` 편의 입력 — 초안 상세(`ChannelPostDraftListItem.publication_id`, 이미 존재하는 필드) 조회로 「마지막 발행」 publication_id를 대신 찾는다. 발행된 적 없으면(publication_id=null) insights 호출 없이 그 사실을 알린다(불필요 호출 0).
- BE 키 목록(`NORMALIZED_KEYS`, 정규화 7키+GA4 유입 3키)을 재선언하지 않고 응답에 실제로 있는 키의 합집합으로 델타를 낸다 — MCP 프로세스가 `backend/app`을 직접 import 못 하는 REST 경계 특성상, BE가 키를 늘려도 이 축이 안 깨진다.
- toolset 그룹은 등록만으로 자동 분류(story #3631 `_GROUP_KEYWORDS`의 "content" 그룹 키워드에 "insight"가 이미 있음 — BE/MCP 두 벤더 사본 모두 확認, 추가 배선 0).
- 후속 스토리 생성은 이 도구가 대신 안 한다 — 기존 `sprintable_add_story`를 쓴다.

## 테스트
신규 7(양성 델타·7d pending→null+사유·미제공 null 유지·타 org draft_id→404 거부·draft_id→publication_id 2단 해소·미발행 초안 조기 반환·둘 다 미지정 거부) + 뮤테이션 1(0/null 병합 로직 제거 → 델타 테스트 2건 정확히 RED 확認 후 복구). MCP 계약 도구 수 126→127(`EXPECTED_TOOLS`·카운트 갱신). 인접 회귀 스윕: MCP 계약 27+콘텐츠 toolset 그룹 회귀 30(총 57)·REST 원장 `test_3497_insight_snapshots.py` 등 17건 그린(내가 기대던 REST 형과 실물이 일치함을 재확認, 이 축은 수정 안 함).

## 라이브(AC4)
스토리 처방 자체가 「[라이브·PO]」로 표기 — PO Test Org 표본 조회·응답 실물 기재는 PO 몫(다른 스토리들의 카디르 QA 표본 관례와 같은 분업).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA