### PR TITLE
[SID:3664] fix(FE·a11y): kanban 카드 컨텍스트 메뉴에 role/aria+키보드

### DIFF
--- a/apps/web/src/components/kanban/story-card-context-menu.test.tsx
+++ b/apps/web/src/components/kanban/story-card-context-menu.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+//
+// story #3664(유나 발견 — kanban 카드 컨텍스트 메뉴가 role=menu/menuitem 없는 맨 div body
+// portal이라 키보드·스크린리더 도달 0) — role/aria·키보드(Shift+F10 열기·방향키 순회·Enter
+// 실행·Esc 닫기+포커스 복귀) 추가분의 회귀가드. story-card.test.tsx는 renderToStaticMarkup만
+// 써(정적 렌더 전용 기존 관례) 상호작용 테스트가 안 된다 — 이 파일이 별도로 createRoot+act
+// (kanban-board.test.tsx와 동형 관례)를 쓴다. 기존 우클릭·좌표·항목 구성은 무변경(회귀 1건).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { DndContext } from '@dnd-kit/core';
+import koMessages from '../../../messages/ko.json';
+import { StoryCard } from './story-card';
+import type { KanbanStory } from './types';
+
+function makeStory(overrides: Partial<KanbanStory> = {}): KanbanStory {
+  return {
+    id: 's1', story_number: 1, title: 'Story', status: 'in-progress', priority: 'medium',
+    story_points: null, assignee_id: null, epic_id: null, sprint_id: null,
+    description: null, acceptance_criteria: null, attachments: null, position: null,
+    success_hypothesis: null, metric_definition: null, measure_after: null,
+    outcome_status: 'n_a', outcome_result: null,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function renderCard(props: Partial<Parameters<typeof StoryCard>[0]> = {}) {
+  const onEdit = props.onEdit ?? vi.fn();
+  const onChangeStatus = props.onChangeStatus ?? vi.fn();
+  const onAssign = props.onAssign ?? vi.fn();
+  const onDelete = props.onDelete ?? vi.fn();
+  act(() => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <DndContext>
+          <StoryCard
+            story={makeStory()}
+            assignees={[]}
+            onClick={() => {}}
+            onEdit={onEdit}
+            onChangeStatus={onChangeStatus}
+            onAssign={onAssign}
+            onDelete={onDelete}
+            {...props}
+          />
+        </DndContext>
+      </NextIntlClientProvider>,
+    );
+  });
+  return { onEdit, onChangeStatus, onAssign, onDelete };
+}
+
+function getCard(): HTMLElement {
+  const card = container.querySelector('[aria-haspopup="menu"]');
+  if (!card) throw new Error('card(트리거) not found');
+  return card as HTMLElement;
+}
+
+function openViaContextMenu() {
+  const card = getCard();
+  act(() => {
+    card.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 100, clientY: 100 }));
+  });
+}
+
+describe('StoryCard 컨텍스트 메뉴 — story #3664 AC1(role/aria)', () => {
+  it('트리거(카드)에 aria-haspopup=menu·닫혀 있으면 aria-expanded=false', () => {
+    renderCard();
+    const card = getCard();
+    expect(card.getAttribute('aria-haspopup')).toBe('menu');
+    expect(card.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('우클릭으로 열면 메뉴 컨테이너 role=menu·항목들 role=menuitem·트리거 aria-expanded=true', () => {
+    renderCard();
+    openViaContextMenu();
+
+    const menu = document.body.querySelector('[role="menu"]');
+    expect(menu).not.toBeNull();
+    const items = document.body.querySelectorAll('[role="menu"] [role="menuitem"]');
+    // editStory·changeStatus·assignMember·deleteStory — 4개 핸들러를 다 넘겼으니 4개.
+    expect(items.length).toBe(4);
+    expect(getCard().getAttribute('aria-expanded')).toBe('true');
+  });
+});
+
+describe('StoryCard 컨텍스트 메뉴 — story #3664 AC2(키보드)', () => {
+  it('Shift+F10으로 카드에서 메뉴가 열린다', () => {
+    renderCard();
+    const card = getCard();
+    act(() => {
+      card.dispatchEvent(new KeyboardEvent('keydown', { key: 'F10', shiftKey: true, bubbles: true, cancelable: true }));
+    });
+    expect(document.body.querySelector('[role="menu"]')).not.toBeNull();
+  });
+
+  it('메뉴가 열리면 첫 항목(role=menuitem)으로 포커스가 옮겨진다', () => {
+    renderCard();
+    openViaContextMenu();
+    const firstItem = document.body.querySelector('[role="menu"] [role="menuitem"]');
+    expect(document.activeElement).toBe(firstItem);
+  });
+
+  it('ArrowDown/ArrowUp이 role=menuitem 사이를 순회한다(wrap 포함)', () => {
+    renderCard();
+    openViaContextMenu();
+    const items = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menu"] [role="menuitem"]'));
+    const menu = document.body.querySelector('[role="menu"]') as HTMLElement;
+
+    expect(document.activeElement).toBe(items[0]);
+    act(() => {
+      menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    });
+    expect(document.activeElement).toBe(items[1]);
+
+    // 맨 위에서 ArrowUp → wrap해서 마지막 항목으로.
+    act(() => {
+      items[0]!.focus();
+      menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true }));
+    });
+    expect(document.activeElement).toBe(items[items.length - 1]);
+  });
+
+  it('Enter로 포커스된 항목이 실행된다(네이티브 버튼 활성화)', () => {
+    const { onEdit } = renderCard();
+    openViaContextMenu();
+    const firstItem = document.body.querySelector('[role="menu"] [role="menuitem"]') as HTMLButtonElement;
+    expect(document.activeElement).toBe(firstItem);
+    // jsdom은 버튼에 Enter keydown을 걸어도 click을 자동 합성하지 않는다(브라우저와의 알려진
+    // 차이) — 네이티브 활성화 자체는 UA 계약이라 여기서는 "포커스가 옳은 항목에 있다"를
+    // 확認한 뒤, 실제 활성화는 click으로 재현한다(핸들러 wiring이 옳다는 증거로 충분).
+    act(() => { firstItem.click(); });
+    expect(onEdit).toHaveBeenCalledWith('s1');
+  });
+
+  it('Esc로 메뉴가 닫히고 포커스가 카드로 되돌아간다', () => {
+    renderCard();
+    const card = getCard();
+    openViaContextMenu();
+    expect(document.body.querySelector('[role="menu"]')).not.toBeNull();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    });
+    expect(document.body.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(card);
+  });
+});
+
+describe('StoryCard 컨텍스트 메뉴 — story #3664 회귀(기존 우클릭·좌표·항목)', () => {
+  it('우클릭 좌표가 메뉴 위치(top/left)로 그대로 쓰인다(기존 동작 무변)', () => {
+    renderCard();
+    const card = getCard();
+    act(() => {
+      card.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 123, clientY: 45 }));
+    });
+    const menu = document.body.querySelector('[role="menu"]') as HTMLElement;
+    expect(menu.style.top).toBe('45px');
+    expect(menu.style.left).toBe('123px');
+  });
+
+  it('항목 4종(수정·상태 변경·담당자 지정·삭제)이 클릭으로 각자의 콜백을 부른다', () => {
+    const { onEdit, onAssign, onDelete } = renderCard();
+    openViaContextMenu();
+    const items = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="menu"] [role="menuitem"]'));
+    expect(items).toHaveLength(4);
+
+    act(() => { items[0]!.click(); });
+    expect(onEdit).toHaveBeenCalledWith('s1');
+
+    openViaContextMenu();
+    const itemsAfterReopen = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="menu"] [role="menuitem"]'));
+    act(() => { itemsAfterReopen[2]!.click(); }); // assignMember(3번째)
+    expect(onAssign).toHaveBeenCalledWith('s1');
+
+    openViaContextMenu();
+    const itemsAfterReopen2 = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="menu"] [role="menuitem"]'));
+    act(() => { itemsAfterReopen2[3]!.click(); }); // deleteStory(4번째) — ConfirmDialog를 연다(실 삭제 아님).
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/kanban/story-card-context-menu.test.tsx
+++ b/apps/web/src/components/kanban/story-card-context-menu.test.tsx
@@ -163,6 +163,58 @@ describe('StoryCard 컨텍스트 메뉴 — story #3664 AC2(키보드)', () => {
   });
 });
 
+function getStatusTrigger(): HTMLButtonElement {
+  const trigger = document.body.querySelector('[role="menu"] [role="menuitem"][aria-haspopup="menu"]');
+  if (!trigger) throw new Error('상태 변경 트리거 not found');
+  return trigger as HTMLButtonElement;
+}
+
+function getSubmenu(): HTMLElement {
+  // 최상위 메뉴가 아닌 두 번째 [role="menu"](서브메뉴, 별도 portal) — 요소 자체를 특정하려면
+  // 상태 변경 항목(statuses.length===5, editStory/assignMember/deleteStory엔 없는 항목 수)로 식별.
+  const menus = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menu"]'));
+  const submenu = menus.find((m) => m.querySelectorAll('[role="menuitem"]').length === 5);
+  if (!submenu) throw new Error('서브메뉴 not found');
+  return submenu;
+}
+
+describe('StoryCard 컨텍스트 메뉴 — story #3664 CHANGES(유나 QA, 상태 변경 서브메뉴 키보드)', () => {
+  it('서브메뉴가 열리면 첫 항목(role=menuitem)으로 포커스, 방향키는 서브메뉴 안에서만 순회', () => {
+    renderCard();
+    openViaContextMenu();
+    const trigger = getStatusTrigger();
+    act(() => { trigger.click(); });
+
+    const submenu = getSubmenu();
+    const items = Array.from(submenu.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+    expect(document.activeElement).toBe(items[0]);
+
+    act(() => {
+      submenu.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    });
+    // 서브메뉴 안에서만 순회 — 상위 메뉴(editStory 등)로 포커스가 안 새 나간다.
+    expect(document.activeElement).toBe(items[1]);
+    expect(items).toContain(document.activeElement as HTMLElement);
+  });
+
+  it('서브메뉴에서 Esc는 서브메뉴만 닫고 트리거로 포커스를 되돌린다(상위 메뉴는 열려 있음)', () => {
+    renderCard();
+    openViaContextMenu();
+    const trigger = getStatusTrigger();
+    act(() => { trigger.click(); });
+    expect(document.body.querySelectorAll('[role="menu"]').length).toBe(2);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    });
+
+    // 서브메뉴만 사라지고 상위 메뉴(카드 트리거의 aria-haspopup 메뉴)는 그대로 열려 있다.
+    expect(document.body.querySelectorAll('[role="menu"]').length).toBe(1);
+    expect(getCard().getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement).toBe(getStatusTrigger());
+  });
+});
+
 describe('StoryCard 컨텍스트 메뉴 — story #3664 회귀(기존 우클릭·좌표·항목)', () => {
   it('우클릭 좌표가 메뉴 위치(top/left)로 그대로 쓰인다(기존 동작 무변)', () => {
     renderCard();

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -177,6 +177,16 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
   const menuRef = useRef<HTMLDivElement>(null);
   const statusMenuRef = useRef<HTMLDivElement>(null);
   const statusTriggerRef = useRef<HTMLButtonElement>(null);
+  // Esc/항목선택으로 메뉴를 닫을 때만 포커스를 카드로 되돌린다(클릭-밖/스크롤/리사이즈로
+  // 닫힐 때는 사용자가 이미 다른 곳에 의도를 두고 있어 포커스를 뺏지 않는다).
+  const returnFocusOnCloseRef = useRef(false);
+  const closeContextMenu = useCallback((returnFocus: boolean) => {
+    setContextMenuOpen(false);
+    setStatusMenuOpen(false);
+    if (returnFocus) {
+      returnFocusOnCloseRef.current = true;
+    }
+  }, []);
   // #1942: 두 메뉴 다 position:fixed + 뷰포트 좌표 clamp(clampToViewport)로 연다 — 트리거(카드/
   // 버튼)의 화면 위치와 무관하게 항상 뷰포트 안에 들어온다(카드-상대 anchor는 카드 자체가 뷰포트
   // 밖일 때 답이 없다는 게 까심 QA 적출).
@@ -213,6 +223,20 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
     data: { story },
     disabled: locked,
   });
+  // story #3664 — dnd-kit의 listeners.onKeyDown(키보드 드래그 픽업/이동)을 그대로 두되,
+  // Shift+F10/ContextMenu 키만 가로채 메뉴를 연다(handleCardKeyDown). 나머지 키는 그대로
+  // dnd-kit에 위임 — 드래그 키보드 조작 회귀 0.
+  const { onKeyDown: dndOnKeyDown, ...dndListenersWithoutKeyDown } = listeners ?? {};
+  // story #3664(유나 발견 — role=menu/menuitem 없는 맨 div) — 카드 자체가 메뉴 트리거다
+  // (우클릭 대상). cardRef는 dnd-kit의 setNodeRef와 별개 로컬 ref(합성 콜백으로 합친다) —
+  // 키보드로 메뉴를 열 때(Shift+F10) 좌표 기준이 필요하고, Esc로 닫을 때 포커스를 돌려줄
+  // 대상이 필요하다(둘 다 setNodeRef만으로는 못 읽는다 — dnd-kit 내부가 그 DOM 노드를
+  // 다른 용도로 관리하지 이 컴포넌트에 되돌려주지 않는다).
+  const cardRef = useRef<HTMLDivElement>(null);
+  const setCardRefs = useCallback((node: HTMLDivElement | null) => {
+    setNodeRef(node);
+    cardRef.current = node;
+  }, [setNodeRef]);
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -239,14 +263,13 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
       const insideMenu = menuRef.current?.contains(target);
       const insideStatusMenu = statusMenuRef.current?.contains(target);
       if (!insideMenu && !insideStatusMenu) {
-        setContextMenuOpen(false);
-        setStatusMenuOpen(false);
+        closeContextMenu(false);
       }
     };
 
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [contextMenuOpen]);
+  }, [contextMenuOpen, closeContextMenu]);
 
   // Close menu on Escape
   useEffect(() => {
@@ -254,13 +277,30 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
 
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        setContextMenuOpen(false);
-        setStatusMenuOpen(false);
+        closeContextMenu(true);
       }
     };
 
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
+  }, [contextMenuOpen, closeContextMenu]);
+
+  // story #3664 AC2 — 메뉴가 열리면 첫 항목으로 포커스를 옮긴다(ARIA menu 관례: 열림=포커스
+  // 진입). 포털이 이 effect보다 먼저 커밋되므로 querySelector 시점엔 이미 DOM에 있다.
+  useEffect(() => {
+    if (!contextMenuOpen) return;
+    const first = menuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    first?.focus();
+  }, [contextMenuOpen]);
+
+  // story #3664 AC2 — Esc/항목선택으로 닫힐 때만(closeContextMenu(true)) 포커스를 카드로
+  // 되돌린다. contextMenuOpen이 false로 커밋된 *다음* effect 타이밍에 실행돼야 포털이 이미
+  // 사라진 뒤라 focus() 대상(카드)이 안전하다.
+  useEffect(() => {
+    if (contextMenuOpen) return;
+    if (!returnFocusOnCloseRef.current) return;
+    returnFocusOnCloseRef.current = false;
+    cardRef.current?.focus();
   }, [contextMenuOpen]);
 
   // 열려있는 동안 스크롤/리사이즈되면 닫는다(까심 QA 지적 ②) — 보드 컬럼의 overflow-x-auto
