### PR TITLE
promote/main-20260907-3629-3635

### DIFF
--- a/backend/alembic/versions/0354_member_anchor_backfill_root_fix.py
+++ b/backend/alembic/versions/0354_member_anchor_backfill_root_fix.py
@@ -1,0 +1,61 @@
+"""story #3635(BE·결함 클래스 근본·prod, 페드루 PO 確定 2026-09-07) — 휴먼 org_member의
+members 앵커 부재를 뿌리에서 닫는다.
+
+migration 0075의 `members.id == org_members.id` 백필 불변식은 그 마이그 시점 한정이었다
+— 이후 org_member 생성 경로(특히 `org_members.py:154` 관리자 직접 추가, story #3635
+그라운딩 확認)가 `ensure_human_member`를 안 불러 앵커가 안 생기는 org_member가 계속
+쌓였다(dev PO Test Org owner가 그 실물). #3627/#3629/#3634가 자리별로 막았지만
+25곳 넘게 흩어진 `type == "human"` 소비처를 전부 세는 대신, 이 마이그가 0075와 완전히
+같은 SELECT(활성 org_member ∖ members)를 다시 돌려 앵커를 전수 채운다 — additive·
+idempotent(대상 없는 ON CONFLICT DO NOTHING — PK·uq_members_active_human 어느 쪽이
+막아도 조용히 스킵, story #3987 CI 실사고로 대상 지정에서 정정)라 재실행해도 안전,
+`OrgMemberRepository.create()`가
+이제 `ensure_human_member`를 호출해도(이 PR의 코드 변경) 이 백필과 중복 INSERT 시도가
+0건 사고 없이 겹친다."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0354"
+down_revision = "0353"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # 0075:116-124와 완전히 동형(그라운딩 재사용, 새 백필 규칙 발명 0) — 활성 org_member 중
+    # members 행이 없는 것만 채운다. story #3987 CI 실사고(2026-09-07, run 34121108303) —
+    # 대상 지정 `ON CONFLICT (id) DO NOTHING`은 PK 충돌만 삼킨다. 같은 (org_id, user_id)에
+    # id가 다른 active human member 행이 이미 있으면(uq_members_active_human 부분 유니크
+    # 인덱스) 그 자리는 PK 충돌이 아니라서 그대로 UniqueViolation으로 죽는다 — "이미
+    # 앵커가 있다"는 이 백필의 목표가 이미 달성된 상태인데도 크래시하는 건 과잉이다.
+    # 대상 없는 bare DO NOTHING으로 바꿔 이 테이블의 어떤 유니크/배제 제약 충돌이든
+    # (지금은 PK·uq_members_active_human 둘) 조용히 건너뛴다 — "이미 있으면 스킵"이라는
+    # 이 백필의 의도 자체가 원래 대상 무관이었다.
+    result = conn.execute(
+        sa.text(
+            """
+            INSERT INTO members (id, org_id, type, user_id, owner_member_id, name, org_role, is_active, created_at, updated_at)
+            SELECT om.id, om.org_id, 'human', u.id, NULL,
+                   COALESCE(u.display_name, u.email, om.user_id::text),
+                   om.role, true, om.created_at, now()
+            FROM org_members om
+            JOIN organizations o ON o.id = om.org_id
+            LEFT JOIN users u ON u.id = om.user_id
+            WHERE om.deleted_at IS NULL
+            ON CONFLICT DO NOTHING
+            """
+        )
+    )
+    # story #3635 AC1 — dev/prod 각각 "몇 건이었나"가 값이다(마이그 로그로 남긴다).
+    print(f"[story #3635] members 앵커 백필 — {result.rowcount}건 신규 INSERT")
+
+
+def downgrade() -> None:
+    # 가역이 아니다(G5류) — 이 마이그가 채운 행이 0075 원 백필 행과 구분 불가(같은 규칙,
+    # 같은 id 공간)이고, 이미 다른 경로(#3627/#3629/#3634/ensure_human_member 호출부)가
+    # 이 앵커 존재를 전제로 동작할 수 있어 삭제가 더 위험하다. 0075 downgrade도 앵커
+    # 테이블 자체를 안 지운다(메타데이터-only 가역) — 그 관례 그대로 no-op.
+    pass

--- a/backend/alembic/versions/0354_member_anchor_backfill_root_fix.py
+++ b/backend/alembic/versions/0354_member_anchor_backfill_root_fix.py
@@ -11,14 +11,19 @@ idempotent(대상 없는 ON CONFLICT DO NOTHING — PK·uq_members_active_human 
 막아도 조용히 스킵, story #3987 CI 실사고로 대상 지정에서 정정)라 재실행해도 안전,
 `OrgMemberRepository.create()`가
 이제 `ensure_human_member`를 호출해도(이 PR의 코드 변경) 이 백필과 중복 INSERT 시도가
-0건 사고 없이 겹친다."""
+0건 사고 없이 겹친다.
+
+prod 승격(promote/main-20260907-3629-3635, 결재 2f9e82fa) — down_revision을 develop의
+"0353"에서 main head "0295"로 재작성했다(develop 전용 마이그 0296~0353은 이 승격에
+안 실린다 — 스키마 따라잡기 0, revision id 자체는 develop과 대조용으로 "0354" 그대로
+유지). 0283/0289/0292 선례와 같은 방식."""
 from __future__ import annotations
 
 import sqlalchemy as sa
 from alembic import op
 
 revision = "0354"
-down_revision = "0353"
+down_revision = "0295"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/repositories/org_member.py
+++ b/backend/app/repositories/org_member.py
@@ -41,6 +41,14 @@ class OrgMemberRepository:
         self.session.add(obj)
         await self.session.flush()
         await self.session.refresh(obj)
+        # story #3635(BE·결함 클래스 근본·prod, 페드루 PO 確定 2026-09-07) — org_member
+        # 생성 경로 전수 그라운딩에서 이 메서드(관리자 직접 추가 org_members.py:154의
+        # 유일한 호출부)만 members 앵커를 안 만들고 있었다(org_invite.py·organizations.py
+        # 등 나머지는 이미 ensure_human_member 호출). 단일 choke point인 이 메서드
+        # 안에서 채워 향후 새 호출부가 생겨도 자동으로 안전하다(호출부별로 흩어 두지
+        # 않는다 — 새 판정자 발명 0, agent_anchor_sync.py의 같은 함수 재사용).
+        from app.services.agent_anchor_sync import ensure_human_member
+        await ensure_human_member(self.session, obj.id)
         return obj
 
     async def update(self, id: uuid.UUID, **data: Any) -> OrgMember | None:

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -95,6 +95,34 @@ class OrganizationRepository:
                 ),
                 {"org_id": str(org.id), "member_id": str(owner_member_id)},
             )
+            # story #3635(BE·결함 클래스 근본·prod, 카디르 PR#3987 재발견, 페드루 코드 재확認
+            # 2026-09-07) — 4번째 org_member 생성 경로. organizations.py::create_organization
+            # 라우터의 owner_member_id=None 갈래(아래)만 ensure_human_member를 불렀고, 이
+            # owner_member_id 지정 갈래(admin이 team_members id로 owner를 지정하는 호출)는
+            # 여기 원자 INSERT만 하고 앵커를 안 만들었다 — ON CONFLICT DO NOTHING이라 RETURNING
+            # 불가라, 라우터의 동형 패턴(94-107행) 그대로 두 단계(대상 user_id 조회 → 그
+            # user_id로 방금 만든 org_member.id 재조회)로 캡처한 뒤 ensure_human_member를 부른다.
+            from app.services.agent_anchor_sync import ensure_human_member
+
+            target_user_id = (
+                await self.session.execute(
+                    text("SELECT user_id FROM team_members WHERE id = :member_id"),
+                    {"member_id": str(owner_member_id)},
+                )
+            ).scalar_one_or_none()
+            if target_user_id is not None:
+                om_id = (
+                    await self.session.execute(
+                        text(
+                            "SELECT id FROM org_members"
+                            " WHERE org_id = :org_id AND user_id = :user_id"
+                            " AND deleted_at IS NULL LIMIT 1"
+                        ),
+                        {"org_id": str(org.id), "user_id": str(target_user_id)},
+                    )
+                ).scalar_one_or_none()
+                if om_id is not None:
+                    await ensure_human_member(self.session, om_id)
         # fresh org에 default implementation 역할 시드 — 없으면 merge gate가
         # "no implementation participation"으로 gate row 없이 영구 보류(교착).
         from app.services.participation_helpers import seed_default_participation_role

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from sqlalchemy import exists, func, select
+from sqlalchemy import case, exists, func, select
 from sqlalchemy.orm import aliased
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -28,6 +28,7 @@ from app.models.agent_run import AgentRun
 from app.models.dependency import ItemDependency
 from app.models.hypothesis import Hypothesis
 from app.models.member import AgentProjectProfile, Member
+from app.models.project import OrgMember
 from app.models.pm import Goal, Story, StoryActivity, Task
 from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
 from app.services.agent_auth_failure import AUTH_FAILURE_THRESHOLD, AUTH_FAILURE_WINDOW_MINUTES
@@ -712,17 +713,33 @@ async def overview(
     ][:10]
 
     # CC-BE.2 기여(에이전트 vs 사람·aggregate only·개인 blame/랭킹 0): done 스토리 assignee type 집계.
+    #
+    # story #3629(3627 클래스, 페드루 PO 確定 2026-09-07) — members.id=org_members.id는
+    # migration 0075 백필 시점(당시 존재하던 org_member) 한정 불변식이다. SSOT 전환
+    # 이후 새로 생긴 org_member는 members 앵커 행이 안 만들어져(member_resolver.py의
+    # canonicalize_member_id가 쓰는 org_member.id 그대로가 canonical, members 행을
+    # 새로 안 만든다) Member.id==Story.assignee_id가 매치 안 되고 "unassigned"로
+    # 잘못 떨어졌다. OrgMember도 같이 LEFT JOIN해 매치되면 "human"으로 보강한다
+    # (org_members 테이블 자체가 휴먼 전용이라 추가 type 조건 불요 — is_human_member_
+    # condition과 같은 전제, 여기는 집계 CASE라 그 헬퍼를 그대로 못 쓰고 같은 규칙만
+    # 재현).
+    effective_type = case(
+        (Member.type.is_not(None), Member.type),
+        (OrgMember.id.is_not(None), "human"),
+        else_=None,
+    )
     contrib_rows = (
         await session.execute(
-            select(Member.type, func.count(Story.id))
+            select(effective_type, func.count(Story.id))
             .select_from(Story)
             # outer join + ON 에 org_id — 타 org member 매칭 차단(cross-org → unassigned 으로 떨어짐).
             .join(Member, (Member.id == Story.assignee_id) & (Member.org_id == org_id), isouter=True)
+            .join(OrgMember, (OrgMember.id == Story.assignee_id) & (OrgMember.org_id == org_id), isouter=True)
             .where(
                 Story.org_id == org_id, Story.status == "done",
                 Story.deleted_at.is_(None), Story.is_excluded.is_(False),
             )
-            .group_by(Member.type)
+            .group_by(effective_type)
         )
     ).all()
     contribution = {"agent": 0, "human": 0, "unassigned": 0}

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -37,7 +37,9 @@ from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
     ResolvedMember,
+    filter_human_member_ids,
     filter_org_member_ids,
+    is_human_member_condition,
     lookup_members_by_ids,
     resolve_member,
     resolve_member_identity,
@@ -937,12 +939,16 @@ async def _dispatch_human_intervention_event(
     if not conversation.project_id:
         return []
 
-    participant_rows = (await db.execute(
-        select(ConversationParticipant.member_id, TeamMember.type)
-        .join(TeamMember, TeamMember.id == ConversationParticipant.member_id)
-        .where(ConversationParticipant.conversation_id == conversation.id)
-    )).all()
-    human_targets = {pid for pid, m_type in participant_rows if m_type == "human"}
+    # story #3629(3627 클래스, 페드루 PO 確定 2026-09-07) — team_members INNER JOIN
+    # 단독으론 org_member-only 휴먼(SSOT 전환 이후 org 다수)이 조용히 human_targets에서
+    # 빠졌다(chain-expired 개입 알림이 그 휴먼에게 영원히 안 감). is_human_member_condition
+    # (member_resolver.py, #3627과 같은 판정자)으로 통일.
+    human_targets = set((await db.execute(
+        select(ConversationParticipant.member_id).where(
+            ConversationParticipant.conversation_id == conversation.id,
+            is_human_member_condition(ConversationParticipant.member_id),
+        )
+    )).scalars().all())
     if not human_targets:
         return []
 
@@ -2882,12 +2888,12 @@ async def send_message(
                 # P0 message-loss savepoint 격리 — dispatch_notification 이 실제 write(outbox)를
                 # 하는 유력 용의자 지점(위 blocks와 동일 근거).
                 async with db.begin_nested():
-                    human_mention_rows = (await db.execute(
-                        select(TeamMember.id).where(
-                            TeamMember.id.in_(mention_targets), TeamMember.type == "human",
-                        )
-                    )).all()
-                    human_mention_targets = [r[0] for r in human_mention_rows]
+                    # story #3629(3627 클래스) — TeamMember.id.in_() 단독 INCLUSION 필터는
+                    # org_member-only 휴먼을 조용히 뺀다(_dispatch_mention_events의 "찾지
+                    # 못하면 human으로 간주" 기본값과 반대 — 여기는 못 찾으면 제외돼 알림
+                    # 자체가 안 감). filter_human_member_ids(member_resolver.py, org_members·
+                    # team_members(human) 둘 다 보는 배치 조회)로 통일.
+                    human_mention_targets = list(await filter_human_member_ids(mention_targets, db))
                     if human_mention_targets:
                         from app.services.notification_dispatch import dispatch_notification
                         await dispatch_notification(
@@ -2924,12 +2930,8 @@ async def send_message(
                 - {sender.id} - discord_exclude_ids - blocked_agent_ids - user_blocker_ids - set(msg.mentioned_ids or [])
             )
             if candidate_targets:
-                human_message_rows = (await db.execute(
-                    select(TeamMember.id).where(
-                        TeamMember.id.in_(candidate_targets), TeamMember.type == "human",
-                    )
-                )).all()
-                message_targets = [r[0] for r in human_message_rows]
+                # story #3629(3627 클래스) — 위 mention 블록과 동형(filter_human_member_ids).
+                message_targets = list(await filter_human_member_ids(candidate_targets, db))
                 if message_targets:
                     from app.services.notification_dispatch import dispatch_notification
                     await dispatch_notification(

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -18,6 +18,7 @@ from app.models.notification_preference import NotificationPreference
 from app.models.team import TeamMember
 from app.models.user_block import UserBlock
 from app.services.chain_depth import compute_agent_chain_depth
+from app.services.member_resolver import is_human_member_condition
 
 logger = logging.getLogger(__name__)
 
@@ -31,13 +32,17 @@ async def _conversation_has_human(db: AsyncSession, conversation_id: uuid.UUID) 
     """story #2617: 대화 참가자 중 human이 1명이라도 있는가 — 실물 참가자 조회(캐시/파생
     금지, PO 지시 2026-08-13). chain-expired 게이트가 사람-부재 대화를 무기한 침묵시키는지
     판정하는 유일한 근거라 정확성이 중요하다 — recipient_type_map처럼 필터된 부분집합에서
-    유도하지 않고, 이 conversation_id의 ConversationParticipant 전체를 매번 새로 스캔한다."""
+    유도하지 않고, 이 conversation_id의 ConversationParticipant 전체를 매번 새로 스캔한다.
+
+    story #3629(3627 클래스, 페드루 PO 確定 2026-09-07) — TeamMember INNER JOIN 단독으론
+    org_member-only 휴먼(SSOT 전환 이후 org 다수)이 참가자여도 조용히 "사람 없음"으로
+    잘못 판정됐다 — chain-expired 게이트가 그 대화를 사람 부재로 오판해 무기한 침묵시킬
+    위험. is_human_member_condition(member_resolver.py, #3627과 같은 판정자)으로 통일."""
     row = (await db.execute(
         select(ConversationParticipant.member_id)
-        .join(TeamMember, TeamMember.id == ConversationParticipant.member_id)
         .where(
             ConversationParticipant.conversation_id == conversation_id,
-            TeamMember.type == "human",
+            is_human_member_condition(ConversationParticipant.member_id),
         )
         .limit(1)
     )).scalar_one_or_none()

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -10,7 +10,7 @@ import uuid
 from dataclasses import dataclass, field
 
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -47,6 +47,61 @@ class ResolvedMember:
     org_id: uuid.UUID
     project_id: uuid.UUID | None = field(default=None)
     avatar_url: str | None = field(default=None)
