### PR TITLE
[SID:3653] fix(ci): weights 드리프트 가드 사각지대 — 타임아웃 shard 침묵을 닫는다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1109,20 +1109,6 @@ jobs:
       SECRET_KEY: ci-test-secret-at-least-32-chars-long
 
     steps:
-      - name: Require all destructive-schema shards to have succeeded
-        if: needs.backend-test-destructive.result != 'success'
-        run: |
-          echo "backend-test-destructive result=${{ needs.backend-test-destructive.result }} — destructive-schema 94개의 유일한 실행처가 실패했거나 안 돎"
-          # story #3541(페드루 PO 確定) — GitHub Actions는 timeout-minutes로 죽인 잡과
-          # 사람이 수동 취소한 잡을 conclusion에서 안 가른다(둘 다 "cancelled"). result가
-          # cancelled면 코드 결함이 아니라 시간 초과였을 가능성이 있다는 걸 여기서
-          # 말해 둔다(#3884 shard 5·7·#3886 shard 2 실사고 — attempt 2는 코드 무변경으로
-          # 통과했었다) — 사람이 곧장 코드를 의심하고 파는 시간을 줄인다.
-          if [ "${{ needs.backend-test-destructive.result }}" = "cancelled" ]; then
-            echo "cancelled=시간 초과 또는 수동 취소 — 잡 소요가 timeout-minutes에 닿았는지 확認(각 샤드 job의 소요 시간을 먼저 볼 것)"
-          fi
-          exit 1
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -1132,11 +1118,20 @@ jobs:
           version: 'latest'
 
       # story #3558(CI·소형) AC2 — 8개 샤드가 낸 shard-durations-{n} 산출물을 모아
-      # weights.json과 절대 배율(2배/0.5배) 대조 «경고만»(실패 0 — continue-on-error도
-      # 필요 없다, _audit_durations_mode 자체가 항상 exit 0). backend-irrelevant PR이라
-      # 샤드가 스킵됐으면 산출물 자체가 없을 수 있어 download 단계를 continue-on-error로
-      # 감싼다(찾는 패턴이 0건이면 actions/download-artifact가 에러를 낸다 — 그게 이
-      # 필수 체크 잡을 죽이면 안 된다, story #2555의 backend-irrelevant 우회 규율과 동형).
+      # weights.json과 절대 배율(2배/0.5배) 대조 «경고만»(원칙 — story #3653이 "성공인데
+      # 산출물 누락"이라는 새 결함 클래스에 한해 예외를 둔다, 아래 Audit 스텝 참고).
+      # backend-irrelevant PR이라 샤드가 스킵됐으면 산출물 자체가 없을 수 있어 download
+      # 단계를 continue-on-error로 감싼다(찾는 패턴이 0건이면 actions/download-artifact가
+      # 에러를 낸다 — 그게 이 필수 체크 잡을 죽이면 안 된다, story #2555의
+      # backend-irrelevant 우회 규율과 동형).
+      #
+      # story #3653(CI·가드, 페드루 PO 確定 2026-09-07) — 이 Download/Audit 2스텝을
+      # "Require all destructive-schema shards"(아래) **앞으로** 옮겼다. 그라운딩 —
+      # 옛 순서(Require 먼저, exit 1 무조건)에서는 샤드 하나라도 실패/타임아웃이면
+      # (needs.backend-test-destructive.result != success) Require가 먼저 죽어 이
+      # Audit이 통째로 스킵됐다 — 다른 7개 정상 샤드의 실측조차 집계되지 못했다(가장
+      # 드리프트가 클 타임아웃 상황에 가드가 침묵하는 사각지대). 이제 이 잡의 첫
+      # 스텝들이라 Require의 결과와 무관하게 항상 돈다.
       - name: Download shard durations (story #3558)
         uses: actions/download-artifact@v4
         continue-on-error: true
@@ -1160,9 +1155,16 @@ jobs:
           restore-keys: |
             weights-drift-streak-
 
-      - name: Audit shard durations vs weights.json (story #3558+#3642, warn-only)
+      # story #3653 — --shard-count(matrix.shard와 동형 8, 기존 인자 재사용)+
+      # --shard-result(needs.backend-test-destructive.result 그대로)로 산출물이 8개
+      # 미만일 때를 가른다: result=success인데 미만이면 업로드 파이프라인 자체가
+      # 조용히 무산된 것(::error+exit 1, 이 스텝 자체가 실패해 아래 Require를 포함한
+      # 나머지 스텝을 건너뛴다) — result!=success(실패/타임아웃)면 그 샤드의 실측
+      # 데이터가 원천적으로 없어 "센다"가 불가능하니 ::warning만(exit 0, 원칙 그대로
+      # CI를 안 죽인다).
+      - name: Audit shard durations vs weights.json (story #3558+#3642+#3653)
         working-directory: backend
-        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations --drift-state /tmp/weights-drift-streak.json --run-id "${{ github.run_id }}"
+        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations --drift-state /tmp/weights-drift-streak.json --run-id "${{ github.run_id }}" --shard-count 8 --shard-result "${{ needs.backend-test-destructive.result }}"
 
       - name: Save weights-drift streak state (story #3642)
         if: always()
@@ -1170,6 +1172,20 @@ jobs:
         with:
           path: /tmp/weights-drift-streak.json
           key: weights-drift-streak-${{ github.run_id }}
+
+      - name: Require all destructive-schema shards to have succeeded
+        if: needs.backend-test-destructive.result != 'success'
+        run: |
+          echo "backend-test-destructive result=${{ needs.backend-test-destructive.result }} — destructive-schema 94개의 유일한 실행처가 실패했거나 안 돎"
+          # story #3541(페드루 PO 確定) — GitHub Actions는 timeout-minutes로 죽인 잡과
+          # 사람이 수동 취소한 잡을 conclusion에서 안 가른다(둘 다 "cancelled"). result가
+          # cancelled면 코드 결함이 아니라 시간 초과였을 가능성이 있다는 걸 여기서
+          # 말해 둔다(#3884 shard 5·7·#3886 shard 2 실사고 — attempt 2는 코드 무변경으로
+          # 통과했었다) — 사람이 곧장 코드를 의심하고 파는 시간을 줄인다.
+          if [ "${{ needs.backend-test-destructive.result }}" = "cancelled" ]; then
+            echo "cancelled=시간 초과 또는 수동 취소 — 잡 소요가 timeout-minutes에 닿았는지 확認(각 샤드 job의 소요 시간을 먼저 볼 것)"
+          fi
+          exit 1
 
       # non-destructive real-PG 테스트(84개 파일, destructive_schema 마커 제외)는 alembic-migrated
       # 스키마(view·nullable·seed 포함 baseline)에 의존한다 — fresh DB를 먼저 heads까지 올린다

--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -387,13 +387,18 @@ def _audit_durations_mode(
     - 그 외(실패·타임아웃·cancelled 등)는 그라운딩②의 결론 그대로 — 그 shard의
       실측 데이터가 원천적으로 없어(타임아웃이 파일 루프 중간을 끊으면 부분 기록도
       없다) "센다"가 물리적으로 불가능하다 — `::warning::`으로 "N개는 집계 밖"만
-      선언(exit 0, 기존 경고-전용 원칙 그대로)."""
-    if not artifact_dir.exists():
-        print(f"산출물 디렉터리 없음({artifact_dir}) — backend-irrelevant PR로 샤드가 스킵됐을 수 있음, 대조 0건", file=sys.stderr)
-        if drift_state_path is not None:
-            state = _load_drift_state(drift_state_path)
-            _save_drift_state(drift_state_path, run_id=run_id, streaks=state["streaks"])
-        return 0
+      선언(exit 0, 기존 경고-전용 원칙 그대로).
+
+    카디르 qa:changes(PR #4005, 2026-09-07, codex 발견) — 예전엔 `artifact_dir.exists()`
+    가 이 shard_result 분기보다 **먼저** 서서, 디렉터리 자체가 통째로 없으면(업로드가
+    전부 무산된 극단형) shard_result 무관하게 항상 조용히 0을 돌려줬다 — 부분 누락은
+    잡는데 전체 누락은 새는 비대칭. `artifact_dir.glob("*.json")`(load_duration_
+    artifacts·load_present_shard_numbers 둘 다)은 디렉터리가 없어도 빈 이터레이터를
+    돌려줄 뿐 예외를 안 던지므로(파이썬 pathlib 표준 동작), 이 조기 return을 그냥
+    없애면 아래 로직이 "산출물 0건"을 자연스럽게 흘려보내 밑의 `expected_shard_count`
+    분기(shard_result 기준 error/warning)에 그대로 합류한다 — 전체 누락도 부분 누락과
+    **같은 문구·같은 코드**를 탄다. drift 상태 write-through(story #3642 CHANGES①)도
+    이 함수 중간에 무조건 도는 블록이라(위치 무변경) 이 삭제로 안 깨진다."""
     measured = load_duration_artifacts(artifact_dir)
     weights = load_weights()
     outliers = ratio_outliers(measured, weights)

--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -312,6 +312,32 @@ def write_durations_json(elapsed_by_file: dict[str, float], out_path: Path, *, s
     out_path.write_text(json.dumps({"shard": shard, "durations": elapsed_by_file}, indent=2, sort_keys=True))
 
 
+def load_present_shard_numbers(artifact_dir: Path) -> set[int]:
+    """story #3653(CI·가드, 페드루 PO 確定 2026-09-07) — `artifact_dir` 아래
+    shard-durations-{n}.json이 실제로 있는 shard 번호만 모은다(`load_duration_
+    artifacts`와 같은 파일을 다시 읽되, 이번엔 병합된 durations가 아니라 "이 shard가
+    산출물을 남겼는가" 자체가 관심사). 그라운딩 확認 — 타임아웃으로 25분 천장에
+    죽은 shard는 `--elapsed-to-json`(파일 루프 완주 뒤에만 도는 마지막 스텝)까지
+    못 가 이 산출물 자체가 없다(부분 기록도 없다) — 이 함수가 그 부재를 shard
+    번호 단위로 드러낸다."""
+    present: set[int] = set()
+    for p in sorted(artifact_dir.glob("*.json")):
+        try:
+            data = json.loads(p.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        shard = data.get("shard")
+        if isinstance(shard, int):
+            present.add(shard)
+    return present
+
+
+def missing_shards(present: set[int], *, expected_count: int) -> list[int]:
+    """story #3653 — 0..expected_count-1(ci.yml matrix.shard와 동형 범위) 중
+    `present`에 없는 번호를 정렬해 반환(재현성)."""
+    return sorted(set(range(expected_count)) - present)
+
+
 def load_duration_artifacts(artifact_dir: Path) -> dict[str, float]:
     """story #3558 AC2 — `artifact_dir` 아래 `*.json`(각 shard-durations-{n}.json,
     `{"shard": n, "durations": {file: sec}}` 모양) 전부를 하나의 {file: sec}로 병합한다.
@@ -330,10 +356,11 @@ def load_duration_artifacts(artifact_dir: Path) -> dict[str, float]:
 
 def _audit_durations_mode(
     artifact_dir: Path, *, drift_state_path: Path | None = None, run_id: str | None = None,
+    expected_shard_count: int | None = None, shard_result: str | None = None,
 ) -> int:
-    """story #3558 AC2 — 항상 0을 반환한다(경고 전용, CI를 절대 안 죽인다). 산출물
-    디렉터리가 없거나 비어 있어도(backend-irrelevant PR이라 샤드 자체가 스킵된 경우)
-    조용히 "대조 대상 0건"으로 끝낸다.
+    """story #3558 AC2 — 원칙은 경고 전용(CI를 절대 안 죽인다). 산출물 디렉터리가
+    없거나 비어 있어도(backend-irrelevant PR이라 샤드 자체가 스킵된 경우) 조용히
+    "대조 대상 0건"으로 끝낸다.
 
     story #3642(AC3) — `drift_state_path`가 주어지면 «과소 등재(ratio≥2.0) 연속 스트릭»
     을 같이 추적한다(ci.yml이 actions/cache로 run 사이에 이 파일을 넘긴다).
@@ -345,7 +372,22 @@ def _audit_durations_mode(
 
     story #3642 CHANGES②(페드루 PO) — `run_id`가 주어지고 복원된 상태의 run_id와
     같으면(=같은 run의 재시도가 attempt 1이 이미 반영한 상태를 복원) 스트릭을 다시
-    증가시키지 않는다(이중 카운트 방지, 멱등)."""
+    증가시키지 않는다(이중 카운트 방지, 멱등).
+
+    story #3653(CI·가드, 페드루 PO 確定 2026-09-07) — 이 audit가 이제 ci.yml에서
+    "Require all destructive-schema shards" **앞으로** 옮겨져 항상 돈다(그라운딩①,
+    타임아웃/실패로 shard가 안 죽어도 이 audit는 실행돼야 다른 정상 shard의 실측이
+    계속 집계된다). 그 재배치가 낳는 새 질문 — "산출물이 8개 미만이면 왜인가"를
+    `expected_shard_count`/`shard_result`(ci.yml이 `needs.backend-test-destructive.
+    result`를 그대로 넘긴다)로 가른다:
+    - `shard_result == "success"`인데 산출물이 빠진 shard가 있으면 그건 코드 결함이
+      아니라 **업로드 파이프라인 자체가 조용히 무산된 것**(예: upload-artifact 설정
+      실수) — 침묵하면 안 되는 새로운 결함 클래스라 `::error`+**exit 1**(가드가
+      "재료를 못 찾았다"고 스스로 빨개진다).
+    - 그 외(실패·타임아웃·cancelled 등)는 그라운딩②의 결론 그대로 — 그 shard의
+      실측 데이터가 원천적으로 없어(타임아웃이 파일 루프 중간을 끊으면 부분 기록도
+      없다) "센다"가 물리적으로 불가능하다 — `::warning::`으로 "N개는 집계 밖"만
+      선언(exit 0, 기존 경고-전용 원칙 그대로)."""
     if not artifact_dir.exists():
         print(f"산출물 디렉터리 없음({artifact_dir}) — backend-irrelevant PR로 샤드가 스킵됐을 수 있음, 대조 0건", file=sys.stderr)
         if drift_state_path is not None:
@@ -355,6 +397,7 @@ def _audit_durations_mode(
     measured = load_duration_artifacts(artifact_dir)
     weights = load_weights()
     outliers = ratio_outliers(measured, weights)
+    exit_code = 0
 
     if drift_state_path is not None:
         state = _load_drift_state(drift_state_path)
@@ -374,15 +417,36 @@ def _audit_durations_mode(
 
     if not outliers:
         print(f"OK: 등재값 대조 — 산출물 {len(measured)}건 중 2배/0.5배 이탈 0건(story #3558)", file=sys.stderr)
-        return 0
-    for o in outliers:
-        direction = "과소 등재" if o["ratio"] >= RATIO_WARN_HIGH_MULTIPLIER else "과대 등재"
-        print(
-            f"::warning::등재값 {direction}(story #3558): {o['file']} — 실측 {o['measured_sec']:.1f}s vs "
-            f"등재 {o['weight_sec']:.1f}s(×{o['ratio']:.2f}) — infra/destructive-schema-shard-weights.json 재측정 검토."
-        )
-    print(f"경고 {len(outliers)}건(산출물 {len(measured)}건 중) — 실패 아님, story #3558 AC2", file=sys.stderr)
-    return 0
+    else:
+        for o in outliers:
+            direction = "과소 등재" if o["ratio"] >= RATIO_WARN_HIGH_MULTIPLIER else "과대 등재"
+            print(
+                f"::warning::등재값 {direction}(story #3558): {o['file']} — 실측 {o['measured_sec']:.1f}s vs "
+                f"등재 {o['weight_sec']:.1f}s(×{o['ratio']:.2f}) — infra/destructive-schema-shard-weights.json 재측정 검토."
+            )
+        print(f"경고 {len(outliers)}건(산출물 {len(measured)}건 중) — 실패 아님, story #3558 AC2", file=sys.stderr)
+
+    if expected_shard_count is not None:
+        missing = missing_shards(load_present_shard_numbers(artifact_dir), expected_count=expected_shard_count)
+        if missing:
+            if shard_result == "success":
+                print(
+                    f"::error::shard 산출물 누락(story #3653): {missing} — backend-test-destructive.result="
+                    "success인데 산출물이 없다(코드 결함 아님 — 업로드 파이프라인이 조용히 무산됐다는 뜻, "
+                    "actions/upload-artifact 설정을 확認하라)."
+                )
+                exit_code = 1
+            else:
+                print(
+                    f"::warning::shard {len(missing)}개는 드리프트 집계 밖(story #3653): {missing} — "
+                    f"backend-test-destructive.result={shard_result!r}(타임아웃/실패)라 이 shard들의 실측 "
+                    "데이터 자체가 없다(부분 기록도 없다) — 등재값 대조·drift 스트릭 어느 쪽도 이 shard를 "
+                    "«못 봤다»는 뜻이지 «정상»이라는 뜻이 아니다."
+                )
+        else:
+            print(f"OK: shard 산출물 {expected_shard_count}/{expected_shard_count} 전부 있음(story #3653)", file=sys.stderr)
+
+    return exit_code
 
 
 # story #3642(CI·소형, 3636 후속, 페드루 PO 確定 2026-09-07) — 3396의 러너 정규화는
@@ -477,7 +541,11 @@ def _check_elapsed_mode(elapsed_path: Path) -> int:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--shard-index", type=int, default=None)
-    ap.add_argument("--shard-count", type=int, default=None)
+    ap.add_argument(
+        "--shard-count", type=int, default=None,
+        help="파티션 모드(--shard-index와 함께)의 샤드 수. story #3653 — --audit-durations "
+             "모드에서도 재사용한다(새 인자 발명 0) — 산출물이 이 수만큼 다 있는지 대조한다.",
+    )
     ap.add_argument("--print-summary", action="store_true", help="전체 샤드 분배를 stderr에 찍는다")
     ap.add_argument(
         "--meta-out", type=Path, default=None,
@@ -514,6 +582,13 @@ def main() -> int:
              "${{ github.run_id }}를 넘긴다). 복원된 상태의 run_id와 같으면(같은 run의 "
              "재시도) 스트릭을 다시 증가시키지 않는다 — 이중 카운트 방지.",
     )
+    ap.add_argument(
+        "--shard-result", type=str, default=None,
+        help="story #3653 — --audit-durations와 함께 쓴다(ci.yml이 "
+             "needs.backend-test-destructive.result를 그대로 넘긴다). --shard-count와 "
+             "짝을 이뤄 «성공인데 산출물이 빈 shard」(업로드 결함, ::error+exit 1)와 "
+             "「실패/타임아웃이라 원천적으로 못 세는 shard」(::warning만)를 가른다.",
+    )
     args = ap.parse_args()
 
     if args.check_elapsed is not None:
@@ -530,6 +605,7 @@ def main() -> int:
     if args.audit_durations is not None:
         return _audit_durations_mode(
             args.audit_durations, drift_state_path=args.drift_state, run_id=args.run_id,
+            expected_shard_count=args.shard_count, shard_result=args.shard_result,
         )
 
     if args.shard_index is None or args.shard_count is None:

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -726,3 +726,90 @@ def test_audit_durations_mode_same_run_retry_does_not_double_count(tmp_path, cap
         mod._audit_durations_mode(artifact_dir, drift_state_path=state_path, run_id="run-B")
         state3 = json.loads(state_path.read_text())
         assert state3 == {"run_id": "run-B", "streaks": {"tests/stale.py": 2}}
+
+
+# ─── story #3653(CI·가드, 페드루 PO 確定 2026-09-07) — 타임아웃으로 죽은 shard가
+# drift 집계 사각지대에 빠지던 것을 닫는다: shard 산출물 개수를 --shard-count와
+# 대조해, «성공인데 산출물 없음»(업로드 결함, ::error+exit 1)과 «실패/타임아웃이라
+# 원천적으로 못 세는 것»(::warning만, exit 0)을 가른다 ────────────────────────────
+
+
+def _write_shard_artifact(artifact_dir, shard: int, durations: dict | None = None) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / f"shard-durations-{shard}.json").write_text(
+        json.dumps({"shard": shard, "durations": durations or {}})
+    )
+
+
+def test_missing_shards_all_8_present_returns_empty():
+    mod = _load()
+    assert mod.missing_shards(set(range(8)), expected_count=8) == []
+
+
+def test_load_present_shard_numbers_reads_shard_field_from_each_artifact(tmp_path):
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"
+    for n in (0, 2, 5):
+        _write_shard_artifact(artifact_dir, n)
+    assert mod.load_present_shard_numbers(artifact_dir) == {0, 2, 5}
+
+
+def test_audit_durations_mode_8_of_8_present_no_shard_warning(capsys, tmp_path):
+    """selftest 1 — 산출물이 기대한 만큼(8/8) 다 있으면 shard-누락 관련 경고/에러가
+    0건이어야 한다(양성대조: 아래 두 테스트가 실제로 다른 조건에서 다르게 뜬다는 것
+    자체가 이 테스트의 「무경고」가 우연이 아님을 증명한다)."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"
+    for n in range(8):
+        _write_shard_artifact(artifact_dir, n)
+    exit_code = mod._audit_durations_mode(artifact_dir, expected_shard_count=8, shard_result="success")
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "::error::" not in captured.out
+    assert "::warning::shard" not in captured.out
+    assert "8/8" in captured.err
+
+
+def test_audit_durations_mode_7_of_8_non_success_warns_only(capsys, tmp_path):
+    """selftest 2 — 7/8만 있고 shard_result가 non-success(타임아웃/실패)면 경고 1건만
+    뜨고 exit 0(원천적으로 못 세는 데이터라 실패시키면 안 된다 — story #3653 그라운딩②)."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"
+    for n in range(7):  # shard 7만 빠짐.
+        _write_shard_artifact(artifact_dir, n)
+    exit_code = mod._audit_durations_mode(artifact_dir, expected_shard_count=8, shard_result="cancelled")
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "::warning::shard 1개는 드리프트 집계 밖" in captured.out
+    assert "[7]" in captured.out
+    assert "::error::" not in captured.out
+
+
+def test_audit_durations_mode_7_of_8_success_errors_and_fails(capsys, tmp_path):
+    """selftest 3 — 7/8만 있는데 shard_result가 success면(업로드 파이프라인이 조용히
+    무산된 것) ::error + exit 1 — 가드 스스로 빨개져야 한다(story #3653 확定)."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"
+    for n in range(7):  # shard 7만 빠짐.
+        _write_shard_artifact(artifact_dir, n)
+    exit_code = mod._audit_durations_mode(artifact_dir, expected_shard_count=8, shard_result="success")
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "::error::shard 산출물 누락" in captured.out
+    assert "[7]" in captured.out
+
+
+def test_mutation_removing_shard_presence_diff_silences_missing_shard_warning(tmp_path, capsys, monkeypatch):
+    """뮤테이션 — missing_shards()가 항상 빈 리스트를 내도록 되돌리면(옛 사각지대
+    재현), 7/8+non-success 케이스에서 경고가 사라지는 것을 고정한다(이 가드가 실제로
+    그 결함을 잡는다는 증거)."""
+    mod = _load()
+    monkeypatch.setattr(mod, "missing_shards", lambda present, *, expected_count: [])
+
+    artifact_dir = tmp_path / "artifacts"
+    for n in range(7):
+        _write_shard_artifact(artifact_dir, n)
+    exit_code = mod._audit_durations_mode(artifact_dir, expected_shard_count=8, shard_result="cancelled")
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "::warning::shard" not in captured.out, "뮤테이션이 걸리지 않았다(경고가 여전히 뜬다)"

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -799,6 +799,33 @@ def test_audit_durations_mode_7_of_8_success_errors_and_fails(capsys, tmp_path):
     assert "[7]" in captured.out
 
 
+def test_audit_durations_mode_dir_missing_entirely_success_errors_and_fails(capsys, tmp_path):
+    """카디르 qa:changes(PR #4005, 2026-09-07) — 산출물 디렉터리 자체가 통째로 없는
+    극단형(업로드가 전부 무산)도 shard_result="success"면 부분 누락(selftest 3)과
+    같은 문구·같은 코드로 실패해야 한다. 예전엔 이 케이스가 shard_result 분기보다
+    앞선 조기 return에 걸려 항상 조용히 0을 돌려줬다(비대칭)."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"  # 만들지 않음 — 디렉터리 자체가 없다.
+    exit_code = mod._audit_durations_mode(artifact_dir, expected_shard_count=8, shard_result="success")
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "::error::shard 산출물 누락" in captured.out
+    assert "[0, 1, 2, 3, 4, 5, 6, 7]" in captured.out
+
+
+def test_audit_durations_mode_dir_missing_entirely_non_success_warns_only(capsys, tmp_path):
+    """양성대조 — 디렉터리 통째 부재도 shard_result가 non-success면(진짜 스킵/타임아웃)
+    여전히 경고-only+exit 0(전체 누락이라고 무조건 실패시키면 안 된다 — 원래 관대한
+    분기는 그대로 살아 있어야 한다)."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"
+    exit_code = mod._audit_durations_mode(artifact_dir, expected_shard_count=8, shard_result="cancelled")
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "::warning::shard 8개는 드리프트 집계 밖" in captured.out
+    assert "::error::" not in captured.out
+
+
 def test_mutation_removing_shard_presence_diff_silences_missing_shard_warning(tmp_path, capsys, monkeypatch):
     """뮤테이션 — missing_shards()가 항상 빈 리스트를 내도록 되돌리면(옛 사각지대
     재현), 7/8+non-success 케이스에서 경고가 사라지는 것을 고정한다(이 가드가 실제로


### PR DESCRIPTION
스토리 id 95cc094c-b668-4eae-9b01-c708389dd71a. 출처: #3996(3642) 카디르 codex 교차발견(세션 01a07bc8).

## 그라운딩(코드 확認)
① `ci.yml:1112-1124` "Require all destructive-schema shards"(needs.backend-test-destructive.result != success면 무조건 exit 1) 바로 뒤에 Download/Audit(드리프트 집계 본체)가 이어져, 어떤 non-success든(실패든 타임아웃이든) audit 전체가 스킵됐다.
② 타임아웃 샤드는 이중 사각 — (a) job result=cancelled가 Require를 즉사시키고 (b) `--elapsed-to-json`(파일 루프 완주 뒤에만 도는 마지막 스텝)까지 못 가 `shard-durations-N.json` 산출물 자체가 원천 부재(부분 기록도 없다 — Upload 스텝은 `if: always()`라 돌지만 `if-no-files-found: ignore`로 조용히 무산).

## 처방(PO 確定 — (a)+(b) 결합)
1. Download/Audit 2스텝을 Require **앞으로** 재배치(같은 job 안 순서만 이동, 새 잡·새 조건 0) — 다른 정상 샤드의 실측은 Require 결과와 무관하게 항상 집계된다.
2. Audit(`_audit_durations_mode`)에 `--shard-count`(기존 인자 재사용, ci.yml 매트릭스와 이미 같은 8)+`--shard-result`(`needs.backend-test-destructive.result` 그대로)를 넘겨 "기대 shard 수 vs 산출물에 실제 있던 shard 번호" 차집합을 계산:
   - `result=success`인데 누락 있으면 **업로드 파이프라인 자체가 조용히 무산된 것**(코드 결함 아님) — `::error`+exit 1(가드가 재료를 못 찾으면 스스로 빨개진다).
   - 그 외(실패/타임아웃/cancelled)면 그 샤드 데이터가 원천적으로 없어 "센다"가 물리적으로 불가능 — `::warning::`으로 "N개는 집계 밖"만 선언(exit 0, 경고-전용 원칙 무변).

## Test plan
- [x] selftest 3 — 8/8 무경고 · 7/8+non-success 경고 1(exit 0) · 7/8+success `::error`+exit 1
- [x] 뮤테이션 1 — `missing_shards()`가 항상 빈 리스트를 내도록 되돌리면(사각지대 재현) 경고가 사라지는 것 확認 후 원복
- [x] 기존 `shard_destructive_tests` 스위트 54/54 무변경 회귀(새 매개변수 전부 기본값 `None` — 호출 안 하면 no-op)
- [x] YAML 파싱·actionlint 그린(무관 pre-existing 1건만)
- [x] `app.main` import 그린
- [x] 3642 재측정 값(weights.json) 무변

## 범위 밖
weights 값 자체의 재측정 · 샤드 시간 한도 조정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)