### PR TITLE
[SID:3660] fix(BE·insights): hosted_site 재발행 뒤 옛 사이클 pending 스냅샷 자가회수

### DIFF
--- a/apps/web/src/components/insights-board/types.ts
+++ b/apps/web/src/components/insights-board/types.ts
@@ -6,7 +6,17 @@
 // insight-snapshot-block.tsx(story #3499)의 InsightSnapshot과 형태가 비슷하지만 이 보드의
 // d1/d7 버킷은 그 스냅샷 히스토리 항목과 다른 모양이다(due_at·source 필드가 없다 — 이
 // 보드는 "지금 이 버킷이 어디 있나"만 보여주는 요약 뷰다, 히스토리 목록이 아니다).
-export type InsightSnapshotStatus = 'pending' | 'captured' | 'unsupported' | 'failed' | 'dead_letter';
+// story #3660(2026-09-07, 페드루 PO CHANGES) — 'in_progress'가 누락돼 있었고(BE가
+// due 도래분을 pending→in_progress로 전이해 실제로 쓰는 값), 재발행 자가회수가 옛
+// 사이클 pending/in_progress 행을 superseded로 회수하는 값을 새로 추가했다.
+export type InsightSnapshotStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'captured'
+  | 'unsupported'
+  | 'failed'
+  | 'superseded'
+  | 'dead_letter';
 
 export interface InsightNormalizedMetrics {
   impressions: number | null;

--- a/backend/app/models/insight_snapshot.py
+++ b/backend/app/models/insight_snapshot.py
@@ -49,8 +49,11 @@ class InsightSnapshot(Base):
     external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     due_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
     captured_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    # 'pending'|'captured'|'unsupported'|'failed'|'dead_letter' — publication_commands.status
-    # 관례와 동형(그라운딩 §9), 새 상태값 체계 발명 안 함.
+    # 'pending'|'in_progress'|'captured'|'unsupported'|'failed'|'superseded' — enum/CHECK
+    # 아님(Text, 마이그 0으로 새 값 추가 가능). 'superseded'는 story #3660(2026-09-07) —
+    # 같은 publication_id 재발행이 새 anchor_at으로 새 2행을 열면서, 옛 사이클의
+    # pending/in_progress 잔존 행을 회수하는 값(captured/failed/unsupported는 이력이라
+    # 이 전이 대상이 아니다 — insight_snapshots.py::schedule_insight_snapshots 참고).
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default="pending")
     attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     # 어댑터 원본 응답 그대로(디버그·재정규화 근거) — 정규화 로직이 나중에 바뀌어도

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -13,7 +13,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -70,15 +70,37 @@ async def schedule_insight_snapshots(
     넘긴다 — `datetime.now()`를 여기서 새로 재면, 같은 발행이 재처리(워커 재시도 등)
     될 때마다 due_at이 미세하게 달라져 UNIQUE(publication_id, due_at) 멱등이 무력화
     된다(페드루 決定①의 "같은 발행 재처리에도 2행 유지"가 실제로 성립하려면 이
-    앵커가 안정적이어야 한다)."""
-    for offset in _SNAPSHOT_OFFSETS:
+    앵커가 안정적이어야 한다).
+
+    story #3660(BE·insights·상태 자가회수, 페드루 PO 確定 2026-09-07, 카디르 발견
+    PR#4003) — 같은 publication_id를 유지한 채 anchor_at만 바뀌는 재발행(hosted_site
+    update·ChannelPublication 같은 (gate_id, version_id) 재처리 둘 다 해당, AC4)에서
+    옛 사이클의 pending/in_progress 행이 그대로 살아남아 수집기가 계속 due로 집었다.
+    새 2행을 연 뒤 같은 트랜잭션에서 이 publication의 **다른** due_at(=이번 anchor가
+    아닌 사이클)에 걸린 pending/in_progress 행을 superseded로 회수한다 — captured/
+    failed/unsupported는 이력이라 손대지 않는다(#3651 MCP superseded_snapshots가 그
+    구분을 이미 전제한다). 같은 anchor 재처리(due_at이 이번 anchor와 일치)는 이
+    UPDATE의 WHERE에 안 걸려 무변(2행 그대로 — 페드루 決定① 회귀 보존)."""
+    new_due_ats = [anchor_at + offset for offset in _SNAPSHOT_OFFSETS]
+    for due_at in new_due_ats:
         stmt = pg_insert(InsightSnapshot).values(
             id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id,
             publication_id=publication_id, publication_kind=publication_kind,
-            channel=channel, external_id=external_id, due_at=anchor_at + offset,
+            channel=channel, external_id=external_id, due_at=due_at,
             status="pending",
         ).on_conflict_do_nothing(constraint="uq_insight_snapshots_publication_due_at")
         await db.execute(stmt)
+
+    await db.execute(
+        update(InsightSnapshot)
+        .where(
+            InsightSnapshot.org_id == org_id,
+            InsightSnapshot.publication_id == publication_id,
+            InsightSnapshot.due_at.notin_(new_due_ats),
+            InsightSnapshot.status.in_(("pending", "in_progress")),
+        )
+        .values(status="superseded")
+    )
 
 
 async def list_insight_snapshots_for_publication(

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -569,6 +569,52 @@ async def _fetch_threads_via_connection(db: AsyncSession, snapshot: InsightSnaps
         return await _fetch_threads(client, access_token=access_token, media_id=pub.external_id)
 
 
+# story #3660 CHANGES①(페드루 PO, 2026-09-07, PR #4015) — 클레임(pending→in_progress
+# 전이·commit) 뒤 개별 처리 사이의 창에서, 같은 publication의 재발행이 이 행을
+# superseded로 회수할 수 있다(schedule_insight_snapshots, 별도 트랜잭션). 실측(라이브
+# 재현) — 처음엔 `snapshot.status = "captured"`처럼 status도 **파이썬 속성**으로 대입해
+# 뒀는데, 그 뒤(같은 반복 안에서) `_maybe_enrich_with_ga4_inflow`가 부르는
+# `db.execute(select(...))` 같은 다른 쿼리가 **autoflush**를 유발해 그 dirty
+# status="captured"가 가드 UPDATE보다 **먼저** 무조건 DB에 써져 버렸다 — 그 뒤로는 내
+# 가드(`WHERE status='in_progress'`)가 항상 거짓으로 "이미 회수됨"이라 오판했다(제 손
+# 으로 in_progress를 지워 놓고). 처방 — **status는 파이썬 속성으로 절대 대입하지
+# 않는다**(다른 필드는 무해 — autoflush돼도 그 값 자체는 그대로 맞다). 오직 이 함수의
+# `new_status` 인자(지역 변수, ORM dirty-tracking 밖)로만 가드 UPDATE에 실린다.
+_NON_STATUS_TERMINAL_FIELDS = ("captured_at", "error_code", "raw_payload", "normalized", "source", "attempt_count")
+
+
+async def _finalize_snapshot_write(db: AsyncSession, snapshot: InsightSnapshot, *, new_status: str) -> bool:
+    """`snapshot`의 status 아닌 필드(이미 파이썬 속성으로 대입돼 있음, autoflush돼도
+    무해)를 그대로 읽고, `new_status`(호출자의 지역 변수 — `snapshot.status`엔 한 번도
+    대입 안 됨)를 더해 `WHERE id=:id AND status='in_progress'` 가드가 붙은 명시적
+    UPDATE로 쓴다. `db.expunge(snapshot)`로 세션 추적에서 뗀 뒤 실행 — 안 그러면
+    `db.execute()`의 autoflush가(non-status 필드라도) 이 객체의 dirty 상태를 내 가드
+    보다 먼저 써 버릴 수 있다. `synchronize_session=False` — 이 UPDATE가 세션의
+    identity map과 동기화하려 들면(기본 "auto"), 같은 배치의 *다른* still-attached
+    InsightSnapshot(예: 같은 tick의 7d 짝)까지 재평가하다 만료된/미로딩 속성을
+    lazy-load하려 시도해 async 세션에서 MissingGreenlet으로 죽는다(실측) — 이 UPDATE는
+    정확히 이 한 행만 겨눈다는 것을 이미 아니 동기화가 불필요하다.
+
+    반환 False(가드 미통과=그 사이 superseded로 회수됨)면 이 트랜잭션 전체를 rollback
+    한다 — 이 반복에서 `db.add()`한 부수 기록(예: `_record_insight_evidence`의 Evidence)
+    도 같이 버려진다(이미 회수된 옛 사이클의 evidence를 남기지 않는다, 올바른 동작)."""
+    values = {f: getattr(snapshot, f) for f in _NON_STATUS_TERMINAL_FIELDS}
+    values["status"] = new_status
+    snapshot_id = snapshot.id
+    db.expunge(snapshot)
+    result = await db.execute(
+        update(InsightSnapshot)
+        .where(InsightSnapshot.id == snapshot_id, InsightSnapshot.status == "in_progress")
+        .values(**values)
+        .execution_options(synchronize_session=False)
+    )
+    if result.rowcount == 0:
+        await db.rollback()
+        return False
+    await db.commit()
+    return True
+
+
 async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | None = None) -> dict[str, int]:
     """story #3497 그라운딩④ — `process_due_publication_commands`와 동형 SKIP LOCKED
     2단계 커밋(클레임 commit → 개별 처리 commit/rollback 격리). due_at이 도래한
@@ -595,10 +641,9 @@ async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | Non
             adapter = CHANNEL_ADAPTERS.get(snapshot.channel)
             declared = adapter.insight_metrics if adapter is not None else ()
             if not declared:
-                snapshot.status = "unsupported"
                 snapshot.captured_at = now
-                await db.commit()
-                counts["unsupported"] += 1
+                if await _finalize_snapshot_write(db, snapshot, new_status="unsupported"):
+                    counts["unsupported"] += 1
                 continue
 
             try:
@@ -609,37 +654,32 @@ async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | Non
                     await _promote_connection_status_for_snapshot(
                         db, snapshot, error_code=exc.error_code, message=str(exc),
                     )
-                    snapshot.status = "failed"
                     snapshot.error_code = exc.error_code
-                    await db.commit()
-                    counts["failed"] += 1
+                    if await _finalize_snapshot_write(db, snapshot, new_status="failed"):
+                        counts["failed"] += 1
                 elif failure_kind == FAILURE_KIND_TRANSIENT:
                     snapshot.attempt_count += 1
                     snapshot.error_code = exc.error_code
                     if snapshot.attempt_count >= 5:
-                        snapshot.status = "failed"
-                        await db.commit()
-                        counts["failed"] += 1
+                        if await _finalize_snapshot_write(db, snapshot, new_status="failed"):
+                            counts["failed"] += 1
                     else:
-                        snapshot.status = "pending"
-                        await db.commit()
-                        counts["pending_retry"] += 1
+                        if await _finalize_snapshot_write(db, snapshot, new_status="pending"):
+                            counts["pending_retry"] += 1
                 else:
-                    snapshot.status = "failed"
                     snapshot.error_code = exc.error_code
-                    await db.commit()
-                    counts["failed"] += 1
+                    if await _finalize_snapshot_write(db, snapshot, new_status="failed"):
+                        counts["failed"] += 1
                 continue
 
             snapshot.raw_payload = result["raw"]
             snapshot.normalized = _normalize(declared_metrics=declared, values=result["values"])
-            snapshot.status = "captured"
             snapshot.captured_at = now
             snapshot.source = snapshot.channel
             await _maybe_enrich_with_ga4_inflow(db, snapshot)
             await _record_insight_evidence(db, snapshot)
-            await db.commit()
-            counts["captured"] += 1
+            if await _finalize_snapshot_write(db, snapshot, new_status="captured"):
+                counts["captured"] += 1
         except Exception:  # noqa: BLE001 — publication_command.py와 동형 2중 방어.
             await db.rollback()
             counts["error"] += 1

--- a/backend/sprintable_mcp/tools/channel_posts.py
+++ b/backend/sprintable_mcp/tools/channel_posts.py
@@ -76,8 +76,17 @@ def _label_snapshots_and_compute_delta(
     낸 정본 라벨만 읽는다(insights_board.py와 같은 헬퍼 `label_snapshot_offset`).
     null 라벨(옛 사이클 잔존)은 델타 계산에서 빼고 개수만 3번째 반환값(superseded_
     snapshots)으로 알린다 — 지어내지 않고 사실 그대로("이 발행 뒤로 안 쓰는 스냅샷이
-    n건 더 있었다")."""
-    superseded = [s for s in snapshots if s.get("offset_label") is None]
+    n건 더 있었다").
+
+    story #3660(2026-09-07) — 서버가 이제 옛 사이클의 pending/in_progress 행을
+    status="superseded"로 회수한다(insight_snapshots.py::schedule_insight_snapshots).
+    이 카운트는 그 값 ∪ offset_label이 null인 행(옛 사이클이지만 이미 captured/
+    failed/unsupported로 종결돼 status는 안 바뀐 행)의 합집합 — 한 스냅샷이 둘 다
+    해당해도 리스트 컴프리헨션이 한 번만 세므로 중복 0."""
+    superseded = [
+        s for s in snapshots
+        if s.get("status") == "superseded" or s.get("offset_label") is None
+    ]
     snapshot_1d = next((s for s in snapshots if s.get("offset_label") == "1d"), None)
     snapshot_7d = next((s for s in snapshots if s.get("offset_label") == "7d"), None)
     if snapshot_1d is None or snapshot_7d is None:

--- a/backend/tests/test_3497_insight_snapshots.py
+++ b/backend/tests/test_3497_insight_snapshots.py
@@ -325,6 +325,123 @@ async def test_republish_already_captured_old_cycle_row_stays_captured_not_super
         await engine.dispose()
 
 
+@pytest.mark.anyio
+async def test_finalize_write_race_in_progress_then_superseded_then_capture_attempt_keeps_superseded():
+    """페드루 PO CHANGES①(PR #4015, 2026-09-07) — 수집기가 행을 클레임(pending→
+    in_progress·commit)한 뒤, 그 사이 같은 publication의 재발행이 그 행을 superseded로
+    회수하면, 수집기가 나중에 그 행을 종결(예: captured)하려 해도 그 회수가 유지돼야
+    한다(status 되돌림 금지 — 역전 결함, 실측으로 발견·처방됨). `_finalize_snapshot_
+    write`를 직접 호출해 그 창을 재현한다."""
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import _finalize_snapshot_write, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            work_item_id = uuid.uuid4()
+            publication_id = uuid.uuid4()
+            first_anchor = datetime.now(timezone.utc) - timedelta(days=20)
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=first_anchor,
+            )
+            await s.commit()
+
+            # 클레임(수집기의 1단계) — pending → in_progress, commit.
+            row = (await s.execute(
+                select(InsightSnapshot).where(
+                    InsightSnapshot.publication_id == publication_id,
+                    InsightSnapshot.due_at == first_anchor + timedelta(days=1),
+                )
+            )).scalar_one()
+            row.status = "in_progress"
+            await s.commit()
+            row_id = row.id
+
+            # 그 사이 재발행 — 이 행을 superseded로 회수(별도 커밋, 클레임과 종결
+            # 사이의 창을 그대로 재현).
+            second_anchor = datetime.now(timezone.utc) - timedelta(days=5)
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=second_anchor,
+            )
+            await s.commit()
+
+            confirm = (await s.execute(
+                select(InsightSnapshot.status).where(InsightSnapshot.id == row_id)
+            )).scalar_one()
+            assert confirm == "superseded", f"사전조건 실패 — 재발행이 회수를 안 함(status={confirm})"
+
+            # 수집기의 2단계(종결) — 이미 detach된 `row` 객체로 captured 시도.
+            wrote = await _finalize_snapshot_write(s, row, new_status="captured")
+            assert wrote is False, "가드가 뚫려 superseded 뒤에도 종결 쓰기가 성공함"
+
+        async with Session() as s:
+            final = (await s.execute(
+                select(InsightSnapshot.status).where(InsightSnapshot.id == row_id)
+            )).scalar_one()
+            assert final == "superseded", f"역전 결함 — captured 시도 뒤 status={final}(superseded 유지돼야)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_unconditional_finalize_write_reverts_superseded_status():
+    """뮤테이션 — `_finalize_snapshot_write`의 가드(WHERE status='in_progress')를
+    없애고 무조건 UPDATE하면(원래 결함 재현), superseded가 captured로 되돌아간다 —
+    RED."""
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import schedule_insight_snapshots
+    from sqlalchemy import select, update
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            work_item_id = uuid.uuid4()
+            publication_id = uuid.uuid4()
+            first_anchor = datetime.now(timezone.utc) - timedelta(days=20)
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=first_anchor,
+            )
+            await s.commit()
+
+            row = (await s.execute(
+                select(InsightSnapshot).where(
+                    InsightSnapshot.publication_id == publication_id,
+                    InsightSnapshot.due_at == first_anchor + timedelta(days=1),
+                )
+            )).scalar_one()
+            row_id = row.id
+            row.status = "in_progress"
+            await s.commit()
+
+            second_anchor = datetime.now(timezone.utc) - timedelta(days=5)
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=second_anchor,
+            )
+            await s.commit()
+
+            # 원래 결함 재현 — 가드 없는 무조건 UPDATE.
+            await s.execute(
+                update(InsightSnapshot).where(InsightSnapshot.id == row_id).values(status="captured")
+            )
+            await s.commit()
+
+            reverted = (await s.execute(
+                select(InsightSnapshot.status).where(InsightSnapshot.id == row_id)
+            )).scalar_one()
+            assert reverted == "captured", "뮤테이션이 무력화됨 — 무조건 UPDATE가 실제로 되돌리지 않음"
+    finally:
+        await engine.dispose()
+
+
 # ─── sandbox 전 과정(멱등 등록 → tick → captured → evidence) ──────────────────
 
 

--- a/backend/tests/test_3497_insight_snapshots.py
+++ b/backend/tests/test_3497_insight_snapshots.py
@@ -152,6 +152,179 @@ async def test_schedule_creates_two_rows_and_is_idempotent_on_same_anchor():
         await engine.dispose()
 
 
+# ─── story #3660 — 재발행 자가회수(옛 사이클 pending/in_progress → superseded) ──
+
+
+@pytest.mark.anyio
+async def test_republish_supersedes_old_pending_rows_collector_skips_them():
+    """AC1·AC2 — 최초 사이클 2행(pending) → 재발행 → 옛 2행 superseded·새 2행
+    pending. 수집기 1틱을 옛 due_at(이미 지남)로 돌려도 superseded는 안 집힌다
+    (status=="pending" 필터가 구조적으로 배제 — 뮤테이션은 아래 별도 테스트)."""
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            work_item_id = uuid.uuid4()
+            publication_id = uuid.uuid4()
+            first_anchor = datetime.now(timezone.utc) - timedelta(days=20)
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=first_anchor,
+            )
+            await s.commit()
+
+            second_anchor = datetime.now(timezone.utc) - timedelta(days=5)
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=second_anchor,
+            )
+            await s.commit()
+
+            rows = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == publication_id)
+                .order_by(InsightSnapshot.due_at.asc())
+            )).scalars().all()
+            assert len(rows) == 4
+            statuses = sorted(r.status for r in rows)
+            assert statuses == ["pending", "pending", "superseded", "superseded"], statuses
+
+        async with Session() as s:
+            # 옛 due_at(20일 전 기준 +1d/+7d)은 이미 지났다 — 수집기가 지금 돌아도
+            # superseded 2행은 안 집힌다(둘 다 지금 처리 대상인 새 pending 2행과 due_at이
+            # 겹치지 않아 이 tick에선 어차피 due 도래도 아니다, 별도로 재확認).
+            counts = await process_due_insight_snapshots(s, now=datetime.now(timezone.utc))
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == publication_id)
+            )).scalars().all()
+            superseded_rows = [r for r in rows if r.status == "superseded"]
+            assert len(superseded_rows) == 2, "superseded 행이 수집기에 건드려짐"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_republish_mutation_removing_status_pending_filter_lets_superseded_get_collected():
+    """뮤테이션 — 수집기 due 쿼리에서 status=="pending" 필터를 빼면(원래 방어가 없어지면)
+    superseded 행도 due 도래분으로 집혀 in_progress로 전이된다 — RED 재현."""
+    from app.models.insight_snapshot import InsightSnapshot
+    from sqlalchemy import select, update
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            snap = InsightSnapshot(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=uuid.uuid4(),
+                publication_id=uuid.uuid4(), publication_kind="site_post", channel="sandbox",
+                due_at=datetime.now(timezone.utc) - timedelta(hours=1), status="superseded",
+            )
+            s.add(snap)
+            await s.commit()
+            snap_id = snap.id
+
+            # 원래 코드의 필터(status=="pending")를 뺀 "버그" 쿼리를 직접 재현 — RED.
+            buggy_due_rows = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.due_at <= datetime.now(timezone.utc))
+            )).scalars().all()
+            assert any(r.id == snap_id for r in buggy_due_rows), (
+                "뮤테이션이 무력화됨 — status 필터 없는 쿼리가 superseded를 안 집었다"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_republish_same_anchor_retry_leaves_two_rows_no_supersede():
+    """PO 確定① 회귀 — 같은 anchor로 재처리(워커 재시도 등)는 due_at이 new_due_ats와
+    일치해 supersede WHERE에 안 걸린다. 2행 그대로(4행 아님)."""
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            work_item_id = uuid.uuid4()
+            publication_id = uuid.uuid4()
+            anchor = datetime.now(timezone.utc)
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=anchor,
+            )
+            await s.commit()
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=anchor,
+            )
+            await s.commit()
+
+            rows = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == publication_id)
+            )).scalars().all()
+            assert len(rows) == 2, "같은 anchor 재처리가 행을 늘리거나 superseded로 잘못 회수함"
+            assert all(r.status == "pending" for r in rows)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_republish_already_captured_old_cycle_row_stays_captured_not_superseded():
+    """AC1 — 옛 사이클 행이 이미 captured(재발행 前에 수집 완료)면 재발행이 그 행을
+    건드리지 않는다(pending/in_progress만 전이 대상 — 이력 불변)."""
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            work_item_id = uuid.uuid4()
+            publication_id = uuid.uuid4()
+            first_anchor = datetime.now(timezone.utc) - timedelta(days=20)
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=first_anchor,
+            )
+            await s.commit()
+
+            captured_due_at = first_anchor + timedelta(days=1)
+            row = (await s.execute(
+                select(InsightSnapshot).where(
+                    InsightSnapshot.publication_id == publication_id, InsightSnapshot.due_at == captured_due_at,
+                )
+            )).scalar_one()
+            row.status = "captured"
+            row.captured_at = datetime.now(timezone.utc)
+            await s.commit()
+            captured_row_id = row.id
+
+            second_anchor = datetime.now(timezone.utc) - timedelta(days=5)
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+                publication_kind="site_post", channel="sandbox", external_id=None, anchor_at=second_anchor,
+            )
+            await s.commit()
+
+            captured_row = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.id == captured_row_id)
+            )).scalar_one()
+            assert captured_row.status == "captured", "이미 captured된 이력이 재발행에 덮어써짐"
+    finally:
+        await engine.dispose()
+
+
 # ─── sandbox 전 과정(멱등 등록 → tick → captured → evidence) ──────────────────
 
 
@@ -660,6 +833,13 @@ async def test_insights_list_endpoint_offset_label_nulls_out_superseded_snapshot
         for row in rows:
             by_label[row["offset_label"]] = by_label.get(row["offset_label"], 0) + 1
         assert by_label == {None: 2, "1d": 1, "7d": 1}, by_label
+
+        # story #3660 — 최초 사이클의 pending 2행이 재발행으로 superseded 회수됐다(옛
+        # pending 스냅샷이 살아서 수집되던 자가회수 부재의 근본 처방).
+        by_status: dict[str, int] = {}
+        for row in rows:
+            by_status[row["status"]] = by_status.get(row["status"], 0) + 1
+        assert by_status == {"superseded": 2, "pending": 2}, by_status
 
         # 카운트만으론 부족 — «어느 사이클»의 due_at이 1d/7d로 라벨됐는지 직접 확認한다
         # (뮤테이션 대상: rows[0].due_at 기준 역산 같은 우회는 이 표본에서 우연히 같은


### PR DESCRIPTION
카디르 발견(PR#4003, 2026-09-07)의 원인 쪽 — 재발행이 같은 publication_id를 유지한 채 anchor_at(published_at)만 갱신하고 새 due_at 2행을 더 열지만(`UNIQUE(publication_id, due_at)`는 「새」 due_at을 안 막는다), 옛 사이클의 pending/in_progress 행은 그대로 살아남아 수집기가 계속 due로 집었다. PR#4003은 라벨 쪽(offset_label=null)을 이미 닫았고, 이 스토리는 그 행 자체를 회수한다.

## 처방
- `schedule_insight_snapshots`가 새 2행을 연 뒤 같은 트랜잭션에서, 이 publication의 **다른** due_at(=이번 anchor가 아닌 사이클)에 걸린 pending/in_progress 행을 superseded로 회수한다. captured/failed/unsupported는 이력이라 손대지 않는다.
- 같은 anchor 재처리(due_at이 이번 anchor와 일치)는 UPDATE의 WHERE에 안 걸려 무변(페드루 決定① — 같은 발행 재처리에도 2행 유지, 회귀 보존).
- `InsightSnapshot.status`는 Text 컬럼(CHECK/enum 없음) — 마이그 0, 모델 docstring만 갱신.
- MCP `get_publication_insights`의 `superseded_snapshots` 카운트를 `status=="superseded"` ∪ `offset_label is None`(중복 없이)로 갱신 — 옛 사이클이 이미 captured/failed/unsupported로 종결된 경우(status 안 바뀜, offset_label만 null)도 놓치지 않는다.

## AC4 — ChannelPublication 같은-id 재발행 경로(grep 근거)
`site_posts.py:1330-1352`의 ChannelPublication upsert가 `uq_channel_publications_gate_version` UNIQUE(gate_id, version_id) 충돌 시 **기존 row를 재사용**(같은 id, published_at만 now로 갱신) — 같은 (gate, version)의 재처리(워커 retry 등)가 hosted_site와 동일한 "같은 publication_id·새 anchor_at" 패턴을 만든다. 이 처방(schedule_insight_snapshots 안에서 publication_id 기준으로 회수)은 publication_kind 무관하게 동일 적용된다 — hosted_site 전용 선언 불필요.

## Test plan
- [x] AC1: 재발행 표본(최초 2행 pending → 재발행) → 옛 2행 superseded·새 2행 pending
- [x] AC1 회귀: 이미 captured된 옛 사이클 행은 재발행에 안 건드려짐
- [x] PO 確定① 회귀: 같은 anchor 재처리는 4행 아닌 2행
- [x] AC2: 수집기가 superseded를 안 집는다(status=="pending" 필터가 구조적으로 배제) + 뮤테이션(필터 없는 쿼리 직접 재현 → superseded가 due로 잡힘, RED)
- [x] AC3: 기존 offset_label 테스트에 status 검증 추가(superseded 2·pending 2) + MCP 9/9(union 로직 회귀 0)
- [x] 기존 test_3497(16)+test_3651_mcp(9) 회귀 0, `app.main` import 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)