### PR TITLE
[SID:3649+3750] prod 승격 — 비밀번호 변경 뒤 옛 세션 무효화 + 세션 stale 판정 초 절삭 수정(마이그 0·cherry-pick d90907ab6·afa6d2c6a)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -323,12 +323,24 @@ def _is_session_stale_after_password_change(user: User, session_started_at: obje
     판정 대상 밖 — 과거 시점을 알 방법이 없어 백필은 거짓 신호(0290 locale과 동형
     논지, 무제약=무회귀). session_started_at이 없거나 int가 아니면(레거시 토큰·
     #3247 seam 이전 발급) totp/disable과 동일하게 fail-closed(세션 무효로 본다) —
-    "판별 불가"를 "안전하다"로 해석하지 않는다(보안 결함 규율)."""
+    "판별 불가"를 "안전하다"로 해석하지 않는다(보안 결함 규율).
+
+    story #3750(BE·보안·bug, 미르코 그라운딩 2026-09-09) — 좌변(`password_set_at.
+    timestamp()`, 소수부 있는 float)과 우변(`session_started_at`, 토큰 클레임에
+    실린 `int(datetime.now(...).timestamp())`, 초 단위 절삭)을 서로 다른 단위로
+    비교했었다. 가입 핸들러가 `password_set_at`을 찍은 뒤(:671) flush·메타데이터
+    조회 await를 거쳐 토큰을 발급하는데(:702), 그 처리가 같은 정수 초 안에
+    끝나면 `1757437200.87 > 1757437200`이 True가 되어 방금 만든 세션이 "비밀번호
+    변경 뒤 stale"로 오판됐다(로컬·CI처럼 처리가 빠른 환경에서 흔함) — refresh·
+    switch-account·switch-project·switch-org 4곳이 이 함수를 공유해 강제
+    재로그인으로 번졌다. 좌변도 같은 단위(초 절삭)로 맞춘다 — 클레임을 float로
+    넓히는 대안은 토큰 계약 변경이라 안 한다. "같은 초에 세션이 시작됐다"는
+    stale이 아니다(다음 초부터가 stale — 기존 보안 판정은 그대로 유지)."""
     if user.password_set_at is None:
         return False
     if not isinstance(session_started_at, int):
         return True
-    return user.password_set_at.timestamp() > session_started_at
+    return int(user.password_set_at.timestamp()) > session_started_at
 
 
 def _explicit_revoke_values(now: datetime) -> dict:

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -311,6 +311,35 @@ async def _get_user_by_id(session: AsyncSession, user_id: uuid.UUID) -> User | N
     return result.scalar_one_or_none()
 
 
+def _is_session_stale_after_password_change(user: User, session_started_at: object) -> bool:
+    """story #3649(BE·보안·prod, 페드루 PO 確定 2026-09-07) — totp/disable의 password
+    재검증 분기(PR#3634, 위 §3247 주석)가 이미 쓰던 "이 비밀번호가 이 세션이 시작된
+    뒤에 심어졌나" 비교식을 공용 함수로 뺐다(refresh·switch-account·switch-project·
+    switch-org 재발급 경로 4곳이 재사용 — 새 판정 로직 0). set-password confirm·
+    change-password·reset-password 셋 다 password_set_at을 갱신하므로(그라운딩②
+    확認 완료) 이 하나의 컬럼으로 세 경로 전부를 잡는다.
+
+    password_set_at IS NULL(migration 0295 이전부터 비밀번호를 가진 기존 유저)은
+    판정 대상 밖 — 과거 시점을 알 방법이 없어 백필은 거짓 신호(0290 locale과 동형
+    논지, 무제약=무회귀). session_started_at이 없거나 int가 아니면(레거시 토큰·
+    #3247 seam 이전 발급) totp/disable과 동일하게 fail-closed(세션 무효로 본다) —
+    "판별 불가"를 "안전하다"로 해석하지 않는다(보안 결함 규율)."""
+    if user.password_set_at is None:
+        return False
+    if not isinstance(session_started_at, int):
+        return True
+    return user.password_set_at.timestamp() > session_started_at
+
+
+def _explicit_revoke_values(now: datetime) -> dict:
+    """story #3649(BE·보안·prod 결함) — logout·set-password confirm·switch-project·
+    switch-org·org_members 관리자 강제폐기(5곳) 전부 이 딕셔너리를 그대로 `.values()`
+    에 넘긴다(단일 seam — 다섯 곳 흩어 두지 않는다). `expires_at`도 함께 내려 refresh()
+    의 §2449 유예창(`expires_at > now()` 조건)이 명시 폐기 RT를 구조적으로 걸러낸다
+    (원자 rotation UPDATE는 이 함수를 안 써 무접촉 — §2449 구제 그대로)."""
+    return {"revoked_at": now, "expires_at": now}
+
+
 _ROLE_RANK: dict[str, int] = {"owner": 4, "admin": 3, "manager": 2, "member": 1}
 
 
@@ -890,6 +919,20 @@ async def refresh_token(
         # seconds→chain_resolve_window_seconds) + 통과 시 오늘과 동일한 독립 fork(다른 row
         # 무접촉)」로 수렴했다 — replaced_by 는 «승자 경로에서만» 기록해 감사열(정상 회전 死
         # vs logout 같은 명시적 dead-end 구분)·향후 family-revoke 훅 기반으로만 쓴다.
+        # story #3649(BE·보안·prod 결함, 페드루 PO 確定 2026-09-07, 카디르 재현 확定) —
+        # 이 select는 애초에 "회전 경합으로 죽은 RT"(진짜 race straggler)만 구제할 셈
+        # 이었지만, logout·set-password confirm·switch-* «대량 무효화»(명시 폐기)로
+        # 죽은 RT도 이 창(기본 180s) 안이면 그냥 통과해 새 토큰을 fork했다(카디르 직접
+        # 재현: confirm 직후/60s/170s 옛 RT refresh 200). replaced_by는 이 구분에 못
+        # 쓴다 — 승자가 그 값을 새 row INSERT+commit «後» 별개 문장으로 채우는 타이밍
+        # 이라(위 §2449 주석), 진짜 동시 경합(asyncio.gather)에서 replaced_by IS NOT
+        # NULL 조건을 걸면 그 커밋 전에 도착한 패자의 select가 오탐 401난다(실측:
+        # test_concurrent_refresh_same_token_exactly_one_succeeds_realdb 회귀 — 새
+        # 컬럼/조건 시도 뒤 되돌림). 대신 명시 폐기 UPDATE(아래 §3649 표시 3곳)가
+        # `expires_at=now()`도 같이 내려 — 이 select가 이미 요구하는
+        # `expires_at > now()` 조건 하나로 명시 폐기 RT가 **구조적으로** 창 밖이 된다
+        # (원자 rotation UPDATE는 expires_at을 안 건드려 §2449 구제 그대로, 새
+        # 컬럼·타이밍 레이스 0 — 마이그 0, PO 확定 2026-09-07 12:40Z).
         resolve_cutoff = datetime.now(timezone.utc) - timedelta(
             seconds=settings.auth_refresh_chain_resolve_window_seconds
         )
@@ -937,6 +980,16 @@ async def refresh_token(
     # 뚫린다 — 카디르+codex 2라운드 QA 실증). 그 토큰에 그 값이 없으면(마이그 이전 구
     # 토큰) 새 토큰에도 없다 — totp/disable이 그걸 fail-closed(password 경로 불허)로 해석.
     _session_started_at = payload.get("session_started_at")
+    # story #3649(보안 결함, 카디르 재현 확定) — 비밀번호 변경/설정 확認 뒤에도 옛
+    # refresh token(만료까지 최장 REFRESH_TOKEN_EXPIRE_DAYS)이 이 경로로 계속 새
+    # 토큰을 낳아 옛 세션이 무기한 이어졌다. 재발급 «직전» 여기서 막는다 —
+    # _store_refresh_token 前이라 새 RT 자체가 안 생긴다(부분 커밋 없음).
+    if _is_session_stale_after_password_change(user, _session_started_at):
+        logger.warning(
+            "auth.refresh 실패 reason=session_invalidated_by_password_change key=%s user_id=%s",
+            correlation_key, user.id,
+        )
+        return _err("SESSION_INVALIDATED", "Password was changed — please log in again", 401)
     tokens = create_tokens(
         str(user.id), email=user.email, app_metadata=_md, session_started_at=_session_started_at,
     )
@@ -1017,6 +1070,9 @@ async def switch_account(
     # story #3247 — refresh_token()과 동형(위 §3247 주석 참고) — 타겟 계정의 원 세션 시작
     # 시각을 그대로 이월.
     _session_started_at = payload.get("session_started_at")
+    # story #3649 — refresh_token()과 동형(위 §3649 주석 참고).
+    if _is_session_stale_after_password_change(user, _session_started_at):
+        return _err("SESSION_INVALIDATED", "Password was changed — please log in again", 401)
     tokens = create_tokens(
         str(user.id), email=user.email, app_metadata=_md, session_started_at=_session_started_at,
     )
@@ -1040,10 +1096,15 @@ async def logout(
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     token_hash = hash_token(body.refresh_token)
+    # story #3649(보안 결함) — expires_at도 함께 내려 refresh()의 유예창 select
+    # (`expires_at > now()` 조건)가 구조적으로 이 RT를 재사용 대상에서 뺀다(§3649
+    # 주석, refresh_token() 참고) — 명시 logout은 회전 경합 straggler 구제 대상이
+    # 아니다.
+    _now = datetime.now(timezone.utc)
     await session.execute(
         update(RefreshToken)
         .where(RefreshToken.token_hash == token_hash, RefreshToken.revoked_at.is_(None))
-        .values(revoked_at=datetime.now(timezone.utc))
+        .values(**_explicit_revoke_values(_now))
     )
     await session.commit()
     return _ok({"ok": True})
@@ -1154,15 +1215,10 @@ async def totp_disable(
             return _err("WRONG_PASSWORD", "Incorrect password", 403)
 
         # ② 그 비밀번호가 "이 세션이 시작된 시각보다 먼저" 존재했을 때만 유효한
-        # 재검증으로 인정. password_set_at이 session_started_at 이후면(=이 세션이
-        # 시작된 뒤 심어진 비밀번호 — refresh로 우회 불가, 세션 시작 자체는 재로그인
-        # 없이 안 바뀜) 우회체인이므로 거부. password_set_at IS NULL(migration 0295
-        # 이전부터 비밀번호를 가진 기존 유저)은 제약 대상 밖(0290 locale과 동형 논지
-        # — 과거 시점을 알 방법이 없어 백필은 거짓 신호, 무제약 유지=무회귀).
-        if user.password_set_at is not None:
-            session_started_at = auth.claims.get("session_started_at")
-            if not isinstance(session_started_at, int) or user.password_set_at.timestamp() > session_started_at:
-                return _err("PASSWORD_TOO_RECENT", "Password was set after this session started — please log in again", 403)
+        # 재검증으로 인정 — story #3649로 공용 함수(_is_session_stale_after_password_
+        # change, 위)로 뺐다(refresh/switch-* 재발급 경로 4곳과 같은 비교식 재사용).
+        if _is_session_stale_after_password_change(user, auth.claims.get("session_started_at")):
+            return _err("PASSWORD_TOO_RECENT", "Password was set after this session started — please log in again", 403)
     else:
         return _err("REVERIFICATION_REQUIRED", "TOTP code or password required", 400)
 
@@ -1818,10 +1874,14 @@ async def confirm_set_password(
     )
     # story #ab2a503f — 탈취 refresh token으로 이후 /auth/refresh가 즉시 401(우회체인 봉합).
     # switch_project/switch_org(이 파일)와 동일 인라인 패턴 재사용.
+    # story #3649(보안 결함) — expires_at도 함께 내려 refresh()의 유예창(§3649 주석)이
+    # 이 RT를 재사용 대상에서 뺀다 — set-password confirm이 죽인 RT는 회전 경합
+    # straggler가 아니라 명시 폐기.
+    _now = datetime.now(timezone.utc)
     await session.execute(
         update(RefreshToken)
         .where(RefreshToken.user_id == user.id, RefreshToken.revoked_at.is_(None))
-        .values(revoked_at=datetime.now(timezone.utc))
+        .values(**_explicit_revoke_values(_now))
     )
     await session.commit()
     return _ok({"message": "Password set successfully — please log in with your new password"})
@@ -1922,6 +1982,13 @@ async def switch_project(
     if user is None:
         return _err("USER_NOT_FOUND", "User not found", 404)
 
+    # story #3649(보안 결함, 카디르 재현 확定) — 옛 access token(비밀번호 변경/설정
+    # 뒤에도 만료까지 최대 60분 유효)으로 이 경로를 부르면 새 refresh token이
+    # 나와 옛 세션이 처음부터 다시 열렸다. mutation 前(어떤 행도 아직 안 건드림)에
+    # 막는다.
+    if _is_session_stale_after_password_change(user, auth.claims.get("session_started_at")):
+        return _err("SESSION_INVALIDATED", "Password was changed — please log in again", 401)
+
     # E-SECURITY SEC-S8(story 83ea3d6a) K — org_id 미전달이면 has_project_access가 org 필터
     # 없이 판정해, J(cross-org project_access grant)로 생긴 행 하나만 있어도 target org의
     # 정식 access+refresh 토큰이 발급되는 증폭 경로였다(SEC-S5~S8 가드를 우회하는 크리덴셜
@@ -1938,11 +2005,14 @@ async def switch_project(
     target_project_id = body.project_id
     user.last_project_id = target_project_id
 
-    # 기존 refresh token 무효화
+    # 기존 refresh token 무효화 — story #3649(보안 결함): expires_at도 함께 내려
+    # refresh()의 유예창(§3649 주석)이 이 RT들을 재사용 대상에서 뺀다(명시 폐기,
+    # 회전 경합 straggler 아님).
+    _now = datetime.now(timezone.utc)
     await session.execute(
         update(RefreshToken)
         .where(RefreshToken.user_id == user.id, RefreshToken.revoked_at.is_(None))
-        .values(revoked_at=datetime.now(timezone.utc))
+        .values(**_explicit_revoke_values(_now))
     )
 
     # 908075db 단계1: target을 명시 의도로 전달 — flag on이면 _build_app_metadata가 추측 없이 그대로 존중.
@@ -1988,6 +2058,10 @@ async def switch_organization(
     if user is None:
         return _err("USER_NOT_FOUND", "User not found", 404)
 
+    # story #3649 — switch_project()와 동형(위 §3649 주석 참고).
+    if _is_session_stale_after_password_change(user, auth.claims.get("session_started_at")):
+        return _err("SESSION_INVALIDATED", "Password was changed — please log in again", 401)
+
     # org_members 소속 여부 확인
     membership = await session.execute(
         select(OrgMember)
@@ -2007,11 +2081,13 @@ async def switch_organization(
     # cross-org 옛 프로젝트 재주입 0 (last_project_id=None이어도 org는 유지).
     user.last_org_id = body.org_id
 
-    # 기존 refresh token 무효화
+    # 기존 refresh token 무효화 — story #3649(보안 결함): switch_project()와 동형
+    # (§3649 주석 참고).
+    _now = datetime.now(timezone.utc)
     await session.execute(
         update(RefreshToken)
         .where(RefreshToken.user_id == user.id, RefreshToken.revoked_at.is_(None))
-        .values(revoked_at=datetime.now(timezone.utc))
+        .values(**_explicit_revoke_values(_now))
     )
 
     # _build_app_metadata 호출 전에 target project_id 고정

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -756,9 +756,15 @@ async def consume_oauth_handoff(
     from app.routers.auth import _build_app_metadata, _store_refresh_token
 
     app_metadata = await _build_app_metadata(user, db)
+    # story #3649(PO 대조 발견, 2026-09-07) — 이 경로가 로그인(새 세션 시작)인데
+    # session_started_at을 안 실었다. login()/oauth_callback()(auth.py)과 동형으로
+    # 지금 시각을 찍는다 — 안 그러면 password_set_at이 있는 유저가 이 핸드오프로
+    # 로그인한 뒤 첫 refresh/switch-*에서 #3649의 세션 무효화 판정(fail-closed,
+    # session_started_at이 int가 아니면 stale로 본다)에 걸려 조용히 락아웃된다.
     tokens = create_tokens(
         str(user.id), user.email, app_metadata,
         auth_source=_OAUTH_HANDOFF_AUTH_SOURCE, device_attested=False,
+        session_started_at=int(datetime.now(timezone.utc).timestamp()),
     )
     refresh_expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     # story #3121 AC3 — RT 저장과 같은 commit에 실린다(_store_refresh_token이 commit).

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -167,11 +167,17 @@ async def get_org_member(
 
 
 async def _revoke_user_refresh_tokens(session: AsyncSession, user_id: uuid.UUID) -> None:
-    """해당 사용자의 refresh token 전량 revoke."""
+    """해당 사용자의 refresh token 전량 revoke. story #3649(보안 결함) — auth.py의
+    단일 seam(_explicit_revoke_values)을 그대로 써 expires_at도 함께 내린다
+    (관리자 강제 폐기, 회전 경합 straggler 아님 — auth.py::refresh_token() 유예창이
+    이 RT들을 재사용 대상에서 뺀다)."""
+    from app.routers.auth import _explicit_revoke_values
+
+    _now = datetime.now(timezone.utc)
     await session.execute(
         update(RefreshToken)
         .where(RefreshToken.user_id == user_id, RefreshToken.revoked_at.is_(None))
-        .values(revoked_at=datetime.now(timezone.utc))
+        .values(**_explicit_revoke_values(_now))
     )
 
 

--- a/backend/tests/test_1931_oauth_handoff_realdb.py
+++ b/backend/tests/test_1931_oauth_handoff_realdb.py
@@ -825,3 +825,74 @@ async def test_oauth_handoff_code_not_consumable_via_attested_native_consume(mon
             assert exc_info.value.status_code in (401, 400)
     finally:
         await engine.dispose()
+
+
+# ─── story #3649(BE·보안·prod, PO 대조 발견 2026-09-07) — 이 핸드오프도 로그인이라
+# session_started_at을 실어야 한다(안 그러면 password_set_at 있는 유저가 refresh에서
+# 조용히 락아웃) ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_consume_mints_session_started_at_and_refresh_succeeds_for_password_changed_user(monkeypatch):
+    """양성대조 — password_set_at이 있는(과거에 비밀번호를 변경/설정한 적 있는) 유저가
+    이 핸드오프로 로그인해도, 그 직후 첫 refresh가 200이어야 한다(#3649의 세션 무효화
+    판정이 session_started_at 누락을 fail-closed로 보는데, 이 로그인 경로가 그 클레임을
+    실었다면 막힐 이유가 없다는 것을 실경로로 증명 — auth_firebase_internal.py:759
+    누락 실사고 재발 방지)."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+            from sqlalchemy import update as sa_update
+            from app.models.user import User
+            await s.execute(
+                sa_update(User).where(User.id == user_id).values(
+                    password_set_at=datetime.now(timezone.utc) - timedelta(days=30),
+                )
+            )
+            await s.commit()
+
+        verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
+
+        async with Session() as s:
+            consumed = await consume_oauth_handoff(
+                _FakeRequest(), _consume_req(issued.code, verifier), authorization=None, db=s,
+            )
+
+        from app.core.security import decode_jwt
+        claims = decode_jwt(consumed.access_token)
+        assert isinstance(claims.get("session_started_at"), int), (
+            "oauth-handoff/consume이 session_started_at을 안 실었다 — #3649 재발"
+        )
+
+        from app.main import app
+
+        async def _db():
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        from tests.conftest import override_db_and_read
+        override_db_and_read(app, _db)
+        from httpx import ASGITransport, AsyncClient
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                refresh_resp = await c.post(
+                    "/api/v2/auth/refresh", json={"refresh_token": consumed.refresh_token},
+                )
+            assert refresh_resp.status_code == 200, refresh_resp.text
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3247_totp_disable.py
+++ b/backend/tests/test_3247_totp_disable.py
@@ -232,27 +232,35 @@ async def test_disable_with_password_set_before_session_started_succeeds():
 
 
 @pytest.mark.anyio
-async def test_password_too_recent_survives_token_refresh():
-    """PO 2라운드 지적의 핵심 AC — set-password→refresh→disable 회귀. 1라운드 방어(iat
-    대조)는 refresh 왕복 한 번에 뚫렸다(카디르+codex 실증: refresh가 iat을 매번 새로
-    찍어 password_set_at을 추월시킴). 이 테스트는 실제 POST /api/v2/auth/refresh를
-    관통시켜, 그 결과 새 access 토큰의 session_started_at이 **원 토큰과 동일하게
-    이월**됨(재로그인 때만 갱신되는 값이라 refresh로는 못 미룸)을 직접 증명한다 —
-    로직 재현이 아니라 실경로 증명(3605/3617 처방 동형)."""
+async def test_password_too_recent_blocks_refresh_itself_story_3649():
+    """PO 2라운드 지적의 핵심 AC — set-password→refresh→disable 회귀(원래 이름:
+    test_password_too_recent_survives_token_refresh). story #3649(2026-09-07,
+    카디르 codex 재현 확定)가 같은 판정(session_started_at < password_set_at)을
+    refresh() 자체에도 걸어, 이 시나리오는 이제 refresh 단계에서 이미 401
+    SESSION_INVALIDATED로 막힌다 — totp/disable까지 갈 필요조차 없어졌다(더 이른
+    층에서 막힘, 우회 표면이 아예 줄어든 것이지 이 테스트가 검증하던 «refresh가
+    session_started_at을 못 미룬다» 사실 자체는 무변 — 여전히 새 토큰의
+    session_started_at이 원값 그대로임을 decode해 직접 확認한다). 1라운드 방어(iat
+    대조)는 refresh 왕복 한 번에 뚫렸다(카디르+codex 실증) — session_started_at
+    seam이 그 우회를 막는다."""
     from app.core.security import create_tokens, decode_jwt, hash_password
     from app.main import app
     from tests.conftest import override_db_and_read
 
-    original_session_started_at = int(time.time()) - 3600  # 세션은 1시간 전 시작
+    # story #3649 — 타임라인을 refresh() 자체의 새 게이트도 정확히 반영하도록 조정한다:
+    # T0 세션 시작 → T1 refresh(그 시점 password_set_at=None이라 #3649 게이트 통과,
+    # 200) → T2 비밀번호 심음(refresh «후») → T3 그 리프레시된 토큰으로 disable 시도.
+    # #3649의 refresh 게이트는 T1 시점 평가라 이 T2(그 뒤 변경)를 못 잡는다 — 이래서
+    # totp/disable 자체 재검증이 여전히 필요한 방어선이다(자리별 처방 걷지 않기).
+    original_session_started_at = int(time.time()) - 3600  # T0: 세션은 1시간 전 시작
     original_tokens = create_tokens(
         str(USER_ID), email="u@example.com", app_metadata={},
         session_started_at=original_session_started_at,
     )
 
-    password_set_at = datetime.now(timezone.utc)  # 방금(원 세션 시작보다 나중) 비밀번호 심음
-    user = _make_user(
+    refresh_time_user = _make_user(
         totp_enabled=True, totp_secret=pyotp.random_base32(),
-        hashed_password=hash_password("just-planted"), password_set_at=password_set_at,
+        hashed_password=hash_password("just-planted"), password_set_at=None,  # T1: 아직 안 바뀜
     )
 
     mock_session = AsyncMock()
@@ -270,14 +278,16 @@ async def test_password_too_recent_survives_token_refresh():
 
     override_db_and_read(app, override_db)
     try:
-        with patch("app.routers.auth._get_user_by_id", new=AsyncMock(return_value=user)), \
+        with patch("app.routers.auth._get_user_by_id", new=AsyncMock(return_value=refresh_time_user)), \
              patch("app.routers.auth._build_app_metadata", new=AsyncMock(return_value={})):
             from httpx import ASGITransport, AsyncClient
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 refresh_resp = await c.post(
                     "/api/v2/auth/refresh", json={"refresh_token": original_tokens["refresh_token"]},
                 )
-            assert refresh_resp.status_code == 200
+            # T1 시점엔 password_set_at이 아직 없어 story #3649 게이트를 그대로 통과(200)
+            # — 이 refresh 자체는 막힐 이유가 없다는 것도 이 테스트가 같이 증명한다.
+            assert refresh_resp.status_code == 200, refresh_resp.text
             new_access_token = refresh_resp.json()["data"]["access_token"]
             new_claims = decode_jwt(new_access_token)
 
@@ -287,10 +297,19 @@ async def test_password_too_recent_survives_token_refresh():
             assert new_claims["session_started_at"] == original_session_started_at
             assert new_claims["iat"] > original_session_started_at
 
-            # 그 새 토큰으로 disable 시도 → password_set_at이 session_started_at(원값)
-            # 보다 나중이라 여전히 거부돼야 한다(refresh 우회 실패 확認). _get_user_by_id
-            # patch를 이 호출까지 이어서(totp_disable도 그 함수를 쓴다) mock_session의
-            # 잔여 execute mock(위 원자 rotation용)을 안 타게 유지.
+            # T2 — 그 뒤(refresh 완료 후) 비밀번호를 심는다.
+            password_set_at = datetime.now(timezone.utc)
+            user = _make_user(
+                totp_enabled=True, totp_secret=pyotp.random_base32(),
+                hashed_password=hash_password("just-planted"), password_set_at=password_set_at,
+            )
+
+            # T3 — 그 새(리프레시된) 토큰으로 disable 시도 → password_set_at(T2)이
+            # session_started_at(T0, 원값 그대로 이월)보다 나중이라 여전히 거부돼야
+            # 한다(#3649의 refresh 게이트는 T1 시점 평가라 T2를 못 잡음 — disable
+            # 자체 재검증이 그 갭을 메운다). _get_user_by_id patch를 이 호출까지
+            # 이어서(totp_disable도 그 함수를 쓴다) mock_session의 잔여 execute
+            # mock(위 원자 rotation용)을 안 타게 유지.
             async def override_auth():
                 ctx = MagicMock()
                 ctx.user_id = str(USER_ID)
@@ -299,10 +318,11 @@ async def test_password_too_recent_survives_token_refresh():
 
             from app.dependencies.auth import get_current_user
             app.dependency_overrides[get_current_user] = override_auth
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                disable_resp = await c.post(
-                    "/api/v2/auth/totp/disable", json={"password": "just-planted"},
-                )
+            with patch("app.routers.auth._get_user_by_id", new=AsyncMock(return_value=user)):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                    disable_resp = await c.post(
+                        "/api/v2/auth/totp/disable", json={"password": "just-planted"},
+                    )
             assert disable_resp.status_code == 403
             assert disable_resp.json()["error"]["code"] == "PASSWORD_TOO_RECENT"
     finally:

--- a/backend/tests/test_3649_create_tokens_session_started_at_pin.py
+++ b/backend/tests/test_3649_create_tokens_session_started_at_pin.py
@@ -1,0 +1,77 @@
+"""story #3649(BE·보안·prod 결함, 페드루 PO 대조 발견 2026-09-07) — `create_tokens()`
+호출부 전수 정적 핀. #3649의 세션 무효화 판정(`_is_session_stale_after_password_change`)
+은 `session_started_at`이 int가 아니면 fail-closed(세션 무효로 본다)로 판정한다 — 그
+판정을 refresh/switch-project/switch-org/switch-account 4개 재발급 경로로 넓히면서,
+이 클레임을 안 싣는 로그인 경로가 하나라도 있으면 「그 경로로 로그인한 password_set_at
+있는 유저는 첫 재발급 호출에서 조용히 락아웃」된다(실사고: `auth_firebase_internal.py`
+의 oauth-handoff/consume이 이 클레임을 누락 — PO가 diff 밖 grep으로 발견, 이 핀이
+그 재발을 막는다).
+
+계약: `backend/app` 안 모든 `create_tokens(...)` 호출은 `session_started_at=` 키워드
+인자를 실어야 한다(로그인 경로=지금 시각, 재발급 경로=원 값 이월 — 어느 쪽이든 "넘긴다"
+는 계약은 같다, 값 자체의 정합성은 이 핀의 범위 밖)."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_APP_DIR = Path(__file__).parent.parent / "app"
+
+
+def _find_create_tokens_calls_missing_session_started_at() -> list[str]:
+    """`create_tokens(...)` 호출 중 `session_started_at=` 키워드가 없는 자리를
+    `file:line` 문자열로 반환(빈 리스트=전부 넘긴다)."""
+    missing: list[str] = []
+    for path in sorted(_APP_DIR.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+            if name != "create_tokens":
+                continue
+            if any(kw.arg == "session_started_at" for kw in node.keywords):
+                continue
+            missing.append(f"{path.relative_to(_APP_DIR.parent)}:{node.lineno}")
+    return missing
+
+
+def test_all_create_tokens_call_sites_pass_session_started_at():
+    """AC2 — 전수 열거해 누락 0을 단언. 양성대조(주석에 못박음, story #3649 PR 본문
+    확認 절차): 이 핀을 auth_firebase_internal.py:759 수정 前 head에서 먼저 돌려
+    빨강(`app/routers/auth_firebase_internal.py:...` 1건)임을 실측한 뒤 되돌렸다 —
+    이 assert가 실제로 그 결함을 잡는다는 증거."""
+    missing = _find_create_tokens_calls_missing_session_started_at()
+    assert missing == [], (
+        "session_started_at 없이 create_tokens()를 호출하는 자리 — 이 로그인 경로로 "
+        f"들어온 password_set_at 있는 유저는 첫 재발급 호출에서 조용히 락아웃된다: {missing}"
+    )
+
+
+def test_positive_control_missing_kwarg_is_actually_detected():
+    """가드 자체가 실제로 걸리는지 자가 증명 — 합성 소스(임시 파일)에 누락 호출을
+    심어 이 함수가 빈 리스트가 아닌 결과를 낸다는 것을 고정."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        fake_app = Path(tmp) / "app"
+        fake_app.mkdir()
+        (fake_app / "fake_router.py").write_text(
+            "def f():\n"
+            "    tokens = create_tokens(str(1), email='e', app_metadata={})\n"
+        )
+        import importlib
+
+        module = importlib.import_module(__name__)
+        original_dir = module._APP_DIR
+        module._APP_DIR = fake_app
+        try:
+            missing = module._find_create_tokens_calls_missing_session_started_at()
+        finally:
+            module._APP_DIR = original_dir
+        assert len(missing) == 1
+        assert "fake_router.py" in missing[0]

--- a/backend/tests/test_3649_session_invalidation_password_change_realdb.py
+++ b/backend/tests/test_3649_session_invalidation_password_change_realdb.py
@@ -1,0 +1,441 @@
+"""story #3649(BE·보안·prod 결함, 페드루 PO 確定 2026-09-07, 카디르 codex 재현 확定) —
+비밀번호 설정/변경 확認 뒤에도 옛 세션이 살아남던 두 결함을 닫는다(재QA #3693/3250 codex
+발견).
+
+① 명시 폐기(logout·set-password confirm·switch-project·switch-org·admin 강제폐기)된
+refresh token이 §2449 유예창(기본 180s, 회전 경합 straggler 구제용)을 그냥 통과해
+refresh()에서 새 토큰을 fork했다 — 「경합」과 「명시 폐기」를 안 갈랐다. 처방: 명시 폐기
+UPDATE가 `revoked_at`과 함께 `expires_at`도 now()로 내려, 유예창 select의 기존
+`expires_at > now()` 조건이 구조적으로 이 RT를 걸러낸다(새 컬럼 0 — replaced_by 기반
+1차 처방은 승자의 그 값이 새 row INSERT+commit "후" 별개 문장으로 채워지는 타이밍이라
+진짜 동시 경합에서 오탐 401 회귀를 냈다, 되돌림).
+
+② refresh·switch-project·switch-org·switch-account 재발급 경로에서 `session_started_at
+< user.password_set_at`이면 401 SESSION_INVALIDATED — 옛 access token(비밀번호 변경
+뒤에도 최대 60분 유효)으로 switch-*를 불러 새 refresh token을 얻는 우회를 막는다.
+공용 판정 `_is_session_stale_after_password_change`(auth.py)는 기존 totp/disable
+password 재검증(PR#3634)이 쓰던 비교식을 그대로 재사용(새 로직 0).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_db_override(app, Session):
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    override_db_and_read(app, _db)
+
+
+def _override_auth(app, *, user_id, org_id, session_started_at):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if session_started_at is not None:
+            claims["session_started_at"] = session_started_at
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _seed_user_with_password(session, *, password_set_at: datetime | None):
+    from app.core.security import hash_password
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id, email=f"story3649-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+        password_set_at=password_set_at,
+    )
+    session.add(user)
+    await session.commit()
+    return user_id
+
+
+async def _seed_refresh_token(session, user_id, *, session_started_at: int | None):
+    from app.core.security import create_refresh_token, hash_token
+
+    raw, exp = create_refresh_token(str(user_id), session_started_at=session_started_at)
+    from app.models.user import RefreshToken
+
+    session.add(RefreshToken(
+        id=uuid.uuid4(), user_id=user_id, token_hash=hash_token(raw), expires_at=exp, revoked_at=None,
+    ))
+    await session.commit()
+    return raw
+
+
+async def _seed_org_and_project(session, user_id):
+    """team_members는 read-only VIEW라 직접 INSERT 불가 — has_project_access의
+    owner/admin 분기(OrgMember.role)만으로 접근을 준다(team_member 행 불요,
+    story #3629/#3635 그라운딩과 동형 관례)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_id, role="owner")
+    session.add(om)
+    await session.commit()
+    return {"org_id": org.id, "project_id": project.id}
+
+
+# ── ② session_started_at < password_set_at → 401 (refresh/switch-*) ──────────
+
+
+@pytest.mark.anyio
+async def test_refresh_with_session_started_before_password_change_401_session_invalidated():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        password_set_at = datetime.now(timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            stale_started_at = int((password_set_at - timedelta(minutes=5)).timestamp())
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=stale_started_at)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert resp.status_code == 401, resp.text
+            assert resp.json()["error"]["code"] == "SESSION_INVALIDATED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_with_session_started_after_password_change_succeeds_200_no_false_positive():
+    """회귀 0 — 비밀번호 변경 «뒤에» 새로 로그인한 정상 세션은 refresh가 계속 통과해야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        password_set_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            fresh_started_at = int(datetime.now(timezone.utc).timestamp())
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=fresh_started_at)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_switch_project_with_stale_session_401():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        password_set_at = datetime.now(timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            seeded = await _seed_org_and_project(s, user_id)
+
+        await _setup_db_override(app, Session)
+        stale_started_at = int((password_set_at - timedelta(minutes=5)).timestamp())
+        _override_auth(app, user_id=user_id, org_id=seeded["org_id"], session_started_at=stale_started_at)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/auth/switch-project", json={"project_id": str(seeded["project_id"])},
+            )
+            assert resp.status_code == 401, resp.text
+            assert resp.json()["error"]["code"] == "SESSION_INVALIDATED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_switch_org_with_stale_session_401():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        password_set_at = datetime.now(timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            seeded = await _seed_org_and_project(s, user_id)
+
+        await _setup_db_override(app, Session)
+        stale_started_at = int((password_set_at - timedelta(minutes=5)).timestamp())
+        _override_auth(app, user_id=user_id, org_id=seeded["org_id"], session_started_at=stale_started_at)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/switch-org", json={"org_id": str(seeded["org_id"])})
+            assert resp.status_code == 401, resp.text
+            assert resp.json()["error"]["code"] == "SESSION_INVALIDATED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_switch_account_with_stale_session_401():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        password_set_at = datetime.now(timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            stale_started_at = int((password_set_at - timedelta(minutes=5)).timestamp())
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=stale_started_at)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/switch-account", json={"refresh_token": raw_rt})
+            assert resp.status_code == 401, resp.text
+            assert resp.json()["error"]["code"] == "SESSION_INVALIDATED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── ① 명시 폐기(logout) RT가 §2449 유예창을 못 통과 ───────────────────────────
+
+
+@pytest.mark.anyio
+async def test_logout_itself_backdates_expires_at_to_now():
+    """logout 엔드포인트 자체가 expires_at을 now()로 내리는지 직접 확認(DB row 조회 —
+    이 축이 실제로 실행되는지의 1차 증거, 아래 refresh 재현 테스트와 상호보완)."""
+    from app.main import app
+    from app.core.security import hash_token
+    from app.models.user import RefreshToken
+    from sqlalchemy import select as sa_select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=None)
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=None)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            before = datetime.now(timezone.utc)
+            logout_resp = await client.post("/api/v2/auth/logout", json={"refresh_token": raw_rt})
+            assert logout_resp.status_code == 200, logout_resp.text
+
+            async with Session() as s:
+                row = (await s.execute(
+                    sa_select(RefreshToken).where(RefreshToken.token_hash == hash_token(raw_rt))
+                )).scalar_one()
+            assert row.revoked_at is not None
+            assert row.expires_at <= before + timedelta(seconds=5), (
+                f"logout이 expires_at을 원래 만료일(수 일 뒤)에서 안 내렸다: {row.expires_at}"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_after_logout_401_on_repeated_retries_within_grace_window():
+    """카디르 재현(confirm 뒤 즉시·60s·170s refresh 200 — 결함) 대응 회귀. logout이
+    expires_at을 now()로 내려두면(위 테스트) 그 뒤 §2449 유예창의 `expires_at > now()`
+    조건이 시간 경과와 무관하게 항상 거짓이 된다 — 실제 로그아웃 1회 뒤, 별도 DB
+    조작 없이 refresh를 반복(3회, 공격자의 재시도 흉내) 재시도해도 매번 401이어야
+    한다(카디르가 재현한 즉시/60s/170s 케이스 전부가 이 하나의 메커니즘으로 닫힌다
+    — 시간 오프셋을 흉내 낼 필요 자체가 없다는 것도 이 처방의 성질)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=None)
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=None)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            logout_resp = await client.post("/api/v2/auth/logout", json={"refresh_token": raw_rt})
+            assert logout_resp.status_code == 200, logout_resp.text
+
+            for attempt in range(3):
+                resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+                assert resp.status_code == 401, f"attempt={attempt}: {resp.text}"
+                assert resp.json()["error"]["code"] == "TOKEN_REVOKED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_genuine_rotation_race_within_window_still_succeeds_200_regression():
+    """회귀 0(§2449 핵심 계약) — «명시 폐기»가 아니라 «진짜 회전 경합»(원자 rotation UPDATE로
+    죽은 RT, expires_at 무접촉)은 유예창 안에서 여전히 200(fork)이어야 한다. 이 파일의 처방이
+    §2449 구제를 깨지 않았다는 직접 증거(test_e5225c0a_refresh_atomic_realdb.py의 동시성
+    테스트와 상호보완 — 여기는 순차 재현으로 명시 폐기와 대비시킨다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=None)
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=None)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            first = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert first.status_code == 200, first.text
+            # 같은(이미 원자 rotation으로 소비된) RT를 다시 제시 — expires_at 무접촉이라
+            # 유예창 안이면 fork(200).
+            second = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert second.status_code == 200, second.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── 뮤테이션 ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_mutation_removing_expires_at_backdate_from_shared_helper_reopens_reuse_window(monkeypatch):
+    """뮤테이션① — 명시 폐기 5곳이 공유하는 단일 seam(_explicit_revoke_values)이
+    expires_at을 안 내리면(옛 동작 재현) logout 뒤에도 유예창 재사용이 다시 200으로
+    통과해야 한다(이 스토리의 처방이 실제로 이 결함을 잡는다는 증거 — 5곳 전부를
+    한 번에 검증하는 단일 seam이라 여기 하나만 패치해도 대표성 있음)."""
+    from app.main import app
+    import app.routers.auth as auth_module
+
+    monkeypatch.setattr(auth_module, "_explicit_revoke_values", lambda now: {"revoked_at": now})
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=None)
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=None)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            logout_resp = await client.post("/api/v2/auth/logout", json={"refresh_token": raw_rt})
+            assert logout_resp.status_code == 200, logout_resp.text
+
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert resp.status_code == 200, (
+                f"뮤테이션 재현인데 401 — expires_at 무접촉 옛 동작에서도 이 케이스는 "
+                f"원래 200이어야 정상(이 테스트 자체가 그 옛 결함을 재현): {resp.text}"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_removing_session_invalidation_check_from_refresh_allows_stale_session(monkeypatch):
+    """뮤테이션② — _is_session_stale_after_password_change를 no-op으로 되돌리면
+    stale 세션 refresh가 다시 200으로 통과해야 한다."""
+    from app.main import app
+    import app.routers.auth as auth_module
+
+    monkeypatch.setattr(auth_module, "_is_session_stale_after_password_change", lambda user, sid: False)
+
+    engine, Session = await _session_factory()
+    try:
+        password_set_at = datetime.now(timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            stale_started_at = int((password_set_at - timedelta(minutes=5)).timestamp())
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=stale_started_at)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert resp.status_code == 200, (
+                f"뮤테이션 재현인데 401 — 판정 제거 후에도 여전히 막히면 이 축의 실제 효과를 "
+                f"증명 못 한 것: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3649_session_invalidation_password_change_realdb.py
+++ b/backend/tests/test_3649_session_invalidation_password_change_realdb.py
@@ -190,6 +190,67 @@ async def test_refresh_with_session_started_after_password_change_succeeds_200_n
 
 
 @pytest.mark.anyio
+async def test_refresh_with_password_set_same_second_as_session_start_succeeds_200():
+    """story #3750(BE·보안·bug, 미르코 그라운딩 2026-09-09) — 좌변(password_set_at.
+    timestamp(), float)과 우변(session_started_at, 초 절삭 int)을 단위 안 맞추고
+    비교하던 결함의 정확히 그 경계. 가입 직후처럼 password_set_at과 토큰 발급이
+    같은 정수 초 안에 떨어지면(password_set_at의 소수부가 0보다 큼) 예전 코드는
+    `float > int`가 True로 나와(초 뒤 소수부만큼 항상 더 크므로) 방금 만든 세션을
+    즉시 stale로 오판했다 — 이 테스트가 그 경계를 정확히 pin한다. 되돌리면 RED."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        # 세션이 시작된 바로 그 정수 초 «안»에서(소수부가 0보다 크게) 비밀번호가
+        # 찍힌 경우 — 가입 핸들러의 실제 순서(password_set_at 먼저, 토큰 발급
+        # 나중)와 반대로 구성해도 "같은 초"라는 사실 자체가 핵심이라 무해하다.
+        session_started_at = int(datetime.now(timezone.utc).timestamp())
+        password_set_at = datetime.fromtimestamp(session_started_at + 0.87, tz=timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=session_started_at)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_with_password_set_next_second_after_session_start_401():
+    """story #3750 — 위 테스트의 반대쪽 경계(기존 보안 판정이 그대로 서 있는지).
+    비밀번호가 세션 시작 «다음 정수 초»에 찍혔으면(진짜로 나중에 바뀐 것) 여전히
+    stale이어야 한다 — 초 절삭 정정이 «항상 False»로 물러진 게 아님을 확認."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        session_started_at = int(datetime.now(timezone.utc).timestamp())
+        password_set_at = datetime.fromtimestamp(session_started_at + 1.01, tz=timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=session_started_at)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert resp.status_code == 401, resp.text
+            assert resp.json()["error"]["code"] == "SESSION_INVALIDATED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_switch_project_with_stale_session_401():
     from app.main import app
 

--- a/backend/tests/test_908075db_stage3_switch_guards.py
+++ b/backend/tests/test_908075db_stage3_switch_guards.py
@@ -28,6 +28,10 @@ def _user():
     u.email = "e@test.com"
     u.last_project_id = None
     u.last_org_id = ORG
+    # story #3649 — MagicMock 기본값은 None이 아니라 truthy MagicMock이라
+    # _is_session_stale_after_password_change의 "password_set_at is None"
+    # 단락이 안 걸려 이 파일의 세션 무효화 무관 테스트들이 401로 오탐됐다.
+    u.password_set_at = None
     return u
 
 

--- a/backend/tests/test_auth_switch_project.py
+++ b/backend/tests/test_auth_switch_project.py
@@ -21,6 +21,10 @@ def _make_user(last_project_id=None) -> MagicMock:
     u.hashed_password = ""
     u.is_active = True
     u.last_project_id = last_project_id
+    # story #3649 — MagicMock 기본값은 None이 아니라 truthy MagicMock이라
+    # _is_session_stale_after_password_change의 "password_set_at is None"
+    # 단락이 안 걸려 이 파일의 세션 무효화 무관 테스트들이 401로 오탐됐다.
+    u.password_set_at = None
     return u
 
 

--- a/backend/tests/test_c_s1.py
+++ b/backend/tests/test_c_s1.py
@@ -55,6 +55,10 @@ def _make_user(
     u.project_id = uuid.uuid4()
     u.role = "member"
     u.user_id = None
+    # story #3649 — MagicMock 기본값은 None이 아니라 truthy MagicMock이라
+    # _is_session_stale_after_password_change의 "password_set_at is None"
+    # 단락이 안 걸려 이 파일의 세션 무효화 무관 테스트들이 401로 오탐됐다.
+    u.password_set_at = None
     return u
 
 

--- a/backend/tests/test_e_org_multi_s2_1_switch_organization.py
+++ b/backend/tests/test_e_org_multi_s2_1_switch_organization.py
@@ -29,6 +29,10 @@ def _mock_user(user_id: uuid.UUID = USER_ID) -> MagicMock:
     u.last_project_id = None
     u.login_fail_count = 0
     u.login_locked_until = None
+    # story #3649 — MagicMock 기본값은 None이 아니라 truthy MagicMock이라
+    # _is_session_stale_after_password_change의 "password_set_at is None"
+    # 단락이 안 걸려 이 파일의 세션 무효화 무관 테스트들이 401로 오탐됐다.
+    u.password_set_at = None
     return u
 
 


### PR DESCRIPTION
스토리 8989e9dd-09aa-420b-8727-4c3955e3f0f5 (3649 · BE·보안·prod 결함). develop 착지 = PR #3999(head 6c3ed63c4) → 머지 228 d90907ab6. 이 PR = main에 그 squash 커밋 1건 cherry-pick(-x·충돌 0·11파일).

## 무엇이 prod에 가는가
- 명시 폐기(logout·set-password confirm·switch-project/org·admin 강제폐기) UPDATE가 `expires_at=now()`도 내려 refresh 유예창(§2449 회전 경합 구제)이 명시 폐기 RT를 구조적으로 걸러낸다 — 단일 seam `_explicit_revoke_values`.
- refresh·switch-project/org/account 재발급 경로에서 `session_started_at < user.password_set_at`이면 401 `SESSION_INVALIDATED`(비밀번호 변경 前 세션 무효화) · 로그인 경로 전부 `session_started_at` 스탬프(oauth-handoff/consume 포함) + AST 정적 핀.
- **마이그 0**(main 0295 그대로). 새 컬럼 0.

## 검증
- PO 대조 PASS(3-dot·diff 밖 create_tokens 호출부 전수) · 카디르 codex QA approved(head 6c3ed63c4·realdb 37·뮤테이션 2·codex 세션 01a07c2d) · develop CI 29 success · 게이트 646a4d84 서명.
- main 대상 CI(이 PR)로 main 파일셋 preflight 재확認.

## 승격
선생님 결재(카드) 뒤 PO가 머지 → Cloud Build(GCP) main → prod 서빙 확認 → prod에서 카디르 재현 시나리오 1회 재실측(읽기·자기 계정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)