### PR TITLE
[SID:3662] fix(FE): 초안 상세 로드 실패 문구를 404·403·그 외 셋으로

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2371,6 +2371,8 @@
     "editSaved": "Saved. A new version was created.",
     "editSaveFailed": "Failed to save.",
     "editLoadFailed": "Failed to load the post.",
+    "editNotFound": "Couldn't find this post.",
+    "editForbidden": "You don't have permission to view this post.",
     "editSaveCta": "Save",
     "editSavingCta": "Saving…",
     "fieldTitle": "Title",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2371,6 +2371,8 @@
     "editSaved": "저장했습니다. 새 버전이 생성됐습니다.",
     "editSaveFailed": "저장하지 못했습니다.",
     "editLoadFailed": "글을 불러오지 못했습니다.",
+    "editNotFound": "이 글을 찾을 수 없습니다.",
+    "editForbidden": "이 글을 볼 권한이 없습니다.",
     "editSaveCta": "저장",
     "editSavingCta": "저장 중…",
     "fieldTitle": "제목",

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -131,6 +131,10 @@ function stubFetchWithVersions(
     // "응답이 안 옴"(연결 끊김·abort, fetchWithAuth 자체가 던짐)은 다른 갈래다. 이
     // 옵션은 후자 — fetch 자체가 reject한다(HTTP 응답 객체 자체가 없다).
     draftReject?: boolean;
+    // story #3662 — 주 데이터(/versions)의 실패를 재현(기본 200). draftStatus/draftReject
+    // (부수 데이터)와 대칭 옵션 — 이 파일의 loadError/notFound/forbidden 판정 대상.
+    versionsStatus?: number;
+    versionsReject?: boolean;
   },
 ) {
   vi.stubGlobal(
@@ -150,6 +154,12 @@ function stubFetchWithVersions(
         return { ok: true, status: 200, json: async () => ({ data: { draft_id: DRAFT_ID, violations: opts?.draftViolations ?? [] }, error: null, meta: null }) };
       }
       if (url === `/api/organizations/${ORG_ID}/site-posts/drafts/${DRAFT_ID}/versions`) {
+        if (opts?.versionsReject) {
+          throw new Error('network error');
+        }
+        if (opts?.versionsStatus && opts.versionsStatus >= 400) {
+          return { ok: false, status: opts.versionsStatus, json: async () => ({ detail: 'boom' }) };
+        }
         return { ok: true, status: 200, json: async () => ({ data: versions, error: null, meta: null }) };
       }
       if (url === `/api/organizations/${ORG_ID}/generation-budget`) {
@@ -736,6 +746,54 @@ describe('ContentPostEditPage (story #3368 S3)', () => {
     expect(container.textContent).toContain(koMessages.content.contentStatusDraft);
     const publishButton = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.publishCta);
     expect(publishButton?.hasAttribute('disabled')).toBe(true);
+  });
+});
+
+// story #3662(campaigns/[campaignId]/page.tsx:76 선례, 유나 確定) — 주 데이터(/versions)
+// 실패를 404/403/그 외/네트워크 예외 4갈래로 문장을 가른다(추정 0, 서버 status 그대로).
+describe('ContentPostEditPage — story #3662(로드 실패 문구 3갈래)', () => {
+  it('로드 실패(500) — 기존 editLoadFailed를 보인다', async () => {
+    stubFetchWithVersions([], undefined, undefined, { versionsStatus: 500 });
+    await act(async () => {
+      root.render(wrap(<ContentPostEditPage />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.content.editLoadFailed);
+  });
+
+  it('로드 실패(404) — 「찾을 수 없습니다」를 보인다', async () => {
+    stubFetchWithVersions([], undefined, undefined, { versionsStatus: 404 });
+    await act(async () => {
+      root.render(wrap(<ContentPostEditPage />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.content.editNotFound);
+    expect(container.textContent).not.toContain(koMessages.content.editLoadFailed);
+  });
+
+  it('로드 실패(403) — 「볼 권한이 없습니다」를 보인다', async () => {
+    stubFetchWithVersions([], undefined, undefined, { versionsStatus: 403 });
+    await act(async () => {
+      root.render(wrap(<ContentPostEditPage />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.content.editForbidden);
+    expect(container.textContent).not.toContain(koMessages.content.editLoadFailed);
+  });
+
+  it('로드 실패(네트워크 예외) — 기존 editLoadFailed로 남는다', async () => {
+    stubFetchWithVersions([], undefined, undefined, { versionsReject: true });
+    await act(async () => {
+      root.render(wrap(<ContentPostEditPage />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.content.editLoadFailed);
+    expect(container.textContent).not.toContain(koMessages.content.editNotFound);
+    expect(container.textContent).not.toContain(koMessages.content.editForbidden);
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -216,6 +216,11 @@ export default function ContentPostEditPage() {
   const [versions, setVersions] = useState<SitePostVersion[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  // story #3662(campaigns/[campaignId]/page.tsx:76 선례, 유나 確定) — notFound/loadError
+  // 하나였던 것에 forbidden을 더해 서버 status를 그대로 세 갈래로 가른다(추정 0). 주
+  // 데이터는 versionsRes(이 파일 자체 관례 — draftRes는 부수 데이터, 위 §16-7 주석 참고).
+  const [notFound, setNotFound] = useState(false);
+  const [forbidden, setForbidden] = useState(false);
 
   const [title, setTitle] = useState('');
   const [summary, setSummary] = useState('');
@@ -361,6 +366,8 @@ export default function ContentPostEditPage() {
     async function load() {
       setLoading(true);
       setLoadError(false);
+      setNotFound(false);
+      setForbidden(false);
       try {
         // story #3514(doc a0da40c9, PO 確定 2026-09-05) — lint-on-read: 단건 GET을
         // /versions와 병렬로 부른다(channel-posts/[draftId]/page.tsx :340-341과 동형
@@ -387,7 +394,13 @@ export default function ContentPostEditPage() {
         ]);
         if (cancelled) return;
         if (!versionsRes.ok) {
-          setLoadError(true);
+          if (versionsRes.status === 404) {
+            setNotFound(true);
+          } else if (versionsRes.status === 403) {
+            setForbidden(true);
+          } else {
+            setLoadError(true);
+          }
           return;
         }
         if (draftRes?.ok) {
@@ -999,6 +1012,24 @@ export default function ContentPostEditPage() {
     );
   }
 
+  if (notFound) {
+    return (
+      <div className="mx-auto w-full max-w-3xl p-6">
+        <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
+          <AlertDescription>{t('editNotFound')}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+  if (forbidden) {
+    return (
+      <div className="mx-auto w-full max-w-3xl p-6">
+        <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
+          <AlertDescription>{t('editForbidden')}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
   if (loadError || !latest) {
     return (
       <div className="mx-auto w-full max-w-3xl p-6">

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -1916,7 +1916,7 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     expect(container.querySelector('[data-testid="channel-post-published-info"]')).toBeNull();
   });
 
-  it('로드 실패 — 오류 알림을 보인다', async () => {
+  it('로드 실패(500) — 오류 알림을 보인다', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })));
     await act(async () => {
       root.render(wrap(<ChannelPostEditPage />));
@@ -1925,6 +1925,43 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
 
     expect(container.textContent).toContain(koMessages.content.editLoadFailed);
   });
+
+  // story #3662(campaigns/[campaignId]/page.tsx:76 선례, 유나 確定) — 404/403/네트워크
+  // 예외까지 4표본으로 문장이 갈리는지 고정(500은 위 표본이 이미 editLoadFailed로 커버).
+  it('로드 실패(404) — 「찾을 수 없습니다」를 보인다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })));
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.content.editNotFound);
+    expect(container.textContent).not.toContain(koMessages.content.editLoadFailed);
+  });
+
+  it('로드 실패(403) — 「볼 권한이 없습니다」를 보인다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 403, json: async () => ({}) })));
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.content.editForbidden);
+    expect(container.textContent).not.toContain(koMessages.content.editLoadFailed);
+  });
+
+  it('로드 실패(네트워크 예외) — 기존 editLoadFailed로 남는다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.content.editLoadFailed);
+    expect(container.textContent).not.toContain(koMessages.content.editNotFound);
+    expect(container.textContent).not.toContain(koMessages.content.editForbidden);
+  });
+
 
   // story f30da19a AC5 — T3(상세 머리).
   it('⭐AC5 — channel=sandbox면 상세 머리에 「테스트」 배지가 뜬다', async () => {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -673,6 +673,10 @@ export default function ChannelPostEditPage() {
     genBudget.status === 'ok' ? genBudget.currency : null;
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  // story #3662(campaigns/[campaignId]/page.tsx:76 선례, 유나 確定) — notFound/loadError
+  // 하나였던 것에 forbidden을 더해 서버 status를 그대로 세 갈래로 가른다(추정 0).
+  const [notFound, setNotFound] = useState(false);
+  const [forbidden, setForbidden] = useState(false);
 
   // story #3428(T3-M·§17-16) — 어댑터가 선언한 이미지 규격(연결 응답에서 읽음).
   // undefined="아직 모른다"(연결 조회 전/실패) — maxCount<=0과 동형으로 첨부 칸을
@@ -811,6 +815,8 @@ export default function ChannelPostEditPage() {
     async function load() {
       setLoading(true);
       setLoadError(false);
+      setNotFound(false);
+      setForbidden(false);
       try {
         const [draftRes, versionsRes] = await Promise.all([
           fetchWithAuth(`/api/organizations/${orgId}/channel-posts/drafts/${draftId}`),
@@ -818,7 +824,17 @@ export default function ChannelPostEditPage() {
         ]);
         if (cancelled) return;
         if (!draftRes.ok || !versionsRes.ok) {
-          setLoadError(true);
+          // story #3662 — 주 데이터(draftRes)의 status로만 가른다(versionsRes는 같은
+          // draft를 다른 각도로 보는 것이라 draftRes가 404/403이면 versionsRes도 사실상
+          // 같은 사유일 것 — draftRes.ok인데 versionsRes만 404/403인 경우는 서버 불변식
+          // 위반에 가까워 그 외/loadError로 접는다, 지어내지 않는다).
+          if (draftRes.status === 404) {
+            setNotFound(true);
+          } else if (draftRes.status === 403) {
+            setForbidden(true);
+          } else {
+            setLoadError(true);
+          }
           return;
         }
         const draftJson = (await draftRes.json().catch(() => null)) as { data?: ChannelPostDraftDetail } | null;
@@ -1706,6 +1722,24 @@ export default function ChannelPostEditPage() {
 
   if (loading) {
     return <div className="mx-auto w-full max-w-2xl space-y-4 p-6" data-testid="channel-post-edit-loading" />;
+  }
+  if (notFound) {
+    return (
+      <div className="mx-auto w-full max-w-2xl p-6">
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{t('editNotFound')}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+  if (forbidden) {
+    return (
+      <div className="mx-auto w-full max-w-2xl p-6">
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{t('editForbidden')}</AlertDescription>
+        </Alert>
+      </div>
+    );
   }
   if (loadError || !draft) {
     return (


### PR DESCRIPTION
PO 재현(2026-09-07)의 실물 — 뭉클랩 소속 초안을 PO Test Org 스코프에서 열면(cross-org 403/404) 「글을 불러오지 못했습니다」 한 문장만 뜬다. 이 문장이 「없음/권한 없음/조회 실패」를 안 갈라, cross-org 오도달인데도 사용자가 새로고침을 반복하게 만든다.

선례(`campaigns/[campaignId]/page.tsx:76`, 유나 정적 판정) — notFound/loadError 두 상태로 "존재 안 함(404)"과 "조회 실패(그 외)"를 가른 것과 같은 형으로, 두 초안 상세 화면에 forbidden(403)까지 더해 셋으로 가른다.

## 구현
- `channel-posts/[draftId]/page.tsx` — 주 데이터는 draftRes(이 파일의 기존 관례, versionsRes는 병렬 부수 조회). `draftRes.status`로 판정.
- `content/[draftId]/page.tsx` — 주 데이터는 versionsRes(이 파일 §16-7 자체 관례, draftRes는 부수 데이터 — violations만 담당). `versionsRes.status`로 판정.
- 신규 i18n 키 2(`editNotFound`·`editForbidden`, ko/en) — `content` 네임스페이스 재사용(두 화면 다 "글 편집" 문맥이라 키 중복 0). 기존 `editLoadFailed`(500·네트워크 예외)는 그대로.
- 판정은 서버가 준 status 그대로(추정 0) — 클라이언트가 지어내지 않는다.

## Test plan
- [x] 두 파일 각 4표본(404·403·500·네트워크 예외) — 문구 4갈래 확認
- [x] 라이브 뮤테이션(두 파일 각각 status 분기를 원래 loadError 하나로 되돌려 RED 재현 확認 후 원복) — vitest 312/312 재그린
- [x] `tsc --noEmit` 그린 · `eslint` 그린 · `check-i18n-keys.js` 0건(누락 0)

## 다음 회차(스토리 AC4, 이 PR 범위 밖)
유나 실픽셀(cross-org 초안 URL → 「권한이 없습니다」 문장·대비) — 배포 뒤 라이브 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)