### PR TITLE
[SID:3661] fix: mismatch Alert 문장이 raw UUID·139자 URL로 무너지는 것을 막는다

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -381,6 +381,49 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
     expect(note?.textContent).toContain('Page 2');
     expect(container.textContent).not.toContain(koMessages.channelConnect.channelConnectSuccess.replace('{channel}', 'Threads'));
   });
+
+  // story #3661(3650 후속, 유나 판정 정정 2026-09-07) — 목록(connections)이 아직 안
+  // 불린 동안 mismatch 파라미터의 raw UUID가 그대로(aria-live=polite라 스크린리더가
+  // 읽는다) 서던 결함. /channel-connections가 아직 응답 안 한 시점(fetch pending)엔
+  // Alert 자체를 안 그린다 — flush()를 부르지 않고 초기 렌더 직후 상태를 본다.
+  it('연결 목록 fetch가 아직 안 끝났으면 mismatch Alert를 안 그린다(raw UUID 노출 0)', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));  // 영원히 안 풀리는 pending
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams('connected=threads&mismatch=382e18bd-target&updated=cdd3106d-updated'),
+    );
+    useDashboardContextMock.mockReturnValue({
+      orgId: ORG_ID, orgMemberships: [{ orgId: ORG_ID, orgName: 'Org', orgSlug: 'org', role: 'owner' }], projectMemberships: [],
+    });
+    await act(async () => { root.render(wrap(<OrganizationChannelsPage />)); });
+    const note = container.querySelector('[data-testid="channel-reauth-mismatch-note"]');
+    expect(note).toBeNull();
+    expect(container.textContent).not.toContain('382e18bd-target');
+    expect(container.textContent).not.toContain('cdd3106d-updated');
+  });
+
+  // story #3661 — account_label이 null인 연결(webhook류는 account_id가 139자 URL)로
+  // 폴백하면 문장을 URL이 관통했다. 폴백은 «채널명 + 연결 id 짧은 꼬리»로 정체만 남긴다
+  // (뮤테이션 대상: channelConnectionIdentityLabel의 폴백을 conn.account_id로
+  // 되돌리면 이 테스트가 RED — 실제로 되돌려 확認, 아래 결과 참고).
+  it('account_label이 없는 연결은 「채널명(…짧은 꼬리)」로 폴백하고 긴 URL을 노출하지 않는다', async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('connected=threads&mismatch=conn-page2&updated=conn-page1'));
+    stubFetch({
+      connections: [
+        {
+          ...CONNECTION_ACTIVE, id: 'conn-page1', channel: 'webhook', account_label: null,
+          account_id: 'https://example.com/webhook/callback?token=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_extra_padding_to_reach_139_chars_xxxxxxxxxxxxxxxxxxxxxxxxx',
+          status: 'active',
+        },
+        { ...CONNECTION_ACTIVE, id: 'conn-page2', account_label: 'Page 2', status: 'revoked' },
+      ],
+    });
+    await mount('owner');
+    const note = container.querySelector('[data-testid="channel-reauth-mismatch-note"]');
+    expect(note).not.toBeNull();
+    expect(note?.textContent).not.toContain('https://example.com');
+    expect(note?.textContent).not.toContain('conn-page1');
+    expect(note?.textContent).toContain('…');
+  });
 });
 
 // story #3436 묶음10(유나 §17-21⑧⑨, PO 確定 2026-09-06) — oauth 갈래 「{channel}

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -8,7 +8,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { fetchWithAuth } from '@/lib/db/client';
-import { channelLabel } from '@/lib/channel-label';
+import { channelConnectionIdentityLabel, channelLabel } from '@/lib/channel-label';
 import { formatRelativeTime } from '@/lib/storage/format';
 import { resolveDisplayTimezone } from '@/components/content/schedule-format';
 import { ChannelStatusChip } from '@/components/channel-connect/channel-status-chip';
@@ -877,6 +877,12 @@ export default function OrganizationChannelsPage() {
   const mismatchUpdatedId = searchParams.get('updated');
   const mismatchTargetConn = connections.find((c) => c.id === mismatchTargetId);
   const mismatchUpdatedConn = connections.find((c) => c.id === mismatchUpdatedId);
+  // story #3661(유나 판정 정정) — mismatch 파라미터가 있으면 이미 「불일치 재연결」로
+  // 확定된 것(plain 성공 배너 대상이 아니다). 목록이 아직 안 불렸으면(connections=[])
+  // find()가 둘 다 undefined라 아래 렌더 조건이 자연히 막는다 — 대상 연결을 못
+  // 찾은 채로(로드 前이든 삭제된 뒤든) raw UUID로 Alert를 그리는 대신 조용히
+  // 건너뛴다(«모르는 것을 UUID로 단정» 금지).
+  const isMismatchCase = Boolean(connected && mismatchTargetId && mismatchUpdatedId);
 
   // story #3549(§13-8②, 3547 계약) — 콜백 BFF(api/oauth-channel/callback/[channel])가
   // 2개 이상 페이지를 찾으면 `?select_pending={channel}&pending_id=...&candidates=...`
@@ -903,16 +909,16 @@ export default function OrganizationChannelsPage() {
         <p className="text-sm text-muted-foreground">{t('pageDescription')}</p>
       </div>
 
-      {connected && mismatchTargetId && mismatchUpdatedId ? (
+      {isMismatchCase && mismatchTargetConn && mismatchUpdatedConn ? (
         <Alert variant="info" role="status" aria-live="polite" aria-atomic="true" data-testid="channel-reauth-mismatch-note">
           <AlertDescription>
             {t('channelReauthMismatchNote', {
-              updated: mismatchUpdatedConn?.account_label ?? mismatchUpdatedConn?.account_id ?? mismatchUpdatedId,
-              intended: mismatchTargetConn?.account_label ?? mismatchTargetConn?.account_id ?? mismatchTargetId,
+              updated: channelConnectionIdentityLabel(mismatchUpdatedConn, t),
+              intended: channelConnectionIdentityLabel(mismatchTargetConn, t),
             })}
           </AlertDescription>
         </Alert>
-      ) : connected ? (
+      ) : connected && !isMismatchCase ? (
         <Alert variant="success" role="status" aria-live="polite" aria-atomic="true">
           <AlertDescription>{t('channelConnectSuccess', { channel: channelLabel(connected, t) })}</AlertDescription>
         </Alert>

--- a/apps/web/src/lib/channel-label.ts
+++ b/apps/web/src/lib/channel-label.ts
@@ -27,3 +27,15 @@ export function channelLabel(channel: string, t: (key: string) => string): strin
   const key = CHANNEL_LABEL_KEYS[channel];
   return key ? t(key) : channel;
 }
+
+// story #3661(3650 후속, 유나 판정 정정 2026-09-07) — mismatch Alert 문장이 account_label
+// null인 연결에서 account_id로 폴백했는데, webhook류는 그 값이 139자 URL이라 문장을
+// 관통했다("무엇이 갱신됐는지"가 URL에 묻힘). 폴백은 «채널명 + 식별자 짧은 꼬리»로
+// 정체는 남기고 자른다 — sha256 앞 8자(story #3641)와 같은 "짧은 꼬리" 관례, 연결
+// 자신의 id(항상 UUID·URL이 아님)에서 뽑아 채널 종류와 무관하게 안전하다. 새 낱말 0
+// (channelLabel 재사용).
+export function channelConnectionIdentityLabel(
+  conn: { id: string; channel: string; account_label: string | null }, t: (key: string) => string,
+): string {
+  return conn.account_label ?? `${channelLabel(conn.channel, t)}(…${conn.id.slice(-8)})`;
+}


### PR DESCRIPTION
## 배경

유나 배포 51 회차 실측(#4000 판정 정정, 2026-09-07) — 코드만 보고 통과시킨 mismatch Alert(PR #4000/story #3650)가 문구 층에서 두 결함을 안고 있었다.

## 결함

1. **목록 로드 前 raw UUID 노출**: 연결 목록(connections)이 아직 안 불린 시점에도 `mismatch`/`updated` 쿼리 파라미터가 있으면 Alert가 그려져 "382e18bd-… 연결이 갱신됐습니다"처럼 UUID가 그대로 섰다. `aria-live=polite`라 스크린리더가 그 UUID를 읽는다.
2. **account_label 없는 연결은 139자 URL로 폴백**: webhook류 연결은 `account_id` 자체가 URL이라, `account_label`이 null이면 그 URL이 문장을 관통했다(실측 187자·2줄).

## 처방

- `channelConnectionIdentityLabel`(`channel-label.ts` 신설) — `account_label`이 없으면 「채널명(…연결id 짧은 꼬리)」로 폴백(정체는 남기고 자른다, story #3641의 sha256 앞 8자와 같은 짧은 꼬리 관례 — 연결 자신의 id는 채널 종류와 무관하게 항상 UUID라 안전, 새 낱말 0).
- mismatch 렌더 조건에 `mismatchTargetConn && mismatchUpdatedConn`(목록에서 실제로 찾은 연결)을 추가 — 로드 前이든 연결이 삭제됐든 못 찾으면 raw UUID로 그리는 대신 조용히 건너뛴다.

## 테스트

신규 2 — ①연결 목록 fetch가 안 끝난 상태에서 mismatch Alert 렌더 0(aria-live 텍스트에 UUID 0) ②account_label 없는 연결이 채널명+짧은 꼬리로 폴백하고 URL·풀 UUID 0. 둘 다 뮤테이션(가드 제거·폴백을 원래 값으로 되돌림) 확認 후 복구 — 정확히 이 2건만 RED. 기존 회귀 91건 그린. i18n 가드 클린(새 낱말 0). `tsc --noEmit`/eslint 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA