### PR TITLE
[SID:3666] feat(BE): 채널 포스트 이미지 원콜 import — MCP/플러그인 에이전트용

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -2,6 +2,8 @@
 API. `app/routers/site_posts.py`(story #3365) 형태를 그대로 미러 — 새 패턴 발명 0."""
 from __future__ import annotations
 
+import base64
+import binascii
 import re
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -14,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.error_envelope import human_error
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.channel_post_image import ChannelPostImage
 from app.models.channel_post_version import ChannelPostVersion
 from app.models.pm import Story
 from app.services.content_rules import get_org_content_rules, lint_content
@@ -84,6 +87,7 @@ from app.services.channel_post_images import (
     create_channel_post_image_upload_url,
     delete_channel_post_image,
     get_channel_post_image_for_version,
+    import_channel_post_image,
     list_channel_post_images_for_version,
     public_url_for_object_path,
     reorder_channel_post_images,
@@ -388,6 +392,14 @@ class ChannelPostImageUploadUrlResponse(BaseModel):
 
 class ConfirmChannelPostImageUploadRequest(BaseModel):
     object_path: str
+
+
+class ImportChannelPostImageRequest(BaseModel):
+    """story #3666(Phase2·마케팅운영, 페드루 PO 確定 2026-09-07) — MCP/플러그인 에이전트
+    전용 원콜 입구. `visual_artifacts.py::ImportImageArtifactRequest`(story b6b9c52d)와
+    같은 모양(title 없음 — 채널 포스트 이미지엔 그 개념이 없다)."""
+    image_base64: str
+    content_type: str
 
 
 class CreateChannelPostVideoUploadUrlRequest(BaseModel):
@@ -753,31 +765,16 @@ async def post_channel_post_video_confirm(
     return _video_response(version, video_row)
 
 
-@router.post(
-    "/{org_id}/channel-posts/drafts/{draft_id}/assets/confirm",
-    response_model=ChannelPostImageResponse, status_code=201,
-)
-async def post_channel_post_image_confirm(
-    org_id: uuid.UUID, draft_id: uuid.UUID, body: ConfirmChannelPostImageUploadRequest,
-    db: AsyncSession = Depends(get_db),
-    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
-    auth: AuthContext = Depends(get_current_user),
-) -> ChannelPostImageResponse:
-    """AC1/AC3 — 업로드 확인+자동 변환(필요 시)+계보 기록. 이 호출 자체가 새
-    `ChannelPostVersion`을 만든다(text/link_url은 직전 버전에서 캐리포워드, image_sha256만
-    갱신) — 텍스트 편집과 동형 축(재승인 판정은 create_channel_post_draft_version의
-    기존 재봉인 훅이 그대로 처리, 신규 메커니즘 0)."""
-    if org_id != verified_org_id:
-        raise HTTPException(status_code=403, detail="org_id mismatch")
-
-    member_id = uuid.UUID(auth.user_id)
-    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
-
+async def _confirm_image_upload_or_raise(
+    coro,
+) -> tuple[ChannelPostVersion, ChannelPostImage]:
+    """story #3666 리팩터 — `post_channel_post_image_confirm`(기존 3단계 업로드-URL 플로우의
+    마지막 걸음)과 `post_channel_post_image_import`(#3666 신규, 에이전트 원콜 base64 입구)
+    둘 다 `confirm_channel_post_image_upload`가 던지는 같은 예외 집합을 같은 HTTP 코드/
+    바디로 매핑해야 한다 — 그 매핑을 한 곳에만 두고(들쭉날쭉 금지 원칙) 호출부는 아직
+    await 안 된 코루틴만 넘긴다."""
     try:
-        version, image_row = await confirm_channel_post_image_upload(
-            db, org_id=org_id, draft_id=draft_id, object_path=body.object_path,
-            member_id=member_id, member_kind=actor_type,
-        )
+        return await coro
     except ChannelPostDraftNotFoundError as exc:
         raise HTTPException(status_code=404, detail={"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(exc)}) from exc
     except ChannelImageStorageNotConfiguredError as exc:
@@ -855,6 +852,78 @@ async def post_channel_post_image_confirm(
         ) from exc
     except ChannelImageUploadFailedError as exc:
         raise HTTPException(status_code=503, detail={"code": "CHANNEL_IMAGE_UPLOAD_FAILED", "message": str(exc)}) from exc
+
+
+@router.post(
+    "/{org_id}/channel-posts/drafts/{draft_id}/assets/confirm",
+    response_model=ChannelPostImageResponse, status_code=201,
+)
+async def post_channel_post_image_confirm(
+    org_id: uuid.UUID, draft_id: uuid.UUID, body: ConfirmChannelPostImageUploadRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelPostImageResponse:
+    """AC1/AC3 — 업로드 확인+자동 변환(필요 시)+계보 기록. 이 호출 자체가 새
+    `ChannelPostVersion`을 만든다(text/link_url은 직전 버전에서 캐리포워드, image_sha256만
+    갱신) — 텍스트 편집과 동형 축(재승인 판정은 create_channel_post_draft_version의
+    기존 재봉인 훅이 그대로 처리, 신규 메커니즘 0)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    member_id = uuid.UUID(auth.user_id)
+    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+
+    version, image_row = await _confirm_image_upload_or_raise(
+        confirm_channel_post_image_upload(
+            db, org_id=org_id, draft_id=draft_id, object_path=body.object_path,
+            member_id=member_id, member_kind=actor_type,
+        )
+    )
+    return _image_response(version, image_row)
+
+
+@router.post(
+    "/{org_id}/channel-posts/drafts/{draft_id}/assets/import-image",
+    response_model=ChannelPostImageResponse, status_code=201,
+)
+async def post_channel_post_image_import(
+    org_id: uuid.UUID, draft_id: uuid.UUID, body: ImportChannelPostImageRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelPostImageResponse:
+    """story #3666(Phase2·마케팅운영, 페드루 PO 確定 2026-09-07) — MCP/플러그인 에이전트
+    전용 원콜 입구. 미르코 배포 52 표본 준비 중 실측 갭: `create_channel_post_draft`가
+    image(산출물 첨부)를 안 받아, 기존 3단계(upload-url 발급→서명 PUT→confirm) 플로우를
+    Bash/HTTP 클라이언트가 없는 에이전트가 스스로 못 탔다. `visual_artifacts.py::
+    import_image_artifact`(story b6b9c52d)와 동일 정신(base64 원콜)이지만 다른 테이블
+    (VisualArtifact가 아니라 ChannelPostImage) — 새 연결 개념(두 시스템 사이 참조)을
+    만드는 대신 서버가 직접 GCS에 쓴 뒤 기존 confirm_channel_post_image_upload를 그대로
+    재사용한다(검증/변환/해시/봉인 로직 사본 0, `_confirm_image_upload_or_raise`로 에러
+    매핑도 confirm과 공유)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    if not body.content_type.startswith("image/"):
+        raise HTTPException(
+            status_code=400, detail={"code": "VALIDATION_ERROR", "message": "content_type must be an image/* type"},
+        )
+    try:
+        image_bytes = base64.b64decode(body.image_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(
+            status_code=400, detail={"code": "VALIDATION_ERROR", "message": "image_base64 is not valid base64"},
+        ) from exc
+
+    member_id = uuid.UUID(auth.user_id)
+    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+
+    version, image_row = await _confirm_image_upload_or_raise(
+        import_channel_post_image(
+            db, org_id=org_id, draft_id=draft_id, image_bytes=image_bytes, content_type=body.content_type,
+            member_id=member_id, member_kind=actor_type,
+        )
+    )
     return _image_response(version, image_row)
 
 

--- a/backend/app/services/channel_post_images.py
+++ b/backend/app/services/channel_post_images.py
@@ -274,6 +274,33 @@ async def create_channel_post_image_upload_url(
     }
 
 
+async def import_channel_post_image(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID, image_bytes: bytes, content_type: str,
+    member_id: uuid.UUID, member_kind: str,
+) -> tuple[ChannelPostVersion, ChannelPostImage]:
+    """story #3666(Phase2·마케팅운영, 페드루 PO 確定 2026-09-07) — MCP/플러그인 에이전트
+    전용 원콜 입구(base64 디코드된 bytes in → confirm까지 한 호출). `visual_artifacts.py
+    ::import_image_artifact`와 동일 정신(Bash/HTTP 클라이언트가 없는 에이전트는 기존
+    3단계 upload-url 발급→서명 PUT→confirm 플로우를 스스로 못 탄다)이지만 다른 테이블
+    (VisualArtifact가 아니라 ChannelPostImage) — 두 시스템 사이에 새 연결 개념을 만드는
+    대신, 서버가 그냥 자기 손으로(신뢰된 서버측 자격증명, signed-URL 우회) `_object_path`
+    스코프에 바로 쓰고 confirm_channel_post_image_upload를 그대로 재사용한다(검증/변환/
+    해시/봉인 로직 사본 0 — content_type은 오브젝트 키 확장자에만 쓰이고, 실제 포맷/
+    규격 검증은 confirm 내부의 PIL 디코드가 그대로 한다, 이 함수는 새 검증을 안 얹는다)."""
+    bucket = _require_bucket()
+    ext = _MIME_TO_EXT.get(content_type, "bin")
+    object_path = _object_path(org_id=org_id, draft_id=draft_id, ext=ext)
+    provider = get_storage_provider()
+    ok = await provider.put_object(bucket, object_path, image_bytes, content_type=content_type)
+    if not ok:
+        raise ChannelImageUploadFailedError(object_path=object_path)
+
+    return await confirm_channel_post_image_upload(
+        db, org_id=org_id, draft_id=draft_id, object_path=object_path,
+        member_id=member_id, member_kind=member_kind,
+    )
+
+
 def _derive_image(raw: bytes, *, adapter) -> tuple[bytes | None, str | None, int | None, int | None, str | None]:
     """규격 위반 원본을 자동 변환한다. 반환: (derived_bytes, derived_content_type,
     derived_width, derived_height, out_format) — 변환 불요면 전부 None.

--- a/backend/tests/test_3666_channel_post_image_import.py
+++ b/backend/tests/test_3666_channel_post_image_import.py
@@ -1,0 +1,222 @@
+"""story #3666(Phase2·마케팅운영, 페드루 PO 確定 2026-09-07) — MCP/플러그인 에이전트
+전용 원콜 이미지 첨부 입구(`POST .../channel-posts/drafts/{draft_id}/assets/import-image`,
+`image_base64`+`content_type` in → `confirm_channel_post_image_upload`까지 한 호출).
+
+실물 갭: 미르코가 배포 52 표본(3656 소재/훅 그룹 성과 비교)을 MCP로 준비하려 했으나
+`create_channel_post_draft`가 image를 안 받고, 기존 이미지 첨부는 3단계(upload-url 발급
+→서명 PUT→confirm)라 Bash/HTTP 클라이언트가 없는 에이전트가 스스로 못 탔다.
+
+세팅 헬퍼·픽스처는 `test_620beefc_channel_post_image_upload.py`에서 그대로 재사용(중복
+재발명 0) — autouse 픽스처만 pytest 관례상 재선언(story #3562 전례와 동일)."""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+
+import pytest
+
+from tests.test_620beefc_channel_post_image_upload import (
+    _client_for,
+    _create_draft,
+    _jpeg_bytes,
+    _png_bytes,
+    _seed_connection,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+_CHANNEL_MEDIA_BUCKET = "test-channel-media-3666"
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage(monkeypatch, tmp_path):
+    import app.services.channel_post_images as cpi_module
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+async def _import_image(client, org_id, draft_id, raw: bytes, *, content_type: str):
+    return await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/import-image",
+        json={"image_base64": base64.b64encode(raw).decode("ascii"), "content_type": content_type},
+    )
+
+
+@pytest.mark.anyio
+async def test_import_image_base64_attaches_and_confirms_in_one_call():
+    """AC1 — 최저 지능 에이전트 AC: 도구 설명만으로(base64+content_type만) 3단계
+    upload-url/PUT/confirm 없이 한 호출로 이미지가 첨부된다. confirm과 동형 응답
+    (final_width·was_converted 등)이 그대로 나온다(새 응답 계약 0)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            raw = _png_bytes(800, 600)
+            r = await _import_image(client, org_id, draft_id, raw, content_type="image/png")
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["was_converted"] is False
+        assert body["original_width"] == 800
+        assert body["final_bytes"] == len(raw)
+        assert body["version"] == 2  # v1=텍스트만, v2=이미지 첨부(새 버전, confirm과 동형).
+        assert body["image_url"] is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_same_bytes_twice_same_sha256():
+    """AC2 — 3656(소재/훅 그룹 성과 비교)의 «같은 소재→같은 asset_sha256s» 전제 실측:
+    같은 원본 bytes를 두 초안(같은 소재, 다른 draft — 훅 A/B 비교 시나리오와 동형)에
+    각각 원콜로 첨부해도 confirm이 계산하는 `original_sha256`(story #3645
+    asset_sha256s의 원자재)은 완전히 같다. 응답에 sha256이 직접 안 실려(계약 무변경)
+    DB 행을 직접 읽어 확認한다."""
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            story_id_a = await _seed_story(s, org_id, project_id, title="포스트 A(훅1)")
+            story_id_b = await _seed_story(s, org_id, project_id, title="포스트 B(훅2)")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        raw = _jpeg_bytes(640, 480)
+        async with _client_for(app) as client:
+            draft_a = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id_a)
+            draft_b = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id_b)
+            r_a = await _import_image(client, org_id, draft_a, raw, content_type="image/jpeg")
+            r_b = await _import_image(client, org_id, draft_b, raw, content_type="image/jpeg")
+        assert r_a.status_code == 201, r_a.text
+        assert r_b.status_code == 201, r_b.text
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(ChannelPostImage.original_sha256).where(
+                    ChannelPostImage.draft_id.in_([uuid.UUID(draft_a), uuid.UUID(draft_b)]),
+                )
+            )).scalars().all()
+        assert len(rows) == 2
+        assert rows[0] == rows[1]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_invalid_base64_returns_400():
+    """content_type이 image/*가 아니거나 base64가 깨졌으면 confirm까지 안 가고
+    즉시 400(VALIDATION_ERROR) — import_image_artifact(visual_artifacts.py)와
+    동형 계약."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+
+            r_bad_type = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/import-image",
+                json={"image_base64": base64.b64encode(b"not-an-image").decode(), "content_type": "text/plain"},
+            )
+            assert r_bad_type.status_code == 400, r_bad_type.text
+            assert (r_bad_type.json().get("error") or r_bad_type.json())["code"] == "VALIDATION_ERROR"
+
+            r_bad_b64 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/assets/import-image",
+                json={"image_base64": "not-valid-base64!!!", "content_type": "image/png"},
+            )
+            assert r_bad_b64.status_code == 400, r_bad_b64.text
+            assert (r_bad_b64.json().get("error") or r_bad_b64.json())["code"] == "VALIDATION_ERROR"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_undecodable_bytes_returns_422_same_as_confirm():
+    """content_type은 image/*로 통과해도 실제로 디코드 불가능한 바이트면(진짜 이미지가
+    아닌 쓰레기 bytes) confirm과 동일하게 422 CHANNEL_IMAGE_UNDECODABLE — 에러 매핑을
+    `_confirm_image_upload_or_raise`로 공유한다는 것의 직접 증거(신규 매핑 사본 0)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r = await _import_image(client, org_id, draft_id, b"garbage-not-a-real-image-payload", content_type="image/png")
+        assert r.status_code == 422, r.text
+        assert (r.json().get("error") or r.json())["code"] == "CHANNEL_IMAGE_UNDECODABLE"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1517,6 +1517,11 @@
       "file": "tests/test_3379_doc_nudge_default_silence.py",
       "sec": 14.5,
       "source": "story-3379-doc-nudge-default-silence(신규 파일 — 5건, PR #4011 CI \"destructive schema weights registered\" 가드가 미등재로 잡으며 출력한 평균 폴백값(14.5s) 그대로 등재, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3666_channel_post_image_import.py",
+      "sec": 22.0,
+      "source": "story-3666-channel-post-image-import(PR 개설 前 선제 등재 — 로컬 raw pytest 4건 3.68s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 22s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
카디르 3648③/미르코 배포 52 표본 준비(2026-09-07) — `create_channel_post_draft`가 image(산출물 첨부)를 안 받아 `3656`(소재/훅 그룹 성과 비교)의 에이전트 쪽 입력이 막혀 있었다. 기존 이미지 첨부는 3단계(upload-url 발급→서명 PUT→confirm)라 Bash/HTTP 클라이언트가 없는 에이전트는 스스로 못 탄다.

## 그라운딩 정정(착수 前)
스토리 처방("기존 sprintable_import_image_artifact로 올린 이미지를 초안에 붙이는 파라미터")의 전제를 확認한 결과, `import_image_artifact`(story b6b9c52d)는 **VisualArtifact**(캔버스) 테이블에 쓰지 채널 포스트 이미지(`ChannelPostImage`) 테이블과는 무관 — 두 시스템을 잇는 기존 연결이 없다. 대신 `import_image_artifact`와 **같은 패턴**(base64 in, 서버가 직접 GCS에 씀)을 다른 테이블에 재사용하는 새 엔드포인트로 처방을 구현했다(새 "연결 개념"은 안 만들고, 검증/변환/해시/봉인은 100% 기존 `confirm_channel_post_image_upload` 재사용).

`asset_sha256s`(story #3645, PR #4002 — 이미 이 브랜치 base에 포함)도 확認: 새 해시 로직이 필요 없다 — `confirm_channel_post_image_upload`가 이미 계산하는 `channel_post_images.original_sha256`이 그 원자재라, 같은 bytes를 어느 draft에 첨부해도 항상 같은 sha256이 나온다(테스트로 직접 증명).

## 구현
- `app/services/channel_post_images.py::import_channel_post_image` — base64 디코드된 bytes를 `_object_path` 스코프에 직접 `put_object`한 뒤 기존 `confirm_channel_post_image_upload`를 그대로 호출(검증/변환/해시/봉인 사본 0).
- `app/routers/channel_posts.py` — `POST .../channel-posts/drafts/{draft_id}/assets/import-image` 신규 엔드포인트(`image_base64`+`content_type` in). 기존 `confirm` 엔드포인트의 ~20개 except 절을 `_confirm_image_upload_or_raise`로 추출해 두 엔드포인트가 같은 에러→HTTP 매핑을 공유(사본 0, 들쭉날쭉 금지).

## Test plan
- [x] `tests/test_3666_channel_post_image_import.py`(4건): 원콜 첨부가 confirm과 동형 응답 · 같은 bytes 두 draft→같은 `original_sha256`(3656 전제 실측) · content_type/base64 검증 400 · undecodable 422(confirm과 에러 매핑 공유의 직접 증거)
- [x] 라이브 뮤테이션(`put_object` 스킵) — 4건 중 3건 FAIL 재현 확認 후 원복
- [x] 기존 `test_620beefc_channel_post_image_*` 3파일(25건) 회귀 0(총 29건 그린)
- [x] `app.main` import 그린 · weights.json 신규 파일 등재(로컬 3.68s×6배 잠정 22s)

## 다음 회차(이 PR 범위 밖)
플러그인(`sprintable-agent-plugins`) 측 도구 노출은 별도 PR — hook_key(PR 46, 카디르 hold)와 순서 조율 필요.

story #3666

🤖 Generated with [Claude Code](https://claude.com/claude-code)