### PR TITLE
[SID:3652] fix: 채팅 「#N」 자동참조가 레포를 몰라 타 레포 PR 번호를 story로 오인식

### DIFF
--- a/backend/app/services/story_ref_promoter.py
+++ b/backend/app/services/story_ref_promoter.py
@@ -39,7 +39,25 @@ _LATIN_RE = re.compile(r"[A-Za-z]")
 # [E-01-S-07…]"·45e9e868 "PR [E-02-S-02…]") 전부 「PR #N」(공백+해시) 형태였다 — dev
 # 라이브 실측(2026-08-14, 착수 시 재검증)으로 「PR N」(해시 없는 형태)의 실사례는
 # 확인되지 않았다: 그 형태는 애초에 `_BARE_STORY_REF_RE`가 `#`을 요구해 매치 자체가 없다.
-_PR_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9_])[Pp][Rr]\s*$")
+# story #3652(PO 確定 2026-09-07) — 「pull #N」도 「PR #N」과 같은 축(PR을 풀어 쓴 형).
+_PR_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9_])(?:[Pp][Rr]|[Pp]ull)\s*$")
+
+# story #3652(PO 確定 2026-09-07) — «owner/repo#N»(슬래시 있음)은 레포가 org 원장에
+# 있는지와 무관하게 항상 story 승격에서 제외한다(rule① "owner/repo#N → 치환 0"은
+# 조건부가 아니다 — 원장 유일 일치 여부는 «PR 링크로 대신 해석할지」만 가른다,
+# _find_explicit_repo_pr_candidates 참조). ⚠️잃는 것(선언) — "owner"/"repo" 자리가
+# 실제 GitHub 식별자인지 확인할 길이 없어(러너가 GitHub API를 안 부름) "a/b #24"류
+# 우연한 슬래시 텍스트도 같은 모양이면 제외된다 — dev 실측(#2660 GROUP BY)이 이런
+# 표현이 실사용에 없었음을 보였으나, 새로 생기면 이 클래스가 못 잡는다.
+_SLASH_QUALIFIED_REPO_RE = re.compile(r"(?<![\w/])[\w.-]+/[\w.-]+\s*$")
+
+# story #3652 — GitHub PR URL(owner/repo/pull/N). 이 형은 `#`이 없어 `_BARE_STORY_REF_RE`
+# 자체가 안 물지만(URL 안에 매치 대상 자체가 없음), 이 URL을 «명시 repo#N 후보»로도
+# 함께 뽑아 PR 링크 해석을 시도한다(_find_explicit_repo_pr_candidates 참조).
+_GITHUB_PR_URL_RE = re.compile(r"https://github\.com/([\w.-]+/[\w.-]+)/pull/(\d+)\b")
+# owner/repo#N — 슬래시 필수(바로 위 _SLASH_QUALIFIED_REPO_RE와 같은 판별축, PR 링크
+# 해석 시도 대상만 별도로 뽑는다).
+_OWNER_REPO_HASH_RE = re.compile(r"(?<![\w/])([\w.-]+/[\w.-]+)#(\d+)\b")
 
 # story #2660(#2651 후속) — GitHub 크로스레포 관례 "repo-name#N"(예: agent-plugins#25·
 # gemini#3)이 실피해로 재발(실측: 실제 원문은 `agent-plugins#25`·`gemini#3` — 백틱 無,
@@ -55,9 +73,24 @@ _PR_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9_])[Pp][Rr]\s*$")
 # `INJECTABLE_EVENT_TYPES`(sprintable_sse.py)와 같은 성격의 닫힌 허용목록. 새 레포가
 # 생기면 이 목록에 추가할 것(자동 발견 불가 — 그 자체가 이 클래스의 한계, 가드가 못
 # 잡는 것으로 명시).
