### PR TITLE
[SID:3667] fix: 초안 상세 404·403 Alert에 목록으로 나가는 링크 1개

### DIFF
--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -1592,6 +1592,25 @@ describe('ContentPostEditPage — 콘텐츠 규칙 위반 표시(story #3483, §
       .toBe(koMessages.content.contentRuleViolationsLoadFailed);
   });
 
+  // 페드루 PO 권고(#4022 리뷰, 2026-09-07) — 유나 #4016 적기만 ③(엇갈린 status
+  // 조합 미측). 부수 데이터(단건 GET)가 404/403이어도 — 그 status가 마치 「이
+  // 초안 자체가 없다/권한 없다」로 보일 수 있는 값이어도 — 주 데이터(/versions)가
+  // 200이면 notFound/forbidden 어느 쪽도 아니다(오직 /versions만 본다는 의도의
+  // 고정, 위 500 표본과 같은 결 — 404/403이라는 "그럴듯한" 값으로도 안 새는지).
+  it('엇갈린 status(부수 단건 GET 404여도 주 데이터 /versions는 200) — notFound가 아니라 violations 안내 줄로 접힌다', async () => {
+    stubFetchWithVersions([VERSION_1], undefined, undefined, { draftStatus: 404 });
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+
+    const titleInput = container.querySelector('#post-title') as HTMLInputElement | null;
+    expect(titleInput?.value).toBe(VERSION_1.title);
+    expect(container.textContent).not.toContain(koMessages.content.editNotFound);
+    expect(container.textContent).not.toContain(koMessages.content.editForbidden);
+    expect(container.querySelector('a[href="/content"]')).toBeNull();
+    expect(container.querySelector('[data-testid="content-rule-violation-load-failed"]')?.textContent)
+      .toBe(koMessages.content.contentRuleViolationsLoadFailed);
+  });
+
   // story #3514(PO REQUIRED, 2026-09-05) — 저장 응답이 violations를 권위 값으로
   // 채운 뒤에는 "불러오지 못했습니다" 줄이 그 곁에 남아 모순되면 안 된다.
   it('⭐단건 GET 500 뒤에도 저장에 성공하면 안내 줄이 사라진다(권위 값이 덮어씀)', async () => {

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -752,7 +752,7 @@ describe('ContentPostEditPage (story #3368 S3)', () => {
 // story #3662(campaigns/[campaignId]/page.tsx:76 선례, 유나 確定) — 주 데이터(/versions)
 // 실패를 404/403/그 외/네트워크 예외 4갈래로 문장을 가른다(추정 0, 서버 status 그대로).
 describe('ContentPostEditPage — story #3662(로드 실패 문구 3갈래)', () => {
-  it('로드 실패(500) — 기존 editLoadFailed를 보인다', async () => {
+  it('로드 실패(500) — 기존 editLoadFailed를 보인다 · 나가는 링크는 0', async () => {
     stubFetchWithVersions([], undefined, undefined, { versionsStatus: 500 });
     await act(async () => {
       root.render(wrap(<ContentPostEditPage />));
@@ -760,9 +760,11 @@ describe('ContentPostEditPage — story #3662(로드 실패 문구 3갈래)', ()
     await flush();
 
     expect(container.textContent).toContain(koMessages.content.editLoadFailed);
+    // story #3667(3662 후속) — 그 외 실패(3644/3632 봉투)엔 목록 링크를 안 그린다.
+    expect(container.querySelector('a[href="/content"]')).toBeNull();
   });
 
-  it('로드 실패(404) — 「찾을 수 없습니다」를 보인다', async () => {
+  it('로드 실패(404) — 「찾을 수 없습니다」+목록으로 나가는 링크', async () => {
     stubFetchWithVersions([], undefined, undefined, { versionsStatus: 404 });
     await act(async () => {
       root.render(wrap(<ContentPostEditPage />));
@@ -771,9 +773,13 @@ describe('ContentPostEditPage — story #3662(로드 실패 문구 3갈래)', ()
 
     expect(container.textContent).toContain(koMessages.content.editNotFound);
     expect(container.textContent).not.toContain(koMessages.content.editLoadFailed);
+    // story #3667 — 유나 #4016 적기만 ②(막다른 길) 처방: 목록으로 나가는 링크 1개.
+    const backLink = container.querySelector('a[href="/content"]');
+    expect(backLink).not.toBeNull();
+    expect(backLink?.textContent).toBe(koMessages.content.channelPostsCalendarBackToListCta);
   });
 
-  it('로드 실패(403) — 「볼 권한이 없습니다」를 보인다', async () => {
+  it('로드 실패(403) — 「볼 권한이 없습니다」+목록으로 나가는 링크', async () => {
     stubFetchWithVersions([], undefined, undefined, { versionsStatus: 403 });
     await act(async () => {
       root.render(wrap(<ContentPostEditPage />));
@@ -782,9 +788,12 @@ describe('ContentPostEditPage — story #3662(로드 실패 문구 3갈래)', ()
 
     expect(container.textContent).toContain(koMessages.content.editForbidden);
     expect(container.textContent).not.toContain(koMessages.content.editLoadFailed);
+    const backLink = container.querySelector('a[href="/content"]');
+    expect(backLink).not.toBeNull();
+    expect(backLink?.textContent).toBe(koMessages.content.channelPostsCalendarBackToListCta);
   });
 
-  it('로드 실패(네트워크 예외) — 기존 editLoadFailed로 남는다', async () => {
+  it('로드 실패(네트워크 예외) — 기존 editLoadFailed로 남는다 · 나가는 링크는 0', async () => {
     stubFetchWithVersions([], undefined, undefined, { versionsReject: true });
     await act(async () => {
       root.render(wrap(<ContentPostEditPage />));
@@ -794,6 +803,7 @@ describe('ContentPostEditPage — story #3662(로드 실패 문구 3갈래)', ()
     expect(container.textContent).toContain(koMessages.content.editLoadFailed);
     expect(container.textContent).not.toContain(koMessages.content.editNotFound);
     expect(container.textContent).not.toContain(koMessages.content.editForbidden);
+    expect(container.querySelector('a[href="/content"]')).toBeNull();
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -1014,19 +1014,28 @@ export default function ContentPostEditPage() {
 
   if (notFound) {
     return (
-      <div className="mx-auto w-full max-w-3xl p-6">
+      <div className="mx-auto w-full max-w-3xl space-y-3 p-6">
         <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
           <AlertDescription>{t('editNotFound')}</AlertDescription>
         </Alert>
+        {/* story #3667(3662 후속, 유나 #4016 적기만 ②) — 링크로 들어와 404/403을
+            읽은 사용자에게 «나가는 길» 하나(막다른 길 클래스, 3650과 같은 결).
+            새 낱말 0 — channel-posts/calendar 페이지가 이미 쓰는 키 재사용. */}
+        <Link href="/content" className="text-sm font-medium text-primary underline">
+          {t('channelPostsCalendarBackToListCta')}
+        </Link>
       </div>
     );
   }
   if (forbidden) {
     return (
-      <div className="mx-auto w-full max-w-3xl p-6">
+      <div className="mx-auto w-full max-w-3xl space-y-3 p-6">
         <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
           <AlertDescription>{t('editForbidden')}</AlertDescription>
         </Alert>
+        <Link href="/content" className="text-sm font-medium text-primary underline">
+          {t('channelPostsCalendarBackToListCta')}
+        </Link>
       </div>
     );
   }

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -1916,7 +1916,7 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     expect(container.querySelector('[data-testid="channel-post-published-info"]')).toBeNull();
   });
 
-  it('로드 실패(500) — 오류 알림을 보인다', async () => {
+  it('로드 실패(500) — 오류 알림을 보인다 · 나가는 링크는 0(막다른 길 아닌 다시 시도 부류)', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })));
     await act(async () => {
       root.render(wrap(<ChannelPostEditPage />));
@@ -1924,11 +1924,13 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     await flush();
 
     expect(container.textContent).toContain(koMessages.content.editLoadFailed);
+    // story #3667(3662 후속) — 그 외 실패(3644/3632 봉투)엔 목록 링크를 안 그린다.
+    expect(container.querySelector('a[href="/content/channel-posts"]')).toBeNull();
   });
 
   // story #3662(campaigns/[campaignId]/page.tsx:76 선례, 유나 確定) — 404/403/네트워크
   // 예외까지 4표본으로 문장이 갈리는지 고정(500은 위 표본이 이미 editLoadFailed로 커버).
-  it('로드 실패(404) — 「찾을 수 없습니다」를 보인다', async () => {
+  it('로드 실패(404) — 「찾을 수 없습니다」+목록으로 나가는 링크', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })));
     await act(async () => {
       root.render(wrap(<ChannelPostEditPage />));
@@ -1937,9 +1939,13 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
 
     expect(container.textContent).toContain(koMessages.content.editNotFound);
     expect(container.textContent).not.toContain(koMessages.content.editLoadFailed);
+    // story #3667 — 유나 #4016 적기만 ②(막다른 길) 처방: 목록으로 나가는 링크 1개.
+    const backLink = container.querySelector('a[href="/content/channel-posts"]');
+    expect(backLink).not.toBeNull();
+    expect(backLink?.textContent).toBe(koMessages.content.channelPostsCalendarBackToListCta);
   });
 
-  it('로드 실패(403) — 「볼 권한이 없습니다」를 보인다', async () => {
+  it('로드 실패(403) — 「볼 권한이 없습니다」+목록으로 나가는 링크', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 403, json: async () => ({}) })));
     await act(async () => {
       root.render(wrap(<ChannelPostEditPage />));
@@ -1948,9 +1954,12 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
 
     expect(container.textContent).toContain(koMessages.content.editForbidden);
     expect(container.textContent).not.toContain(koMessages.content.editLoadFailed);
+    const backLink = container.querySelector('a[href="/content/channel-posts"]');
+    expect(backLink).not.toBeNull();
+    expect(backLink?.textContent).toBe(koMessages.content.channelPostsCalendarBackToListCta);
   });
 
-  it('로드 실패(네트워크 예외) — 기존 editLoadFailed로 남는다', async () => {
+  it('로드 실패(네트워크 예외) — 기존 editLoadFailed로 남는다 · 나가는 링크는 0', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
     await act(async () => {
       root.render(wrap(<ChannelPostEditPage />));
@@ -1960,6 +1969,7 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     expect(container.textContent).toContain(koMessages.content.editLoadFailed);
     expect(container.textContent).not.toContain(koMessages.content.editNotFound);
     expect(container.textContent).not.toContain(koMessages.content.editForbidden);
+    expect(container.querySelector('a[href="/content/channel-posts"]')).toBeNull();
   });
 
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -1972,6 +1972,31 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     expect(container.querySelector('a[href="/content/channel-posts"]')).toBeNull();
   });
 
+  // 페드루 PO 권고(#4022 리뷰, 2026-09-07) — 유나 #4016 적기만 ③(엇갈린 status
+  // 조합 미측). 주 데이터(draftRes)는 200인데 보조(versionsRes)만 404/403이면
+  // 「서버 불변식 위반에 가까워 그 외/loadError로 접는다」(코드 주석 그대로)가
+  // 실제로도 그렇게 동작함을 못 박는다 — draftRes.status만 본다는 의도의 고정.
+  it('엇갈린 status(주 데이터 200 + 보조 404) — notFound가 아니라 editLoadFailed로 접힌다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes(`/channel-posts/drafts/${DRAFT_ID}/versions`)) {
+        return { ok: false, status: 404, json: async () => ({}) };
+      }
+      if (url.includes(`/channel-posts/drafts/${DRAFT_ID}`)) {
+        return { ok: true, status: 200, json: async () => ({ data: DRAFT_DETAIL }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.content.editLoadFailed);
+    expect(container.textContent).not.toContain(koMessages.content.editNotFound);
+    expect(container.textContent).not.toContain(koMessages.content.editForbidden);
+    expect(container.querySelector('a[href="/content/channel-posts"]')).toBeNull();
+  });
+
 
   // story f30da19a AC5 — T3(상세 머리).
   it('⭐AC5 — channel=sandbox면 상세 머리에 「테스트」 배지가 뜬다', async () => {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1725,19 +1725,28 @@ export default function ChannelPostEditPage() {
   }
   if (notFound) {
     return (
-      <div className="mx-auto w-full max-w-2xl p-6">
+      <div className="mx-auto w-full max-w-2xl space-y-3 p-6">
         <Alert variant="destructive" role="alert">
           <AlertDescription>{t('editNotFound')}</AlertDescription>
         </Alert>
+        {/* story #3667(3662 후속, 유나 #4016 적기만 ②) — 링크로 들어와 404/403을
+            읽은 사용자에게 «나가는 길» 하나(막다른 길 클래스, 3650과 같은 결).
+            새 낱말 0 — channel-posts/calendar 페이지가 이미 쓰는 키 재사용. */}
+        <Link href="/content/channel-posts" className="text-sm font-medium text-primary underline">
+          {t('channelPostsCalendarBackToListCta')}
+        </Link>
       </div>
     );
   }
   if (forbidden) {
     return (
-      <div className="mx-auto w-full max-w-2xl p-6">
+      <div className="mx-auto w-full max-w-2xl space-y-3 p-6">
         <Alert variant="destructive" role="alert">
           <AlertDescription>{t('editForbidden')}</AlertDescription>
         </Alert>
+        <Link href="/content/channel-posts" className="text-sm font-medium text-primary underline">
+          {t('channelPostsCalendarBackToListCta')}
+        </Link>
       </div>
     );
   }


### PR DESCRIPTION
#4016(base) 위 stacked — #4016 착지 뒤 develop으로 rebase 예정.

## 배경

3662(#4016) 후속, 유나 #4016 적기만 ② — 404/403/그 외 문장은 갈렸지만, 링크로 들어와 「이 글을 찾을 수 없습니다.」/「이 글을 볼 권한이 없습니다.」를 읽은 사용자에게 뒤로가기 말고는 할 수 있는 것이 0(막다른 길 클래스, story #3650과 같은 결).

## 처방

- `content/channel-posts/[draftId]`·`content/[draftId]` 두 화면의 notFound·forbidden Alert 아래에 목록으로 가는 링크 1개(각각 `/content/channel-posts`·`/content`).
- 낱말은 새로 안 만든다 — channel-posts/calendar 페이지가 이미 쓰는 `content.channelPostsCalendarBackToListCta`("목록으로") 재사용.
- loadError(3644/3632 봉투, 그 외 실패)엔 링크를 안 그린다 — 범위 그대로.

## 테스트

두 파일 기존 404/403/500/네트워크예외 4표본 테스트를 확장 — 404·403엔 링크 존재+href+텍스트, 500·네트워크예외엔 링크 0. 뮤테이션(링크 블록 제거)으로 그 자리만 RED 확認 후 복구. 기존 회귀 312건(두 파일 합) 그린. i18n 가드 클린(새 낱말 0). `tsc --noEmit` 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA