### PR TITLE
[SID:3665] fix(BE·결함): standup_history days= 필터가 date.today()(프로세스 로컬 TZ)를 써 자정 경계에서 오判

### DIFF
--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import exists, select
@@ -305,7 +305,16 @@ async def list_standup_history(
     # 누락하면 파이썬 기본값인 Query(...) 센티넬 객체(정수 아님·truthy) 가 그대로 들어온다.
     # int가 아니면 필터 없음으로 취급(cursor의 isinstance(..., str) 가드와 동형).
     if isinstance(days, int):
-        q = q.where(StandupEntry.date >= date.today() - timedelta(days=days - 1))
+        # story #3665(BE·결함, 2026-09-07) — `date.today()`는 프로세스(OS) 로컬 타임존
+        # 기준이라, 배포 컨테이너의 시스템 TZ가 UTC가 아니면(또는 이 값을 읽는 시점이
+        # 로컬 자정 경계와 겹치면) 실행마다 "오늘"이 달라지는 비결정적 필터가 된다 —
+        # 실측(로컬 TZ=Asia/Seoul, UTC 17시대) 재현: days=1 필터가 UTC 기준으로 명시
+        # 심어진 "오늘" 항목을 놓쳤다(0건 vs 기대 1건), TZ=UTC로 바꾸면 즉시 통과.
+        # `datetime.now(timezone.utc).date()`로 명시 UTC 고정 — 환경(컨테이너 TZ)에
+        # 무관하게 항상 같은 값을 낸다(StandupEntry.date 자체는 client-supplied라 그
+        # 값의 타임존 관례는 이 수정의 범위 밖 — 여기서 고치는 것은 "오늘"의 계산 방식
+        # 만이다).
+        q = q.where(StandupEntry.date >= datetime.now(timezone.utc).date() - timedelta(days=days - 1))
     # #2540 CI 교훈(오르테가군): "값이 있는지"만 보면 안 되고 "그 값이 문자열인지"까지 봐야
     # 한다 — 이 함수를 FastAPI DI 없이 직접 호출하며 cursor= 를 누락하면 파이썬 기본값인
     # Query(...) 센티넬 객체(truthy) 가 그대로 들어온다. 문자열이 아니면 커서 없음으로 취급.

--- a/backend/app/services/deployment_lifecycle.py
+++ b/backend/app/services/deployment_lifecycle.py
@@ -47,6 +47,18 @@ class DeploymentLifecycleError(Exception):
         self.details = details or {}
 
 
+def _utc_midnight_today() -> datetime:
+    """UTC 자정(오늘 0시)을 프로세스 로컬 TZ 영향 없이 직접 구한다.
+
+    story #3665 CHANGES(페드루 PO, 2026-09-07) — 예전엔 `date.today()`(프로세스 로컬
+    타임존 기준)로 날짜를 얻은 뒤 `.replace(tzinfo=timezone.utc)`로 라벨만 UTC로 갈아
+    끼웠다(값 자체는 안 바뀜) — 배포 컨테이너 시스템 TZ가 UTC가 아니면 자정 경계에서
+    "오늘 0시"가 실제 UTC 자정과 최대 하루 어긋난다(#3665 원 결함, standups.py:308과
+    같은 클래스). `datetime.now(timezone.utc)`에서 시:분:초만 0으로 잘라 UTC 자정을
+    직접 구해 이 클래스의 결함을 원천 차단한다."""
+    return datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
 # ---------------------------------------------------------------------------
 # Webhook dispatch
 # ---------------------------------------------------------------------------
@@ -852,8 +864,7 @@ class DeploymentLifecycleService:
             )
             persona_name_by_id = {row.id: row.name for row in pr.all()}
 
-        from datetime import date
-        today_start = datetime.combine(date.today(), datetime.min.time()).replace(tzinfo=timezone.utc)
+        today_start = _utc_midnight_today()
 
         runs_today_r = await self.session.execute(
             select(AgentRun.deployment_id, AgentRun.input_tokens, AgentRun.output_tokens)

--- a/backend/app/services/ga4_client.py
+++ b/backend/app/services/ga4_client.py
@@ -7,15 +7,22 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import date, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
 def _make_date_range(date_range_days: int) -> tuple[str, str]:
-    """date_range_days일 전 ~ 어제 (GA4 데이터 지연 고려)."""
-    end = date.today() - timedelta(days=1)
+    """date_range_days일 전 ~ 어제 (GA4 데이터 지연 고려).
+
+    story #3665 CHANGES(페드루 PO, 2026-09-07) — `date.today()`는 프로세스(OS) 로컬
+    타임존 기준이라 배포 컨테이너 시스템 TZ가 UTC가 아니면 "어제"가 실행 환경에 따라
+    비결정적이다(#3665 원 결함과 같은 클래스, standups.py:308 참고). "오늘"의 뜻이
+    org 로컬 일 경계(organizations.timezone)여야 하는지는 별도 제품 질문 — 그 헬퍼가
+    아직 없어(그라운딩 확認) 이번엔 UTC로 결정적으로만 만든다(org 로컬 일 경계 정합은
+    범위 밖, PO 확定)."""
+    end = datetime.now(timezone.utc).date() - timedelta(days=1)
     start = end - timedelta(days=date_range_days - 1)
     return start.isoformat(), end.isoformat()
 

--- a/backend/tests/test_3665_utc_date_boundary_regression.py
+++ b/backend/tests/test_3665_utc_date_boundary_regression.py
@@ -1,0 +1,58 @@
+"""story #3665(BE·결함, 페드루 PO CHANGES 2026-09-07) — `standups.py:308`의 원 결함
+(`date.today()`=프로세스 로컬 타임존 기준이라 배포 컨테이너 시스템 TZ가 UTC가 아니면
+"오늘" 계산이 실행 환경마다 비결정적)과 같은 클래스가 전수 grep으로 2곳 더 나왔다.
+이 파일은 그 2곳(`ga4_client._make_date_range`, `deployment_lifecycle.
+_utc_midnight_today`)의 UTC 결정화가 실제로 지켜지는지를, monkeypatch로 "로컬 TZ가
+이미 다음 날로 넘어갔지만 UTC로는 아직 전날"인 경계를 강제 재현해 고정한다.
+
+두 헬퍼 모두 `datetime`(과, ga4_client의 경우 `date`)을 모듈 top-level에서 import해
+쓰므로, `monkeypatch.setattr(모듈, "datetime"/"date", Fake클래스)`로 그 이름이
+가리키는 클래스 자체를 갈아 끼우면 함수 안에서의 모든 호출이 고정값을 본다(freezegun
+없이 표준 라이브러리만으로 결정적 시각 고정 — 이 레포에 이미 있는 unittest.mock류
+관례와 동형)."""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+
+def test_make_date_range_uses_utc_not_process_local_date(monkeypatch):
+    """date.today()가 이미 "내일"(로컬 TZ가 UTC보다 앞선 경우)로 갈린 순간을 강제 —
+    UTC 기준 계산이면 "어제"(1일 전)가 UTC 오늘(1/1)의 전날인 12/31, `date.today()`
+    (뮤테이션 시 1/2)를 다시 쓰면 1/1이 되어 이 assert가 깨진다."""
+    import app.services.ga4_client as mod
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2026, 1, 2)  # 로컬(프로세스) "오늘"이 이미 다음 날로 갈린 상황.
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 1, 1, 23, 30, tzinfo=timezone.utc)  # UTC로는 아직 전날 밤.
+
+    monkeypatch.setattr(mod, "date", FakeDate, raising=False)
+    monkeypatch.setattr(mod, "datetime", FakeDatetime)
+
+    start, end = mod._make_date_range(1)
+
+    assert end == "2025-12-31"
+    assert start == "2025-12-31"
+
+
+def test_utc_midnight_today_uses_utc_not_process_local_date(monkeypatch):
+    """같은 경계를 `deployment_lifecycle._utc_midnight_today()`에도 강제 — UTC
+    기준이면 2026-01-01 00:00:00+00:00, `date.today()`(1/2)를 다시 쓰면 2026-01-02
+    00:00:00+00:00가 되어 이 assert가 깨진다."""
+    import app.services.deployment_lifecycle as mod
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 1, 1, 23, 30, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(mod, "datetime", FakeDatetime)
+
+    result = mod._utc_midnight_today()
+
+    assert result == datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
카디르 3648③ 스윕 발견(2026-09-07) — `tests/test_2412_standup_history_days_filter_realdb.py::test_days_one_means_today_only_realdb`가 develop 50da7d485에서 재현 FAIL(`days=1`인데 0건, 기대 1건).

## 원인
`backend/app/routers/standups.py:308`의 `date.today()`는 **프로세스(OS) 로컬 타임존** 기준 날짜라 배포 컨테이너 시스템 TZ에 따라 "오늘"이 비결정적이다. 이 테스트의 seed는 `datetime.now(timezone.utc).date()`(명시 UTC)로 "오늘"을 심는데, 두 "오늘"이 갈리는 순간(예: KST=UTC+9 환경에서 UTC 15:00~23:59, KST로는 이미 다음 날) `date.today()`가 하루 앞선 값을 반환해 방금 심은 항목이 필터 밖으로 밀린다.

**실측**(로컬, 이 세션) — 시스템 TZ=Asia/Seoul(현재 UTC 17시대=KST 다음날 새벽)로 실행 → FAIL 재현. `TZ=UTC`만 바꿔 재실행 → 3/3 PASS. 재현이 "프로세스 로컬 TZ vs UTC"가 정확한 원인임을 직접 증명한다.

**프로덕션 영향**: 테스트에서만 재현되는 게 아니라, 배포 컨테이너 시스템 TZ가 UTC가 아니면(또는 미래에 바뀌면) `/api/v2/standups/history?days=N`을 쓰는 아무 호출(FE 스탠드업 히스토리 화면·MCP `standup_history` 도구)이 매일 자정 근접 시간대에 조용히 하루 어긋난 결과를 낼 수 있는 잠재 결함이다.

## 처방
`date.today()` → `datetime.now(timezone.utc).date()`(같은 파일 `_seed` 관례와 동형, `timezone` import 추가)로 교체 — 환경(컨테이너 TZ) 무관하게 항상 같은 값.

## 같은 클래스 2곳 (페드루 PO CHANGES, 이 PR에 합류)
전수 grep으로 나온 나머지 2곳도 이 PR에서 같이 교체:
- `backend/app/services/ga4_client.py:18`(`_make_date_range`) — `date.today() - timedelta(days=1)` → `datetime.now(timezone.utc).date() - timedelta(days=1)`.
- `backend/app/services/deployment_lifecycle.py:856` — `datetime.combine(date.today(), ...).replace(tzinfo=timezone.utc)`(날짜는 로컬 기준인데 tzinfo만 UTC로 갈아 끼우는 패턴, 값은 안 바뀜) → 순수 헬퍼 `_utc_midnight_today()`로 추출, `datetime.now(timezone.utc)`에서 시:분:초만 잘라 UTC 자정을 직접 구함.

각각 monkeypatch로 "로컬 TZ가 이미 다음 날, UTC로는 아직 전날"인 경계를 강제 재현하는 단위 테스트 신설(`tests/test_3665_utc_date_boundary_regression.py`, 2건) + 라이브 뮤테이션(두 함수 다 `date.today()` 패턴으로 되돌림 → 둘 다 FAIL 확認 후 원복).

## 잃는 것
"오늘"의 뜻이 UTC 자정 경계가 맞는지, 아니면 org 로컬 일 경계(`organizations.timezone`)여야 하는지는 이 PR의 3곳 전부 **제품 질문**이다 — org 로컬 일 경계를 계산하는 헬퍼가 지금 레포에 없다(그라운딩 확認). 이번엔 세 곳 다 "환경(컨테이너 TZ)에 무관하게 결정적"으로만 만들었을 뿐, org 로컬 일 경계 정합 자체는 별건으로 남긴다.

## Test plan
- [x] 실측 재현 — TZ=Asia/Seoul(시스템 기본)에서 FAIL 확認 → TZ=UTC로 PASS 확認(원인 직접 증명)
- [x] 라이브 뮤테이션(`date.today()`로 되돌림) — standups.py는 TZ=Asia/Seoul에서 동일 FAIL 재현 확認 후 원복, ga4_client·deployment_lifecycle은 monkeypatch 경계로 재현 확認 후 원복
- [x] 기존 test_2412(3/3, TZ 무관 그린)+표준업 관련 파일 13개 회귀(61건)+ga4/workflow_template/s41 등 관련 파일 11개 회귀(103건)+신설 2건 그린
- [x] `app.main` import 그린

story #3665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
