### PR TITLE
[SID:3654] fix(BE·REST): org 스코프 콘텐츠 경로 content 그룹 매핑 + 정적 가드(2pt)

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -297,6 +297,72 @@ _PATH_GROUP_PREFIXES: tuple[tuple[str, str], ...] = (
     ("/api/v2/visual-artifacts", "canvas"),
 )
 
+# story #3654(BE·REST·소형, 페드루 PO 確定 2026-09-07) — org 스코프 콘텐츠 경로
+# (`/api/v2/organizations/{org_id}/<segment>...`). `_PATH_GROUP_PREFIXES`(위, 고정
+# prefix 매칭)는 이 형을 표현 못 한다 — org_id가 동적 값으로 리터럴 prefix 사이에 끼어
+# 있어 `path.startswith(prefix)`가 안 통한다(test_3614_content_toolset_group_changes.py
+# 의 옛 pin이 이 갭을 기록해 뒀었다). 정규식 신설 대신 org_id **뒤 첫 세그먼트**만 뽑아
+# (그라운딩③ 싼 쪽) 이 표와 대조한다 — org_id 값 자체는 안 본다(UUID든 아니든 위치만).
+#
+# 그라운딩② 전수 — 6개 라우터(channel_posts·channel_connections·site_posts·
+# channel_post_comments·insight_snapshots·publishing_metrics)뿐 아니라 같은 콘텐츠
+# 파이프라인의 나머지 org-scoped 라우터(channel_post_comment_replies·insights_board)
+# 까지 실제 세그먼트를 전수 스캔하면 9개다(스토리 초안이 5개로 적었던 것보다 많다 —
+# publication-commands(발행 재시도)·comments(댓글 답변 초안)·insights/insights-board
+# (콘텐츠 성과 조회)도 같은 콘텐츠 파이프라인 자원이라 포함했다, PO 재확認 요청 완료).
+_ORG_SCOPED_PATH_GROUP_SEGMENTS: tuple[tuple[str, str], ...] = (
+    ("channel-posts", "content"),
+    ("site-posts", "content"),
+    ("publication-commands", "content"),
+    ("channel-connections", "content"),
+    ("publications", "content"),
+    ("comments", "content"),
+    ("insights", "content"),
+    ("insights-board", "content"),
+    ("publishing-metrics", "content"),
+)
+
+# story #3654(정적 가드) — `test_3654_org_scoped_content_rest_group.py`의 가드 테스트가
+# `app/routers/` 전수를 스캔해, `/api/v2/organizations/{org_id}/<segment>...`(또는
+# `/{id}/<segment>`) 형 라우터의 모든 세그먼트가 위 표에 있거나 이 목록에 «이유»와 함께
+# 있어야만 통과시킨다 — 새 org-scoped 자원이 표·목록 어느 쪽에도 없이 추가되면 가드가
+# 스스로 RED(b4027b2e류 사각지대의 재발을 "조용한 통과"가 아니라 "빨간 실패"로 바꾼다).
+# 아래 사유는 전부 실측 확認(sprintable_mcp/ 전수 grep) — 이 세그먼트들과 매칭되는 MCP
+# 도구/키워드가 현재 0건이라, REST를 미매핑으로 두는 것이 MCP 쪽 취급(core, 이미 존재하는
+# 별도 갭)과 최소한 "새로 벌어지지는" 않는다는 뜻 — 이 갭 자체를 정당화하지 않는다(이
+# 스토리 범위 밖일 뿐, 후속 후보로 남긴다).
+_ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON: dict[str, str] = {
+    "campaigns": "MCP 도구/키워드 0건(REST·MCP 양쪽 다 core 취급 — 이 스토리가 새로 벌리는 격차 아님)",
+    "connectors": "MCP 도구/키워드 0건(connectors.py, 위와 동형)",
+    "content-rules": "MCP 도구/키워드 0건(content_rules.py, 콘텐츠 거버넌스 설정 — 산출물 자체가 아님)",
+    "generation-budget": "MCP 도구/키워드 0건(content_rules.py, 생성 한도 조회 — 산출물 자체가 아님)",
+    "domain-labels": "MCP 도구/키워드 0건(domain_labels.py, 사이트 도메인 설정·admin류)",
+    "gate-config": "MCP 도구/키워드 0건(gate_config.py, 승인 게이트 거버넌스 설정·admin류)",
+    "measurement-connections": "MCP 도구/키워드 0건(measurement_connections.py, GA4 연결 설정)",
+    "invites": "MCP 도구/키워드 0건(org_invites.py, org 멤버 초대·admin류)",
+    "metering-key": "MCP 도구/키워드 0건(pageview_metering.py, hosted-site 계측 설정·admin류)",
+    "pageviews": "MCP 도구/키워드 0건(pageview_metering.py, hosted-site pageview 조회)",
+    "impact": "MCP 도구/키워드 0건(organizations.py, org 임팩트 조회·admin류)",
+    "resolve": "MCP 도구/키워드 0건(organizations.py, slug→org 해소·session 유틸류)",
+    "(empty/root)": "MCP 도구/키워드 0건(organizations.py, org 목록/생성 자체·admin류)",
+    "(root, org_id only)": "MCP 도구/키워드 0건(organizations.py, org 단건 조회/수정·admin류)",
+}
+
+
+def _org_scoped_content_group(path: str) -> str | None:
+    """story #3654 — `/api/v2/organizations/<org_id>/<segment>[...]`에서 `<segment>`만
+    뽑아 `_ORG_SCOPED_PATH_GROUP_SEGMENTS`와 대조한다. org_id 자체는 값 무관(위치만
+    본다) — 정규식 없이 split만으로 충분하다."""
+    parts = [p for p in path.split("/") if p]
+    # ["api", "v2", "organizations", "<org_id>", "<segment>", ...]
+    if len(parts) < 5 or parts[0] != "api" or parts[1] != "v2" or parts[2] != "organizations":
+        return None
+    segment = parts[4]
+    for seg, group in _ORG_SCOPED_PATH_GROUP_SEGMENTS:
+        if seg == segment:
+            return group
+    return None
+
 
 def path_to_tool_group(path: str) -> str | None:
     """요청 path → toolset group. always-allowed/미매핑(core 취급)이면 None(강제 면제)."""
@@ -306,6 +372,9 @@ def path_to_tool_group(path: str) -> str | None:
     for prefix, group in _PATH_GROUP_PREFIXES:
         if path == prefix or path.startswith(prefix + "/"):
             return group
+    org_scoped_group = _org_scoped_content_group(path)
+    if org_scoped_group is not None:
+        return org_scoped_group
     return None  # 미매핑 → core 취급(허용)
 
 

--- a/backend/tests/test_3614_content_toolset_group_changes.py
+++ b/backend/tests/test_3614_content_toolset_group_changes.py
@@ -46,27 +46,20 @@ def test_content_group_registered_in_all_groups_and_catalog_order():
     assert "content" in _CATALOG_DISPLAY_ORDER
 
 
-def test_channel_posts_rest_path_is_currently_unmapped_and_permissive():
-    """PO 요청 — REST 경계(`_PATH_GROUP_PREFIXES`) 등재 시도 결과를 선언한다.
-
-    channel_posts.py 라우터는 `/api/v2/organizations`(공유 prefix) 아래 `/{org_id}/
-    channel-posts/...`형이라 — 이 리스트의 다른 모든 항목(`/api/v2/stories`처럼 독립
-    top-level 자원)과 달리 org_id가 리터럴 prefix 사이에 끼어 있어 `path.startswith(prefix)`
-    단순 매칭으로는 표현이 안 된다(신규 매칭 방식 없이는 `/api/v2/organizations` 전체를
-    "content"로 묶어 다른 모든 org-scoped 자원까지 잘못 끌어오게 된다). 그래서 이 스토리는
-    등재하지 않는다 — 결과: `channel-posts` REST 엔드포인트는 지금 `_PATH_GROUP_PREFIXES`
-    미등록 → `path_to_tool_group()`가 None → `path_allowed_for_scope()`가 **scope 막론
-    True**(story b4027b2e가 canvas 편입 前 visual-artifacts에서 겪은 것과 정확히 같은
-    permissive-unmapped 폴백, 까심 라이브 실증 선례). 이 gap은 MCP 도구 쪽 그룹 경계
-    (위 테스트들)와는 독립적 축이고, channel-posts 라우터가 애초에 이 REST 경계 자체를
-    강제하는 의존성(get_verified_org_id)을 쓰는지와도 별개 문제 — 이 PR 범위 밖, 별건으로
-    남긴다(story #3631 이후 후속 후보)."""
+def test_channel_posts_rest_path_now_gated_into_content_story_3654():
+    """story #3654가 이 pin을 뒤집는다 — 이 테스트 이름·docstring이 옛 갭을 기록해 뒀던
+    자리(REST `_PATH_GROUP_PREFIXES`는 고정 prefix라 org_id가 동적으로 끼는
+    `/{org_id}/channel-posts` 형을 못 표현했다)를 그 갭이 닫혔다는 증거로 대체한다.
+    `_org_scoped_content_group()`(정규식 없이 org_id 뒤 세그먼트만 split으로 뽑는 새 매칭
+    축, mcp_toolset.py)가 이제 이 경로를 "content"로 판정한다 — 상세 계약(9개 세그먼트
+    전수·미매핑 예외 목록)은 test_3654_org_scoped_content_rest_group.py 참고."""
     from app.services.mcp_toolset import path_allowed_for_scope, path_to_tool_group
 
     withdraw_path = "/api/v2/organizations/org-1/channel-posts/drafts/draft-1/withdraw"
-    assert path_to_tool_group(withdraw_path) is None
-    assert path_allowed_for_scope(withdraw_path, ["stories"]) is True  # 무관 scope도 통과(gap)
-    assert path_allowed_for_scope(withdraw_path, []) is True
+    assert path_to_tool_group(withdraw_path) == "content"
+    assert path_allowed_for_scope(withdraw_path, ["stories"]) is False  # 무관 scope는 이제 막힌다.
+    assert path_allowed_for_scope(withdraw_path, ["content"]) is True
+    assert path_allowed_for_scope(withdraw_path, []) is True  # 레거시 빈 scope=전체 허용, 무회귀.
 
 
 def test_build_toolset_catalog_covers_withdraw_tool_in_content_group():

--- a/backend/tests/test_3654_org_scoped_content_rest_group.py
+++ b/backend/tests/test_3654_org_scoped_content_rest_group.py
@@ -24,7 +24,7 @@ _APP_DIR = Path(__file__).parent.parent / "app"
 _ROUTERS_DIR = _APP_DIR / "routers"
 
 
-def _extract_org_scoped_segments() -> dict[str, list[str]]:
+def _extract_org_scoped_segments(routers_dir: Path = _ROUTERS_DIR) -> dict[str, list[str]]:
     """`app/routers/*.py` 전수에서 `<var> = APIRouter(prefix="/api/v2/organizations", ...)`
     로 선언된 라우터 변수(파일당 여러 개 가능 — 예: gate_config.py의 router+org_router)를
     찾고, 그 변수에 걸린 `@<var>.<method>("<path>", ...)` 데코레이터의 path 리터럴에서
@@ -38,10 +38,23 @@ def _extract_org_scoped_segments() -> dict[str, list[str]]:
       "(root, org_id only)".
     - path가 비어있으면("") "(empty/root)".
     - 그 외(동적 파라미터로 시작 안 함 — 이 스토리 대상 밖 모양)는 무시(collect 안 함,
-      org_id 뒤에 붙는 형이 아니므로 이 가드의 관심사가 아니다)."""
-    router_method_re = re.compile(r'@(\w+)\.(get|post|put|patch|delete)\(\s*\n?\s*"([^"]*)"')
+      org_id 뒤에 붙는 형이 아니므로 이 가드의 관심사가 아니다).
+
+    카디르 qa:changes(PR #4006, 2026-09-07) — `@router.get("/path", ...)` 위치 인자
+    형만 잡고 `@router.get(path="/path", ...)` 키워드 인자 형은 못 봤다(실 라우트 추가로
+    재현·현재 사용례 0이지만 이 가드의 존재 이유가 "미래 누락 방지"라 이 구멍은 닫는다).
+    아래 정규식에 선택적 "path=" 키워드 접두 허용 그룹을 추가했다.
+
+    ⚠️이 가드가 여전히 못 잡는 것(의도적 잔여 사각 — AST 전환은 지금 안 함, 아래가
+    그 신뢰 경계 선언) — `router.add_api_route(...)` 동적 등록 · 변수/f-string으로
+    조립된 경로(`f"/{prefix}/..."` 등, 문자열 리터럴이 아니라서 정규식이 값을 못 봄)
+    · `router.api_route(...)`(메서드 무관 다중 등록). 다음에 이 사각을 밟는 사람이
+    있다면 그게 이 판단이 틀렸다는 신호이니 그때 확장한다."""
+    router_method_re = re.compile(
+        r'@(\w+)\.(get|post|put|patch|delete)\(\s*\n?\s*(?:path\s*=\s*)?"([^"]*)"'
+    )
     segments: dict[str, list[str]] = {}
-    for path in sorted(_ROUTERS_DIR.glob("*.py")):
+    for path in sorted(routers_dir.glob("*.py")):
         text = path.read_text()
         org_router_vars = set(re.findall(r'(\w+)\s*=\s*APIRouter\(\s*prefix="/api/v2/organizations"', text))
         if not org_router_vars:
@@ -69,6 +82,24 @@ def test_grounding_extraction_finds_known_content_segments():
     assert "channel_posts.py" in segments["channel-posts"]
     assert "publications" in segments
     assert {"channel_post_comments.py", "insight_snapshots.py"} <= set(segments["publications"])
+
+
+def test_scanner_regex_catches_path_keyword_argument_style(tmp_path):
+    """카디르 qa:changes(PR #4006, 2026-09-07) 양성대조 — `@router.get(path="/x/y", ...)`
+    처럼 path를 키워드 인자로 넘긴 데코레이터도 실 스캐너 함수(`_extract_org_scoped_
+    segments`, 정규식 중복 없이 그대로 재사용)가 세그먼트를 뽑는다. 고치기 前엔 이
+    표본이 못 잡혀야 한다(실패 가능한 양성대조 — `routers_dir` 주입으로 실 app/routers
+    무접촉, 합성 파일 하나로 스캐너 로직만 격리 재확認)."""
+    (tmp_path / "sample_router.py").write_text(
+        'router = APIRouter(prefix="/api/v2/organizations")\n'
+        '@router.get(path="/{org_id}/widgets")\n'
+        'async def f(): ...\n'
+    )
+    segments = _extract_org_scoped_segments(routers_dir=tmp_path)
+    assert "widgets" in segments, (
+        "스캐너가 path= 키워드 인자 형을 못 잡음 — 정규식이 여전히 위치 인자 형만 본다"
+    )
+    assert segments["widgets"] == ["sample_router.py"]
 
 
 def test_every_org_scoped_segment_is_mapped_or_explicitly_excused():

--- a/backend/tests/test_3654_org_scoped_content_rest_group.py
+++ b/backend/tests/test_3654_org_scoped_content_rest_group.py
@@ -1,0 +1,163 @@
+"""story #3654(BE·REST·소형, 페드루 PO 確定 2026-09-07) — org 스코프 콘텐츠 REST 경로
+(`/api/v2/organizations/{org_id}/<segment>...`)가 `_PATH_GROUP_PREFIXES`(고정 prefix
+매칭)에 없어 toolset 그룹 게이트 밖이었다 — MCP 쪽은 story #3631로 "content" 그룹이
+섰는데 같은 기능의 REST 문은 그룹 없이 열려 있던 것(story b4027b2e가 visual-artifacts에서
+겪은 것과 동일 클래스, 까심 라이브 실증 선례).
+
+이 파일의 관심사 둘:
+1. 그라운딩②에서 실제 스캔한 9개 콘텐츠 세그먼트가 정확히 "content"로 판정되는지
+   (`test_3614_content_toolset_group_changes.py`의 대표 표본 pin과 별개로 여기서 전수).
+2. **정적 가드**(페드루 PO 追加 요구) — `app/routers/` 전수에서 `/api/v2/organizations`
+   (또는 `/api/v2/projects` 등 다른 prefix에 얹힌 org-scope 서브라우터, 예: gate_config.py
+   의 org_router) prefix 라우터의 모든 `{org_id}`(또는 `{id}`) 뒤 첫 세그먼트를 모아,
+   `_ORG_SCOPED_PATH_GROUP_SEGMENTS`(매핑)나 `_ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON`
+   (명시 예외+이유) 어느 한쪽에도 없으면 가드가 스스로 RED — 새 org-scoped 자원이 표
+   없이 조용히 미매핑(permissive)으로 빠지는 것을 막는다."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_APP_DIR = Path(__file__).parent.parent / "app"
+_ROUTERS_DIR = _APP_DIR / "routers"
+
+
+def _extract_org_scoped_segments() -> dict[str, list[str]]:
+    """`app/routers/*.py` 전수에서 `<var> = APIRouter(prefix="/api/v2/organizations", ...)`
+    로 선언된 라우터 변수(파일당 여러 개 가능 — 예: gate_config.py의 router+org_router)를
+    찾고, 그 변수에 걸린 `@<var>.<method>("<path>", ...)` 데코레이터의 path 리터럴에서
+    "org_id 뒤 첫 세그먼트"를 뽑는다. 반환은 {segment: [file, ...]}(어느 파일이 그 세그먼트를
+    쓰는지, 실패 메시지 진단용).
+
+    세그먼트 규칙(mcp_toolset.py::_org_scoped_content_group의 런타임 매칭과 동형) — path를
+    "/"로 쪼갠 뒤:
+    - 첫 조각이 `{...}`(동적 파라미터, org_id 또는 id)이고 그 다음 조각이 있으면 그것.
+    - 첫 조각이 `{...}`인데 그 다음이 없으면(그 파라미터 자체가 리소스, 예 `/{id}`)
+      "(root, org_id only)".
+    - path가 비어있으면("") "(empty/root)".
+    - 그 외(동적 파라미터로 시작 안 함 — 이 스토리 대상 밖 모양)는 무시(collect 안 함,
+      org_id 뒤에 붙는 형이 아니므로 이 가드의 관심사가 아니다)."""
+    router_method_re = re.compile(r'@(\w+)\.(get|post|put|patch|delete)\(\s*\n?\s*"([^"]*)"')
+    segments: dict[str, list[str]] = {}
+    for path in sorted(_ROUTERS_DIR.glob("*.py")):
+        text = path.read_text()
+        org_router_vars = set(re.findall(r'(\w+)\s*=\s*APIRouter\(\s*prefix="/api/v2/organizations"', text))
+        if not org_router_vars:
+            continue
+        for m in router_method_re.finditer(text):
+            varname, _method, route_path = m.groups()
+            if varname not in org_router_vars:
+                continue
+            parts = [p for p in route_path.split("/") if p]
+            if not parts:
+                seg = "(empty/root)"
+            elif parts[0].startswith("{"):
+                seg = parts[1] if len(parts) > 1 else "(root, org_id only)"
+            else:
+                continue  # org_id로 시작 안 하는 모양 — 이 가드 대상 밖.
+            segments.setdefault(seg, []).append(path.name)
+    return segments
+
+
+def test_grounding_extraction_finds_known_content_segments():
+    """자가 확認 — 스캐너 자체가 실제로 라우터를 읽고 있다는 증거(빈 결과로 「전수 0건이라
+    전부 통과」하는 항진명제 가드가 되지 않도록)."""
+    segments = _extract_org_scoped_segments()
+    assert "channel-posts" in segments
+    assert "channel_posts.py" in segments["channel-posts"]
+    assert "publications" in segments
+    assert {"channel_post_comments.py", "insight_snapshots.py"} <= set(segments["publications"])
+
+
+def test_every_org_scoped_segment_is_mapped_or_explicitly_excused():
+    """정적 가드 본체(페드루 PO 追加 요구) — app/routers/ 전수의 org-scoped 세그먼트가
+    _ORG_SCOPED_PATH_GROUP_SEGMENTS(매핑)나 _ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON
+    (명시 예외+이유) 어느 한쪽에도 없으면 이 테스트가 RED — 새 org-scoped 리소스가 표
+    없이 조용히 미매핑(permissive-unmapped)으로 새 프로덕션에 들어가는 것을 막는다."""
+    from app.services.mcp_toolset import (
+        _ORG_SCOPED_PATH_GROUP_SEGMENTS,
+        _ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON,
+    )
+
+    mapped = {seg for seg, _group in _ORG_SCOPED_PATH_GROUP_SEGMENTS}
+    excused = set(_ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON)
+    declared = mapped | excused
+
+    found_segments = set(_extract_org_scoped_segments())
+    unaccounted = found_segments - declared
+    assert not unaccounted, (
+        f"org-scoped 세그먼트가 매핑 표에도 예외 목록에도 없다(가드 정의, story #3654): "
+        f"{sorted(unaccounted)} — mcp_toolset.py의 _ORG_SCOPED_PATH_GROUP_SEGMENTS(content면) "
+        f"또는 _ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON(아니면 이유와 함께)에 등재하라."
+    )
+
+    # 반대 방향(표에 있는데 실제 라우터엔 없는 segment) — 죽은 등재를 조용히 안 남긴다.
+    stale_in_map = mapped - found_segments
+    assert not stale_in_map, f"매핑 표에 있지만 실제 라우터에서 못 찾은 세그먼트(죽은 등재): {sorted(stale_in_map)}"
+
+
+def test_content_group_reason_dict_has_no_overlap_with_mapped_segments():
+    """표와 예외 목록이 같은 세그먼트를 이중 등재하지 않는다(어느 쪽이 이기는지 모호해지는
+    것을 막는다 — 둘은 배타적 집합이어야 한다)."""
+    from app.services.mcp_toolset import (
+        _ORG_SCOPED_PATH_GROUP_SEGMENTS,
+        _ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON,
+    )
+
+    mapped = {seg for seg, _group in _ORG_SCOPED_PATH_GROUP_SEGMENTS}
+    excused = set(_ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON)
+    assert not (mapped & excused), f"표·예외 목록 중복 등재: {sorted(mapped & excused)}"
+
+
+@pytest.mark.parametrize(
+    "path,expected_group",
+    [
+        ("/api/v2/organizations/org-1/channel-posts/drafts", "content"),
+        ("/api/v2/organizations/org-1/site-posts", "content"),
+        ("/api/v2/organizations/org-1/publication-commands/cmd-1/retry", "content"),
+        ("/api/v2/organizations/org-1/channel-connections", "content"),
+        ("/api/v2/organizations/org-1/publications/pub-1/comments", "content"),
+        ("/api/v2/organizations/org-1/publications/pub-1/insights", "content"),
+        ("/api/v2/organizations/org-1/comments/c-1/replies", "content"),
+        ("/api/v2/organizations/org-1/insights-board", "content"),
+        ("/api/v2/organizations/org-1/publishing-metrics", "content"),
+    ],
+)
+def test_all_nine_content_segments_gated_positive(path, expected_group):
+    """AC1 — 그라운딩②가 찾은 9개 세그먼트 전부가 실제로 content로 판정되고, content
+    scope 없는 키는 403급으로 막힌다(path_allowed_for_scope False)."""
+    from app.services.mcp_toolset import path_allowed_for_scope, path_to_tool_group
+
+    assert path_to_tool_group(path) == expected_group
+    assert path_allowed_for_scope(path, ["stories"]) is False
+    assert path_allowed_for_scope(path, ["content"]) is True
+
+
+def test_unmapped_segment_stays_permissive_as_declared():
+    """예외 목록에 있는 세그먼트(예: campaigns)는 여전히 미매핑·허용 — 이 스토리가
+    건드리는 축이 아니라는 것을 실제로도 못박는다(그룹 재설계는 범위 밖)."""
+    from app.services.mcp_toolset import path_allowed_for_scope, path_to_tool_group
+
+    campaigns_path = "/api/v2/organizations/org-1/campaigns"
+    assert path_to_tool_group(campaigns_path) is None
+    assert path_allowed_for_scope(campaigns_path, ["stories"]) is True
+
+
+def test_mutation_removing_channel_posts_from_map_reopens_gap_and_fails_static_guard(monkeypatch):
+    """뮤테이션(페드루 PO 명시) — 표에서 세그먼트 1개(channel-posts)를 제거하면 (a)
+    path_allowed 테스트가 RED(무관 scope도 다시 통과) (b) 정적 가드도 RED(스캐너는 여전히
+    라우터에서 channel-posts를 찾는데 표에 없으니 unaccounted)."""
+    import app.services.mcp_toolset as mod
+
+    mutated = tuple((seg, g) for seg, g in mod._ORG_SCOPED_PATH_GROUP_SEGMENTS if seg != "channel-posts")
+    monkeypatch.setattr(mod, "_ORG_SCOPED_PATH_GROUP_SEGMENTS", mutated)
+
+    path = "/api/v2/organizations/org-1/channel-posts/drafts"
+    assert mod.path_to_tool_group(path) is None, "뮤테이션이 걸리지 않았다(여전히 content로 판정)"
+    assert mod.path_allowed_for_scope(path, ["stories"]) is True, "뮤테이션이 걸리지 않았다(여전히 막힘)"
+
+    mapped = {seg for seg, _g in mod._ORG_SCOPED_PATH_GROUP_SEGMENTS}
+    excused = set(mod._ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON)
+    assert "channel-posts" not in (mapped | excused), "뮤테이션이 표/예외 목록 어느 쪽에서도 안 빠졌다"


### PR DESCRIPTION
스토리 id 371088fb-fdaa-4966-91bc-ba8eff198ad9. 출처: story #3614 CHANGES가 남긴 pin — REST `_PATH_GROUP_PREFIXES`에 channel-posts 미등록, MCP는 #3631로 "content" 그룹이 섰는데 REST는 그룹 없이 열려 있었다(b4027b2e/visual-artifacts와 동일 클래스 갭, 까심 라이브 실증 선례).

## 그라운딩
① 미매핑 취급: `path_to_tool_group()`가 `None` → `path_allowed_for_scope()`가 group 무관 `True`(강제 면제).
② 전수 스캔 — org-scoped 콘텐츠 세그먼트 **9개**(스토리 초안의 5개보다 많다): `channel-posts`·`site-posts`·`publication-commands`(channel_posts.py) · `channel-connections`(channel_connections.py) · `publications`(channel_post_comments.py+insight_snapshots.py 공유) · `comments`(channel_post_comment_replies.py) · `insights`·`insights-board`(insights_board.py) · `publishing-metrics`(publishing_metrics.py) — 같은 콘텐츠 파이프라인 자원이라 포함(PO 재확認 완료, 채팅에 정정 보고 済).
③ 매핑 형: 정규식 대신 org_id 뒤 첫 세그먼트를 split으로 뽑아 별도 표와 대조(기존 튜플 스타일 재사용, 새 의존성 0).

## 처방
1. `_ORG_SCOPED_PATH_GROUP_SEGMENTS`(9개→"content")+`_org_scoped_content_group()`을 `path_to_tool_group()`에 배선.
2. `_ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON` — content 아닌 나머지 세그먼트(campaigns·connectors·content-rules·generation-budget·domain-labels·gate-config·measurement-connections·invites·metering-key·pageviews·organizations 자기자신) 전부를 실측 확認한 이유(MCP 도구/키워드 0건)와 함께 등재.
3. **정적 가드**(페드루 PO 追加 요구) — `app/routers/` 전수에서 org-scoped 세그먼트를 스캔해 위 표·목록 어느 쪽에도 없으면 RED.

## Test plan
- [x] AC1 — 9개 세그먼트 전수 positive(content 판정+무관 scope 차단+content scope 통과)
- [x] 정적 가드 — 라우터 전수 스캔이 표·예외 목록 합집합과 100% 일치(양방향: 가짜 미매핑도·죽은 등재도 0)
- [x] 예외 목록 세그먼트(campaigns)는 여전히 허용 그대로(범위 밖 확認)
- [x] 뮤테이션 1 — 표에서 `channel-posts` 제거 → `path_allowed` 테스트 RED + 정적 가드 RED 둘 다 확認
- [x] 기존 pin(test_3614) 뒤집힘 반영 — content 판정+scope 차단으로 갱신
- [x] 영향 스위트(b4027b2e·2058·byoa·be_scope_enforce·toolset_catalog·e_mcp_s2) 67/67 무변경 회귀
- [x] `app.main` import 그린

## 범위 밖
그룹 자체 재설계 · MCP 도구 변경 · content 5개 밖 세그먼트의 그룹 배정(예외 목록에 남긴다).

## 라이브
dev에서 content 그룹 없는 에이전트 키로 `/organizations/{org}/channel-posts/drafts` → 403 · 있는 키 → 200(PO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)