@@ -270,8 +310,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
   useEffect(() => {
     if (!contextMenuOpen) return;
     const closeOnScrollOrResize = () => {
-      setContextMenuOpen(false);
-      setStatusMenuOpen(false);
+      closeContextMenu(false);
     };
     window.addEventListener('scroll', closeOnScrollOrResize, true);
     window.addEventListener('resize', closeOnScrollOrResize);
@@ -279,7 +318,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
       window.removeEventListener('scroll', closeOnScrollOrResize, true);
       window.removeEventListener('resize', closeOnScrollOrResize);
     };
-  }, [contextMenuOpen]);
+  }, [contextMenuOpen, closeContextMenu]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -290,32 +329,64 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
     setContextMenuOpen(true);
   }, []);
 
+  // story #3664 AC2 — 키보드로 메뉴 열기(Shift+F10 또는 Menu/ContextMenu 키, OS 표준
+  // "컨텍스트 메뉴 열기" 제스처). 우클릭과 동형으로 카드의 바운딩 사각형을 앵커로 쓴다
+  // (마우스 좌표가 없으니 카드 자체의 화면 위치를 대신 쓴다 — statusTriggerRef가 서브메뉴를
+  // 여는 자리와 같은 패턴).
+  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+      e.preventDefault();
+      const rect = cardRef.current?.getBoundingClientRect();
+      if (rect) {
+        setMenuPos({ top: rect.bottom, left: clampToViewport(rect.left) });
+      }
+      setContextMenuOpen(true);
+      return;
+    }
+    dndOnKeyDown?.(e);
+  }, [dndOnKeyDown]);
+
+  // story #3664 — 메뉴/서브메뉴 컨테이너 공용 키보드 순회(위/아래 화살표로 role="menuitem"
+  // 사이 이동, wrap). Enter/Space는 네이티브 <button> 활성화로 이미 동작해 별도 처리 0.
+  const handleMenuKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    const container = e.currentTarget;
+    const items = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+    if (items.length === 0) return;
+    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+    const direction = e.key === 'ArrowDown' ? 1 : -1;
+    const nextIndex = currentIndex === -1
+      ? (direction === 1 ? 0 : items.length - 1)
+      : (currentIndex + direction + items.length) % items.length;
+    items[nextIndex]?.focus();
+  }, []);
+
   const handleEdit = useCallback(() => {
     if (onEdit) {
       onEdit(story.id);
     }
-    setContextMenuOpen(false);
-  }, [story.id, onEdit]);
+    closeContextMenu(true);
+  }, [story.id, onEdit, closeContextMenu]);
 
   const handleChangeStatusClick = useCallback((newStatus: string) => {
     if (onChangeStatus) {
       onChangeStatus(story.id, newStatus);
     }
-    setContextMenuOpen(false);
-    setStatusMenuOpen(false);
-  }, [story.id, onChangeStatus]);
+    closeContextMenu(true);
+  }, [story.id, onChangeStatus, closeContextMenu]);
 
   const handleAssign = useCallback(() => {
     if (onAssign) {
       onAssign(story.id);
     }
-    setContextMenuOpen(false);
-  }, [story.id, onAssign]);
+    closeContextMenu(true);
+  }, [story.id, onAssign, closeContextMenu]);
 
   const handleDelete = useCallback(() => {
     setDeleteConfirmOpen(true);
-    setContextMenuOpen(false);
-  }, []);
+    closeContextMenu(true);
+  }, [closeContextMenu]);
 
   const confirmDelete = useCallback(() => {
     setDeleteConfirmOpen(false);
@@ -335,12 +406,18 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setCardRefs}
       style={style}
       {...(locked ? {} : attributes)}
-      {...(locked ? {} : listeners)}
+      {...(locked ? {} : dndListenersWithoutKeyDown)}
       onClick={onClick}
       onContextMenu={handleContextMenu}
+      onKeyDown={locked ? undefined : handleCardKeyDown}
+      // story #3664 AC1 — 카드=메뉴 트리거. aria-haspopup/expanded로 "이 카드가 여는 메뉴가
+      // 있다·지금 열려 있다"를 스크린리더에 알린다(role은 dnd-kit attributes가 이미
+      // "button"으로 준다 — 새로 안 얹는다).
+      aria-haspopup="menu"
+      aria-expanded={contextMenuOpen}
       title={story.story_number ? `#${story.story_number}` : story.title}
       className="group relative cursor-pointer transition"
     >
@@ -511,6 +588,9 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
       {contextMenuOpen && menuPos && createPortal(
         <div
           ref={menuRef}
+          role="menu"
+          tabIndex={-1}
+          onKeyDown={handleMenuKeyDown}
           style={{ position: 'fixed', top: menuPos.top, left: menuPos.left, width: MENU_WIDTH }}
           // story #2998 로드맵 PR-A(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
           className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]"
@@ -518,6 +598,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
         >
           {onEdit && (
             <button
+              role="menuitem"
               onClick={handleEdit}
               className="w-full rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
             >
@@ -528,6 +609,9 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
             <div className="relative">
               <button
                 ref={statusTriggerRef}
+                role="menuitem"
+                aria-haspopup="menu"
+                aria-expanded={statusMenuOpen}
                 onClick={() => {
                   const rect = statusTriggerRef.current?.getBoundingClientRect();
                   if (rect) {
@@ -543,14 +627,18 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
               {statusMenuOpen && statusMenuPos && createPortal(
                 <div
                   ref={statusMenuRef}
+                  role="menu"
+                  tabIndex={-1}
+                  onKeyDown={handleMenuKeyDown}
                   style={{ position: 'fixed', top: statusMenuPos.top, left: statusMenuPos.left, width: MENU_WIDTH }}
                   // story #2998 로드맵 PR-A(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
-          className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]"
+                  className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {statuses.map((status) => (
                     <button
                       key={status.id}
+                      role="menuitem"
                       onClick={() => handleChangeStatusClick(status.id)}
                       className="w-full rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
                     >
@@ -564,6 +652,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
           )}
           {onAssign && (
             <button
+              role="menuitem"
               onClick={handleAssign}
               className="w-full rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
             >
@@ -572,6 +661,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
           )}
           {onDelete && (
             <button
+              role="menuitem"
               onClick={handleDelete}
               className="w-full rounded-sm px-3 py-2 text-left text-sm text-foreground hover:bg-destructive-tint"
             >

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -187,6 +187,16 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
       returnFocusOnCloseRef.current = true;
     }
   }, []);
+  // story #3664 CHANGES(유나 QA, 2026-09-07) — 서브메뉴(상태 변경)에서 Esc는 전체 메뉴를
+  // 닫는 게 아니라 "상위로 복귀"(서브메뉴만 닫고 트리거 버튼에 포커스)여야 한다. 상위
+  // closeContextMenu(카드로 포커스 복귀)와 별도 경로 — statusMenuOpen 열려 있을 때만 쓴다.
+  const returnFocusToStatusTriggerRef = useRef(false);
+  const closeStatusSubmenu = useCallback((returnFocus: boolean) => {
+    setStatusMenuOpen(false);
+    if (returnFocus) {
+      returnFocusToStatusTriggerRef.current = true;
+    }
+  }, []);
   // #1942: 두 메뉴 다 position:fixed + 뷰포트 좌표 clamp(clampToViewport)로 연다 — 트리거(카드/
   // 버튼)의 화면 위치와 무관하게 항상 뷰포트 안에 들어온다(카드-상대 anchor는 카드 자체가 뷰포트
   // 밖일 때 답이 없다는 게 까심 QA 적출).
@@ -277,13 +287,19 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
 
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        closeContextMenu(true);
+        // story #3664 CHANGES — 서브메뉴가 열려 있으면 Esc는 서브메뉴만 닫고 상위(트리거
+        // 버튼)로 복귀한다. 상위 메뉴 자체는 그대로 열어 둔다(전체 종료가 아님).
+        if (statusMenuOpen) {
+          closeStatusSubmenu(true);
+        } else {
+          closeContextMenu(true);
+        }
       }
     };
 
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
-  }, [contextMenuOpen, closeContextMenu]);
+  }, [contextMenuOpen, statusMenuOpen, closeContextMenu, closeStatusSubmenu]);
 
   // story #3664 AC2 — 메뉴가 열리면 첫 항목으로 포커스를 옮긴다(ARIA menu 관례: 열림=포커스
   // 진입). 포털이 이 effect보다 먼저 커밋되므로 querySelector 시점엔 이미 DOM에 있다.
@@ -302,6 +318,23 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
     returnFocusOnCloseRef.current = false;
     cardRef.current?.focus();
   }, [contextMenuOpen]);
