### PR TITLE
[SID:3646] fix(BE·결함): provider 5xx가 connection을 error(재인증 필요)로 승격하지 않는다

### DIFF
--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -690,7 +690,7 @@ async def _promote_connection_status(
 
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
-    from app.services.graph_api_errors import connection_status_for_error_code
+    from app.services.graph_api_errors import mark_connection_failed
 
     pub = (await db.execute(
         select(ChannelPublication).where(ChannelPublication.id == publication_id)
@@ -700,11 +700,10 @@ async def _promote_connection_status(
     connection = await db.get(ChannelConnection, pub.connection_id)
     if connection is None:
         return
-    connection.status = connection_status_for_error_code(error_code, current_status=connection.status)
-    if message is not None:
-        connection.last_error = message[:2000]
-    connection.last_error_code = error_code
-    connection.last_error_at = datetime.now(timezone.utc)
+    # story #3646 — insight_snapshots.py::_promote_connection_status_for_snapshot·
+    # publication_command.py::apply_command_failure(CONNECTION 분기)와 이제 이
+    # 4줄을 한 헬퍼로 공유한다(중복 3벌 → 1).
+    mark_connection_failed(connection, error_code=error_code, message=message, now=datetime.now(timezone.utc))
 
 
 async def refresh_comments_now(

--- a/backend/app/services/graph_api_errors.py
+++ b/backend/app/services/graph_api_errors.py
@@ -237,10 +237,15 @@ def mark_connection_failed(
 
     status는 `connection_status_for_error_code`(sticky 포함)로 고른다 — 호출자가
     직접 `connection.status = ...`를 대입하지 않는다(그 자리마다 sticky 규율을
-    다시 안 짜도록)."""
+    다시 안 짜도록).
+
+    카디르 qa:changes(PR #4004, 2026-09-07) — `message is not None`일 때만 last_error를
+    쓰면, message=None으로 호출됐을 때 그 연결의 옛 last_error가 그대로 남는다(「틀린
+    진단문구 표시」 회귀 — 지운 인라인 3곳은 전부 `(message or "")[:2000]`으로 항상
+    덮어쓰고 있었다). status/code/at은 이 자리에서 항상 최신으로 갱신되는데 last_error만
+    구식으로 남으면 셋이 서로 다른 실패를 가리키는 자리가 생긴다 — 무조건 덮어쓴다."""
     connection.status = connection_status_for_error_code(error_code, current_status=connection.status)
-    if message is not None:
-        connection.last_error = message[:2000]
+    connection.last_error = (message or "")[:2000]
     connection.last_error_code = error_code
     connection.last_error_at = now
 

--- a/backend/app/services/graph_api_errors.py
+++ b/backend/app/services/graph_api_errors.py
@@ -65,6 +65,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     import httpx
 
     from app.models.channel_connection import ChannelConnection
@@ -216,6 +218,31 @@ def mark_connection_recovered(connection: "ChannelConnection") -> None:
     connection.last_error = None
     connection.last_error_code = None
     connection.last_error_at = None
+
+
+def mark_connection_failed(
+    connection: "ChannelConnection", *, error_code: str | None, message: str | None, now: "datetime",
+) -> None:
+    """story #3646(BE·결함·소형·3605 후속, 페드루 PO 確定 2026-09-07) — `mark_connection_
+    recovered`(위)의 짝 — 그쪽은 "복귀할 때 실패 흔적 4종을 지운다", 이건 "실패로
+    갈 때 4종(status·last_error·last_error_code·last_error_at)을 같이 채운다"를 한
+    자리로 고정한다.
+
+    `_promote_connection_status`(channel_post_comments.py)·`_promote_connection_
+    status_for_snapshot`(insight_snapshots.py)이 각자 인라인으로 갖고 있던 정확히
+    같은 4줄을 이 함수로 뺐다(새 판정 로직 0, 중복 제거) — `publication_command.py::
+    apply_command_failure`의 CONNECTION 분기는 실측(3646 그라운딩) 그 3곳과 달리
+    `last_error_code`/`last_error_at` 2종을 안 채우고 있었다. 이 헬퍼로 그 갭을
+    닫는다(message만 서는 자리 0).
+
+    status는 `connection_status_for_error_code`(sticky 포함)로 고른다 — 호출자가
+    직접 `connection.status = ...`를 대입하지 않는다(그 자리마다 sticky 규율을
+    다시 안 짜도록)."""
+    connection.status = connection_status_for_error_code(error_code, current_status=connection.status)
+    if message is not None:
+        connection.last_error = message[:2000]
+    connection.last_error_code = error_code
+    connection.last_error_at = now
 
 
 def parse_graph_error_envelope(resp: "httpx.Response") -> tuple[int | None, int | None, str | None]:

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -611,7 +611,7 @@ async def _promote_connection_status_for_snapshot(
 
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
-    from app.services.graph_api_errors import connection_status_for_error_code
+    from app.services.graph_api_errors import mark_connection_failed
 
     if snapshot.publication_kind != "channel_publication":
         return
@@ -623,11 +623,10 @@ async def _promote_connection_status_for_snapshot(
     connection = await db.get(ChannelConnection, pub.connection_id)
     if connection is None:
         return
-    connection.status = connection_status_for_error_code(error_code, current_status=connection.status)
-    if message is not None:
-        connection.last_error = message[:2000]
-    connection.last_error_code = error_code
-    connection.last_error_at = datetime.now(timezone.utc)
+    # story #3646 — channel_post_comments.py::_promote_connection_status·
+    # publication_command.py::apply_command_failure(CONNECTION 분기)와 이제 이
+    # 4줄을 한 헬퍼로 공유한다(중복 3벌 → 1).
+    mark_connection_failed(connection, error_code=error_code, message=message, now=datetime.now(timezone.utc))
 
 
 _GA4_RUN_REPORT_URL_TMPL = "https://analyticsdata.googleapis.com/v1beta/properties/{property_id}:runReport"

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -672,12 +672,15 @@ async def apply_command_failure(
         # connection_status·insight_snapshots.py::_promote_connection_status_
         # for_snapshot)과 공유하는 단일 지점이다.
         from app.models.channel_connection import ChannelConnection
-        from app.services.graph_api_errors import connection_status_for_error_code
+        from app.services.graph_api_errors import mark_connection_failed
 
         connection = await db.get(ChannelConnection, command.destination)
         if connection is not None:
-            connection.last_error = (last_error or "")[:2000]
-            connection.status = connection_status_for_error_code(error_code, current_status=connection.status)
+            # story #3646 그라운딩 — 이 자리만 last_error_code/last_error_at를 안
+            # 채우고 있었다(channel_post_comments.py::_promote_connection_status·
+            # insight_snapshots.py::_promote_connection_status_for_snapshot은 이미
+            # 4필드 다 채움). 공용 헬퍼로 갭을 닫는다(message만 서는 자리 0).
+            mark_connection_failed(connection, error_code=error_code, message=last_error, now=now)
         command.status = "blocked"
         return
 
@@ -699,26 +702,23 @@ async def apply_command_failure(
     command.attempt_count += 1
     if command.attempt_count >= MAX_RETRIES:
         # story #3598(AC6, PO 確定 2026-09-06 · 유나 Design CHANGES 1 정정
-        # 2026-09-07) — transient가 재시도 상한(댓글수집 attempt_count>=5와 동형
-        # 임계값=MAX_RETRIES)에 도달해도 connection.status가 "active"로 남아
-        # 「연결됨」 칩이 거짓으로 보이는 결함을 닫되, CHANNEL_RATE_LIMITED(시간이
-        # 지나면 스스로 풀리는 한도 초과)는 이 승격에서 제외한다 — 3595 본문·
-        # AC6 원칙 그대로 "연결 상태는 사람이 고쳐야 풀리는 것에만"(한도 초과는
-        # 잔량·시각 축이지 connection 축이 아니다). 제외 없이 그대로 승격하면
-        # 일시 한도 초과 5연속(부하가 몰리는 정상 상황)만으로 발행이 전면
-        # 차단되고 사람의 재연결 없인 못 풀리는 자해 잠금이 된다. 페드루 PO
-        # 정정(2026-09-07) — 이 transient 분기(위 CONNECTION·NEEDS_CHECK
-        # 분기는 이미 return돼 여기 안 옴)에 이 제외 뒤 남는 error_code는
-        # CHANNEL_PUBLISH_PROVIDER_ERROR뿐(_TRANSIENT_CODES 정의 그대로) —
-        # "인증/권한 계열"은 이 분기에 애초에 못 온다(과장 표현 정정).
-        if error_code != "CHANNEL_RATE_LIMITED":
-            from app.models.channel_connection import ChannelConnection
-
-            connection = await db.get(ChannelConnection, command.destination)
-            if connection is not None:
-                connection.last_error = (last_error or "")[:2000]
-                if connection.status not in ("revoked", "error"):
-                    connection.status = "error"
+        # 2026-09-07)이 재시도 상한 소진 시 connection.status="error" 승격을 이
+        # 자리에 얹었었다(CHANNEL_RATE_LIMITED만 제외). story #3646(BE·결함,
+        # 페드루 PO 確定 2026-09-07, dev 실측 — PO Test Org IG sandbox 502
+        # 발행 실패가 「재인증 필요」로 잘못 승격) — #3598 AC6 자신의 주석이 이미
+        # "이 transient 분기엔 인증/권한 계열이 애초에 못 오고, 남는 error_code는
+        # CHANNEL_PUBLISH_PROVIDER_ERROR뿐"이라고 못박아 놓고도 그 유일한 코드를
+        # 승격 대상에 남겨 뒀다 — 결과적으로 «5xx/네트워크/타임아웃(=이 TRANSIENT
+        # 분기 전체, _TRANSIENT_CODES 정의 그대로)이 재시도 5회를 채우면 예외 없이
+        # 전부 승격」이 됐다. 원칙(3605·3612) "연결 상태는 사람이 고쳐야 풀리는
+        # 것에만"은 CHANNEL_RATE_LIMITED뿐 아니라 CHANNEL_PUBLISH_PROVIDER_ERROR
+        # (일시 provider 오류 — 「다시 연결」해도 provider가 살아나는 것과 무관)
+        # 에도 똑같이 적용된다. 그래서 이 TRANSIENT 분기 전체에서 connection
+        # 승격을 없앤다 — command만 dead_letter로 보내고 재시도는 사람 몫(AC5),
+        # connection의 status·last_error 3종은 이 분기가 손대지 않는다(불변).
+        # 인증 계열 승격은 위 FAILURE_KIND_CONNECTION 분기(즉시, 재시도 무관)가
+        # 전담 — 그 분기와 이 분기는 _CONNECTION_BLOCKED_CODES/_TRANSIENT_CODES로
+        # 이미 배타적으로 갈린다(한 error_code가 둘 다 탈 수 없다).
         command.status = "dead_letter"
         command.dead_letter_at = now
         command.next_attempt_at = None

--- a/backend/tests/test_3414_publication_command_cron_retry.py
+++ b/backend/tests/test_3414_publication_command_cron_retry.py
@@ -409,13 +409,19 @@ async def test_cron_rate_limited_max_retries_reaches_dead_letter_but_connection_
 
 
 @pytest.mark.anyio
-async def test_cron_max_retries_reaches_dead_letter_also_escalates_connection_to_error():
-    """story #3598(AC6, PO 確定 2026-09-06) — transient가 재시도 상한(MAX_RETRIES, 댓글
-    수집 attempt_count>=5와 동형 임계값)에 도달해도 connection.status가 그대로
-    "active"로 남아 「연결됨」 칩이 거짓으로 보이던 결함(3595 표 ③④류 "미표시"와 같은
-    클래스). dead_letter 승격과 같은 자리에서 connection.status="error"(reason=error)
-    로도 승격해야 한다. 위 test_cron_max_retries_reaches_dead_letter와 완전히 동형
-    세팅 — command 승격만 추가 검증."""
+async def test_cron_max_retries_provider_error_reaches_dead_letter_but_connection_unchanged():
+    """story #3598(AC6, PO 確定 2026-09-06)이 이 자리에 얹었던 connection.status="error"
+    승격을 story #3646(BE·결함·소형·3605 후속, 페드루 PO 確定 2026-09-07, dev 실측 — PO
+    Test Org IG sandbox `[sandbox:provider-error]` 502 발행 실패가 「재인증 필요」로
+    잘못 승격)이 되돌린다 — #3598 AC6 자신의 주석이 이미 "이 transient 분기엔 인증/권한
+    계열이 애초에 못 오고, 남는 error_code는 CHANNEL_PUBLISH_PROVIDER_ERROR뿐"이라고
+    못박아 놓고도 그 유일한 코드를 승격 대상에 남겨 뒀던 것 — 결과적으로 5xx/네트워크/
+    타임아웃이 재시도 5회를 채우면 예외 없이 전부 승격되던 결함이었다. 위
+    test_cron_rate_limited_max_retries_reaches_dead_letter_but_connection_stays_active와
+    같은 원칙(「연결 상태는 사람이 고쳐야 풀리는 것에만」)을 CHANNEL_PUBLISH_PROVIDER_
+    ERROR에도 그대로 적용 — command는 dead_letter로 소진되지만(재시도 정책 자체는
+    무변), connection은 status·last_error 4필드 다 그대로다. 세팅은 위
+    test_cron_max_retries_reaches_dead_letter와 완전히 동형."""
     from unittest.mock import AsyncMock, patch
     import app.services.threads_publish as tp
     from app.services.publication_command import MAX_RETRIES, process_due_publication_commands
@@ -453,6 +459,7 @@ async def test_cron_max_retries_reaches_dead_letter_also_escalates_connection_to
             )
             s.add(cmd)
             await s.commit()
+            cmd_id = cmd.id
 
         from app.services.threads_publish import ThreadsPublishError
         with (
@@ -466,13 +473,21 @@ async def test_cron_max_retries_reaches_dead_letter_also_escalates_connection_to
 
         async with Session() as s:
             from app.models.channel_connection import ChannelConnection
+            from app.models.publication_command import PublicationCommand
             from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
             conn = (await s.execute(
                 select(ChannelConnection).where(ChannelConnection.id == connection_id)
             )).scalar_one()
-        assert conn.status == "error", (
-            "transient 재시도 상한 도달 후에도 「연결됨」 칩이 거짓으로 남으면 안 된다"
+        assert cmd.status == "dead_letter", "재시도 상한 도달(=일시 오류 소진) 자체는 그대로여야 한다"
+        assert cmd.dead_letter_at is not None
+        assert conn.status == "active", (
+            "일시 provider 오류(5xx)가 재시도 상한에 닿아도 connection은 건드리면 안 된다 — "
+            "「다시 연결해 주세요」는 사람에게 틀린 처방이다(dev 실사고 #3646)"
         )
+        assert conn.last_error is None
+        assert conn.last_error_code is None
+        assert conn.last_error_at is None
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -545,6 +560,10 @@ async def test_cron_retryable_failure_below_cap_does_not_prematurely_escalate_co
 
 @pytest.mark.anyio
 async def test_cron_token_expired_blocks_command_and_escalates_connection_status():
+    """story #3646 CHANGES — 인증 계열(FAILURE_KIND_CONNECTION 분기)은 첫 실패에서
+    바로 승격되고(재시도 무관, 위 provider-error 테스트와 대조축), 이제 last_error_
+    code/last_error_at도 같이 채운다(공용 헬퍼 `mark_connection_failed`, 이전엔
+    이 분기만 status/last_error 2필드뿐이었다)."""
     from unittest.mock import AsyncMock, patch
     import app.services.threads_publish as tp
     from app.services.publication_command import process_due_publication_commands
@@ -602,6 +621,242 @@ async def test_cron_token_expired_blocks_command_and_escalates_connection_status
             assert cmd.failure_kind == "connection"
             conn = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == connection_id))).scalar_one()
             assert conn.status == "expired"
+            assert conn.last_error_code == "CHANNEL_TOKEN_EXPIRED"
+            assert conn.last_error_at is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_connection_revoked_blocks_command_and_sets_status_revoked():
+    """story #3646 회귀 — 인증 계열 3종 중 REVOKED. `CONNECTION_ERROR_CODE_TO_STATUS`
+    매핑을 그대로 pin(회귀 0, 새 판정 0)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        from app.services.threads_publish import ThreadsPublishError
+        with (
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "create_container", AsyncMock(side_effect=ThreadsPublishError(
+                status_code=401, code="OAUTH_REVOKED", provider_error_code=190, provider_error_subcode=460,
+                message="revoked",
+            ))),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_connection import ChannelConnection
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.status == "blocked"
+            conn = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == connection_id))).scalar_one()
+            assert conn.status == "revoked"
+            assert conn.last_error_code == "CHANNEL_CONNECTION_REVOKED"
+            assert conn.last_error_at is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_permission_error_blocks_command_and_sets_status_error():
+    """story #3646 회귀 — 인증 계열 3종 중 AUTH_ERROR(permission family, code=10).
+    `CONNECTION_ERROR_CODE_TO_STATUS`가 이 코드를 지정 안 해 "expired"로 기본
+    폴백되는 다른 매핑 밖 코드들과 달리, `classify_graph_oauth_error`가 permission
+    family를 항상 "error"로 내는 것과 짝을 이룬다(회귀 0, 새 판정 0)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        from app.services.threads_publish import ThreadsPublishError
+        with (
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "create_container", AsyncMock(side_effect=ThreadsPublishError(
+                status_code=403, code="OAUTH_PERMISSION", provider_error_code=10, message="permission",
+            ))),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_connection import ChannelConnection
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.status == "blocked"
+            conn = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == connection_id))).scalar_one()
+            assert conn.status == "error"
+            assert conn.last_error_code == "CHANNEL_CONNECTION_AUTH_ERROR"
+            assert conn.last_error_at is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_reintroducing_transient_exhaustion_promotion_reopens_bug(monkeypatch):
+    """뮤테이션 — apply_command_failure의 소진 분기가 다시 error_code!=RATE_LIMITED로
+    connection을 승격하도록 되돌리면(#3598 AC6 옛 동작 재현), 위 provider-error
+    「불변」 테스트가 정확히 그 이유로 RED가 되는 것을 고정한다."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.publication_command as pc_module
+    import app.services.threads_publish as tp
+    from app.services.publication_command import MAX_RETRIES, process_due_publication_commands
+
+    original = pc_module.apply_command_failure
+
+    async def _reintroduce_old_promotion(db, command, *, error_code, last_error, now, retry_after_seconds=None):
+        from app.services.publication_command import (
+            FAILURE_KIND_CONNECTION, FAILURE_KIND_NEEDS_CHECK, MAX_RETRIES, classify_failure_kind,
+        )
+        command.last_error = last_error[:2000] if last_error else None
+        failure_kind = classify_failure_kind(error_code)
+        command.failure_kind = failure_kind
+        if failure_kind in (FAILURE_KIND_CONNECTION, FAILURE_KIND_NEEDS_CHECK):
+            return await original(
+                db, command, error_code=error_code, last_error=last_error, now=now,
+                retry_after_seconds=retry_after_seconds,
+            )
+        command.attempt_count += 1
+        if command.attempt_count >= MAX_RETRIES:
+            if error_code != "CHANNEL_RATE_LIMITED":
+                from app.models.channel_connection import ChannelConnection
+                connection = await db.get(ChannelConnection, command.destination)
+                if connection is not None:
+                    connection.last_error = (last_error or "")[:2000]
+                    if connection.status not in ("revoked", "error"):
+                        connection.status = "error"
+            command.status = "dead_letter"
+            command.dead_letter_at = now
+            command.next_attempt_at = None
+            return
+        command.status = "pending"
+
+    monkeypatch.setattr(pc_module, "apply_command_failure", _reintroduce_old_promotion)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+                attempt_count=MAX_RETRIES - 1,
+            )
+            s.add(cmd)
+            await s.commit()
+
+        from app.services.threads_publish import ThreadsPublishError
+        with (
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "create_container", AsyncMock(side_effect=ThreadsPublishError(
+                status_code=500, code="SERVER_ERROR", message="boom",
+            ))),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.channel_connection import ChannelConnection
+            from sqlalchemy import select
+            conn = (await s.execute(
+                select(ChannelConnection).where(ChannelConnection.id == connection_id)
+            )).scalar_one()
+        assert conn.status == "error", "뮤테이션이 걸리지 않았다(옛 승격이 재현돼야 한다)"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3646_mark_connection_failed_message_none.py
+++ b/backend/tests/test_3646_mark_connection_failed_message_none.py
@@ -1,0 +1,55 @@
+"""story #3646 카디르 qa:changes(PR #4004, 2026-09-07) — `mark_connection_failed`
+(graph_api_errors.py)이 `if message is not None:`일 때만 last_error를 썼다. 지운 인라인
+3곳(channel_post_comments.py·insight_snapshots.py·publication_command.py)은 전부
+`(message or "")[:2000]`으로 항상 덮어쓰던 것이라, message=None으로 이 헬퍼를 부르면
+그 연결의 옛(무관한) last_error가 그대로 남는다 — 「틀린 진단문구 표시」 회귀.
+
+`mark_connection_failed`는 `connection`을 속성 읽기/쓰기로만 다뤄(status/last_error/
+last_error_code/last_error_at) DB가 필요 없다 — 순수 단위 테스트(마커 없음)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+
+def _fake_connection(**overrides):
+    base = dict(status="active", last_error=None, last_error_code=None, last_error_at=None)
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_message_none_clears_stale_last_error_but_still_updates_code_and_at():
+    from app.services.graph_api_errors import mark_connection_failed
+
+    conn = _fake_connection(
+        status="error", last_error="옛 진단 문구(무관한 이전 실패)",
+        last_error_code="CHANNEL_CONNECTION_AUTH_ERROR",
+        last_error_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+    )
+    now = datetime.now(timezone.utc)
+
+    mark_connection_failed(conn, error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=None, now=now)
+
+    assert conn.last_error == "", "message=None인데 옛 last_error가 남음 — 틀린 진단문구 표시 회귀"
+    assert conn.last_error_code == "CHANNEL_PUBLISH_PROVIDER_ERROR"
+    assert conn.last_error_at == now
+
+
+def test_mutation_reintroducing_conditional_last_error_leaves_stale_text(monkeypatch):
+    """뮤테이션 — `if message is not None:` 조건부로 되돌리면(원래 결함 재현) 옛
+    last_error가 안 지워져 RED."""
+    import app.services.graph_api_errors as mod
+
+    def _buggy_mark_connection_failed(connection, *, error_code, message, now):
+        connection.status = mod.connection_status_for_error_code(error_code, current_status=connection.status)
+        if message is not None:
+            connection.last_error = message[:2000]
+        connection.last_error_code = error_code
+        connection.last_error_at = now
+
+    monkeypatch.setattr(mod, "mark_connection_failed", _buggy_mark_connection_failed)
+
+    conn = _fake_connection(status="error", last_error="옛 진단 문구(무관한 이전 실패)")
+    mod.mark_connection_failed(conn, error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=None, now=datetime.now(timezone.utc))
+
+    assert conn.last_error == "옛 진단 문구(무관한 이전 실패)", "뮤테이션이 무력화됨 — 조건부 복원이 실제로 재현되지 않음"


### PR DESCRIPTION
스토리 id eaacb955-4c8b-47c9-8c9c-a83176bde991. dev 실측(2026-09-07 12:01Z, PO Test Org) — IG sandbox 연결에 `[sandbox:provider-error]` 502 발행 실패 뒤 status=error·「재인증 필요 — 다시 연결해 주세요」. 재연결해도 provider가 살아나는 것과 무관해 사람에게 틀린 처방.

## 그라운딩(코드 확認)
IG/Threads classify는 갈림 0 — 둘 다 `ThreadsPublishError`+`classify_graph_error_code` 공유, 5xx·no-code는 정확히 `CHANNEL_PUBLISH_PROVIDER_ERROR`(비-인증)로 분류된다. 실제 원인은 `publication_command.py::apply_command_failure`의 재시도-소진 분기(story #3598 AC6) — `MAX_RETRIES` 소진 시 `error_code != CHANNEL_RATE_LIMITED`면 무조건 승격했다. #3598 AC6 자신의 주석이 이미 "이 분기엔 인증 계열이 애초에 못 오고 남는 건 PROVIDER_ERROR뿐"이라고 못박아 놓고도 그 유일한 코드를 승격 대상에 남겨 뒀던 것 — Threads sandbox가 승격 0으로 보인 건 재시도 5회 미달(mid-backoff)이었을 뿐, 채우면 동일 증상.

## 전/후 표

| error_code | 소진 前 | 소진(5회) |
|---|---|---|
| `CHANNEL_PUBLISH_PROVIDER_ERROR`(5xx) | pending 재시도 | dead_letter · connection 불변 **(변경)** |
| `CHANNEL_RATE_LIMITED` | pending 재시도 | dead_letter · connection 불변(기존) |
| `CHANNEL_TOKEN_EXPIRED`/`REVOKED`/`AUTH_ERROR` | 즉시 blocked+승격(재시도 무관) | — |

## 처방
1. 소진 분기에서 connection 승격을 완전 제거 — TRANSIENT 분기(`_TRANSIENT_CODES` 전부) 전체가 command만 `dead_letter`, connection의 status·last_error 4필드는 불변. 인증 계열은 `FAILURE_KIND_CONNECTION` 분기가(재시도 무관, 즉시) 전담 — 두 분기는 이미 배타적으로 갈린다.
2. 새 공용 헬퍼 `graph_api_errors.mark_connection_failed`(`mark_connection_recovered`의 짝) — status(sticky)·last_error·last_error_code·last_error_at 4필드를 한 자리로. `apply_command_failure`(CONNECTION 분기, 그라운딩에서 `last_error_code`/`at` 2필드 누락 확認)·`_promote_connection_status`(channel_post_comments.py)·`_promote_connection_status_for_snapshot`(insight_snapshots.py) 3곳의 인라인 중복을 이 헬퍼 하나로 통일(새 판정 로직 0).

## Test plan
- [x] provider 5xx 소진 → dead_letter·connection 4필드 불변(#3598 AC6 테스트 단언 뒤집음, 같은 테스트에서 dead_letter 성립도 같이 잼)
- [x] rate-limited 소진 → connection 불변(기존 회귀, 무변)
- [x] 인증 계열 3종(TOKEN_EXPIRED·REVOKED·AUTH_ERROR) 즉시 승격+4필드 — 회귀/신규
- [x] 뮤테이션 1(소진 분기 옛 승격 재도입 → RED)
- [x] 영향 스위트 전수 재검(3597·3603·3605·3598·3516·3497·3414) 96/96 그린
- [x] `app.main` import 그린

## 라이브
PO Test Org IG `[sandbox:provider-error]` 표본 재발행 → connection active 유지 확認은 PO 몫(그라운딩 AC4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)