-_REPO_SHORTHAND_SUFFIX_RE = re.compile(
-    r"(?i:agent-plugins|gemini|admin|claude-plugin|mobile)$"
+#
+# story #3652(PO 確定 2026-09-07) — 이 정적 다섯 개는 «닫힌 허용목록»으로 계속 남는다
+# (예: "admin"은 pull_request_story_link에 없는 별개 제품일 수 있어 원장이 못 대신함).
+# 실피해(디디 conv 52fd99d0, 2026-09-07)는 **공백**이 낀 「sprintable-agent-plugins #46」
+# 형태였는데 이 정적 목록엔 원래 공백 허용(`\s*`)이 없었다(#2660 당시 실측이 전부
+# 공백-無 형태였기 때문 — 모듈 docstring "공백 없음" 문구가 그 경계를 그대로 선언한다).
+# 이번에 `\s*`를 더해 「이름 + 공백 + #N」도 같이 잡는다(_PR_PREFIX_RE가 이미 쓰던
+# 관례 그대로 확장 — 새 패턴 발명 0). `extra_repo_short_names`(org 원장 파생, 동적)가
+# 이 정적 다섯과 합쳐진다 — `extract_bare_story_ref_candidates` 참조.
+_STATIC_REPO_SHORTHANDS: frozenset[str] = frozenset(
+    {"agent-plugins", "gemini", "admin", "claude-plugin", "mobile"}
 )
+
+
+def _repo_shorthand_suffix_re(extra_repo_short_names: frozenset[str]) -> re.Pattern[str]:
+    names = _STATIC_REPO_SHORTHANDS | extra_repo_short_names
+    alternation = "|".join(re.escape(n) for n in sorted(names, key=len, reverse=True))
+    return re.compile(rf"(?i:{alternation})\s*$")
 
 # 보호 구간(스캔에서 제외) — fenced 코드블록·인라인 코드·이미 만들어진 entity 토큰.
 _FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
@@ -78,21 +111,33 @@ _KOREAN_BRACKET_QUOTE_RE = re.compile(r"「[^」\n]*」|『[^』\n]*』|《[^》
 _BLOCKQUOTE_LINE_RE = re.compile(r"^>.*$", re.MULTILINE)
 
 
-def extract_bare_story_ref_candidates(content: str) -> list[tuple[int, int, int]]:
+def extract_bare_story_ref_candidates(
+    content: str, *, extra_repo_short_names: frozenset[str] = frozenset(),
+) -> list[tuple[int, int, int]]:
     """본문에서 «#숫자» 후보 위치를 뽑는다(DB 조회 없는 순수 함수 — 모양만 본다, 존재 여부는
     별도 async 함수의 몫. 은퇴한 @handle 파서의 `extract_handle_tokens`와 같은 형태였다).
 
+    `extra_repo_short_names`(story #3652) — org의 `pull_request_story_link.repo_full_name`
+    (원장, 동적)에서 파생한 짧은이름 집합. 정적 다섯(`_STATIC_REPO_SHORTHANDS`)과 합쳐
+    레포명 배제 판별에 쓴다 — 호출부(`promote_bare_story_refs`)가 DB 조회 결과를 넘긴다
+    (이 함수 자신은 여전히 DB 왕복 0).
+
     반환: (start, end, story_number) 튜플 리스트. 매치 직후 문자가 라틴 알파벳이면
     헥스 컬러류(`#74747c`)로 보고 그 후보 자체를 버린다(dev 실측 근거 — 모듈 docstring
-    참조). 매치 직전 토큰이 「PR」/「pr」이면(story #2651) PR 번호로 보고 마찬가지로
-    버린다 — `_PR_PREFIX_RE` 참조. 매치 직전이 알려진 레포 짧은이름 접미사로 끝나면
-    (story #2660) GitHub「repo-name#N」류로 보고 버린다 — `_REPO_SHORTHAND_SUFFIX_RE`
-    참조(⛔허용목록 방식 — "라틴 단어문자 전부"가 아니다. story#N/BE#N류 정상 팀 표기는
-    이 목록에 없어 계속 승격된다, #2660 GROUP BY 실측). 코드블록/인라인코드/기존 entity
-    토큰 내부는 여기서 걸러지지 않는다 — 그건 `_protected_spans`가 별도로 처리(관심사
-    분리: 이 함수는 "무엇이 숫자 토큰처럼 생겼는가"만, 저건 "어디를 건드리면 안 되는가"만)."""
+    참조). 매치 직전 토큰이 「PR」/「pr」/「pull」이면(story #2651·#3652) PR 번호로 보고
+    마찬가지로 버린다 — `_PR_PREFIX_RE` 참조. 매치 직전이 「owner/repo」꼴(슬래시 있음)
+    이면(story #3652) 레포가 원장에 있는지와 무관하게 항상 버린다 — `_SLASH_QUALIFIED_
+    REPO_RE` 참조(PR 링크 해석 시도는 `_find_explicit_repo_pr_candidates`가 별도로
+    한다). 매치 직전이 알려진 레포 짧은이름(정적+동적, 공백 유무 무관)으로 끝나면
+    (story #2660·#3652) GitHub「repo-name#N」류로 보고 버린다 — `_repo_shorthand_
+    suffix_re` 참조(⛔허용목록 방식 — "라틴 단어문자 전부"가 아니다. story#N/BE#N류
+    정상 팀 표기는 이 목록에 없어 계속 승격된다, #2660 GROUP BY 실측). 코드블록/
+    인라인코드/기존 entity 토큰 내부는 여기서 걸러지지 않는다 — 그건 `_protected_spans`
+    가 별도로 처리(관심사 분리: 이 함수는 "무엇이 숫자 토큰처럼 생겼는가"만, 저건
+    "어디를 건드리면 안 되는가"만)."""
     if not content:
         return []
+    repo_shorthand_re = _repo_shorthand_suffix_re(extra_repo_short_names)
     candidates: list[tuple[int, int, int]] = []
     for m in _BARE_STORY_REF_RE.finditer(content):
         start = m.start()
@@ -101,10 +146,63 @@ def extract_bare_story_ref_candidates(content: str) -> list[tuple[int, int, int]
             continue
         if _PR_PREFIX_RE.search(content, 0, start):
             continue
-        if _REPO_SHORTHAND_SUFFIX_RE.search(content, 0, start):
+        if _SLASH_QUALIFIED_REPO_RE.search(content, 0, start):
+            continue
+        if repo_shorthand_re.search(content, 0, start):
             continue
         candidates.append((start, end, int(m.group(1))))
     return candidates
+
+
+def _repo_short_name(full_name: str) -> str:
+    return full_name.rsplit("/", 1)[-1]
+
+
+def _find_explicit_repo_pr_candidates(
+    content: str, *, known_full_names: frozenset[str],
+) -> list[tuple[int, int, str, int]]:
+    """story #3652(PO 確定 2026-09-07) — GitHub PR URL·`owner/repo#N`·(원장 유일 일치 시)
+    맨 `repo#N`을 찾아 (start, end, repo_full_name, pr_number) 4-tuple로 돌려준다.
+    repo_full_name은 `normalize_repo()`로 정규화(lowercase) — `pull_request_story_link`
+    조회 키와 항상 같은 프레임(PO 재確定 — "다른 출처 둘을 비교하면 갈리는 창이 생긴다").
+
+    ⛔`repo#N`(슬래시 없는 맨 이름)은 `known_full_names`의 짧은이름이 **유일하게** 일치할
+    때만 후보가 된다 — 두 개 이상의 full_name이 같은 짧은이름을 공유하면(예: 서로 다른
+    owner의 동명 레포) 어느 쪽인지 원리적으로 모른다는 뜻이라 후보에서 뺀다(모호=조용히
+    스킵, `owner/repo#N`으로 명시하면 이 모호함 자체가 없다)."""
+    from app.services.pr_story_link import normalize_repo
+
+    found: list[tuple[int, int, str, int]] = []
+    consumed: list[tuple[int, int]] = []
+
+    for m in _GITHUB_PR_URL_RE.finditer(content):
+        found.append((m.start(), m.end(), normalize_repo(m.group(1)), int(m.group(2))))
+        consumed.append(m.span())
+
+    for m in _OWNER_REPO_HASH_RE.finditer(content):
+        if _in_protected_span(m.start(), consumed):
+            continue
+        found.append((m.start(), m.end(), normalize_repo(m.group(1)), int(m.group(2))))
+        consumed.append(m.span())
+
+    if known_full_names:
+        short_to_fulls: dict[str, set[str]] = {}
+        for full in known_full_names:
+            short_to_fulls.setdefault(_repo_short_name(normalize_repo(full)), set()).add(normalize_repo(full))
+        unique_shorts = {short: next(iter(fulls)) for short, fulls in short_to_fulls.items() if len(fulls) == 1}
+        if unique_shorts:
+            alternation = "|".join(re.escape(s) for s in sorted(unique_shorts, key=len, reverse=True))
+            bare_repo_hash_re = re.compile(rf"(?<![\w/])({alternation})\s*#(\d+)\b", re.IGNORECASE)
+            for m in bare_repo_hash_re.finditer(content):
+                if _in_protected_span(m.start(), consumed):
+                    continue
+                full = unique_shorts.get(m.group(1).lower())
+                if full is None:
+                    continue
+                found.append((m.start(), m.end(), full, int(m.group(2))))
+                consumed.append(m.span())
+
+    return found
 
 
 def _protected_spans(content: str) -> list[tuple[int, int]]:
@@ -127,13 +225,26 @@ def _in_protected_span(pos: int, spans: list[tuple[int, int]]) -> bool:
 async def promote_bare_story_refs(
     db: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID, content: str,
 ) -> tuple[str, set[uuid.UUID]]:
-    """본문의 «#N» 후보를 org+project 스코프 story_number로 resolve해 entity 참조 토큰
-    (`build_reference_token`, #2282 SSOT 그대로 재사용 — 새 escape 규칙 발명 안 함)으로
-    치환한다.
+    """본문의 «#N» 후보를 두 갈래로 나눠 처리한다(story #3652, PO 確定 2026-09-07 —
+    실사고: 「sprintable-agent-plugins #46」이 이 org의 story #46로 옷을 입었다. story
+    번호와 PR 번호가 같은 `#N` 표기 공간을 공유하는데, 치환기가 그 사실을 몰랐다).
 
-    resolve 실패(그 번호의 story가 없음·타 project 소속)면 **그 매치만** 원문 그대로
-    남긴다(전체 all-or-nothing 아님 — 은퇴한 @handle 파서의 "매치 0건=조회도 없이 조기
-    반환" 관대함과 동형 철학, 성실한 오독에서도 메시지 발신 자체는 막지 않는다).
+    ① 명시 repo#N(`owner/repo#N`·GitHub PR URL·원장 유일 일치 시 맨 `repo#N`) — 항상
+    story_number 승격 대상에서 빠진다. repo가 org의 `pull_request_story_link`
+    (repo_full_name, pr_number)와 일치하면 그 PR의 연결 스토리로(있으면), 없으면
+    본문 그대로(«아니면 침묵» — PO rule①, 새 참조 종류를 만들지 않는다: PR 자체를
+    가리키는 entity type이 없어 «연결된 스토리»로만 표현 가능하다).
+    ② 맨 `#N`(레포 표식 0) — 지금처럼 org+project 스코프 story_number로 resolve하되,
+    같은 N이 org 전체(레포 무관) `pull_request_story_link.pr_number`에도 있으면
+    모호(스토리 번호와 PR 번호가 우연히 겹침)로 보고 치환하지 않는다(PO rule② — 둘
+    다 이 플랫폼 원장이라 "같은 프레임"으로 판정, 다른 소스를 비교하지 않는다).
+
+    두 갈래 모두 resolve 실패(그 번호/PR의 대상이 없음·타 project 소속)면 **그 매치만**
+    원문 그대로 남긴다(전체 all-or-nothing 아님 — 은퇴한 @handle 파서의 "매치 0건=조회도
+    없이 조기 반환" 관대함과 동형 철학, 성실한 오독에서도 메시지 발신 자체는 막지 않는다).
+
+    치환된 링크 텍스트는 원문 `#N`을 제목 앞에 남긴다(PO rule③ — 사람이 오인을 바로
+    잡을 수 있게, 예: `#46 → [#46 S209: pm-api 정리…]`).
 
     story #2679(BE): 반환이 `str`에서 `(content, auto_story_ids)`로 바뀌었다 — 이번 호출에서
     **실제로 성공 치환한** story_id 집합을 같이 돌려준다(resolve 실패로 원문 그대로 남은
@@ -144,17 +255,87 @@ async def promote_bare_story_refs(
     넘긴다."""
     if not content:
         return content, set()
-    candidates = extract_bare_story_ref_candidates(content)
-    if not candidates:
+    # story #3652 CHANGES(자체 발견, 실사고 없이 회귀 테스트로 적발 — test_conversations.py
+    # ::test_send_message_201) — 아래 PullRequestStoryLink 조회를 무조건 앞세우면 「#」도
+    # 「/pull/」도 없는 평범한 메시지("안녕")마다 매 발신 시 DB 왕복 1회가 새로 붙는다(기존
+    # 계약: 후보 0건이면 DB 왕복 0회, extract_bare_story_ref_candidates의 早期 반환과
+    # 동형). 세 정규식 중 하나도 안 물면 이 함수가 만질 수 있는 게 원리적으로 없다(맨
+    # #N·owner/repo#N 전부 `#`을 요구, GitHub URL은 `/pull/`을 요구) — 이 셋 다 없으면
+    # DB 조회 자체를 건너뛴다.
+    if not (
+        _BARE_STORY_REF_RE.search(content)
+        or _OWNER_REPO_HASH_RE.search(content)
+        or _GITHUB_PR_URL_RE.search(content)
+    ):
         return content, set()
-    protected = _protected_spans(content)
+
+    from app.models.pm import Story
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    # org 전체(모든 repo) PR 링크 원장 — story #3652의 SSOT(둘 다 이 원장을 쓴다: ①의
+    # repo_full_name 대조·②의 pr_number 모호 판정).
+    pr_link_rows = (await db.execute(
+        select(
+            PullRequestStoryLink.repo_full_name, PullRequestStoryLink.pr_number,
+            PullRequestStoryLink.story_id,
+        ).where(PullRequestStoryLink.org_id == org_id, PullRequestStoryLink.deleted_at.is_(None))
+    )).all()
+    known_full_names = frozenset(r.repo_full_name for r in pr_link_rows)
+    pr_story_by_key: dict[tuple[str, int], uuid.UUID] = {
+        (r.repo_full_name, r.pr_number): r.story_id for r in pr_link_rows
+    }
+    org_pr_numbers = frozenset(r.pr_number for r in pr_link_rows)
+
+    result = content
+    promoted_ids: set[uuid.UUID] = set()
+
+    # ── ① 명시 repo#N — story_number 승격보다 먼저(우선순위가 이긴다, PO rule①).
+    # 코드블록/인용부호/블록인용 안은 맨 #N과 같은 이유로 여기서도 보호(story #3162
+    # 원칙 — 예시로 재인용된 repo#N도 "새로 참조하려는 의도"가 아니다).
+    explicit_protected = _protected_spans(content)
+    explicit = [
+        c for c in _find_explicit_repo_pr_candidates(content, known_full_names=known_full_names)
+        if not _in_protected_span(c[0], explicit_protected)
+    ]
+    if explicit:
+        story_ids_needed = {
+            pr_story_by_key[(repo, n)]
+            for _, _, repo, n in explicit
+            if (repo, n) in pr_story_by_key
+        }
+        title_by_id: dict[uuid.UUID, str] = {}
+        if story_ids_needed:
+            rows = (await db.execute(
+                select(Story.id, Story.title).where(
+                    Story.id.in_(story_ids_needed), Story.deleted_at.is_(None),
+                )
+            )).all()
+            title_by_id = {sid: title for sid, title in rows}
+        for start, end, repo, pr_number in sorted(explicit, key=lambda c: c[0], reverse=True):
+            story_id = pr_story_by_key.get((repo, pr_number))
+            if story_id is None or story_id not in title_by_id:
+                continue  # 레포는 식별됐지만(원장 유일 일치) 그 PR에 스토리 링크가 없다 — 본문 그대로.
+            token = build_reference_token("story", story_id, f"#{pr_number} {title_by_id[story_id]}")
+            if token is None:
+                continue
+            result = result[:start] + token + result[end:]
+            promoted_ids.add(story_id)
+
+    # ── ② 맨 #N(스토리 번호) — ①이 이미 치환한 자리는 지금 entity 토큰이라
+    # `_protected_spans`의 `_ENTITY_TOKEN_RE`가 자연히 다시 보호한다(별도 좌표 보정 불요).
+    known_short_names = frozenset(_repo_short_name(f) for f in known_full_names)
+    candidates = extract_bare_story_ref_candidates(result, extra_repo_short_names=known_short_names)
+    if not candidates:
+        return result, promoted_ids
+    protected = _protected_spans(result)
     candidates = [c for c in candidates if not _in_protected_span(c[0], protected)]
+    # PO rule② — 같은 N이 org(레포 무관) pr_number에도 있으면 모호. story_number와
+    # pr_number가 같은 플랫폼 원장(다른 소스가 아니다)이라 이 대조가 "같은 프레임"이다.
+    candidates = [c for c in candidates if c[2] not in org_pr_numbers]
     if not candidates:
-        return content, set()
+        return result, promoted_ids
 
     numbers = {c[2] for c in candidates}
-    from app.models.pm import Story
-
     rows = (await db.execute(
         select(Story.story_number, Story.id, Story.title).where(
             Story.org_id == org_id,
@@ -165,17 +346,15 @@ async def promote_bare_story_refs(
     )).all()
     story_by_number = {number: (story_id, title) for number, story_id, title in rows}
     if not story_by_number:
-        return content, set()
+        return result, promoted_ids
 
     # 뒤에서부터 치환 — 앞쪽 매치의 인덱스가 뒤 치환으로 밀리지 않게.
-    result = content
-    promoted_ids: set[uuid.UUID] = set()
     for start, end, number in sorted(candidates, key=lambda c: c[0], reverse=True):
         found = story_by_number.get(number)
         if found is None:
             continue
         story_id, title = found
-        token = build_reference_token("story", story_id, title)
+        token = build_reference_token("story", story_id, f"#{number} {title}")
         if token is None:
             continue
         result = result[:start] + token + result[end:]

--- a/backend/app/services/story_ref_promoter.py
+++ b/backend/app/services/story_ref_promoter.py
@@ -95,7 +95,16 @@ def _repo_shorthand_suffix_re(extra_repo_short_names: frozenset[str]) -> re.Patt
 # 보호 구간(스캔에서 제외) — fenced 코드블록·인라인 코드·이미 만들어진 entity 토큰.
 _FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
-_ENTITY_TOKEN_RE = re.compile(r"\[[^\]]*\]\(entity:[a-z_]+:[^)]+\)")
+# 페드루 PO CHANGES(카디르 발견, 2026-09-07) — `[^\]]*`는 라벨 안의 escape된 `\]`도
+# 그 자리에서 매치를 끊는다(문자 클래스는 백슬래시 유무를 안 본다, `]` 자체를
+# 제외했을 뿐). `reference_token`이 대괄호로 시작하는 제목("[BE·insights] 제목…")을
+# `[\[BE·insights\] 제목…](entity:story:…)`처럼 escape해 실어 보내는데(우리 스토리
+# 제목 대부분이 이 모양) — 그 escape된 `\]`에서 라벨 매치가 조기종료되면 토큰의
+# 나머지 절반(예: 라벨 안의 「PR #4003」 같은 bare 번호)이 보호 구간 밖으로 새어나가
+# 2단계 재스캔에서 다시 치환되어 중첩·깨진 토큰이 된다. `(?:\\.|[^\]\\])*`로 —
+# escape 시퀀스(`\.`아무거나) 하나로 통째 소비하거나, 대괄호·백슬래시가 아닌 문자를
+# 소비 — 진짜 닫는 `]`에 도달할 때까지 안 끊긴다.
+_ENTITY_TOKEN_RE = re.compile(r"\[(?:\\.|[^\]\\])*\]\(entity:[a-z_]+:[^)]+\)")
 
 # story #3162(채팅·치환 결함 조사) — 인용부호/블록인용 안의 `#N`은 「예시로 재인용」이지
 # 「새로 참조하려는 의도」가 아니다(디캄포 오늘 밤 재발 실사고: 정정 메시지에서 오염된

--- a/backend/tests/test_2629_bare_story_ref_promotion.py
+++ b/backend/tests/test_2629_bare_story_ref_promotion.py
@@ -225,6 +225,59 @@ async def test_promote_skips_existing_entity_token():
         await engine.dispose()
 
 
+# 카디르 발견(PR#4007 QA, 2026-09-07) — `reference_token`은 대괄호로 시작하는 스토리
+# 제목을 `[\[BE·insights\] 제목…](entity:story:…)`처럼 escape해 싣는다(우리 스토리
+# 제목 대부분이 「[…]」로 시작 — story_number.py::reference_token). `_ENTITY_TOKEN_RE`의
+# 옛 `[^\]]*`는 그 escape된 `\]`에서 라벨 매치를 조기종료해(문자 클래스는 백슬래시를
+# 안 본다) 토큰 전체가 보호 구간 밖으로 샜다 — 양성대조(다음 두 테스트는 옛 정규식
+# 기준 실패였다).
+async def test_promote_protects_entity_token_with_escaped_bracket_in_label():
+    """라벨이 escape된 대괄호를 포함한 entity 토큰 전체가 한 span으로 보호돼야 한다 —
+    라벨 안의 bare 번호(#4003, "PR" 접두 없음이라 _PR_PREFIX_RE로는 안 걸리는 경우)까지
+    포함해서 통째 무변경."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            await _seed_story(s, org.id, project.id, number=4003, title="별개 스토리")
+            content = (
+                r"[\[BE·insights\] 훅 #4003 착지](entity:story:"
+                "11111111-1111-1111-1111-111111111111) 참고"
+            )
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content, "escape된 대괄호 라벨이 토큰 매치를 조기종료시켜 재치환됨"
+            assert promoted_ids == set()
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_bare_number_inside_escaped_label_not_reresolved():
+    """라벨 안의 bare 「#4003」이 보호 구간 밖으로 새어나가 별도 후보로 재승격되면
+    토큰 안에 또 다른 entity 링크가 중첩된다 — 그 중첩이 없어야 한다."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            await _seed_story(s, org.id, project.id, number=4003, title="별개 스토리")
+            content = (
+                r"[\[BE·insights\] 훅 #4003 착지](entity:story:"
+                "11111111-1111-1111-1111-111111111111) 참고"
+            )
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result.count("(entity:story:") == 1, "라벨 안 bare #4003이 재치환돼 중첩 토큰이 생김"
+            assert promoted_ids == set()
+    finally:
+        await engine.dispose()
+
+
 # story #3162(채팅·치환 결함) — 인용부호/블록인용 안의 #N은 재인용이지 새 참조 의도가
 # 아니다(디캄포 오늘 밤 재발 실사고: 정정 메시지에서 오염된 원문을 그대로 다시 인용해
 # 재승격됨). 코드블록/인라인코드와 같은 "예시 영역" 원칙을 확장.

--- a/backend/tests/test_2629_bare_story_ref_promotion.py
+++ b/backend/tests/test_2629_bare_story_ref_promotion.py
@@ -296,7 +296,11 @@ async def test_promote_bare_ref_outside_quotes_still_promotes_no_regression():
                 s, org_id=org.id, project_id=project.id, content=content,
             )
             assert promoted_ids == {story.id}
-            assert "#24" not in result
+            # story #3652 — 치환 텍스트가 이제 원문 #24를 링크 제목 앞에 남긴다(PO rule③)라
+            # "#24"라는 부분문자열 자체는 남지만, 그것이 «치환 안 된 맨 #24»가 아니라
+            # entity 토큰 «안에» 있다는 것으로 회귀 여부를 가른다.
+            assert "#24 보드 확인" not in result  # 맨 #24(미치환)는 없다
+            assert "[#24 보드 리팩터](entity:story:" in result  # entity 토큰 안에 있다
     finally:
         await engine.dispose()
 
@@ -314,7 +318,8 @@ async def test_promote_resolves_existing_story_to_entity_token():
             result, promoted_ids = await promote_bare_story_refs(
                 s, org_id=org.id, project_id=project.id, content="확인은 #24 참고",
             )
-            expected_token = build_reference_token("story", story.id, "보드 리팩터")
+            # story #3652(PO rule③) — 치환 텍스트가 원문 #24를 제목 앞에 남긴다.
+            expected_token = build_reference_token("story", story.id, "#24 보드 리팩터")
             assert result == f"확인은 {expected_token} 참고"
             # story #2679: 실제 치환된 story_id 집합도 반환 — caller가 origin='auto' 판정에 씀.
             assert promoted_ids == {story.id}
@@ -335,7 +340,9 @@ async def test_promote_unresolved_number_kept_verbatim():
             result, promoted_ids = await promote_bare_story_refs(
                 s, org_id=org.id, project_id=project.id, content="#24 그리고 #9999",
             )
-            expected_token = build_reference_token("story", story.id, "보드 리팩터")
+            # story #3652(PO rule③) — 치환된 #24는 원문을 제목 앞에 남기고, resolve
+            # 실패한 #9999는 손 안 댄 원문 그대로(all-or-nothing 아님, 기존 계약 그대로).
+            expected_token = build_reference_token("story", story.id, "#24 보드 리팩터")
             assert result == f"{expected_token} 그리고 #9999"
             # #9999는 resolve 실패라 promoted_ids엔 안 들어간다(원문 그대로 남은 것과 대칭).
             assert promoted_ids == {story.id}
@@ -481,7 +488,8 @@ async def test_send_message_promotes_bare_ref_for_agent_sender():
                 background_tasks=BackgroundTasks(),
                 db=s, auth=_agent_auth(agent_id, org.id), org_id=org.id,
             )
-            expected_token = build_reference_token("story", story.id, "보드 리팩터")
+            # story #3652(PO rule③) — 치환 텍스트가 원문 #24를 제목 앞에 남긴다.
+            expected_token = build_reference_token("story", story.id, "#24 보드 리팩터")
             assert result["data"]["content"] == f"확인은 {expected_token} 참고"
     finally:
         await engine.dispose()
@@ -508,7 +516,8 @@ async def test_send_message_promotes_bare_ref_for_human_sender():
                 background_tasks=BackgroundTasks(),
                 db=s, auth=_human_auth(user_id, org.id), org_id=org.id,
             )
-            expected_token = build_reference_token("story", story.id, "보드 리팩터")
+            # story #3652(PO rule③) — 치환 텍스트가 원문 #24를 제목 앞에 남긴다.
+            expected_token = build_reference_token("story", story.id, "#24 보드 리팩터")
             assert result["data"]["content"] == f"확인은 {expected_token} 참고"
     finally:
         await engine.dispose()
@@ -615,5 +624,175 @@ async def test_send_message_no_bare_ref_unaffected():
                 db=s, auth=_agent_auth(agent_id, org.id), org_id=org.id,
             )
             assert result["data"]["content"] == "그냥 평문 메시지"
+    finally:
+        await engine.dispose()
+
+
+# ── story #3652(PO 確定 2026-09-07) — 실사고: 「sprintable-agent-plugins #46」이
+# 이 org의 story #46(S209 표기)로 잘못 옷을 입었다. story 번호와 PR 번호가 같은
+# `#N` 표기 공간을 공유하는데 치환기가 그 사실을 몰랐다 — 두 규칙으로 처방한다:
+# ① 명시 repo#N(owner/repo·bare repo#N·URL) → story 승격 0(원장 유일 일치 시만 PR
+# 링크로 별도 해석) ② 맨 #N인데 같은 N이 org pr_number에도 있으면 모호(치환 0).
+async def _seed_pr_link(session, org_id, story_id, *, repo_full_name, pr_number):
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    link = PullRequestStoryLink(
+        id=uuid.uuid4(), org_id=org_id, story_id=story_id,
+        repo_full_name=repo_full_name, pr_number=pr_number,
+        link_source="explicit", confidence="high",
+    )
+    session.add(link)
+    await session.commit()
+    return link
+
+
+async def test_promote_owner_repo_hash_prefixed_not_promoted_to_story():
+    """PO rule① — `owner/repo#N`은 그 repo가 org 원장에도, 정적/동적 짧은이름
+    허용목록에도 없어도(슬래시 자체가 판별축) 항상 story 승격에서 빠진다(원장
+    부재=본문 그대로, story_number로 대체 해석하지 않는다). repo 이름을 허용목록
+    밖의 임의 문자열("randomorg/randomrepo")로 골라 `_SLASH_QUALIFIED_REPO_RE`
+    자신의 효과만 단독으로 잰다(레포 짧은이름 허용목록 축과 뒤섞이지 않게)."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            await _seed_story(s, org.id, project.id, number=46, title="아무 스토리")
+            content = "randomorg/randomrepo#46 확인 바라는"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content  # 원장에 이 repo#46 링크가 없으니 완전히 그대로
+            assert promoted_ids == set()
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_repo_hash_unique_ledger_match_resolves_to_linked_story():
+    """PO rule① — 맨 `repo#N`(슬래시 없음)이 org 원장의 짧은이름과 «유일하게» 일치하고
+    그 PR에 연결된 스토리가 있으면 그 스토리로 해석한다(story_number 축과 무관한
+    별도 해석 경로 — repo#N이 story #46이 아니라 sprintable-agent-plugins PR#46에
+    연결된 스토리로 옷을 입는다, 실사고의 «올바른» 결과)."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            wrong_story = await _seed_story(s, org.id, project.id, number=46, title="S209: pm-api 정리")
+            linked_story = await _seed_story(s, org.id, project.id, number=999, title="플러그인 정리 작업")
+            await _seed_pr_link(
+                s, org.id, linked_story.id,
+                repo_full_name="moonklabs/sprintable-agent-plugins", pr_number=46,
+            )
+            content = "sprintable-agent-plugins #46 확인 바라는"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            expected_token = build_reference_token("story", linked_story.id, "#46 플러그인 정리 작업")
+            assert result == f"{expected_token} 확인 바라는"
+            assert promoted_ids == {linked_story.id}
+            assert wrong_story.id not in promoted_ids  # 실사고의 오승격 대상은 안 걸림
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_bare_number_still_promotes_when_no_pr_collision():
+    """PO rule② 음성대조 — 같은 N이 org pr_number 어디에도 없으면(콜리전 0) 맨 #N은
+    지금까지처럼 story_number로 승격된다(무회귀)."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content="확인은 #24 참고",
+            )
+            expected_token = build_reference_token("story", story.id, "#24 보드 리팩터")
+            assert result == f"확인은 {expected_token} 참고"
+            assert promoted_ids == {story.id}
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_bare_number_ambiguous_with_org_pr_number_not_promoted():
+    """PO rule② — 같은 N이 story_number에도, org(레포 무관) pr_number에도 있으면
+    모호 — 치환 0(실사고의 근본 원인: story #46와 PR #46이 같은 표기 공간을 공유).
+    이 org의 다른 repo(예: 「sprintable」 본체)에 PR#24가 있어도 같은 판정 —
+    레포 무관(«이 플랫폼 원장 전체»가 판정 대상)."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            other_story = await _seed_story(s, org.id, project.id, number=25, title="다른 작업")
+            await _seed_pr_link(
+                s, org.id, other_story.id, repo_full_name="moonklabs/sprintable", pr_number=24,
+            )
+            content = "확인은 #24 참고"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content  # 모호 — 손 안 댐
+            assert promoted_ids == set()
+            assert story.id not in promoted_ids
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_github_pr_url_resolves_to_linked_story():
+    """PO rule① — GitHub PR URL은 owner/repo가 URL 자체에 명시돼 있어 원장 유일성
+    문제 없이 바로 (repo_full_name, pr_number)를 뽑아 대조한다."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            linked_story = await _seed_story(s, org.id, project.id, number=999, title="플러그인 정리 작업")
+            await _seed_pr_link(
+                s, org.id, linked_story.id,
+                repo_full_name="moonklabs/sprintable-agent-plugins", pr_number=46,
+            )
+            content = "실물은 https://github.com/moonklabs/sprintable-agent-plugins/pull/46 참고"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            expected_token = build_reference_token("story", linked_story.id, "#46 플러그인 정리 작업")
+            assert result == f"실물은 {expected_token} 참고"
+            assert promoted_ids == {linked_story.id}
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_quoted_repo_hash_not_resolved_example_reuse():
+    """story #3162 원칙 재확認 — 인용부호 안의 `owner/repo#N`도 「예시로 재인용」이지
+    새 참조 의도가 아니다. 원장에 실제 PR 링크가 있어도(정정 메시지가 오염된 원문을
+    그대로 다시 인용하는 실사고 재현) 인용부호 안이면 치환하지 않는다."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            linked_story = await _seed_story(s, org.id, project.id, number=999, title="플러그인 정리 작업")
+            await _seed_pr_link(
+                s, org.id, linked_story.id,
+                repo_full_name="moonklabs/sprintable-agent-plugins", pr_number=46,
+            )
+            content = '아까 "moonklabs/sprintable-agent-plugins#46 확인"이라고 적었던'
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content
+            assert promoted_ids == set()
     finally:
         await engine.dispose()


### PR DESCRIPTION
실사고(2026-09-07, 디디 conv 52fd99d0): 「sprintable-agent-plugins #46」(다른 레포의 PR 번호)이 이 org 프로젝트의 story #46(story_number=46, 제목이 우연히 "S209:"로 시작)로 옷을 입었다. story 번호와 PR 번호가 같은 `#N` 표기 공간을 공유하는데 치환기(`story_ref_promoter.py`)가 그 사실을 몰랐다.

## 처방(PO 確定 2026-09-07, 3회 왕복 — 최초 가설 "PR 경유 해석"은 실물 대조로 반증하고 PO가 직접 정정한 규칙)

① 명시 접두가 이긴다 — `PR #N`·`PR#N`·`pull #N`(신규)·`owner/repo#N`(신규, 슬래시 있으면 원장 존재와 무관하게 항상 제외)·GitHub PR URL(신규)·`repo#N`(기존 정적 다섯 + org `pull_request_story_link.repo_full_name` 동적 파생, 이번에 공백 허용 `\s*` 추가 — 실사고 문장 자체가 「이름 + 공백 + #46」형이었는데 기존 규칙엔 공백 허용이 없었다) → story_number 승격에서 항상 제외. repo가 org 원장과 유일 일치하면 그 PR의 연결 스토리로(있으면) 대신 해석, 없으면 본문 그대로.
② 맨 `#N`(레포 표식 0) — 지금처럼 story_number로 resolve하되, 같은 N이 org(레포 무관) `pull_request_story_link.pr_number`에도 있으면 모호로 보고 치환하지 않는다(story 번호와 PR 번호가 같은 플랫폼 원장이라 "같은 프레임"으로 판정 — 실사고의 근본 원인을 직접 막는 축).
③ 치환 텍스트가 원문 `#N`을 제목 앞에 남긴다(`#46 → [#46 S209: ...]`) — 사람이 오인을 바로 잡을 수 있게.

## 구현 메모
- `_find_explicit_repo_pr_candidates`(신규) — GitHub PR URL·owner/repo#N·(원장 유일 일치 시) bare repo#N을 찾아 `pull_request_story_link` 조회로 해석. story #3162 원칙(인용부호/블록인용 안은 예시 재인용) 동일 적용.
- `extract_bare_story_ref_candidates`에 `extra_repo_short_names` 파라미터 추가(org 원장 파생 동적 짧은이름 — 함수 자신은 여전히 DB 왕복 0, 호출부가 넘긴다) + `_SLASH_QUALIFIED_REPO_RE`(신규, 슬래시 있으면 무조건 제외).
- 자체 발견 회귀(실사고 아님, 구현 중 CHANGES) — `PullRequestStoryLink` 조회를 무조건 앞세우면 「#」도 「/pull/」도 없는 평범한 메시지마다 새 DB 왕복이 붙는다(`test_conversations.py::test_send_message_201` 실패로 적발) — 세 정규식 중 하나도 안 물면 DB 조회 자체를 건너뛰는 가드 추가.

## 잃는 것(선언)
`owner/repo#N`의 owner·repo 자리가 실제 GitHub 식별자인지 확인할 길이 없어(러너가 GitHub API를 안 부름) "a/b #24"류 우연한 슬래시 텍스트도 같은 모양이면 story 승격에서 제외된다 — dev 실측(#2660 GROUP BY)이 이런 표현이 실사용에 없었음을 보였으나, 새로 생기면 이 클래스가 못 잡는다.

## 테스트
기존 30건 전부 그린(3곳은 치환 텍스트에 원문 #N이 남는 새 계약대로 기댓값 갱신 — rule③). 신규 6(owner/repo#N 무조건 제외·bare repo#N 원장 유일일치 PR연결 해석·맨#N 콜리전無 시 무회귀·맨#N 콜리전 시 모호 제외·GitHub URL 해석·인용부호 안 repo#N 보호) + 뮤테이션 2(②의 콜리전 검사 제거→RED, ①의 슬래시 제외 검사 제거→RED, 각각 의도한 테스트만 정확히 실패 확認 후 복구). 인접 회귀 스윕 225건 그린(conversations·mention_parser·backlinks·pr_story_link·reference_registry).

## 라이브(AC3)
PO가 디디 conv에 「sprintable-agent-plugins #46」 재전송(치환 0) · GitHub PR URL(해당 PR/스토리로만) 확認 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA