### PR TITLE
[SID:3681] fix: 후속 — 잔여 폴백 2자리도 channelConnectionIdentityLabel로 통일

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -281,6 +281,39 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
     expect(testBtn?.disabled).toBeFalsy();
   });
 
+  // story #3661 후속(2026-09-07) — 「연결 시험」 성공 응답에 계정 username이 없으면
+  // 이전엔 conn.account_id(webhook류는 139자 URL)로 폴백했다. channelConnectionIdentityLabel
+  // 재사용으로 통일 — account_label이 없으면 「채널명(…짧은 꼬리)」.
+  it('연결 시험 성공 응답에 username이 없으면 raw account_id 대신 채널명+짧은 꼬리로 폴백한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes('/channel-connections/available-channels')) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ data: [{ channel: 'webhook', display_name: 'Webhook', credential_kind: 'pasted_secret', kind: 'social' }] }),
+        } as Response;
+      }
+      if (url.includes('/app-credentials')) {
+        return { ok: true, status: 200, json: async () => ({ data: { configured: false, app_id_suffix: null, effective_source: 'platform' } }) } as Response;
+      }
+      if (url.endsWith('/test') && init?.method === 'POST') {
+        return { ok: true, status: 200, json: async () => ({ data: { ok: true, account: {} } }) } as Response;
+      }
+      if (url.includes('/channel-connections')) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ data: [{ ...CONNECTION_ACTIVE, id: 'conn-webhook-1', channel: 'webhook', account_label: null, account_id: 'https://example.com/webhook' }] }),
+        } as Response;
+      }
+      return { ok: false, status: 404, json: async () => ({ data: null, error: { code: 'NOT_FOUND' } }) } as Response;
+    }));
+    await mount('owner');
+    const testBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '연결 시험') as HTMLButtonElement;
+    await act(async () => { testBtn.click(); });
+    await flush();
+    expect(container.textContent).not.toContain('https://example.com/webhook');
+    expect(container.textContent).toContain('…');
+  });
+
   it('?connected= 쿼리로 성공 배너가 뜬다', async () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams('connected=threads'));
     stubFetch({ connections: [] });
@@ -647,13 +680,15 @@ describe('OrganizationChannelsPage — available-channels 목록 기반 렌더(s
   it('⭐sandbox 「연결 만들기」를 누르면 BFF POST 성공 뒤 리로드 없이 새 연결 행이 추가된다', async () => {
     stubFetch({ connections: [], availableChannels: AVAILABLE_WITH_SANDBOX });
     await mount('owner');
-    expect(container.textContent).not.toContain('sandbox-org-1');
+    // story #3661 후속 — account_label이 null인 새 연결은 raw account_id(sandbox-org-1)가
+    // 아니라 channelConnectionIdentityLabel 폴백(「테스트용(…연결id 짧은 꼬리)」)으로 선다.
+    expect(container.textContent).not.toContain('테스트용(…onn-sb-1)');
 
     const btn = container.querySelector('[data-testid="channel-connect-sandbox-button"]') as HTMLButtonElement;
     await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
-    expect(container.textContent).toContain('sandbox-org-1');
+    expect(container.textContent).toContain('테스트용(…onn-sb-1)');
     expect(container.querySelector('[data-testid="channel-connect-sandbox-error"]')).toBeNull();
   });
 

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -474,7 +474,7 @@ function ConnectionRow({
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0">
           <p className="flex flex-wrap items-center gap-1.5 truncate text-sm font-medium text-foreground">
-            {conn.account_label ?? conn.account_id}
+            {channelConnectionIdentityLabel(conn, t)}
             {/* story f30da19a AC4③(유나 확定) — 연결 카드는 「테스트용 연결」(글 목록/
                 캘린더의 「테스트」와 다른 정본 — 여기는 "이 연결 자체가 테스트"라는 뜻).
                 story #3523(PO 실측(3523 그라운딩·page.tsx:239)·確定 2026-09-06) — channel===
@@ -526,7 +526,7 @@ function ConnectionRow({
             aria-hidden="true"
           />
           {testResult.ok
-            ? t('channelTestOk', { account: String(testResult.account?.['username'] ?? conn.account_id) })
+            ? t('channelTestOk', { account: String(testResult.account?.['username'] ?? channelConnectionIdentityLabel(conn, t)) })
             : t('channelTestFailed', { error: testResult.error ?? '' })}
         </p>
       ) : null}


### PR DESCRIPTION
#4017(base) 위 stacked — #4017 착지 뒤 develop으로 rebase 예정.

## 배경

페드루 PO 지적(2026-09-07) — #4017이 mismatch Alert 한 자리만 고쳤는데, `account_label ?? account_id` 형 raw 폴백이 이 화면에 2곳 더 있었다.

- `page.tsx:477`(연결 카드 헤더) — `account_label`이 없으면 raw `account_id`(webhook은 139자 URL)가 그대로 서던 것.
- `page.tsx:529`(「연결 시험」 성공 메시지) — 응답에 username이 없으면 같은 raw `account_id`로 폴백하던 것.

## 처방

둘 다 `channelConnectionIdentityLabel`(#4017 신설)로 통일 — 값 의미는 그대로(있으면 그 값, 없으면 채널명+짧은 꼬리), 새 낱말 0.

## 테스트

- 기존 sandbox 연결-추가 테스트 1건의 기대값을 raw `account_id`에서 새 폴백 형태로 갱신(동작 변경을 반영 — 회귀 아님).
- 신규 1 — 「연결 시험」 성공 응답에 username 없을 때 raw URL 노출 0.
- 둘 다 뮤테이션(각 폴백을 raw `account_id`로 되돌림) 확認 — 정확히 그 자리만 RED, 나머지 92건 그린. i18n 가드 클린(새 낱말 0). `tsc --noEmit` 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA