### PR TITLE
[SID:3658] fix: specPinSaveFailedNote → saveFailedNote — 키 이름이 쓰임을 속임

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5033,7 +5033,7 @@
     "specPinSaveAction": "Save",
     "specPinSavingAction": "Saving…",
     "specPinCancelAction": "Cancel",
-    "specPinSaveFailedNote": "The save didn't go through. Please try again in a moment.",
+    "saveFailedNote": "The save didn't go through. Please try again in a moment.",
     "artifactCreateFailed": "Couldn't create it. Please try again in a moment.",
     "changeCount": "{count} changes",
     "commitSummaryPlaceholder": "What changed…",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -5033,7 +5033,7 @@
     "specPinSaveAction": "저장",
     "specPinSavingAction": "저장하는 중…",
     "specPinCancelAction": "취소",
-    "specPinSaveFailedNote": "저장하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    "saveFailedNote": "저장하지 못했습니다. 잠시 후 다시 시도해 주세요.",
     "artifactCreateFailed": "만들지 못했습니다. 잠시 후 다시 시도해 주세요.",
     "changeCount": "변경 {count}건",
     "commitSummaryPlaceholder": "변경 이유…",

--- a/apps/web/src/components/canvas/artifact-section.tsx
+++ b/apps/web/src/components/canvas/artifact-section.tsx
@@ -177,7 +177,10 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
     if (!detail) {
       // 빈 catch 금지 계열 — 커밋 실패를 삼키지 않고 로깅, 편집 모드 유지(사용자 재시도 가능).
       console.error('[canvas-edit] artifact edit commit failed', item.artifact.id);
-      addToast({ title: t('specPinSaveFailedNote'), type: 'error' });
+      // story #3658 — specPinSaveFailedNote(스펙 핀 전용 이름)를 재사용해 키 이름이
+      // 쓰임을 속이던 것을 saveFailedNote(공용, 값 무변)로 rename — 스펙 핀 자리
+      // (pin-authoring-popover.tsx)도 같은 키로 갈아탔다.
+      addToast({ title: t('saveFailedNote'), type: 'error' });
       return;
     }
     const { artifact, versions } = adaptArtifactDetail(detail);

--- a/apps/web/src/components/canvas/pin-authoring-popover.tsx
+++ b/apps/web/src/components/canvas/pin-authoring-popover.tsx
@@ -69,7 +69,7 @@ export function PinAuthoringPopover({ open, onOpenChange, initialDescription, on
           rows={4}
           className="w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
         />
-        {error ? <p className="mt-1 text-[10px] text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{t('specPinSaveFailedNote')}</p> : null}
+        {error ? <p className="mt-1 text-[10px] text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{t('saveFailedNote')}</p> : null}
 
         <DialogFooter className="flex items-center justify-between gap-2 sm:justify-between">
           {onDelete ? (


### PR DESCRIPTION
## 배경

유나 관측(#3998 재QA, 2026-09-07) — `artifact-section.tsx`의 `handleCommitEdit`(커밋 편집 저장 실패)가 `pin-authoring-popover.tsx` 전용 키 `specPinSaveFailedNote`를 재사용해, 다음 편집자가 "스펙 핀 문구를 고치면 커밋 편집 문구도 바뀐다"로 오인할 함정이 될 수 있었다.

그라운딩 메모 — 이 재사용 코드는 #3998(PR#3998, 이 PR의 base sha `200db4174`) 자체가 새로 추가한 것으로, develop에는 #3998 착지 전까지 존재하지 않았다. 그래서 이 수정은 #3998 브랜치에 stacked로 시작해, #3998 착지 뒤 develop 위로 rebase했다(base sha `200db4174` — #3998·#3647 둘 다 포함).

## 판단

`specPinSaveFailedNote`의 값 자체가 이미 도메인 무관 범용 문구("저장하지 못했습니다. 잠시 후 다시 시도해 주세요.")라 커밋편집 전용 새 키를 따로 파지 않고 공용 이름(`saveFailedNote`)으로 rename — 두 소비처(`pin-authoring-popover.tsx`·`artifact-section.tsx`) 다 이 키로. 값 무변.

## 검증

- 소비처 전수 확認: repo 전체 grep 결과 이 두 곳 + 메시지 파일 2곳이 전부(옛 키 잔존 0)
- i18n 가드 2종(중복 키·한자) 클린
- `artifact-section.test.tsx` 6건 그린, `tsc --noEmit` 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA