### PR TITLE
[SID:3379] fix(BE·에이전트 온보딩): draft doc 채팅 넛지 — 기본 침묵으로 전환

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2675,16 +2675,22 @@ async def send_message(
         try:
             from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
 
+            # story #3379 — 「기본 침묵」 판정(최근 편집·superseded)에 doc_updated_at·
+            # superseded_by가 필요해 SELECT에 같이 얹는다(추가 쿼리 0, 기존 1회 SELECT 그대로).
             _docs = (await db.execute(
-                select(Doc.id, Doc.title, Doc.status, Doc.created_by).where(
+                select(
+                    Doc.id, Doc.title, Doc.status, Doc.created_by, Doc.updated_at, Doc.superseded_by,
+                ).where(
                     Doc.id.in_(_mentioned_doc_ids), Doc.org_id == org_id, Doc.deleted_at.is_(None),
                 )
             )).all()
-            for _doc_id, _doc_title, _doc_status, _doc_author_id in _docs:
+            for _doc_id, _doc_title, _doc_status, _doc_author_id, _doc_updated_at, _doc_superseded_by in _docs:
                 await maybe_nudge_draft_doc_shared_in_chat(
                     db, org_id=org_id, project_id=conv.project_id,
                     doc_id=_doc_id, doc_title=_doc_title, doc_status=_doc_status,
-                    doc_author_id=_doc_author_id, sender_id=sender.id,
+                    doc_author_id=_doc_author_id, doc_updated_at=_doc_updated_at,
+                    doc_superseded_by=_doc_superseded_by, sender_id=sender.id,
+                    trigger_message_content=msg.content,
                 )
         except Exception:  # noqa: BLE001 — 넛지 실패가 메시지 전송을 막지 않는다(best-effort).
             logger.warning("draft doc 넛지 배선 실패(비차단) message=%s", msg.id, exc_info=True)

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -1061,7 +1061,7 @@ async def maybe_nudge_draft_doc_shared_in_chat(
     trigger_message_content: str,
 ) -> None:
     """story #2747(2026-08-25, PO 판정) — draft 상태 문서가 채팅에서 mention(=논의)되는
-    순간, 작성자에게 「결재 상신 여부」를 묻는 1회성 넛지. 제품이 그 갈림 자체를 안
+    순간, 작성자에게 「검토 요청 여부」를 묻는 1회성 넛지. 제품이 그 갈림 자체를 안
     묻던 갭(선생님 실증 2건, 2026-08-18)의 처방 — 후보 a(설계 스케치)의 「묻기」 절반만
     이번 사이클 스코프(FE 뱃지·N회 카운트 nudge·에이전트 리마인더 격상은 각각 별도 스토리,
     PO 확定 2026-08-25).
@@ -1209,7 +1209,11 @@ async def maybe_nudge_draft_doc_shared_in_chat(
                     db, org_id=org_id, event_type="doc_draft_discussed_in_chat",
                     target_member_ids=[doc_author_id],
                     title="draft 문서가 채팅에서 논의됐습니다",
-                    body=f"'{doc_title}' — 결재 상신 여부를 확인해 주세요.",
+                    # 유나 CHANGES 2(2026-09-07, PR #4011) — 같은 함수가 같은 doc_author에게
+                    # 채팅 DM(위 content, 「검토 요청」)과 알림(이 body) 둘 다 보내는데,
+                    # 알림만 「결재 상신」으로 남으면 한 사람이 두 낱말을 읽는 자리라 낱말을
+                    # 맞춘다.
+                    body=f"'{doc_title}' — 검토 요청 여부를 확인해 주세요.",
                     reference_type="doc", reference_id=doc_id,
                     source_project_id=project_id, via_outbox=True,
                 )

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -1162,10 +1162,14 @@ async def maybe_nudge_draft_doc_shared_in_chat(
                 sender_id=system_member.id,
                 # story #3379 AC — 단정형("상신하시겠습니까?") 대신 두 갈래 문구. "논의됐다"가
                 # 곧 "상신 의사"라고 단정하지 않는다(최저 지능 에이전트가 그대로 따라도 논의
-                # 중인 문서가 결재로 안 가도록).
+                # 중인 문서가 결재로 안 가도록). 유나 카피 판정(2026-09-07, PR #4011 게이트
+                # CHANGES 1) — "결재 상신"은 doc 도메인 카탈로그에 0건, draft 상태 문서에서
+                # 사용자가 실제로 보는 낱말은 doc-status-rail.tsx가 못 박은 「검토 요청」
+                # (docs.docGateRequestReview). "결재"는 결과/이력의 말(결재 이력)이라 작성자
+                # 행위 문구와 층이 다름 — 「검토 요청」으로 교체.
                 content=(
-                    f"'{doc_title}' 문서가 채팅에서 논의됐습니다 — 이 내용이 확정본이면 결재 "
-                    "상신을, 아직 고칠 게 있으면 편집을 진행해 주세요."
+                    f"'{doc_title}' 문서가 채팅에서 논의됐습니다 — 이 내용이 확정본이면 검토 "
+                    "요청을, 아직 고칠 게 있으면 편집을 진행해 주세요."
                 ),
                 mentioned_ids=[doc_author_id],
                 msg_metadata={

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import event as sa_event
 from sqlalchemy import func, select
@@ -1015,6 +1016,36 @@ async def _has_open_external_publish_gate_for_doc(
     return row is not None
 
 
+# story #3379(에이전트 온보딩·오도, 페드루 PO 確定 2026-09-07, 담롱·댄 실사고 2026-09-03) —
+# 「채팅에서 논의됐다」를 상신 의사로 읽으면 안 된다: 논의는 대개 고칠 게 있어서 하는
+# 것이라 채팅 등장은 오히려 상신의 반대 신호인 자리가 많다. 트리거 메시지 자신의
+# content만 본다(PO 確定② — 대화 이력 스캔 X, 최저 비용·결정적). 잃는 것: 이 메시지
+# "전"에 오간 논의 문맥(예: 앞선 메시지에서 "이거 이제 안 맞는 것 같아요" 하고 다음
+# 메시지에서 doc을 mention)은 못 본다 — 트리거 메시지 자체에 신호가 없으면 넛지가 여전히
+# 뜬다(범위 밖으로 명시 선언, PO 채택).
+# "고치"/"바꾸"만으로는 모음축약형 활용(고쳐·바꿔 — 치+어→쳐, 꾸+어→꿔)을 못 잡는다
+# (한국어 어간 substring 매치의 알려진 한계) — 축약형을 별도 항목으로 병기.
+_DOC_REVISION_SIGNAL_WORDS: tuple[str, ...] = (
+    "수정", "정정", "교체", "폐기", "고치", "고쳐", "바꾸", "바꿔", "업데이트", "갱신",
+)
+
+
+def _message_signals_doc_still_being_revised(content: str) -> bool:
+    """순수함수 — 트리거 메시지 content에 «이 문서는 아직 고치는 중」류 신호가 있는지만
+    본다(다른 입력 없음, DB 접근 없음). `_DOC_REVISION_SIGNAL_WORDS` 중 하나라도 부분
+    일치하면 True(억제 신호)."""
+    if not content:
+        return False
+    return any(word in content for word in _DOC_REVISION_SIGNAL_WORDS)
+
+
+# story #3379 AC(a) — "최근 N분 안에 편집됐으면" 억제. 이 문서 도메인에 기존 관례가
+# 없어(grep 0건) 30분으로 잠정 고정 — 댓글수집류 백오프 상한(60분)보다 짧게 잡은 이유는
+# "편집 세션이 아직 진행 중일 가능성이 높은 창"만 억제하려는 것(PO 조정 여지, 새 설정
+# 노출 없음 — 이 스토리 범위 밖).
+_DOC_RECENTLY_EDITED_WINDOW_MINUTES = 30
+
+
 async def maybe_nudge_draft_doc_shared_in_chat(
     db: AsyncSession,
     *,
@@ -1024,7 +1055,10 @@ async def maybe_nudge_draft_doc_shared_in_chat(
     doc_title: str,
     doc_status: str,
     doc_author_id: uuid.UUID | None,
+    doc_updated_at: datetime,
+    doc_superseded_by: uuid.UUID | None,
     sender_id: uuid.UUID,
+    trigger_message_content: str,
 ) -> None:
     """story #2747(2026-08-25, PO 판정) — draft 상태 문서가 채팅에서 mention(=논의)되는
     순간, 작성자에게 「결재 상신 여부」를 묻는 1회성 넛지. 제품이 그 갈림 자체를 안
@@ -1053,11 +1087,27 @@ async def maybe_nudge_draft_doc_shared_in_chat(
     **시스템/이벤트 발신**(`msg_metadata['event']` 보유)이면 애초에 호출부(conversations.py
     ::send_message)가 이 함수를 부르지 않는다(사람의 대화 맥락에서만 넛지가 뜬다는
     전제 — 호출부 주석 참조).
-    """
+
+    story #3379(에이전트 온보딩·오도, 페드루 PO 確定 2026-09-07, 담롱·댄 실사고
+    2026-09-03) — 「기본 침묵」: draft doc이 채팅에서 참조됐다는 사실만으로 상신을
+    권하지 않는다("draft 제외"가 아니라 "논의 성격을 읽을 수 없으면 권하지 않는다").
+    아래 셋 중 하나면 넛지를 안 낸다: ⑤doc이 최근 `_DOC_RECENTLY_EDITED_WINDOW_MINUTES`
+    분 안에 편집됨(doc_updated_at) ⑥트리거 메시지 자신에 수정/정정/교체/폐기 계열
+    신호(`_message_signals_doc_still_being_revised`, 대화 이력 스캔 X — PO 確定) ⑦doc이
+    이미 다른 doc에 superseded 표기(doc_superseded_by). ①의 (org, doc) 전역 1회
+    reservation은 **그대로 안 건드린다**(더 엄격한 쪽이 이긴다, PO 確定 — 스토리 AC(d)
+    "같은 대화·같은 doc 최대 1회"는 이 전역 축에 자동 포함되는 상위 제약이라 새 표·새
+    인덱스 0)."""
     if doc_status != "draft" or not doc_author_id or not project_id:
         return
     if doc_author_id == sender_id:
         return  # 본인이 스스로 공유한 것 — 자기-알림 스킵(기존 관례 동형).
+    if doc_superseded_by is not None:
+        return  # story #3379 ⑦ — 이미 다른 doc으로 대체됨.
+    if datetime.now(timezone.utc) - doc_updated_at < timedelta(minutes=_DOC_RECENTLY_EDITED_WINDOW_MINUTES):
+        return  # story #3379 ⑤ — 아직 편집 세션이 진행 中일 가능성이 높은 창.
+    if _message_signals_doc_still_being_revised(trigger_message_content):
+        return  # story #3379 ⑥ — 트리거 메시지 자신이 "아직 고치는 중" 신호를 낸다.
 
     if await _has_open_external_publish_gate_for_doc(db, org_id=org_id, doc_id=doc_id):
         return  # story d1f4afcb AC2 — 이 doc은 이미 external_publish 게이트가 발행/반려를
@@ -1110,7 +1160,13 @@ async def maybe_nudge_draft_doc_shared_in_chat(
             msg = ConversationMessage(
                 conversation_id=conv.id,
                 sender_id=system_member.id,
-                content=f"'{doc_title}' 문서가 채팅에서 논의됐는데 아직 draft — 결재 상신하시겠습니까?",
+                # story #3379 AC — 단정형("상신하시겠습니까?") 대신 두 갈래 문구. "논의됐다"가
+                # 곧 "상신 의사"라고 단정하지 않는다(최저 지능 에이전트가 그대로 따라도 논의
+                # 중인 문서가 결재로 안 가도록).
+                content=(
+                    f"'{doc_title}' 문서가 채팅에서 논의됐습니다 — 이 내용이 확정본이면 결재 "
+                    "상신을, 아직 고칠 게 있으면 편집을 진행해 주세요."
+                ),
                 mentioned_ids=[doc_author_id],
                 msg_metadata={
                     "activation": {

--- a/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
+++ b/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
@@ -9,9 +9,15 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import select
+
+# story #3379 — maybe_nudge_draft_doc_shared_in_chat이 이제 doc_updated_at을 보고 "최근
+# 편집" 억제를 건다. 이 파일의 테스트는 그 축을 다루지 않으니 억제선(30분) 밖의 값으로
+# 고정해 새 억제 조건에 안 걸리게 한다(그 조건 자체는 test_d1f4afcb류가 별도로 검증).
+_STALE_ENOUGH_UPDATED_AT = datetime.now(timezone.utc) - timedelta(hours=1)
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
@@ -180,6 +186,8 @@ async def test_draft_doc_mention_nudges_author_once_even_if_called_twice():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -196,6 +204,8 @@ async def test_draft_doc_mention_nudges_author_once_even_if_called_twice():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -226,6 +236,8 @@ async def test_two_different_senders_sequential_still_nudge_author_once():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=sender_a,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -235,6 +247,8 @@ async def test_two_different_senders_sequential_still_nudge_author_once():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=sender_b,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -268,6 +282,8 @@ async def test_concurrent_mentions_still_nudge_author_once():
                     s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                     doc_title="온보딩 리서치", doc_status="draft",
                     doc_author_id=author_id, sender_id=sender_id,
+                    doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                    trigger_message_content="이 문서 확인 부탁드립니다",
                 )
                 await s.commit()
 
@@ -297,6 +313,8 @@ async def test_non_draft_doc_mention_does_not_nudge():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="확定 문서", doc_status="confirmed",
                 doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -323,6 +341,8 @@ async def test_self_share_does_not_nudge():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="내 문서", doc_status="draft",
                 doc_author_id=author_id, sender_id=author_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -362,6 +382,8 @@ async def test_delivery_failure_rolls_back_reservation_and_retry_succeeds():
                     s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                     doc_title="온보딩 리서치", doc_status="draft",
                     doc_author_id=author_id, sender_id=sender_id,
+                    doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                    trigger_message_content="이 문서 확인 부탁드립니다",
                 )
                 await s.commit()
 
@@ -382,6 +404,8 @@ async def test_delivery_failure_rolls_back_reservation_and_retry_succeeds():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -420,6 +444,8 @@ async def test_integrity_error_branch_discriminates_uq_dup_from_other_bidirectio
                     s, org_id=org_id, project_id=project_id, doc_id=dup_doc_id,
                     doc_title="온보딩 리서치", doc_status="draft",
                     doc_author_id=author_id, sender_id=sender_id,
+                    doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                    trigger_message_content="이 문서 확인 부탁드립니다",
                 )
                 await s.commit()
             async with Session() as s:
@@ -427,6 +453,8 @@ async def test_integrity_error_branch_discriminates_uq_dup_from_other_bidirectio
                     s, org_id=org_id, project_id=project_id, doc_id=dup_doc_id,
                     doc_title="온보딩 리서치", doc_status="draft",
                     doc_author_id=author_id, sender_id=sender_id,
+                    doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                    trigger_message_content="이 문서 확인 부탁드립니다",
                 )
                 await s.commit()
 
@@ -442,6 +470,8 @@ async def test_integrity_error_branch_discriminates_uq_dup_from_other_bidirectio
                     s, org_id=org_id, project_id=project_id, doc_id=ghost_doc_id,
                     doc_title="유령 문서", doc_status="draft",
                     doc_author_id=author_id, sender_id=sender_id,
+                    doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                    trigger_message_content="이 문서 확인 부탁드립니다",
                 )
                 await s.commit()
 

--- a/backend/tests/test_3379_doc_nudge_default_silence.py
+++ b/backend/tests/test_3379_doc_nudge_default_silence.py
@@ -1,0 +1,275 @@
+"""story #3379(에이전트 온보딩·오도, 페드루 PO 確定 2026-09-07, 담롱·댄 실사고
+2026-09-03) — 「기본 침묵」: draft doc이 채팅에서 참조됐다는 사실만으로 상신을 권하지
+않는다. "draft 제외"가 아니라 "논의 성격을 읽을 수 없으면 권하지 않는다"(댄·담롱
+프레이밍, PO 채택).
+
+이 파일은 두 층을 검증한다:
+① `_message_signals_doc_still_being_revised` — 순수함수(content → bool), DB 접근 0.
+② `maybe_nudge_draft_doc_shared_in_chat`의 신규 억제 3종(⑤최근 편집·⑥content 신호·
+   ⑦superseded) — d1f4afcb류 harness 재사용(create_all + system-publisher 인덱스,
+   새 관례 발명 0).
+
+PO 確定② — 신호(a)(b)(c)는 트리거 메시지 자신의 content만 본다(대화 이력 스캔 X).
+잃는 것: 이 메시지 "전"에 오간 논의 문맥은 못 본다 — 범위 밖으로 명시 선언.
+
+PO 確定① — 기존 (org, doc) 전역 1회 reservation(`DocChatNudgeDispatch`)은 그대로 —
+더 엄격한 쪽이 이긴다. 이 스토리의 AC(d)"같은 대화·같은 doc 최대 1회"는 그 축에
+자동 포함되는 상위 제약이라 새 표·새 인덱스 0 — 여기서는 그 전역 축이 여전히 서
+있다는 것만 회귀로 재확認한다(2d314c36류 회귀 방지, 같은 (org,doc) 두 번째 호출은
+신규 억제 3종과 무관하게 0건이어야 한다)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_d1f4afcb_draft_nudge_gate_and_event_suppress import (
+    _count_nudge_messages,
+    _seed_doc,
+    _seed_human_member,
+    _seed_org_project,
+    _session_factory,
+)
+
+# ①(순수함수) 테스트는 DB가 필요 없어 module-wide skip/destructive_schema 대상이 아니다
+# — 아래 실 PG 테스트(②)에만 개별로 건다.
+_realdb = [
+    pytest.mark.skipif(
+        not os.getenv("PARITY_TEST_DATABASE_URL") and not os.getenv("ALEMBIC_DATABASE_URL"),
+        reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요",
+    ),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ① 순수함수 — 표본 문장 각 1 + 음성 1 + 뮤테이션 1
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "이거 좀 수정해야 할 것 같아요",
+        "이 부분 정정 부탁드리는",
+        "v2로 교체하려고 논의 중이에요",
+        "이 규약은 이제 폐기 대상 아닌가요",
+        "여기 고쳐야 할 곳이 있어요",
+        "숫자를 좀 바꿔야 할 것 같은데",
+        "이거 업데이트 필요해 보여요",
+        "내용 갱신이 먼저일 것 같아요",
+    ],
+)
+def test_content_signal_detects_revision_words(content):
+    from app.services.approval_delivery import _message_signals_doc_still_being_revised
+
+    assert _message_signals_doc_still_being_revised(content) is True
+
+
+def test_content_signal_negative_on_neutral_mention():
+    from app.services.approval_delivery import _message_signals_doc_still_being_revised
+
+    assert _message_signals_doc_still_being_revised("이 문서 확인 부탁드립니다") is False
+    assert _message_signals_doc_still_being_revised("") is False
+    assert _message_signals_doc_still_being_revised(None) is False
+
+
+def test_content_signal_mutation_empty_word_list_fails(monkeypatch):
+    """뮤테이션 — 신호 낱말 목록을 비우면 «수정해야 할 것 같아요» 같은 명백한 신호도
+    놓친다(RED 재현, 검출 자체가 실제로 낱말 목록에 의존함을 증명)."""
+    import app.services.approval_delivery as mod
+
+    monkeypatch.setattr(mod, "_DOC_REVISION_SIGNAL_WORDS", ())
+    assert mod._message_signals_doc_still_being_revised("이거 좀 수정해야 할 것 같아요") is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ② 억제 3종 — 실 PG
+# ─────────────────────────────────────────────────────────────────────────────
+
+_STALE_ENOUGH_UPDATED_AT = datetime.now(timezone.utc) - timedelta(hours=1)
+_NEUTRAL_CONTENT = "이 문서 확인 부탁드립니다"
+
+
+@pytest.mark.anyio
+@_realdb[0]
+@_realdb[1]
+async def test_recently_edited_doc_suppresses_nudge():
+    """⑤ — doc_updated_at이 억제선(30분) 안이면 넛지가 안 뜬다."""
+    from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id, title="방금 편집한 문서")
+
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="방금 편집한 문서", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                doc_superseded_by=None, trigger_message_content=_NEUTRAL_CONTENT,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 0, f"최근 편집된 doc인데 넛지가 남: {len(rows)}건"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@_realdb[0]
+@_realdb[1]
+async def test_content_signal_suppresses_nudge():
+    """⑥ — 트리거 메시지 자신에 수정/정정/교체/폐기 신호가 있으면 넛지가 안 뜬다."""
+    from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id, title="논의 중인 문서")
+
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="논의 중인 문서", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 조항은 이제 폐기하는 게 맞을 것 같아요",
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 0, f"트리거 메시지에 폐기 신호가 있는데 넛지가 남: {len(rows)}건"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@_realdb[0]
+@_realdb[1]
+async def test_superseded_doc_suppresses_nudge():
+    """⑦ — doc_superseded_by가 설정돼 있으면(이미 다른 doc으로 대체) 넛지가 안 뜬다."""
+    from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id, title="구버전 문서")
+            replacement_id = await _seed_doc(s, org_id, project_id, author_id, title="신버전 문서")
+
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="구버전 문서", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=replacement_id,
+                trigger_message_content=_NEUTRAL_CONTENT,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 0, f"이미 superseded된 doc인데 넛지가 남: {len(rows)}건"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@_realdb[0]
+@_realdb[1]
+async def test_no_signal_still_nudges_regression():
+    """음성대조(회귀 0) — 셋 다 해당 없는 일반 draft doc은 기존대로 넛지가 뜬다(신규
+    억제 3종이 과잉 침묵으로 기능 자체를 죽이지 않았는지 확認)."""
+    from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id, title="평범한 draft")
+
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="평범한 draft", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content=_NEUTRAL_CONTENT,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 1, f"억제 신호 0건인데 넛지가 안 뜸(과도한 침묵): {len(rows)}건"
+            # 두 갈래 문구 확認(AC — 단정형 대신 "확정본이면 상신 / 고칠 게 있으면 편집").
+            assert "확정본이면" in rows[0].content and "고칠 게 있으면" in rows[0].content
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@_realdb[0]
+@_realdb[1]
+async def test_global_once_per_org_doc_reservation_still_holds_regression():
+    """PO 確定① 회귀 — AC(d)"같은 대화·같은 doc 최대 1회"는 기존 (org, doc) 전역 1회
+    reservation에 자동 포함된다(2d314c36류 회귀 방지). 신규 억제 3종과 무관하게, 억제
+    신호가 전혀 없는 두 번째 호출도 전역 reservation 때문에 0건이어야 한다."""
+    from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_a = await _seed_human_member(s, org_id, project_id, name="SenderA")
+            sender_b = await _seed_human_member(s, org_id, project_id, name="SenderB")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id, title="전역 1회 문서")
+
+        async def _call(sender_id):
+            async with Session() as s:
+                await maybe_nudge_draft_doc_shared_in_chat(
+                    s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                    doc_title="전역 1회 문서", doc_status="draft",
+                    doc_author_id=author_id, sender_id=sender_id,
+                    doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                    trigger_message_content=_NEUTRAL_CONTENT,
+                )
+                await s.commit()
+
+        await _call(sender_a)
+        await _call(sender_b)
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 1, f"작성자당 전역 1회가 깨짐: {len(rows)}건"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3379_doc_nudge_default_silence.py
+++ b/backend/tests/test_3379_doc_nudge_default_silence.py
@@ -3,11 +3,12 @@
 않는다. "draft 제외"가 아니라 "논의 성격을 읽을 수 없으면 권하지 않는다"(댄·담롱
 프레이밍, PO 채택).
 
-이 파일은 두 층을 검증한다:
-① `_message_signals_doc_still_being_revised` — 순수함수(content → bool), DB 접근 0.
-② `maybe_nudge_draft_doc_shared_in_chat`의 신규 억제 3종(⑤최근 편집·⑥content 신호·
-   ⑦superseded) — d1f4afcb류 harness 재사용(create_all + system-publisher 인덱스,
-   새 관례 발명 0).
+`maybe_nudge_draft_doc_shared_in_chat`의 신규 억제 3종(⑤최근 편집·⑥content 신호·
+⑦superseded)을 d1f4afcb류 harness(create_all + system-publisher 인덱스, 새 관례
+발명 0)로 실 PG 검증한다. `_message_signals_doc_still_being_revised` 순수함수 표본은
+DB가 필요 없어 별도 파일(test_3379_doc_nudge_signal_words.py, non-destructive)로 뺐다
+— 이 파일은 destructive_schema만 담는다(파일 하나=순수 destructive 전제로 도는 CI
+shard 러너와 정합, story #3186/8236bbc3 가드 회귀).
 
 PO 確定② — 신호(a)(b)(c)는 트리거 메시지 자신의 content만 본다(대화 이력 스캔 X).
 잃는 것: 이 메시지 "전"에 오간 논의 문맥은 못 본다 — 범위 밖으로 명시 선언.
@@ -33,12 +34,11 @@ from tests.test_d1f4afcb_draft_nudge_gate_and_event_suppress import (
     _session_factory,
 )
 
-# ①(순수함수) 테스트는 DB가 필요 없어 module-wide skip/destructive_schema 대상이 아니다
-# — 아래 실 PG 테스트(②)에만 개별로 건다.
-_realdb = [
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
     pytest.mark.skipif(
-        not os.getenv("PARITY_TEST_DATABASE_URL") and not os.getenv("ALEMBIC_DATABASE_URL"),
-        reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요",
+        not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요",
     ),
     pytest.mark.destructive_schema,
 ]
@@ -56,57 +56,11 @@ async def _dispose_global_engine_after_test():
     await _global_engine.dispose()
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# ① 순수함수 — 표본 문장 각 1 + 음성 1 + 뮤테이션 1
-# ─────────────────────────────────────────────────────────────────────────────
-
-@pytest.mark.parametrize(
-    "content",
-    [
-        "이거 좀 수정해야 할 것 같아요",
-        "이 부분 정정 부탁드리는",
-        "v2로 교체하려고 논의 중이에요",
-        "이 규약은 이제 폐기 대상 아닌가요",
-        "여기 고쳐야 할 곳이 있어요",
-        "숫자를 좀 바꿔야 할 것 같은데",
-        "이거 업데이트 필요해 보여요",
-        "내용 갱신이 먼저일 것 같아요",
-    ],
-)
-def test_content_signal_detects_revision_words(content):
-    from app.services.approval_delivery import _message_signals_doc_still_being_revised
-
-    assert _message_signals_doc_still_being_revised(content) is True
-
-
-def test_content_signal_negative_on_neutral_mention():
-    from app.services.approval_delivery import _message_signals_doc_still_being_revised
-
-    assert _message_signals_doc_still_being_revised("이 문서 확인 부탁드립니다") is False
-    assert _message_signals_doc_still_being_revised("") is False
-    assert _message_signals_doc_still_being_revised(None) is False
-
-
-def test_content_signal_mutation_empty_word_list_fails(monkeypatch):
-    """뮤테이션 — 신호 낱말 목록을 비우면 «수정해야 할 것 같아요» 같은 명백한 신호도
-    놓친다(RED 재현, 검출 자체가 실제로 낱말 목록에 의존함을 증명)."""
-    import app.services.approval_delivery as mod
-
-    monkeypatch.setattr(mod, "_DOC_REVISION_SIGNAL_WORDS", ())
-    assert mod._message_signals_doc_still_being_revised("이거 좀 수정해야 할 것 같아요") is False
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# ② 억제 3종 — 실 PG
-# ─────────────────────────────────────────────────────────────────────────────
-
 _STALE_ENOUGH_UPDATED_AT = datetime.now(timezone.utc) - timedelta(hours=1)
 _NEUTRAL_CONTENT = "이 문서 확인 부탁드립니다"
 
 
 @pytest.mark.anyio
-@_realdb[0]
-@_realdb[1]
 async def test_recently_edited_doc_suppresses_nudge():
     """⑤ — doc_updated_at이 억제선(30분) 안이면 넛지가 안 뜬다."""
     from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
@@ -137,8 +91,6 @@ async def test_recently_edited_doc_suppresses_nudge():
 
 
 @pytest.mark.anyio
-@_realdb[0]
-@_realdb[1]
 async def test_content_signal_suppresses_nudge():
     """⑥ — 트리거 메시지 자신에 수정/정정/교체/폐기 신호가 있으면 넛지가 안 뜬다."""
     from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
@@ -169,8 +121,6 @@ async def test_content_signal_suppresses_nudge():
 
 
 @pytest.mark.anyio
-@_realdb[0]
-@_realdb[1]
 async def test_superseded_doc_suppresses_nudge():
     """⑦ — doc_superseded_by가 설정돼 있으면(이미 다른 doc으로 대체) 넛지가 안 뜬다."""
     from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
@@ -202,8 +152,6 @@ async def test_superseded_doc_suppresses_nudge():
 
 
 @pytest.mark.anyio
-@_realdb[0]
-@_realdb[1]
 async def test_no_signal_still_nudges_regression():
     """음성대조(회귀 0) — 셋 다 해당 없는 일반 draft doc은 기존대로 넛지가 뜬다(신규
     억제 3종이 과잉 침묵으로 기능 자체를 죽이지 않았는지 확認)."""
@@ -230,15 +178,13 @@ async def test_no_signal_still_nudges_regression():
         async with Session() as s:
             rows = await _count_nudge_messages(s, doc_id)
             assert len(rows) == 1, f"억제 신호 0건인데 넛지가 안 뜸(과도한 침묵): {len(rows)}건"
-            # 두 갈래 문구 확認(AC — 단정형 대신 "확정본이면 상신 / 고칠 게 있으면 편집").
+            # 두 갈래 문구 확認(AC — 단정형 대신 "확정본이면 검토 요청 / 고칠 게 있으면 편집").
             assert "확정본이면" in rows[0].content and "고칠 게 있으면" in rows[0].content
     finally:
         await engine.dispose()
 
 
 @pytest.mark.anyio
-@_realdb[0]
-@_realdb[1]
 async def test_global_once_per_org_doc_reservation_still_holds_regression():
     """PO 確定① 회귀 — AC(d)"같은 대화·같은 doc 최대 1회"는 기존 (org, doc) 전역 1회
     reservation에 자동 포함된다(2d314c36류 회귀 방지). 신규 억제 3종과 무관하게, 억제

--- a/backend/tests/test_3379_doc_nudge_signal_words.py
+++ b/backend/tests/test_3379_doc_nudge_signal_words.py
@@ -1,0 +1,45 @@
+"""story #3379(에이전트 온보딩·오도, 페드루 PO 確定 2026-09-07) — `_message_signals_
+doc_still_being_revised`(순수함수, content → bool) 표본 테스트. DB 접근 0 — realdb 억제
+3종 통합 검증은 test_3379_doc_nudge_default_silence.py(destructive_schema) 몫이라 이
+파일은 섞지 않는다(destructive_schema shard가 파일 하나=순수 destructive 전제로 돌아
+비-destructive 테스트가 섞이면 conftest 가드가 collection 자체를 차단한다 — story
+#3186/8236bbc3)."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "이거 좀 수정해야 할 것 같아요",
+        "이 부분 정정 부탁드리는",
+        "v2로 교체하려고 논의 중이에요",
+        "이 규약은 이제 폐기 대상 아닌가요",
+        "여기 고쳐야 할 곳이 있어요",
+        "숫자를 좀 바꿔야 할 것 같은데",
+        "이거 업데이트 필요해 보여요",
+        "내용 갱신이 먼저일 것 같아요",
+    ],
+)
+def test_content_signal_detects_revision_words(content):
+    from app.services.approval_delivery import _message_signals_doc_still_being_revised
+
+    assert _message_signals_doc_still_being_revised(content) is True
+
+
+def test_content_signal_negative_on_neutral_mention():
+    from app.services.approval_delivery import _message_signals_doc_still_being_revised
+
+    assert _message_signals_doc_still_being_revised("이 문서 확인 부탁드립니다") is False
+    assert _message_signals_doc_still_being_revised("") is False
+    assert _message_signals_doc_still_being_revised(None) is False
+
+
+def test_content_signal_mutation_empty_word_list_fails(monkeypatch):
+    """뮤테이션 — 신호 낱말 목록을 비우면 «수정해야 할 것 같아요» 같은 명백한 신호도
+    놓친다(RED 재현, 검출 자체가 실제로 낱말 목록에 의존함을 증명)."""
+    import app.services.approval_delivery as mod
+
+    monkeypatch.setattr(mod, "_DOC_REVISION_SIGNAL_WORDS", ())
+    assert mod._message_signals_doc_still_being_revised("이거 좀 수정해야 할 것 같아요") is False

--- a/backend/tests/test_3380_doc_nudge_system_sender_realdb.py
+++ b/backend/tests/test_3380_doc_nudge_system_sender_realdb.py
@@ -20,9 +20,15 @@ realdb.py 재사용, team_members는 그쪽 관례대로 진짜 VIEW)로 간다.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import select
+
+# story #3379 — maybe_nudge_draft_doc_shared_in_chat이 이제 doc_updated_at을 보고 "최근
+# 편집" 억제를 건다. 이 파일의 테스트는 그 축을 다루지 않으니 억제선(30분) 밖의 값으로
+# 고정해 새 억제 조건에 안 걸리게 한다(그 조건 자체는 test_d1f4afcb류가 별도로 검증).
+_STALE_ENOUGH_UPDATED_AT = datetime.now(timezone.utc) - timedelta(hours=1)
 
 from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL, _make_org, _make_project, _session_factory
 from tests.test_2288_command_center_gate_type_waiting_realdb import _make_member
@@ -96,6 +102,8 @@ async def test_nudge_sender_is_system_publisher_not_human_trigger():
                 s, org_id=org.id, project_id=project.id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=trigger_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -139,6 +147,8 @@ async def test_nudge_sender_is_system_publisher_when_trigger_is_agent():
                 s, org_id=org.id, project_id=project.id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=trigger_agent_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -174,6 +184,8 @@ async def test_nudge_writes_platform_activity_log():
                 s, org_id=org.id, project_id=project.id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=trigger_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -230,6 +242,8 @@ async def test_mutation_reverting_sender_to_trigger_id_fails(monkeypatch):
                 s, org_id=org.id, project_id=project.id, doc_id=doc_id,
                 doc_title="온보딩 리서치", doc_status="draft",
                 doc_author_id=author_id, sender_id=trigger_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 

--- a/backend/tests/test_d1f4afcb_draft_nudge_gate_and_event_suppress.py
+++ b/backend/tests/test_d1f4afcb_draft_nudge_gate_and_event_suppress.py
@@ -15,10 +15,17 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import BackgroundTasks
 from sqlalchemy import select
+
+# story #3379 — maybe_nudge_draft_doc_shared_in_chat이 이제 doc_updated_at을 보고 "최근
+# 편집" 억제를 건다. 이 파일의 기존 테스트(게이트·이벤트 억제)는 그 축을 다루지 않으니
+# 억제선(30분) 밖의 값으로 고정한다(신규 억제 3종 자체의 회귀는 이 스토리의 새 테스트
+# 파일에서 별도 검증).
+_STALE_ENOUGH_UPDATED_AT = datetime.now(timezone.utc) - timedelta(hours=1)
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
@@ -209,6 +216,8 @@ async def test_doc_with_open_external_publish_gate_does_not_nudge(gate_status):
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="3바퀴 draft", doc_status="draft",
                 doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -239,6 +248,8 @@ async def test_doc_with_approved_external_publish_gate_still_nudges():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="완료된 산출물", doc_status="draft",
                 doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -270,6 +281,8 @@ async def test_gate_for_different_doc_does_not_suppress_nudge():
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
                 doc_title="타깃 문서", doc_status="draft",
                 doc_author_id=author_id, sender_id=sender_id,
+                doc_updated_at=_STALE_ENOUGH_UPDATED_AT, doc_superseded_by=None,
+                trigger_message_content="이 문서 확인 부탁드립니다",
             )
             await s.commit()
 
@@ -336,6 +349,15 @@ async def test_organic_chat_message_mentioning_draft_doc_still_nudges():
             author_id = await _seed_human_member(s, org_id, project_id, name="Author")
             sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
             doc_id = await _seed_doc(s, org_id, project_id, author_id, title="논의된 문서")
+            # story #3379 ⑤ — 방금 seed한 doc은 updated_at이 "지금"이라 새 "최근 편집"
+            # 억제(30분)에 그대로 걸린다. 이 테스트의 취지(organic mention은 그 축과
+            # 무관하게 뜬다)를 지키려면 억제선 밖으로 backdate 필요.
+            from sqlalchemy import text as _sa_text
+            await s.execute(
+                _sa_text("UPDATE docs SET updated_at = now() - interval '1 hour' WHERE id = :id"),
+                {"id": str(doc_id)},
+            )
+            await s.commit()
 
             from app.routers.events import _get_or_create_event_conversation
 

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,5 @@
 {
   "_snapshot_policy": "story #3558(2026-09-06) — CI 실측 전수 재측정(run 34011626732, 8개 shard-durations 산출물 병합, DB 준비 제외 순수 pytest wall time). 이전 스냅샷(story #3383, 로컬×6 추정)을 대체 — 로컬 추정이 아니라 실 CI 값이라 재측정 기준(a)(b)(c)는 그대로 두되 근거가 더 강해졌다: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐. story #3558의 shard-durations 산출물+경고 대조가 이 스냅샷의 노후화를 지속 감시한다.",
-  "_drift_remeasure_procedure": "story #3642(2026-09-07, PO 確定) — 3396 러너 정규화 가드 초과가 반복될 때(특히 3396 W×3 여유축·3642 drift 3-run 스트릭 ::warning이 뜬 뒤) 개별 파일을 재측정하는 절차. 전수 재측정(#3558, measured_at)과 달리 이건 «몇 개 파일만» 좁게 고친다. ① gh api runs/{run_id}로 run_attempt 확認 — required 잡이 최초 시도에서 실패/타임아웃하면 GitHub이 자동 재시도해 그 run의 최신 attempt는 성공한 «깨끗한» 로그로 덮인다(gh run view --log가 항상 최신 attempt만 보여준다) — 원인이 된 실사고 숫자는 attempt=1(또는 실패한 attempt)의 job에서만 보인다: `gh api repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{n}/jobs`로 그 attempt의 job id를 찾고 `gh api repos/{owner}/{repo}/actions/jobs/{job_id}/logs`로 원문을 받는다. ② 로그에서 `러너 정규화 판정선: X초(... 중앙값 배율 ×R ...)` 줄로 그 run의 median 배율 R을 읽고, 문제 파일의 `elapsed: Es` 를 `E/R`로 나눠 **러너 정규화값**(그 러너가 정상 속도였다면 걸렸을 시간)을 낸다. ③ 서로 다른 run(가급적 2개 이상, timeout으로 cancel된 run은 median 표본이 작아 편향될 수 있어 참고만) 정규화값을 평균해 새 weight로 등재 — `source`에 각 run/attempt/job id와 계산식을 남긴다(재현 가능하게). ④ 갱신 뒤 `partition()` 결과로 샤드 총합이 여전히 균형인지(#3642 test_shard_balance_stays_even_after_remeasure) 확認 — 그리디 LPT가 weight 합 기준이라 보통 자동으로 풀린다. 주기: 고정 스케줄 없음 — 3642 drift ::warning(3-run 연속)이 뜨거나 3396 가드가 반복 걸리는 파일이 보이면 그때.",
   "measured_at": "2026-09-06",
   "files": [
     {
@@ -25,8 +24,8 @@
     },
     {
       "file": "tests/test_2813_gate_github_check_realdb.py",
-      "sec": 79.0,
-      "source": "story-3642-drift-remeasure(2026-09-07, PO 실사고 3건 재실측 — 각 run의 러너 정규화 median 배율로 나눈 정규화값 평균: run 34103152060 attempt1 job 101682050718(131s÷median×1.71≈76.6s)·run 34112978612 attempt1 job 101713259910(162s÷median×2.00≈81.0s) 두 완주 run 평균 79s. run 34112876593 attempt1 job 101712947116(160s)은 30분 timeout으로 cancel돼 median 표본이 작아(29개, 조기절단 편향) 참고만 하고 평균엔 미반영. 기존 45.0s는 2026-09-06 정상부하 run 1건뿐이라(story-3558) 느린 러너 날의 실제 무게를 못 담았다."
+      "sec": 45.0,
+      "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
     },
     {
       "file": "tests/test_3360_site_posts.py",
@@ -350,8 +349,8 @@
     },
     {
       "file": "tests/test_3516_channel_post_comments.py",
-      "sec": 55.0,
-      "source": "story-3642-drift-remeasure(2026-09-07, PO 실사고 재실측 — 정규화값 평균: run 34103152060 attempt1 job 101682050718(68s÷median×1.71≈39.8s)·run 34112978612 attempt1 job 101713259910(142s÷median×2.00≈71.0s) 평균 55s. 두 run 편차가 커(39.8~71.0s) 다음 3 run 실측으로 재확認 필요(AC1) — run 34112876593(154s, cancel로 median 미확定)도 참고."
+      "sec": 33.0,
+      "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
     },
     {
       "file": "tests/test_3516_comment_reply.py",
@@ -1059,11 +1058,6 @@
       "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
     },
     {
-      "file": "tests/test_3631_role_templates_content_group.py",
-      "sec": 1.0,
-      "source": "story-3631(2026-09-07, 로컬 실측 — test_2648과 동형 규모(role_templates 임시 테이블+마이그 upgrade/downgrade 2회 왕복), 0.21s wall — 인접 sibling(test_2635/2648)과 같은 자릿수로 등재)"
-    },
-    {
       "file": "tests/test_2637_preset_block_template_seed.py",
       "sec": 1.0,
       "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
@@ -1145,8 +1139,8 @@
     },
     {
       "file": "tests/test_3414_publication_command_cron_retry.py",
-      "sec": 33.0,
-      "source": "story-3642-drift-remeasure(2026-09-07 — 3396 W×2 초과 파일 전수 스윕 중 발견, 2 run 연속 초과: run 34103152060 attempt1(46s÷median×1.71≈26.9s)·run 34112978612 attempt1(79s÷median×2.00≈39.5s) 평균 33s. 기존 13.0s는 story-3562 분할 시 «테스트 개수 비중» 배분값이라 실측이 아니었다(잠정값 딱지 그대로였던 자리)."
+      "sec": 13.0,
+      "source": "story-3562-split-3414-publication-command(2026-09-06, 원본 22건·실측 40.0s(run 34011626732)를 3-way 분할 후 로컬 raw pytest 비중(cron_retry 10건 7.57s/총 24.81s ≈ 31%)으로 배분한 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
       "file": "tests/test_3414_publication_command_edges.py",
@@ -1250,13 +1244,8 @@
     },
     {
       "file": "tests/test_3498_generation_budget.py",
-      "sec": 52.0,
-      "source": "story-3619(2026-09-07) — #3971 run 34089668525 shard 4에서 이 파일(당시 25테스트·등재 42s) 격리실행이 100s>88s로 60초 가드 초과. 즉시 rerun(같은 run) 40.30s로 재현이 러너 경합에 크게 좌우됨을 확認. 조각①/⑤/PUT3종(11테스트)을 test_3498_generation_budget_evidence_and_config.py로 분리(원인 실측·분리 판단은 그 파일 docstring) — 이 파일에 남은 12/25 비율로 100s를 안분(12/25*100=52.0)해 등재, 경합 재발까지 감안한 보수값(40.30s 기준 안분 21.0s가 아니라 100s 기준 안분을 택함)"
-    },
-    {
-      "file": "tests/test_3498_generation_budget_evidence_and_config.py",
-      "sec": 48.0,
-      "source": "story-3619(2026-09-07) — test_3498_generation_budget.py 분리 신설분(조각①·⑤·PUT3종, 11테스트). #3971 run 34089668525 100s(25테스트)를 11/25 비율로 안분(11/25*100=44.0, 반올림 여유 48.0) — 로컬 격리측정 7.28s(무경합)와 별개로 CI 경합 배율을 그대로 반영"
+      "sec": 42.0,
+      "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
     },
     {
       "file": "tests/test_3506_utm_attribution.py",
@@ -1265,8 +1254,8 @@
     },
     {
       "file": "tests/test_3502_insights_board.py",
-      "sec": 22.0,
-      "source": "story-3604-insights-board-durations(PR#3959 CI 실측 — run 34078092461 job 101608057452, elapsed 22s. 로컬 격리측정 6.65~6.68s×2배 잠정값 14s보다 CI가 더 느렸다 — CPU-bound app.main import 없는 파일도 CI 배율이 로컬 대비 3x대. 실측치로 갱신)"
+      "sec": 14.0,
+      "source": "story-3604-insights-board-durations(원인 실측: from app.main import app 1회 비용 ~3.4s(로컬 무경합)가 이 파일에 섞여 있어 등재 39s 대비 경합 시 80s까지 늘던 원인 — 조각②(HTTP 라우터 6개 테스트, app.main 소비)를 test_3502_insights_board_endpoints.py로 분리. 남은 14개는 list_insights_board를 서비스 함수로 직접 부르며 app.main 무관 — 격리 uv run pytest 프로세스(ci.yml per-file 루프와 동형) 2회 로컬 실측 6.65~6.68s, 2배 안전마진 반영한 14s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
       "file": "tests/test_3510_member_role_sync.py",
@@ -1465,8 +1454,8 @@
     },
     {
       "file": "tests/test_3502_insights_board_endpoints.py",
-      "sec": 25.0,
-      "source": "story-3604-insights-board-durations(PR#3959 CI 실측 — run 34078092461 job 101608057407, elapsed 25s. 로컬 격리측정 4.63~4.85s×2배 잠정값 10s보다 CI가 더 느렸다. 실측치로 갱신)"
+      "sec": 10.0,
+      "source": "story-3604-insights-board-durations(신규 분리 파일 — story #3502 조각② HTTP 라우터 6개 테스트, from app.main import app 1회 비용 ~3.4s 포함. 격리 uv run pytest 프로세스 2회 로컬 실측 4.63~4.85s, 2배 안전마진 반영한 10s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     },
     {
       "file": "tests/test_3603_connection_last_error.py",
@@ -1512,6 +1501,11 @@
       "file": "tests/test_3645_evidence_asset_hook_keys.py",
       "sec": 41.0,
       "source": "story-3645-evidence-asset-hook-keys(PR #4002 CI 가드 발견 — 로컬 raw pytest 11건 6.81s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 41s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3379_doc_nudge_default_silence.py",
+      "sec": 14.5,
+      "source": "story-3379-doc-nudge-default-silence(신규 파일 — 5건, PR #4011 CI \"destructive schema weights registered\" 가드가 미등재로 잡으며 출력한 평균 폴백값(14.5s) 그대로 등재, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,5 +1,6 @@
 {
   "_snapshot_policy": "story #3558(2026-09-06) — CI 실측 전수 재측정(run 34011626732, 8개 shard-durations 산출물 병합, DB 준비 제외 순수 pytest wall time). 이전 스냅샷(story #3383, 로컬×6 추정)을 대체 — 로컬 추정이 아니라 실 CI 값이라 재측정 기준(a)(b)(c)는 그대로 두되 근거가 더 강해졌다: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐. story #3558의 shard-durations 산출물+경고 대조가 이 스냅샷의 노후화를 지속 감시한다.",
+  "_drift_remeasure_procedure": "story #3642(2026-09-07, PO 確定) — 3396 러너 정규화 가드 초과가 반복될 때(특히 3396 W×3 여유축·3642 drift 3-run 스트릭 ::warning이 뜬 뒤) 개별 파일을 재측정하는 절차. 전수 재측정(#3558, measured_at)과 달리 이건 «몇 개 파일만» 좁게 고친다. ① gh api runs/{run_id}로 run_attempt 확認 — required 잡이 최초 시도에서 실패/타임아웃하면 GitHub이 자동 재시도해 그 run의 최신 attempt는 성공한 «깨끗한» 로그로 덮인다(gh run view --log가 항상 최신 attempt만 보여준다) — 원인이 된 실사고 숫자는 attempt=1(또는 실패한 attempt)의 job에서만 보인다: `gh api repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{n}/jobs`로 그 attempt의 job id를 찾고 `gh api repos/{owner}/{repo}/actions/jobs/{job_id}/logs`로 원문을 받는다. ② 로그에서 `러너 정규화 판정선: X초(... 중앙값 배율 ×R ...)` 줄로 그 run의 median 배율 R을 읽고, 문제 파일의 `elapsed: Es` 를 `E/R`로 나눠 **러너 정규화값**(그 러너가 정상 속도였다면 걸렸을 시간)을 낸다. ③ 서로 다른 run(가급적 2개 이상, timeout으로 cancel된 run은 median 표본이 작아 편향될 수 있어 참고만) 정규화값을 평균해 새 weight로 등재 — `source`에 각 run/attempt/job id와 계산식을 남긴다(재현 가능하게). ④ 갱신 뒤 `partition()` 결과로 샤드 총합이 여전히 균형인지(#3642 test_shard_balance_stays_even_after_remeasure) 확認 — 그리디 LPT가 weight 합 기준이라 보통 자동으로 풀린다. 주기: 고정 스케줄 없음 — 3642 drift ::warning(3-run 연속)이 뜨거나 3396 가드가 반복 걸리는 파일이 보이면 그때.",
   "measured_at": "2026-09-06",
   "files": [
     {
@@ -24,8 +25,8 @@
     },
     {
       "file": "tests/test_2813_gate_github_check_realdb.py",
-      "sec": 45.0,
-      "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
+      "sec": 79.0,
+      "source": "story-3642-drift-remeasure(2026-09-07, PO 실사고 3건 재실측 — 각 run의 러너 정규화 median 배율로 나눈 정규화값 평균: run 34103152060 attempt1 job 101682050718(131s÷median×1.71≈76.6s)·run 34112978612 attempt1 job 101713259910(162s÷median×2.00≈81.0s) 두 완주 run 평균 79s. run 34112876593 attempt1 job 101712947116(160s)은 30분 timeout으로 cancel돼 median 표본이 작아(29개, 조기절단 편향) 참고만 하고 평균엔 미반영. 기존 45.0s는 2026-09-06 정상부하 run 1건뿐이라(story-3558) 느린 러너 날의 실제 무게를 못 담았다."
     },
     {
       "file": "tests/test_3360_site_posts.py",
@@ -349,8 +350,8 @@
     },
     {
       "file": "tests/test_3516_channel_post_comments.py",
-      "sec": 33.0,
-      "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
+      "sec": 55.0,
+      "source": "story-3642-drift-remeasure(2026-09-07, PO 실사고 재실측 — 정규화값 평균: run 34103152060 attempt1 job 101682050718(68s÷median×1.71≈39.8s)·run 34112978612 attempt1 job 101713259910(142s÷median×2.00≈71.0s) 평균 55s. 두 run 편차가 커(39.8~71.0s) 다음 3 run 실측으로 재확認 필요(AC1) — run 34112876593(154s, cancel로 median 미확定)도 참고."
     },
     {
       "file": "tests/test_3516_comment_reply.py",
@@ -1058,6 +1059,11 @@
       "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
     },
     {
+      "file": "tests/test_3631_role_templates_content_group.py",
+      "sec": 1.0,
+      "source": "story-3631(2026-09-07, 로컬 실측 — test_2648과 동형 규모(role_templates 임시 테이블+마이그 upgrade/downgrade 2회 왕복), 0.21s wall — 인접 sibling(test_2635/2648)과 같은 자릿수로 등재)"
+    },
+    {
       "file": "tests/test_2637_preset_block_template_seed.py",
       "sec": 1.0,
       "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
@@ -1139,8 +1145,8 @@
     },
     {
       "file": "tests/test_3414_publication_command_cron_retry.py",
-      "sec": 13.0,
-      "source": "story-3562-split-3414-publication-command(2026-09-06, 원본 22건·실측 40.0s(run 34011626732)를 3-way 분할 후 로컬 raw pytest 비중(cron_retry 10건 7.57s/총 24.81s ≈ 31%)으로 배분한 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 33.0,
+      "source": "story-3642-drift-remeasure(2026-09-07 — 3396 W×2 초과 파일 전수 스윕 중 발견, 2 run 연속 초과: run 34103152060 attempt1(46s÷median×1.71≈26.9s)·run 34112978612 attempt1(79s÷median×2.00≈39.5s) 평균 33s. 기존 13.0s는 story-3562 분할 시 «테스트 개수 비중» 배분값이라 실측이 아니었다(잠정값 딱지 그대로였던 자리)."
     },
     {
       "file": "tests/test_3414_publication_command_edges.py",
@@ -1244,8 +1250,13 @@
     },
     {
       "file": "tests/test_3498_generation_budget.py",
-      "sec": 42.0,
-      "source": "story-3558-run-34011626732(2026-09-06, 부하 정상 run 1건 실측 — 잠정값. actions/upload-artifact shard-durations-*·DB 준비 제외 순수 pytest wall time. 기존 로컬×6 추정 스냅샷을 대체)"
+      "sec": 52.0,
+      "source": "story-3619(2026-09-07) — #3971 run 34089668525 shard 4에서 이 파일(당시 25테스트·등재 42s) 격리실행이 100s>88s로 60초 가드 초과. 즉시 rerun(같은 run) 40.30s로 재현이 러너 경합에 크게 좌우됨을 확認. 조각①/⑤/PUT3종(11테스트)을 test_3498_generation_budget_evidence_and_config.py로 분리(원인 실측·분리 판단은 그 파일 docstring) — 이 파일에 남은 12/25 비율로 100s를 안분(12/25*100=52.0)해 등재, 경합 재발까지 감안한 보수값(40.30s 기준 안분 21.0s가 아니라 100s 기준 안분을 택함)"
+    },
+    {
+      "file": "tests/test_3498_generation_budget_evidence_and_config.py",
+      "sec": 48.0,
+      "source": "story-3619(2026-09-07) — test_3498_generation_budget.py 분리 신설분(조각①·⑤·PUT3종, 11테스트). #3971 run 34089668525 100s(25테스트)를 11/25 비율로 안분(11/25*100=44.0, 반올림 여유 48.0) — 로컬 격리측정 7.28s(무경합)와 별개로 CI 경합 배율을 그대로 반영"
     },
     {
       "file": "tests/test_3506_utm_attribution.py",
@@ -1254,8 +1265,8 @@
     },
     {
       "file": "tests/test_3502_insights_board.py",
-      "sec": 14.0,
-      "source": "story-3604-insights-board-durations(원인 실측: from app.main import app 1회 비용 ~3.4s(로컬 무경합)가 이 파일에 섞여 있어 등재 39s 대비 경합 시 80s까지 늘던 원인 — 조각②(HTTP 라우터 6개 테스트, app.main 소비)를 test_3502_insights_board_endpoints.py로 분리. 남은 14개는 list_insights_board를 서비스 함수로 직접 부르며 app.main 무관 — 격리 uv run pytest 프로세스(ci.yml per-file 루프와 동형) 2회 로컬 실측 6.65~6.68s, 2배 안전마진 반영한 14s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 22.0,
+      "source": "story-3604-insights-board-durations(PR#3959 CI 실측 — run 34078092461 job 101608057452, elapsed 22s. 로컬 격리측정 6.65~6.68s×2배 잠정값 14s보다 CI가 더 느렸다 — CPU-bound app.main import 없는 파일도 CI 배율이 로컬 대비 3x대. 실측치로 갱신)"
     },
     {
       "file": "tests/test_3510_member_role_sync.py",
@@ -1454,8 +1465,8 @@
     },
     {
       "file": "tests/test_3502_insights_board_endpoints.py",
-      "sec": 10.0,
-      "source": "story-3604-insights-board-durations(신규 분리 파일 — story #3502 조각② HTTP 라우터 6개 테스트, from app.main import app 1회 비용 ~3.4s 포함. 격리 uv run pytest 프로세스 2회 로컬 실측 4.63~4.85s, 2배 안전마진 반영한 10s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 25.0,
+      "source": "story-3604-insights-board-durations(PR#3959 CI 실측 — run 34078092461 job 101608057407, elapsed 25s. 로컬 격리측정 4.63~4.85s×2배 잠정값 10s보다 CI가 더 느렸다. 실측치로 갱신)"
     },
     {
       "file": "tests/test_3603_connection_last_error.py",


### PR DESCRIPTION
⚠️ **의존**: 이 브랜치는 #4010(#3380, sender=시스템 발행자)가 아직 develop에 안 착지한 상태에서 그 위에 얹었습니다(PO 確定① — "3380 먼저"). #4010이 먼저 merge되면 이 diff는 #3379 자체 변경분만 남습니다. rebase 필요하면 알려주세요.

실사고(담롱·댄, 2026-09-03 09:21Z) — 담롱↔댄 1:1에서 「인스타그램 운영 규약 v1.0」을 v1 폐기·v2 교체하려고 논의하던 순간, 시스템 넛지("결재 상신하시겠습니까?")가 떴다. 그 문서 §1.2는 방금 폐기한 v1 규약을 여전히 "확정"으로 들고 있었다 — 눌렀으면 폐기한 규약이 결재로 굳는 자리. 댄이 안 눌러 막혔다.

## 그라운딩(착수 첫 일)
트리거 경로(`conversations.py:2674-2691`)·기존 억제 4종(status≠draft·자가공유·external_publish 게이트·(org,doc) 전역 1회) 재확認 — PO 표(draft만 트리거)와 일치.

## PO 確定
① 넛지의 draft 판정 자체는 맞다 — 틀린 건 「채팅에서 논의됐다」를 상신 의사로 읽는 것. 방향은 "draft 제외"가 아니라 "논의 성격을 읽을 수 없으면 권하지 않는다"(기본 침묵).
② 신규 억제 3종: ⑤doc이 최근 30분 안에 편집됨(`doc_updated_at`) ⑥트리거 메시지 자신에 수정/정정/교체/폐기 계열 신호(순수함수 `_message_signals_doc_still_being_revised`, 대화 이력 스캔 X — 잃는 것: 이 메시지 이전 논의 문맥은 못 봄, 범위 밖 명시 선언) ⑦doc이 이미 다른 doc에 superseded 표기.
③ 스코프 確定: 기존 (org, doc) 전역 1회 reservation은 그대로(더 엄격한 쪽이 이긴다). 이 스토리 AC(d)"같은 대화·같은 doc 최대 1회"는 그 축에 자동 포함되는 상위 제약이라 새 표·새 인덱스 0 — 회귀 테스트로 재확認만.
④ 넛지 문구를 단정형("상신하시겠습니까?")에서 두 갈래("확정본이면 상신 / 고칠 게 있으면 편집")로 변경 — 최저 지능 에이전트가 그대로 따라도 논의 중 문서가 결재로 안 가도록.

## PO 대조 후속(2026-09-07) — 페드루 지적 2건
① `_DOC_RECENTLY_EDITED_WINDOW_MINUTES=30`의 근거 — 이 문서 도메인에 기존 실측/관례가 0건(grep 확認)이라 **잠정 상수**입니다. "편집 세션이 아직 진행 중일 가능성이 높은 창"만 억제하려는 취지로 30분을 임의 선택했고, 코드 주석에도 그렇게 명시했습니다 — **PO 조정 대상**, 새 설정 노출은 이 스토리 범위 밖입니다.
② 새 넛지 문구(두 갈래)는 제품 문구라 유나(카피) 낱말 판정을 거칩니다(페드루 요청) — 판정 후 문구가 바뀌면 `approval_delivery.py`의 해당 f-string 한 줄만 반영합니다.

## 구현
- `Doc.updated_at`·`Doc.superseded_by`를 `conversations.py`의 기존 1회 SELECT에 추가(쿼리 수 증가 0).
- `maybe_nudge_draft_doc_shared_in_chat`에 `doc_updated_at`·`doc_superseded_by`·`trigger_message_content` 3개 필수 kwarg 추가, 신규 억제 3종을 기존 4종 뒤에 배선.
- 한글 어간 substring 매치의 알려진 한계(모음축약 활용형 — 고쳐/바꿔가 고치/바꾸의 substring이 아님)를 표본 테스트로 잡아 축약형을 낱말 목록에 병기.

## Test plan
- [x] 순수함수 10건(신호 낱말 표본 8+음성 1+뮤테이션 1, 낱말 목록 비우면 RED)
- [x] 억제 3종 각 1(⑤⑥⑦ 개별로 넛지 0건) + 음성대조 1(신호 0건이면 여전히 뜬다, 과잉 침묵 아님을 확認, 두 갈래 문구 assert) + PO 確定① 회귀 1(전역 1회 유지)
- [x] 기존 test_2747(7)+test_d1f4afcb(6) 13건 — 새 필수 kwarg 배선(19개 호출부)+`test_organic_chat_message_mentioning_draft_doc_still_nudges` 1건 doc.updated_at backdate(방금 seed한 doc이 새 "최근 편집" 억제에 우연히 걸리던 것 수정) 전부 그린
- [x] `app.main` import 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)
