### PR TITLE
[SID:3380] fix(BE·감사 신뢰): draft doc 채팅 넛지 sender를 시스템 발행자로 고정

### DIFF
--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -1089,13 +1089,27 @@ async def maybe_nudge_draft_doc_shared_in_chat(
             ))
             await db.flush()  # UNIQUE(org_id, doc_id) 위반이면 여기서 IntegrityError.
 
+            # story #3380(BE·결함·감사 신뢰, 페드루 PO 確定 2026-09-07, 담롱 실사고) — 이
+            # 메시지는 시스템이 짓는 문장이지 sender_id가 실제로 쓴 게 아니다. DM 자체
+            # (어느 1:1 스레드에 나타나는가)는 여전히 requester=트리거한 사람 축을 그대로
+            # 쓴다(_get_or_create_approval_dm — 그 축은 "이 doc을 누가 mention했나"를 DM
+            # 상대로 삼는 기존 설계 그대로, 이 스토리 범위 밖) — 바뀌는 건 오직 "이 메시지의
+            # sender 명의"뿐: `_get_or_create_system_publisher`(events.py, story #2791 —
+            # 새 개념 발명 0, recipe_repeat_scheduler.py::_notify_owner_paused와 동형 재사용)
+            # 가 반환하는 org당 1개의 「시스템 발행」 anchor member로 sender_id를 고정한다.
+            # 트리거한 사람은 sender 명의를 안 빌리는 대신 msg_metadata.triggered_by_
+            # member_id로 감사 추적을 남긴다(누가 이 넛지를 유발했는지는 여전히 기록).
+            from app.routers.events import _get_or_create_system_publisher
+
+            system_member = await _get_or_create_system_publisher(db, org_id)
+
             conv = await _get_or_create_approval_dm(
                 db, org_id=org_id, project_id=project_id,
                 requester_id=sender_id, approver_id=doc_author_id,
             )
             msg = ConversationMessage(
                 conversation_id=conv.id,
-                sender_id=sender_id,
+                sender_id=system_member.id,
                 content=f"'{doc_title}' 문서가 채팅에서 논의됐는데 아직 draft — 결재 상신하시겠습니까?",
                 mentioned_ids=[doc_author_id],
                 msg_metadata={
@@ -1103,12 +1117,32 @@ async def maybe_nudge_draft_doc_shared_in_chat(
                         "audience": [str(doc_author_id)], "kind": "request", "expects_response": False,
                     },
                     "nudge_target": {"doc_id": str(doc_id), "kind": "draft_doc_chat_share"},
+                    "triggered_by_member_id": str(sender_id),
                 },
             )
             db.add(msg)
             await db.flush()
+            # story #3380 — 채널 릴레이(_msg_payload)가 SSE/webhook payload의 "sender" 필드를
+            # msg.sender_id(DB)가 아니라 이 인자 자체에서 조립한다. 이전엔 여기 `author`(doc
+            # 작성자)가 실려 DB의 sender_id(트리거한 사람)와 릴레이 표시가 서로 다른 두
+            # 사람을 가리키는 이중 오귀속이었다(실사고: Sprintable 원본=댄·릴레이 표시=담롱,
+            # 둘 다 문장을 안 씀) — 같은 system_member를 넘겨 두 층이 항상 일치하게 한다.
             from app.routers.conversations import _dispatch_conversation_event
-            await _dispatch_conversation_event(db, conv, msg, org_id, author)
+            await _dispatch_conversation_event(db, conv, msg, org_id, system_member)
+
+            # story #3380 AC — 감사축(activity_logs)도 채팅 sender와 같은 판정을 든다.
+            # channel_posts.py::_publish_channel_post 등 기존 platform-action 관례
+            # (actor_type="platform"·actor_id=None) 그대로 재사용 — 새 actor 유형 발명 0.
+            from app.services.activity_log import ActivityLogService
+
+            await ActivityLogService(db).record(
+                org_id=org_id, action="doc_chat_nudge_sent", actor_type="platform", actor_id=None,
+                entity_type="doc", entity_id=doc_id,
+                context={
+                    "conversation_id": str(conv.id), "message_id": str(msg.id),
+                    "triggered_by_member_id": str(sender_id), "doc_author_id": str(doc_author_id),
+                },
+            )
             if author.type == "human":
                 from app.services.notification_dispatch import dispatch_notification
                 await dispatch_notification(

--- a/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
+++ b/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
@@ -43,6 +43,7 @@ def _async_url() -> str:
 
 async def _session_factory():
     import app.models  # noqa: F401
+    from sqlalchemy import text as sa_text
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     from app.core.database import Base
@@ -51,6 +52,15 @@ async def _session_factory():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
+        # story #3380 — maybe_nudge_draft_doc_shared_in_chat이 이제 _get_or_create_
+        # system_publisher를 부른다. 그 ON CONFLICT가 겨누는 부분 유니크 인덱스(마이그
+        # 0258)는 raw op.execute라 ORM 모델 메타데이터에 없어 create_all이 못 만든다 —
+        # test_3475_publishing_metrics.py 등 기존 create_all 하네스의 동일 선례 그대로
+        # 직접 만든다(새 관례 발명 0).
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
@@ -103,7 +113,30 @@ async def _seed_org_project(session):
     project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
     session.add(project)
     await session.commit()
+    await _ensure_system_publisher_team_members_row(session, org.id, project.id)
     return org.id, project.id
+
+
+async def _ensure_system_publisher_team_members_row(session, org_id, project_id):
+    """story #3380 — maybe_nudge_draft_doc_shared_in_chat이 이제 sender/이벤트 sender로
+    _get_or_create_system_publisher(events.py)를 쓴다. 그 함수는 members+project_access
+    에만 쓰고 team_members 투영은 실 VIEW(0110)에 기댄다 — create_all 환경은 team_members
+    가 평범한 물리 테이블(위 관례 그대로, VIEW 아님, project_id NOT NULL)이라 투영이 안
+    되므로, 여기서 직접 같은 id로 TeamMember 행을 짝지어 심는다(conversation_messages.
+    sender_id FK가 요구). project_id는 _get_or_create_system_publisher 자신이 anchor로
+    쓰는 "org 내 가장 오래된 project"와 같은 값(이 헬퍼가 호출되는 시점엔 이 project가
+    유일하므로 항상 일치)."""
+    from app.models.team import TeamMember
+    from app.routers.events import _get_or_create_system_publisher
+
+    system_member = await _get_or_create_system_publisher(session, org_id)
+    await session.commit()
+    session.add(TeamMember(
+        id=system_member.id, org_id=org_id, project_id=project_id, user_id=None,
+        type="agent", name=system_member.name, role="member",
+    ))
+    await session.commit()
+    return system_member.id
 
 
 async def _seed_doc(session, org_id, project_id, author_id, *, status="draft", title="Doc"):
@@ -153,7 +186,10 @@ async def test_draft_doc_mention_nudges_author_once_even_if_called_twice():
         async with Session() as s:
             rows = await _count_nudge_messages(s, doc_id)
             assert len(rows) == 1
-            assert rows[0].sender_id == sender_id
+            # story #3380 — sender는 트리거한 사람(sender_id)이 아니라 시스템 발행자
+            # (_get_or_create_system_publisher)여야 한다(디테일은 test_3380*.py 참고).
+            assert rows[0].sender_id != sender_id
+            assert rows[0].msg_metadata["triggered_by_member_id"] == str(sender_id)
 
         async with Session() as s:
             await maybe_nudge_draft_doc_shared_in_chat(

--- a/backend/tests/test_3380_doc_nudge_system_sender_realdb.py
+++ b/backend/tests/test_3380_doc_nudge_system_sender_realdb.py
@@ -1,0 +1,240 @@
+"""story #3380(BE·결함·감사 신뢰, 페드루 PO 確定 2026-09-07, 담롱 실사고) — 제품이 생성하는
+draft-doc 채팅 넛지("결재 상신하시겠습니까?")가 그 문장을 쓰지 않은 「대화 참가자(mention을
+트리거한 사람)」 이름을 sender로 달고 나갔다(Sprintable 원본=댄·채널 릴레이 표시=담롱,
+둘 다 안 쓴 문장 — 두 층이 서로 다른 사람을 가리키는 이중 오귀속이었다).
+
+처방: `_get_or_create_system_publisher`(events.py, story #2791 — 새 개념 발명 0,
+recipe_repeat_scheduler.py::_notify_owner_paused와 동형 재사용)가 반환하는 org당 1개
+「시스템 발행」 anchor member로 (a) ConversationMessage.sender_id (b) `_dispatch_
+conversation_event`에 넘기는 sender 인자(=Event.payload.sender·채널 릴레이가 읽는
+바로 그 필드) 둘 다 고정한다. 트리거한 사람은 msg_metadata.triggered_by_member_id로만
+남는다(sender 명의를 안 빌림). 감사축(activity_logs)도 actor_type="platform"·
+actor_id=None(channel_posts.py 등 기존 platform-action 관례 재사용, 새 actor 유형 0).
+
+`_get_or_create_system_publisher`가 실 alembic 마이그(0258)의 부분 유니크 인덱스
+(ON CONFLICT 대상)에 의존해 test_2747의 create_all 하네스(team_members=평범한 물리
+테이블로 만드는 관례)와 안 맞는다(그 인덱스는 raw op.execute라 ORM 모델 메타데이터에
+없어 create_all이 못 만든다, 실측 확認) — 이 파일은 실 alembic 스키마 대상 하네스
+(test_2301_story_body_mentions_realdb.py·test_2288_command_center_gate_type_waiting_
+realdb.py 재사용, team_members는 그쪽 관례대로 진짜 VIEW)로 간다."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL, _make_org, _make_project, _session_factory
+from tests.test_2288_command_center_gate_type_waiting_realdb import _make_member
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_doc(session, org_id, project_id, author_id, *, status="draft", title="Doc"):
+    from app.models.doc import Doc
+
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, created_by=author_id,
+        status=status, title=title, slug=f"{title.lower()}-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc.id
+
+
+async def _get_nudge_message_and_event(session, doc_id):
+    from app.models.conversation import ConversationMessage
+    from app.models.event import Event
+
+    msg = (await session.execute(
+        select(ConversationMessage).where(
+            ConversationMessage.msg_metadata["nudge_target"]["doc_id"].astext == str(doc_id),
+        )
+    )).scalars().one()
+    event = (await session.execute(
+        select(Event).where(Event.source_entity_id == msg.id)
+    )).scalars().first()
+    return msg, event
+
+
+@pytest.mark.anyio
+async def test_nudge_sender_is_system_publisher_not_human_trigger():
+    """AC — 인간이 draft doc을 mention해도 넛지 sender는 시스템 발행자, 트리거한 사람은
+    msg_metadata에만 남는다. 채널 릴레이(Event.payload.sender)도 같은 신원이어야 한다."""
+    from app.routers.events import _get_or_create_system_publisher
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            author_id, _ = await _make_member(s, org.id, project.id)
+            trigger_id, _ = await _make_member(s, org.id, project.id)
+            doc_id = await _seed_doc(s, org.id, project.id, author_id)
+            system_publisher = await _get_or_create_system_publisher(s, org.id)
+            await s.commit()
+            system_publisher_id = system_publisher.id
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org.id, project_id=project.id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=trigger_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            msg, event = await _get_nudge_message_and_event(s, doc_id)
+            assert msg.sender_id == system_publisher_id, "Sprintable 원본 sender가 여전히 트리거한 사람이다"
+            assert msg.sender_id != trigger_id
+            assert msg.sender_id != author_id
+            assert msg.msg_metadata["triggered_by_member_id"] == str(trigger_id), "트리거 감사 추적 누락"
+
+            assert event is not None, "채널 릴레이가 읽는 Event 행이 없다"
+            assert event.sender_id == system_publisher_id
+            assert event.payload["sender"]["id"] == str(system_publisher_id), (
+                "채널 릴레이 표시(Event.payload.sender)가 Sprintable 원본과 다르다"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nudge_sender_is_system_publisher_when_trigger_is_agent():
+    """AC — 트리거가 에이전트여도(대화 참가자 이름을 빌리는 원 사고가 담롱 케이스에서
+    에이전트였다) 결과는 동일하게 시스템 발행자."""
+    from app.routers.events import _get_or_create_system_publisher
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            author_id, _ = await _make_member(s, org.id, project.id)
+            trigger_agent_id, _ = await _make_member(s, org.id, project.id, type_="agent")
+            doc_id = await _seed_doc(s, org.id, project.id, author_id)
+            system_publisher = await _get_or_create_system_publisher(s, org.id)
+            await s.commit()
+            system_publisher_id = system_publisher.id
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org.id, project_id=project.id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=trigger_agent_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            msg, event = await _get_nudge_message_and_event(s, doc_id)
+            assert msg.sender_id == system_publisher_id
+            assert msg.msg_metadata["triggered_by_member_id"] == str(trigger_agent_id)
+            assert event.payload["sender"]["id"] == str(system_publisher_id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nudge_writes_platform_activity_log():
+    """AC — 감사축(activity_logs)도 actor_type="platform"·actor_id=None."""
+    from app.models.activity_log import ActivityLog
+    from app.routers.events import _get_or_create_system_publisher
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            author_id, _ = await _make_member(s, org.id, project.id)
+            trigger_id, _ = await _make_member(s, org.id, project.id)
+            doc_id = await _seed_doc(s, org.id, project.id, author_id)
+            await _get_or_create_system_publisher(s, org.id)
+            await s.commit()
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org.id, project_id=project.id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=trigger_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            log = (await s.execute(
+                select(ActivityLog).where(
+                    ActivityLog.entity_type == "doc", ActivityLog.entity_id == doc_id,
+                    ActivityLog.action == "doc_chat_nudge_sent",
+                )
+            )).scalars().one()
+            assert log.actor_type == "platform"
+            assert log.actor_id is None
+            assert log.context["triggered_by_member_id"] == str(trigger_id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_reverting_sender_to_trigger_id_fails(monkeypatch):
+    """뮤테이션 — sender를 트리거로 되돌리면(옛 결함 재현) 이 테스트가 RED가 되는 것을
+    고정한다(위 positive 테스트들이 실제로 그 결함을 잡는다는 증거)."""
+    from app.routers.events import _get_or_create_system_publisher
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            author_id, _ = await _make_member(s, org.id, project.id)
+            trigger_id, _ = await _make_member(s, org.id, project.id)
+            doc_id = await _seed_doc(s, org.id, project.id, author_id)
+            await _get_or_create_system_publisher(s, org.id)
+            await s.commit()
+
+        class _TriggerAsSystemPublisher:
+            id = trigger_id
+            name = "Trigger"
+            type = "human"
+            avatar_url = None
+            runtime_type = None
+
+        async def _revert_to_trigger(db, org_id):
+            return _TriggerAsSystemPublisher()
+
+        # approval_delivery.py는 함수 안에서 `from app.routers.events import
+        # _get_or_create_system_publisher`를 그때그때 부른다(지연 import) — 원본 모듈
+        # 속성을 갈아끼우면 다음 호출부터 대역이 잡힌다(3635 뮤테이션 테스트와 동형 관례).
+        import app.routers.events as events_module
+        monkeypatch.setattr(events_module, "_get_or_create_system_publisher", _revert_to_trigger)
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org.id, project_id=project.id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=trigger_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            msg, _event = await _get_nudge_message_and_event(s, doc_id)
+            assert msg.sender_id == trigger_id, "뮤테이션이 걸리지 않았다(sender가 여전히 시스템 발행자)"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_d1f4afcb_draft_nudge_gate_and_event_suppress.py
+++ b/backend/tests/test_d1f4afcb_draft_nudge_gate_and_event_suppress.py
@@ -50,6 +50,7 @@ def _async_url() -> str:
 
 async def _session_factory():
     import app.models  # noqa: F401
+    from sqlalchemy import text as sa_text
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     from app.core.database import Base
@@ -58,6 +59,15 @@ async def _session_factory():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
+        # story #3380 — maybe_nudge_draft_doc_shared_in_chat이 이제 _get_or_create_
+        # system_publisher를 부른다. 그 ON CONFLICT가 겨누는 부분 유니크 인덱스(마이그
+        # 0258)는 raw op.execute라 ORM 모델 메타데이터에 없어 create_all이 못 만든다 —
+        # test_3475_publishing_metrics.py 등 기존 create_all 하네스의 동일 선례 그대로
+        # 직접 만든다(새 관례 발명 0).
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
@@ -118,6 +128,8 @@ async def _seed_org_project(session, *, slug_prefix="d1f4afcb"):
     project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
     session.add(project)
     await session.commit()
+    from tests.test_2747_draft_doc_chat_nudge_realdb import _ensure_system_publisher_team_members_row
+    await _ensure_system_publisher_team_members_row(session, org.id, project.id)
     return org.id, project.id
 
 


### PR DESCRIPTION
담롱 실사고(2026-09-03) — 제품이 생성한 넛지("결재 상신하시겠습니까?")가 그 문장을 안 쓴 「대화 참가자(mention을 트리거한 사람)」 이름을 sender로 달고 나갔다. 더 나쁘게도 **Sprintable 원본 DB 행(sender=트리거)과 채널 릴레이 표시(Event.payload.sender=author)가 서로 다른 두 사람을 가리키는 이중 오귀속**이었다(실사고: 원본=댄·릴레이=담롱, 둘 다 문장을 안 씀).

## 그라운딩
① 발신 자리: `conversations.py:2684`(send_message) → `approval_delivery.py::maybe_nudge_draft_doc_shared_in_chat`.
② sender 결정: `sender_id=sender.id`(트리거 그대로 재사용) — "누가 트리거했나"와 "누가 이 문장을 썼나"를 혼동. `_dispatch_conversation_event(...author)`의 `author` 인자가 별도로 `Event.payload.sender`를 조립해 DB 원본과 또 다른 값이 되는 것도 확認.
③ 시스템 발신자: 이미 존재 — `_get_or_create_system_publisher`(events.py, story #2791, org당 1개 anchor) — `recipe_repeat_scheduler.py::_notify_owner_paused`가 동형 패턴(system_member.id를 sender_id·requester_id 둘 다에)으로 이미 재사용 중.

## 처방
- `ConversationMessage.sender_id`·`_dispatch_conversation_event`에 넘기는 sender 인자 둘 다 system_member로 고정(두 층이 항상 일치).
- DM 자체(어느 1:1에 나타나는가)는 requester=트리거 축 그대로(범위 밖 축 보존).
- 트리거한 사람은 `msg_metadata.triggered_by_member_id`로 감사 추적.
- `activity_logs`에도 `actor_type="platform"`·`actor_id=None`(channel_posts.py 등 기존 platform-action 관례 재사용, `action="doc_chat_nudge_sent"`).

## 다른 자리 감사(전수 grep, 표 한 줄)
`approval_delivery.py`의 다른 4개 `ConversationMessage` 생성 자리(결재 요청·결과·discuss·토스)는 `sender=requester_id/resolver_id/tossed_by_id` — 전부 「그 워크플로 행위를 실제로 한 사람」이라 정상(이 결함 클래스 아님). `chat_command_catalog.py:327`(슬래시 명령 시스템 회신)은 `sender=명령 발신자 자신` — 같은 결함 클래스일 가능성 있으나 자기 자신에게만 보여 피해가 약함, 이 스토리 범위 밖(PO 판단 후보로 남김).

## Test plan
- [x] 신규 4건(sender=시스템 발행자·트리거=휴먼/에이전트 둘 다·`Event.payload.sender` 일치·`activity_log` actor_type=platform)
- [x] 뮤테이션 1(system_publisher를 트리거로 되돌리면 RED)
- [x] 기존 test_2747(7)·test_d1f4afcb(6) 전부 갱신 세팅(`_get_or_create_system_publisher`가 새로 요구하는 부분 유니크 인덱스·team_members 짝을 create_all 하네스에 추가, test_3475 등 기존 선례 재사용)+assertion 갱신 후 13/13 그린
- [x] `app.main` import 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)