+
+  // story #3664 CHANGES(유나 QA) — 서브메뉴가 열리면 첫 항목으로 포커스(상위 메뉴 열림과
+  // 동형 관례).
+  useEffect(() => {
+    if (!statusMenuOpen) return;
+    const first = statusMenuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    first?.focus();
+  }, [statusMenuOpen]);
+
+  // story #3664 CHANGES — 서브메뉴가 Esc로 닫히면(closeStatusSubmenu(true)) 트리거 버튼으로
+  // 포커스를 되돌린다(상위 메뉴 복귀).
+  useEffect(() => {
+    if (statusMenuOpen) return;
+    if (!returnFocusToStatusTriggerRef.current) return;
+    returnFocusToStatusTriggerRef.current = false;
+    statusTriggerRef.current?.focus();
+  }, [statusMenuOpen]);
 
   // 열려있는 동안 스크롤/리사이즈되면 닫는다(까심 QA 지적 ②) — 보드 컬럼의 overflow-x-auto
   // 가로스크롤은 캡처 리스너로만 잡힌다(스크롤 이벤트는 버블링하지 않음). 재측정 대신 close가
@@ -351,6 +384,12 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
   const handleMenuKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
     e.preventDefault();
+    // story #3664 CHANGES(유나 QA) — 서브메뉴는 body portal이라 DOM 트리 상 상위 메뉴 밖에
+    // 있지만, React는 JSX(포털을 만든) 트리를 기준으로 synthetic event를 버블링한다 — 그대로
+    // 두면 서브메뉴 안의 방향키가 상위 메뉴의 이 같은 핸들러에도 도달해 e.currentTarget이
+    // 상위 메뉴 div로 바뀌어(현재 컨테이너 기준 querySelectorAll) 엉뚱한(상위) 항목 집합에서
+    // 포커스를 옮긴다. stopPropagation으로 "방향키는 서브메뉴 안에서만 순회"를 보장한다.
+    e.stopPropagation();
     const container = e.currentTarget;
     const items = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
     if (items.length === 0) return;


### PR DESCRIPTION
유나 발견 — 카드 우클릭 컨텍스트 메뉴가 `role="menu"`/`role="menuitem"` 없는 맨 div body portal이라 `[role=menu]` 탐지가 0건이었다. 키보드(Shift+F10/방향키/Esc)와 스크린리더 축은 role 부재라 노출 자체가 없었다(마우스 기능 자체는 정상 — `verify:no-handrolled-modal` 클래스와 같은 결).

집안에 이 정확한 형태(우클릭 좌표 기준 open, 손으로 짠 `position:fixed`+뷰포트 clamp, #1942/까심 QA로 여러 차례 벼려진 포지셔닝 로직)를 대체할 컨텍스트-메뉴 프리미티브가 없어(`dropdown-menu.tsx`는 트리거-앵커형, 좌표 기준 오픈 미지원) — 스토리 처방의 명시 허용 폴백(기존 포지셔닝/우클릭/좌표/항목 무변경 + role/aria/키보드만 추가)을 택했다.

## 구현
- 카드(트리거): `aria-haspopup="menu"`·`aria-expanded`(dnd-kit이 이미 `role="button"`·`tabIndex=0`을 준다 — role은 새로 안 얹음).
- 메뉴 컨테이너 2곳(컨텍스트+상태 서브메뉴): `role="menu"`·`tabIndex={-1}`·항목 `role="menuitem"`. 상태 변경 트리거 버튼엔 `aria-haspopup="menu"`+`aria-expanded` 추가.
- 키보드: Shift+F10/ContextMenu 키로 카드에서 열기(dnd-kit `listeners.onKeyDown`과 분리 합성 — 드래그 키보드 조작 회귀 0) · 방향키로 `role=menuitem` 순회(wrap) · Enter/Space는 네이티브 버튼 활성화(추가 코드 0) · Esc 닫기+포커스를 카드로 복귀(항목 선택으로 닫힐 때도 동일 — click-outside/스크롤/리사이즈로 닫힐 땐 포커스 안 뺏음).
- 메뉴 열릴 때 첫 항목으로 자동 포커스(ARIA menu 관례).

## 범위 밖(스토리 명시)
메뉴 항목 추가·문구 변경 0. 우클릭 좌표·기존 3(+담당자 지정 포함 4)항목 동작 무변.

## Test plan
- [x] 신규 파일(`story-card.test.tsx`는 `renderToStaticMarkup` 전용이라 상호작용 불가 — 별도 파일로 `createRoot`+`act`, `kanban-board.test.tsx` 동형 관례): role/aria 확認 2 · 키보드(Shift+F10 열기·자동 포커스·방향키 순회+wrap·Enter 활성화·Esc 닫기+포커스 복귀) 5 · 회귀(우클릭 좌표·항목 4종 클릭) 2 — 9/9
- [x] 라이브 뮤테이션(role/aria 속성 전부 제거) — 신규 9건 전부 RED 재현 확認 후 원복
- [x] 기존 `story-card.test.tsx`(14)+`kanban-board.test.tsx`(49) 회귀 0
- [x] `tsc --noEmit` 그린 · `eslint` 그린 · i18n 가드 0건(문구 변경 없음)

## 다음 회차(스토리 AC3, 이 PR 범위 밖)
유나 실픽셀 — 포커스 링·메뉴 대비·스크린리더 이름 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## CHANGES(유나 QA, 2026-09-07) — 상태 변경 서브메뉴 키보드
상위 메뉴는 규격대로 됐는데 "상태 변경" 서브메뉴는 키보드로 진입이 안 됐다(서브메뉴 열림 시 포커스 이동 자리 0·`statusMenuOpen` deps effect 0·그 축 테스트 0 — 그래서 CI는 초록이었다).

처방(두 조각 같이 — 하나만 넣으면 다른 하나가 무력화):
- 서브메뉴 열릴 때 첫 `[role=menuitem]`으로 자동 포커스(상위 메뉴 관례와 동형).
- `handleMenuKeyDown`에 `stopPropagation` — 서브메뉴는 body portal이라 DOM 트리 상 상위 메뉴 밖이지만, React는 JSX(포털을 만든) 트리 기준으로 synthetic event를 버블링한다. 이게 없으면 서브메뉴 안의 방향키가 상위 메뉴의 같은 핸들러에도 도달해(그 핸들러의 `e.currentTarget`이 상위 메뉴 div로 바뀜) 엉뚱한(상위) 항목 집합에서 포커스를 옮긴다.

추가로 Esc도 분기: 서브메뉴가 열려 있으면 Esc는 서브메뉴만 닫고 트리거 버튼으로 포커스를 되돌린다(상위 메뉴는 열어 둔 채) — 기존엔 Esc가 항상 전체 메뉴를 닫아 "상위로 복귀" 자체가 없었다.

## Test plan(추가분)
- [x] 신규 2(서브메뉴 열림→첫 항목 포커스+방향키가 서브메뉴 안에서만 순회, Esc→서브메뉴만 닫히고 트리거로 포커스+상위 메뉴는 열려 있음)
- [x] 라이브 뮤테이션 2건 — stopPropagation 제거→RED(방향키 상위로 새는 것 재현), Esc 분기 제거→RED(서브메뉴+상위 메뉴 동시에 닫히는 것 재현) — 둘 다 확認 후 원복
- [x] `story-card-context-menu.test.tsx`(11)+`story-card.test.tsx`(14)+`kanban-board.test.tsx`(49) 회귀 0(74건 그린)
- [x] `tsc --noEmit` 그린 · `eslint` 그린

head bed15910f96681a209de8488184298f81c1d92ce

🤖 Generated with [Claude Code](https://claude.com/claude-code)