+
+
+def is_human_member_condition(member_id_col, *, user_id: uuid.UUID | None = None):
+    """story #3627/#3629(prod 결함 클래스, 페드루 PO 確定 2026-09-07) — 이 member_id가
+    「휴먼」인지 판정하는 유일한 자리(이 모듈 첫 줄의 규칙과 같은 자리 — 새 판정자
+    발명 0). SQL WHERE 절에 그대로 끼워 넣을 수 있는 boolean 조건을 돌려준다.
+
+    E-MEMBER-SSOT Phase 0부터 JWT 휴먼의 참여자/발신자 id는 `org_members.id`다
+    (org_members 테이블 자체가 휴먼 전용이라 추가 type 조건 불요) — 그런데 코드
+    곳곳(conversations.py 멘션/알림 대상 필터·channel_router.py 대화-내-휴먼
+    존재 판정 등)이 여전히 `team_members(type='human')`로만 이었다. team_members에
+    그 org의 휴먼 행이 하나도 없으면(SSOT 전환 이후 만들어진 org 다수) 그 자리들이
+    org_member-only 휴먼을 조용히 "휴먼 아님"으로 판정한다(3627 원 사고: 온보딩
+    왕복·딥링크. 3629: 멘션 알림·chain-expired 휴먼 존재 판정 등으로 같은 클래스가
+    번져 있음을 확認).
+
+    둘 다 인정(OR) — legacy team_member(type='human') 행이 남아있는 org도 회귀
+    없이 그대로 통과해야 한다. `user_id`를 주면 그 유저 소유 여부까지, 안 주면
+    "휴먼이기만 하면" 통과.
+
+    story #3629(카디르 발견, #3627 후속) — `OrgMember.deleted_at.is_(None)` 가드
+    없이는 soft-delete된 org_member도 여전히 휴먼으로 오판정된다(뮤테이션 확認,
+    회귀 테스트 참고)."""
+    org_member_conditions = [OrgMember.id == member_id_col, OrgMember.deleted_at.is_(None)]
+    team_member_conditions = [TeamMember.id == member_id_col, TeamMember.type == "human"]
+    if user_id is not None:
+        org_member_conditions.append(OrgMember.user_id == user_id)
+        team_member_conditions.append(TeamMember.user_id == user_id)
+    return or_(
+        select(OrgMember.id).where(*org_member_conditions).exists(),
+        select(TeamMember.id).where(*team_member_conditions).exists(),
+    )
+
+
+async def filter_human_member_ids(
+    candidate_ids: set[uuid.UUID],
+    session: AsyncSession,
+) -> set[uuid.UUID]:
+    """story #3629 — `candidate_ids` 중 휴먼인 것만 반환(org_members 또는 legacy
+    team_members(type='human') 둘 다 인정, `is_human_member_condition`과 같은 규칙).
+
+    conversations.py의 멘션/일반 메시지 notification 대상 필터 2곳이 각자 `TeamMember.
+    id.in_(candidates)` INCLUSION 쿼리만 써서 org_member-only 휴먼을 조용히 빼던 것을
+    한 자리로 통일(배치-멤버십 조회라 `filter_org_member_ids`와 같은 형 — 다만 그 함수는
+    "org 소속인가"(agent 포함)이고 이건 "휴먼인가"라 목적이 다르다, 새 판정자 발명은
+    아니다)."""
+    if not candidate_ids:
+        return set()
+    org_member_ids = set((await session.execute(
+        select(OrgMember.id).where(OrgMember.id.in_(candidate_ids), OrgMember.deleted_at.is_(None))
+    )).scalars().all())
+    team_member_ids = set((await session.execute(
+        select(TeamMember.id).where(TeamMember.id.in_(candidate_ids), TeamMember.type == "human")
+    )).scalars().all())
+    return org_member_ids | team_member_ids
 
 
 async def resolve_member(

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -19,7 +19,7 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import or_, select, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
@@ -27,33 +27,12 @@ from app.models.conversation import Conversation, ConversationMessage, Conversat
 from app.models.project import OrgMember
 from app.models.team import TeamMember
 from app.models.user import User
+# story #3629 — org_member SSOT 인정 판정자가 conversations.py·channel_router.py 등
+# 여러 모듈에서 재사용돼 member_resolver.py(그 규칙의 원 자리)로 옮겼다(_is_human_member
+# 사설 사본 폐기, 새 판정자 발명 0 원칙을 이 모듈 간 이관에도 그대로 적용).
+from app.services.member_resolver import is_human_member_condition as _is_human_member
 
 logger = logging.getLogger(__name__)
-
-
-def _is_human_member(member_id_col, *, user_id: uuid.UUID | None = None):
-    """story #3627(prod 결함, 페드루 PO 確定 2026-09-07) — 이 member_id가 「휴먼」인지
-    판정하는 유일한 자리(member_resolver.py 첫 줄과 같은 규칙, 새 판정자 발명 0).
-
-    E-MEMBER-SSOT Phase 0부터 JWT 휴먼의 참여자/발신자 id는 `org_members.id`다
-    (org_members 테이블 자체가 휴먼 전용이라 추가 type 조건 불요) — 그런데
-    이 모듈의 왕복·딥링크 판정은 여전히 `team_members(type='human')`로만 이었다.
-    team_members에 그 org의 휴먼 행이 하나도 없으면(SSOT 전환 이후 만들어진
-    org 다수) `human_before`·`requester_is_participant`가 영원히 false로
-    떨어져 "대화 中인데도 미완료·딥링크 null"이 났다(dev PO Test Org 실측).
-
-    둘 다 인정(OR) — legacy team_member(type='human') 행이 남아있는 org도
-    회귀 없이 그대로 통과해야 한다(#3607 기존 테스트가 그 표본).
-    `user_id`를 주면 그 유저 소유 여부까지, 안 주면 "휴먼이기만 하면" 통과."""
-    org_member_conditions = [OrgMember.id == member_id_col, OrgMember.deleted_at.is_(None)]
-    team_member_conditions = [TeamMember.id == member_id_col, TeamMember.type == "human"]
-    if user_id is not None:
-        org_member_conditions.append(OrgMember.user_id == user_id)
-        team_member_conditions.append(TeamMember.user_id == user_id)
-    return or_(
-        select(OrgMember.id).where(*org_member_conditions).exists(),
-        select(TeamMember.id).where(*team_member_conditions).exists(),
-    )
 
 
 async def get_owner_org_id(db: AsyncSession, user_id: uuid.UUID) -> uuid.UUID | None:

--- a/backend/tests/test_2608_human_intervention_dispatch.py
+++ b/backend/tests/test_2608_human_intervention_dispatch.py
@@ -25,6 +25,15 @@ def _result_all(rows: list):
     return r
 
 
+def _result_scalars(ids: list):
+    """story #3629 — human_targets 조회가 (member_id, type) 튜플 join 대신 이미 휴먼으로
+    필터된 member_id 스칼라 목록을 `.scalars().all()`로 받는 형으로 바뀌었다(is_human_
+    member_condition WHERE절이 SQL에서 이미 걸러낸다 — agent는 애초에 이 목록에 없다)."""
+    r = SimpleNamespace()
+    r.scalars = lambda: SimpleNamespace(all=lambda: list(ids))
+    return r
+
+
 def _msg(mentioned=None):
     return SimpleNamespace(
         id=uuid.uuid4(),
@@ -70,7 +79,7 @@ async def test_only_human_participants_receive_intervention_event():
     blocked = {uuid.uuid4()}  # 상대 agent(연쇄 게이트에 막힌 agent recipient)
 
     db = _DB([
-        _result_all([(human1, "human"), (human2, "human"), (agent_other, "agent")]),
+        _result_scalars([human1, human2]),  # agent_other는 SQL WHERE절이 이미 제외.
     ])
 
     import contextlib
@@ -99,9 +108,9 @@ async def test_no_human_participants_no_event_and_no_db_roundtrip():
     conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
     msg = _msg()
     sender = _sender()
-    agent_only = uuid.uuid4()
+    agent_only = uuid.uuid4()  # SQL WHERE절이 애초에 걸러내 mock 목록에도 안 실린다.
 
-    db = _DB([_result_all([(agent_only, "agent")])])
+    db = _DB([_result_scalars([])])
 
     result = await conv._dispatch_human_intervention_event(
         db, conversation, msg, uuid.uuid4(), sender, {uuid.uuid4()}, chain_depth_cap=4,

--- a/backend/tests/test_3629_member_ssot_notification_command_center_realdb.py
+++ b/backend/tests/test_3629_member_ssot_notification_command_center_realdb.py
@@ -1,0 +1,182 @@
+"""story #3629(3627 클래스 전수, 페드루 PO 確定 2026-09-07) — 「휴먼」을 team_members
+(type='human')로만 잇던 자리들이 org_member-only 휴먼(SSOT 전환 이후 org 다수, dev PO
+Test Org 실물 모양)에서 조용히 빠졌는지 실측 회귀.
+
+세팅 헬퍼는 test_2301_story_body_mentions_realdb.py·test_2288_command_center_gate_
+type_waiting_realdb.py 재사용(app.main 1회 import 비용 분리 관례 그대로) — 다만 두 파일의
+`_make_member`/`_make_human_member`는 OrgMember+Member(앵커) 둘 다 만드는 "정상 앵커됨"
+휴먼이라, 이 스토리가 재현해야 하는 "team_members 행이 아예 없는" 갭 모양과 반대다.
+`_make_org_member_only_human`이 그 갭 모양을 직접 만든다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+)
+from tests.test_2288_command_center_gate_type_waiting_realdb import _make_member, _setup_app_human
+
+pytestmark = [
+    # 페드루 PO CHANGES(2026-09-07, 3877/3878 전례) — command_center 테스트가 `app.main`의
+    # 전역 엔진·실 HTTP 클라이언트를 거치는 신규 real-DB 파일이라 destructive_schema 짝(모듈
+    # 마커+infra/destructive-schema-shard-weights.json 등재)이 요구된다 — 미등재면 샤드 가드가
+    # 빨개진다.
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _migrated_session_factory():
+    """destructive_schema 마커의 autouse 리셋(conftest.py::_reset_schema_for_destructive_
+    tests)이 매 테스트 前 스키마를 통째로 지운다 — test_2301의 `_session_factory`는 이미
+    migrated 스키마가 있다는 전제(non-destructive 파일 전용)라 그대로 재사용하면 "relation
+    ... does not exist"로 죽는다. create_all로 재건(idempotent — 이미 있으면 no-op)."""
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine, Session = await _session_factory()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, Session
+
+
+async def _make_agent_only(session, org_id, project_id):
+    """test_2288의 `_make_member(type_='agent')`는 OrgMember도 같이 만든다(그 파일 자신의
+    편의 단축 — 실 에이전트는 org_members 행을 안 갖는다, org_members는 휴먼 전용 테이블).
+    이 테스트는 정확히 그 구분을 검증해야 해서 실물 모양(Member+AgentProjectProfile만,
+    OrgMember 0행)으로 직접 만든다."""
+    from app.models.member import AgentProjectProfile, Member
+
+    m = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name="Agent")
+    session.add(m)
+    await session.flush()
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=m.id, project_id=project_id))
+    await session.commit()
+    return m.id
+
+
+async def _make_org_member_only_human(session, org_id):
+    """team_members(Member 앵커) 행이 아예 없는 SSOT-only 휴먼 — dev PO Test Org 실물
+    모양(human TeamMember 0행·API 참여자는 org_member). org_members 딱 1행만 만든다."""
+    from app.models.user import User
+    from app.models.project import OrgMember
+
+    user = User(id=uuid.uuid4(), email=f"story3629-{uuid.uuid4().hex[:8]}@t.test", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.commit()
+    return om.id, user.id
+
+
+# ─── member_resolver.py::filter_human_member_ids — 배치 조회 자체 ────────────
+
+
+async def test_filter_human_member_ids_includes_org_member_only_and_legacy_team_member():
+    """org_member-only 휴먼·legacy team_member(human) 휴먼 둘 다 포함, agent는 제외."""
+    from app.services.member_resolver import filter_human_member_ids
+
+    engine, Session = await _migrated_session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            om_human_id, _ = await _make_org_member_only_human(s, org.id)
+            anchored_human_id, _ = await _make_member(s, org.id, project.id, type_="human")
+            agent_id = await _make_agent_only(s, org.id, project.id)
+
+            result = await filter_human_member_ids(
+                {om_human_id, anchored_human_id, agent_id, uuid.uuid4()}, s,
+            )
+            assert result == {om_human_id, anchored_human_id}
+    finally:
+        await engine.dispose()
+
+
+async def test_filter_human_member_ids_excludes_soft_deleted_org_member():
+    """story #3629 후속(카디르 발견, #3627 클래스 공유) — soft-delete된 org_member는
+    휴먼으로 인정하면 안 된다(뮤테이션: deleted_at 가드 제거 시 이 테스트가 RED여야
+    가드가 실제로 뭘 잡는지 스스로 증명한다)."""
+    from app.models.project import OrgMember
+    from sqlalchemy import update
+    from app.services.member_resolver import filter_human_member_ids
+
+    engine, Session = await _migrated_session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            om_human_id, _ = await _make_org_member_only_human(s, org.id)
+            await s.execute(
+                update(OrgMember).where(OrgMember.id == om_human_id).values(deleted_at=datetime.now(timezone.utc))
+            )
+            await s.commit()
+
+            result = await filter_human_member_ids({om_human_id}, s)
+            assert result == set(), "soft-delete된 org_member는 휴먼으로 인정되면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+# ─── command_center.py — done 스토리 contribution 집계 ───────────────────────
+
+
+async def test_command_center_overview_counts_org_member_only_assignee_as_human():
+    """story #3629(command_center.py:~715, 그라운딩 확認) — Member.id==Story.assignee_id
+    단독 조인은 org_member-only 휴먼 assignee를 조용히 unassigned로 떨어뜨렸다(members.id
+    ==org_members.id 불변식은 migration 0075 백필 시점 한정 — SSOT 전환 이후 새 org_member
+    는 members 앵커 행이 안 만들어진다). OrgMember도 LEFT JOIN해 human으로 보강."""
+    from app.models.pm import Story
+    from sqlalchemy import update
+    from app.main import app
+
+    engine, Session = await _migrated_session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            om_human_id, caller_user_id = await _make_org_member_only_human(s, org.id)
+            story = await _make_story(s, org.id, project.id, title="Done by SSOT-only human")
+            await s.execute(
+                update(Story).where(Story.id == story.id).values(status="done", assignee_id=om_human_id)
+            )
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        # overview()는 read-replica 축(get_read_db)을 쓴다(story #2451 §6 Phase3 A1) —
+        # _setup_app_human은 get_db만 오버라이드하므로 여기서 같은 세션 팩토리로 추가.
+        from app.dependencies.database import get_db, get_read_db
+        app.dependency_overrides[get_read_db] = app.dependency_overrides[get_db]
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/overview")
+            assert resp.status_code == 200, resp.text
+            contribution = resp.json()["project_status"]["contribution"]
+            assert contribution["human"] == 1
+            assert contribution["unassigned"] == 0
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3635_member_anchor_root_fix_realdb.py
+++ b/backend/tests/test_3635_member_anchor_root_fix_realdb.py
@@ -1,0 +1,347 @@
+"""story #3635(BE·결함 클래스 근본·prod, 페드루 PO 確定 2026-09-07) — 휴먼 org_member의
+members 앵커 부재를 뿌리에서 닫는다. #3627/#3629/#3634가 자리별로(is_human_member_
+condition·filter_human_member_ids·ensure_human_member lazy call) 막은 것을, 이 스토리는
+데이터(백필 마이그)+생성 경로(OrgMemberRepository.create) 전수로 뿌리에서 닫는다.
+
+세팅 헬퍼는 test_2301_story_body_mentions_realdb.py·test_2288_command_center_gate_
+type_waiting_realdb.py 재사용(중복 재발명 금지, #3629/#3634와 동일 관례) — 실 alembic
+마이그레이션 스키마 대상(team_members는 read-only VIEW라 create_all 기반 픽스처를 못 쓴다,
+test_member_ssot_parity_realdb.py가 obsolete로 skip된 이유와 동형)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL, _make_org, _make_project, _session_factory
+from tests.test_2288_command_center_gate_type_waiting_realdb import _make_member
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_org_member_only_human(session, org_id, *, role="member"):
+    """team_members/members 앵커가 아예 없는 SSOT-only 휴먼 — org_members 딱 1행만
+    (#3629/#3634와 동일 헬퍼 모양)."""
+    from app.models.user import User
+    from app.models.project import OrgMember
+
+    user = User(id=uuid.uuid4(), email=f"story3635-{uuid.uuid4().hex[:8]}@t.test", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return om.id, user.id
+
+
+async def _count_orphan_active_org_members(session, org_id) -> int:
+    """AC1 불변식 — 활성 휴먼 org_member 중 members 앵커 행이 없는 것의 수(0이어야 정상)."""
+    from sqlalchemy import select
+    from app.models.member import Member
+    from app.models.project import OrgMember
+
+    rows = (await session.execute(
+        select(OrgMember.id)
+        .outerjoin(Member, Member.id == OrgMember.id)
+        .where(OrgMember.org_id == org_id, OrgMember.deleted_at.is_(None), Member.id.is_(None))
+    )).scalars().all()
+    return len(rows)
+
+
+# ─── AC2 — OrgMemberRepository.create()가 이제 앵커를 멱등 생성한다 ────────────
+
+
+@pytest.mark.anyio
+async def test_org_member_repository_create_ensures_member_anchor():
+    """관리자 직접 추가(org_members.py:154, OrgMemberRepository.create 유일 호출부)도
+    이제 members 앵커를 만든다 — 이전엔 이 자리만 ensure_human_member를 안 불렀다."""
+    from app.models.member import Member
+    from app.repositories.org_member import OrgMemberRepository
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            repo = OrgMemberRepository(s, org.id)
+            user_id = uuid.uuid4()
+            om = await repo.create(user_id=user_id, role="member")
+
+            anchor = await s.get(Member, om.id)
+            assert anchor is not None
+            assert anchor.type == "human"
+            assert anchor.org_id == org.id
+
+            assert await _count_orphan_active_org_members(s, org.id) == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_member_repository_create_anchor_removed_is_orphan_regression(monkeypatch):
+    """뮤테이션 — ensure_human_member 호출을 없애면(옛 동작 재현) 불변식 카운트가
+    다시 1로 뜬다(이 카운트 테스트가 실제로 그 결함을 잡는다는 증거)."""
+    import app.repositories.org_member as org_member_module
+
+    async def _never_ensures(session, org_member_id):
+        return False
+
+    monkeypatch.setattr(
+        "app.services.agent_anchor_sync.ensure_human_member", _never_ensures,
+    )
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            repo = org_member_module.OrgMemberRepository(s, org.id)
+            await repo.create(user_id=uuid.uuid4(), role="member")
+
+            assert await _count_orphan_active_org_members(s, org.id) == 1
+    finally:
+        await engine.dispose()
+
+
+# ─── AC2b — OrganizationRepository.create(owner_member_id=...)도 앵커를 만든다
+# (4번째 생성 경로, PR#3987 qa:changes·카디르 재발견·페드루 코드 재확認 2026-09-07) ────
+
+
+async def _seed_project_scoped_human(session, org_id, project_id):
+    """team_members VIEW가 실제로 행을 내려면 project_access가 있어야 한다(0110 뷰 정의
+    — project_access와의 JOIN이 필수). 완전 앵커된 휴먼(기존 test_2288 패턴 그대로,
+    새 세팅 발명 0) — 이 스토리의 관심사는 「이 사람을 새 org의 owner로 지정했을 때 그
+    새 org_member」쪽이지, 이 소스 멤버 자체의 앵커 상태가 아니다."""
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@t.test", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Owner")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id  # m.id == team_members.id(0110 뷰: SELECT m.id FROM members m ...)
+
+
+@pytest.mark.anyio
+async def test_organization_repository_create_with_owner_member_id_ensures_member_anchor():
+    """POST /organizations에 owner_member_id를 지정한 생성 경로 — repositories/
+    organization.py::create()의 owner_member_id 갈래(원자 INSERT ... FROM team_members)가
+    이제 새로 만든 org의 org_member에도 members 앵커를 보장한다. 이전엔 organizations.py
+    라우터의 owner_member_id=None 갈래만 ensure_human_member를 불렀다(4번째 생성 경로 갭)."""
+    from sqlalchemy import select
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.repositories.organization import OrganizationRepository
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            source_org = await _make_org(s)
+            project = await _make_project(s, source_org.id)
+            owner_member_id, owner_user_id = await _seed_project_scoped_human(s, source_org.id, project.id)
+
+            repo = OrganizationRepository(s)
+            new_org = await repo.create(
+                name="New Org", slug=f"neworg-{uuid.uuid4().hex[:8]}", owner_member_id=owner_member_id,
+            )
+            await s.commit()
+
+            new_om = (await s.execute(
+                select(OrgMember).where(OrgMember.org_id == new_org.id, OrgMember.user_id == owner_user_id)
+            )).scalar_one()
+            anchor = await s.get(Member, new_om.id)
+            assert anchor is not None, "owner_member_id 갈래로 만든 새 org의 org_member에 members 앵커가 없다"
+            assert anchor.type == "human"
+            assert anchor.org_id == new_org.id
+
+            assert await _count_orphan_active_org_members(s, new_org.id) == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_organization_repository_create_owner_member_id_anchor_removed_is_orphan_regression(monkeypatch):
+    """뮤테이션 — 위 자리의 ensure_human_member 호출을 없애면(4번째 경로의 옛 결함
+    재현) 새 org에도 다시 orphan org_member가 생긴다."""
+    import app.repositories.organization as org_repo_module
+
+    async def _never_ensures(session, org_member_id):
+        return False
+
+    # org_repo_module.create()가 함수 안에서 `from app.services.agent_anchor_sync import
+    # ensure_human_member`를 그때그때 다시 부른다(지연 import, org_member.py 선례와 동형) —
+    # 원본 모듈의 속성을 갈아끼우면 그 다음 호출부터 이 대역이 잡힌다.
+    monkeypatch.setattr("app.services.agent_anchor_sync.ensure_human_member", _never_ensures)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            source_org = await _make_org(s)
+            project = await _make_project(s, source_org.id)
+            owner_member_id, owner_user_id = await _seed_project_scoped_human(s, source_org.id, project.id)
+
+            repo = org_repo_module.OrganizationRepository(s)
+            new_org = await repo.create(
+                name="New Org", slug=f"neworg-{uuid.uuid4().hex[:8]}", owner_member_id=owner_member_id,
+            )
+            await s.commit()
+
+            assert await _count_orphan_active_org_members(s, new_org.id) == 1, "뮤테이션이 걸리지 않았다"
+    finally:
+        await engine.dispose()
+
+
+# ─── AC1 — 백필 마이그가 기존 갭을 채운다(마이그 SQL을 직접 재현·회귀) ─────────
+
+
+@pytest.mark.anyio
+async def test_backfill_query_fills_pre_existing_gap():
+    """0354 마이그의 INSERT SELECT를 그대로 재현 — 백필 前엔 갭 1, 백필 뒤엔 0.
+
+    story #3987 CI 실사고(2026-09-07, run 34121108303) — 대상 지정
+    `ON CONFLICT (id) DO NOTHING`은 이 org_member의 (org_id, user_id)에 이미 id가
+    다른 active human member 행이 있으면(공유 비-destructive DB에서 다른 자리가
+    먼저 앵커를 만들어 둔 경우 등, uq_members_active_human 부분 유니크 인덱스)
+    PK 충돌이 아니라서 그대로 UniqueViolation으로 죽는다 — 백필의 목표(그
+    (org_id, user_id)에 앵커가 있다)는 이미 달성된 상태인데도 크래시하는 과잉이었다.
+    마이그를 대상 없는 bare `ON CONFLICT DO NOTHING`으로 고쳤다 — 이 테스트도 그에
+    맞춰 「id==om_id인 특정 행」이 아니라 「그 (org_id, user_id)에 active human
+    anchor가 존재한다」는 백필의 실제 목표 자체를 단언한다(어느 경로로 채워졌든
+    통과 — Pedro PO 방향)."""
+    from sqlalchemy import select, text
+    from app.models.member import Member
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            om_id, user_id = await _seed_org_member_only_human(s, org.id)
+
+            assert await _count_orphan_active_org_members(s, org.id) == 1
+
+            # alembic/versions/0354_member_anchor_backfill_root_fix.py와 동일 SQL.
+            await s.execute(text(
+                """
+                INSERT INTO members (id, org_id, type, user_id, owner_member_id, name, org_role, is_active, created_at, updated_at)
+                SELECT om.id, om.org_id, 'human', u.id, NULL,
+                       COALESCE(u.display_name, u.email, om.user_id::text),
+                       om.role, true, om.created_at, now()
+                FROM org_members om
+                JOIN organizations o ON o.id = om.org_id
+                LEFT JOIN users u ON u.id = om.user_id
+                WHERE om.deleted_at IS NULL
+                ON CONFLICT DO NOTHING
+                """
+            ))
+            await s.commit()
+
+            assert await _count_orphan_active_org_members(s, org.id) == 0
+            anchor = (await s.execute(
+                select(Member).where(
+                    Member.org_id == org.id, Member.user_id == user_id,
+                    Member.type == "human", Member.deleted_at.is_(None),
+                )
+            )).scalar_one()
+            assert anchor.user_id == user_id
+    finally:
+        await engine.dispose()
+
+
+# ─── AC4 — member_resolver 두 갈래(legacy/anchor)가 같은 id를 낸다 ─────────────
+
+
+@pytest.mark.anyio
+async def test_legacy_and_anchor_resolver_agree_after_anchor_exists():
+    """백필로 앵커가 채워진 뒤(또는 정상 생성 경로로 이미 있는 뒤) legacy 갈래
+    (org_members 직조회)와 anchor 갈래(members 조회)가 같은 id를 낸다 — 백필이
+    「레거시 휴먼」 갈래를 「정상 앵커됨」 갈래로 옮겨도 신원(id)이 안 바뀜을
+    못박는다(페드루 PO 지시)."""
+    from unittest.mock import MagicMock
+    from app.services.member_resolver import _resolve_member_anchor, _resolve_member_legacy
+    from app.repositories.org_member import OrgMemberRepository
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            repo = OrgMemberRepository(s, org.id)
+            user_id = uuid.uuid4()
+            om = await repo.create(user_id=user_id, role="member")  # 이제 앵커 자동 생성.
+
+            auth = MagicMock()
+            auth.user_id = str(user_id)
+            auth.claims = {"app_metadata": {}}
+
+            legacy = await _resolve_member_legacy(auth, org.id, s)
+            anchor = await _resolve_member_anchor(auth, org.id, s)
+
+            assert legacy.id == anchor.id == om.id
+            assert legacy.type == anchor.type == "human"
+    finally:
+        await engine.dispose()
+
+
+# ─── AC5 — is_human_member_condition의 deleted_at 가드(카디르 #3983 발견 흡수) ──
+
+
+@pytest.mark.anyio
+async def test_is_human_member_condition_excludes_soft_deleted_org_member_directly():
+    """filter_human_member_ids를 거치지 않고 is_human_member_condition 자체를 직접
+    단위 테스트한다(#3629는 filter_human_member_ids만 간접으로 잡았다 — 카디르 #3983
+    지적).
+
+    ⚠️ member_id_col에 OrgMember.id를 그대로 넣고 outer select도 OrgMember에서
+    걸면(alias 없이) EXISTS 서브쿼리가 outer 행 자기 자신과 자동 상관돼(같은
+    미별칭 테이블) "이 행이 존재하는가"라는 항진명제로 무너진다(memory:
+    feedback_sqlalchemy_exists_alias_correlation_trap과 동형 함정). 실사용(예:
+    filter_human_member_ids)은 항상 다른 테이블의 컬럼(ConversationParticipant.
+    member_id 등)을 넘겨 이 문제가 없다 — 이 테스트는 리터럴 UUID 바인드 값을
+    넘겨(어떤 테이블에도 안 묶임) 같은 함정을 피한다."""
+    from sqlalchemy import literal, select, update
+    from app.models.project import OrgMember
+    from app.services.member_resolver import is_human_member_condition
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            om_id, _ = await _seed_org_member_only_human(s, org.id)
+
+            # soft-delete 前 — 조건이 True.
+            is_human_before = (await s.execute(
+                select(is_human_member_condition(literal(om_id)))
+            )).scalar_one()
+            assert is_human_before is True
+
+            await s.execute(update(OrgMember).where(OrgMember.id == om_id).values(deleted_at=datetime.now(timezone.utc)))
+            await s.commit()
+
+            is_human_after = (await s.execute(
+                select(is_human_member_condition(literal(om_id)))
+            )).scalar_one()
+            assert is_human_after is False, "soft-delete된 org_member는 휴먼으로 인정되면 안 된다"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
결재 2f9e82fa 승인 뒤 PO가 머지 — 이 PR은 draft 상태로 두고 미르코가 직접 머지하지 않는다.

## prod 승격 — members 앵커 결함 클래스 잔여 2건 (3629·3635 cherry-pick만·그 외 develop 변경 미포함)

| develop 커밋 | 스토리 | 내용 |
|---|---|---|
| a036a7469 (#3983) | 3629 | 3627 클래스 전수 — 멘션·chain-expired·기여 집계 4곳 통일 |
| 89825c81e (#3987) | 3635 | 휴먼 org_member의 members 앵커 부재를 뿌리에서 닫는다(마이그 0354 백필) |

main(14fab6f35) 위 cherry-pick 2건(`-x`) — 두 커밋 다 develop 원본과 content-identical(라인 컨텍스트만 이동, 실질 diff 0). 의존 확認: 3627(#3980)·3634(#3985)는 main에 이미 존재(이전 승격 PR #3991).

## 마이그 재배선(별도 커밋, cherry-pick 커밋 자체는 무변경)
- 0354(story #3635)의 `down_revision`을 develop 전용 "0353"(main엔 없음) → main head "0295"로 재작성(0283/0289/0292 선례와 같은 방식 — develop 전용 마이그 0296~0353은 이 승격에 안 실린다, 스키마 따라잡기 0).
- `alembic heads` main 기준 단일 head(0354) 확認.
- fresh DB `alembic upgrade head` 클린(0295→0354 직행).

## 충돌·의존
- `infra/destructive-schema-shard-weights.json` — 3629 cherry-pick이 이 CI 샤드-타이밍 스냅샷 파일도 건드리는데, main과 develop 사이 이 파일이 크게 갈려 있어(수십 개 무관 항목) main 쪽(HEAD)을 그대로 유지 — 순수 CI 샤드 균형 힌트일 뿐 앱 동작과 무관(새 destructive 테스트 1개는 "평균 가중치"로 흡수, 파일 자신의 docstring이 이 저하를 허용 범위로 명시).
- 그 외 신규 의존 없음.

## 테스트
- backend `tests/test_3629_member_ssot_notification_command_center_realdb.py`·`tests/test_3635_member_anchor_root_fix_realdb.py`·`tests/test_2608_human_intervention_dispatch.py` — destructive 3건 + non-destructive 3건(7 skip은 실DB 플래그 미설정 환경) 전부 그린(main 코드베이스 위에서 재실행 확認).
- CI(이 PR): 진행 예정 — 결과는 별도 코멘트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA