### PR TITLE
[SID:3671] fix(FE): 3661 클래스 잔여 2자리 — account_label ?? account_id 폴백 닫음

### DIFF
--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -138,6 +138,12 @@ function stubFetch(opts: {
   // story #3458 — 연결 «상태»(토큰 등). 기본 'active'.
   connectionStatus?: 'active' | 'expired' | 'revoked' | 'error';
   connectionsOk?: boolean;
+  // story #3671(유나 QA 2026-09-07) — 기본 'c1'은 2자라 channelConnectionIdentityLabel의
+  // 「…뒤 8자」 절단 자체가 재현이 안 된다(2자는 잘라도 그대로 2자) — 절단이 실제로
+  // 일어나는 걸 단언하려면 36자 uuid 표본이 필요한 테스트가 이 값을 덮어쓴다. draftDetail
+  // 의 connection_id도 같이 맞춰야 conn을 찾는다(호출부 책임 — 이 헬퍼가 자동 동기화하지
+  // 않음, DRAFT_DETAIL 기본 connection_id='c1'과 이 값이 다르면 draftDetail도 함께 override).
+  connectionId?: string;
   // story #3428 — 이미지 규격(어댑터 성질). 기본값 0 = 이미지 미지원(기존 74건 전부가
   // 이 값을 몰라도 되므로 명시 안 하면 첨부 칸 자체가 안 뜨는 쪽이 자연스러운 기본).
   imageMaxCount?: number;
@@ -265,7 +271,7 @@ function stubFetch(opts: {
           ok: true, status: 200,
           json: async () => ({
             data: [{
-              id: 'c1', channel: 'threads', max_text_length: maxTextLength, account_label: accountLabel, account_id: 'acct-1',
+              id: opts.connectionId ?? 'c1', channel: 'threads', max_text_length: maxTextLength, account_label: accountLabel, account_id: 'acct-1',
               can_unpublish: canUnpublish, unpublish_blocked_reason: unpublishBlockedReason, status: connectionStatus,
               image_formats: ['image/jpeg', 'image/png'], image_max_bytes: 8 * 1024 * 1024,
               image_aspect_max: opts.imageAspectMax ?? 10, image_aspect_min: opts.imageAspectMin ?? 0,
@@ -789,16 +795,20 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
   // story #3671(3661 클래스 잔여, 페드루 PO 確定 2026-09-07) — account_id를 그대로
   // 쓰면 webhook류가 139자 URL로 문장을 무너뜨린다(3661과 동형 결함) — 채널명+연결
   // id 짧은 꼬리로 폴백한다(channelConnectionIdentityLabel, 새 낱말 0).
-  it('⭐AC9 — account_label이 null이면 「채널명(…연결id 짧은 꼬리)」로 폴백한다(raw account_id 노출 0)', async () => {
-    stubFetch({ accountLabel: null });
+  it('⭐AC9 — account_label이 null이면 「채널명(…연결id 짧은 꼬리)」로 폴백한다(raw account_id 노출 0, 실제 8자 절단 확認)', async () => {
+    // story #3671 CHANGES(유나 QA) — 기본 표본 'c1'(2자)은 「…뒤 8자」 절단이 안 재현된다
+    // (2자를 slice(-8)해도 그대로 2자) — 36자 uuid 표본으로 실제 절단을 단언.
+    const CONNECTION_UUID = 'a1b2c3d4-e5f6-4789-a0b1-c2d3e4f56789';
+    stubFetch({ accountLabel: null, connectionId: CONNECTION_UUID, draftDetail: { connection_id: CONNECTION_UUID } });
     await act(async () => {
       root.render(wrap(<ChannelPostEditPage />));
     });
     await flush();
 
     const label = container.querySelector('[data-testid="channel-post-account-label"]')?.textContent;
-    expect(label).toBe('Threads(…c1)');
+    expect(label).toBe(`Threads(…${CONNECTION_UUID.slice(-8)})`);
     expect(label).not.toContain('acct-1');
+    expect(label).not.toContain(CONNECTION_UUID);
   });
 
   // story #3671 — 3661 원 재현 조건(webhook의 account_id=139자 URL) 그대로. 뮤테이션

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -265,7 +265,7 @@ function stubFetch(opts: {
           ok: true, status: 200,
           json: async () => ({
             data: [{
-              id: 'c1', max_text_length: maxTextLength, account_label: accountLabel, account_id: 'acct-1',
+              id: 'c1', channel: 'threads', max_text_length: maxTextLength, account_label: accountLabel, account_id: 'acct-1',
               can_unpublish: canUnpublish, unpublish_blocked_reason: unpublishBlockedReason, status: connectionStatus,
               image_formats: ['image/jpeg', 'image/png'], image_max_bytes: 8 * 1024 * 1024,
               image_aspect_max: opts.imageAspectMax ?? 10, image_aspect_min: opts.imageAspectMin ?? 0,
@@ -786,14 +786,65 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     expect(container.querySelector('[data-testid="channel-post-account-label"]')?.textContent).toBe('Marketing Bot');
   });
 
-  it('⭐AC9 — account_label이 null이면 account_id로 폴백한다(지어내지 않는다)', async () => {
+  // story #3671(3661 클래스 잔여, 페드루 PO 確定 2026-09-07) — account_id를 그대로
+  // 쓰면 webhook류가 139자 URL로 문장을 무너뜨린다(3661과 동형 결함) — 채널명+연결
+  // id 짧은 꼬리로 폴백한다(channelConnectionIdentityLabel, 새 낱말 0).
+  it('⭐AC9 — account_label이 null이면 「채널명(…연결id 짧은 꼬리)」로 폴백한다(raw account_id 노출 0)', async () => {
     stubFetch({ accountLabel: null });
     await act(async () => {
       root.render(wrap(<ChannelPostEditPage />));
     });
     await flush();
 
-    expect(container.querySelector('[data-testid="channel-post-account-label"]')?.textContent).toBe('acct-1');
+    const label = container.querySelector('[data-testid="channel-post-account-label"]')?.textContent;
+    expect(label).toBe('Threads(…c1)');
+    expect(label).not.toContain('acct-1');
+  });
+
+  // story #3671 — 3661 원 재현 조건(webhook의 account_id=139자 URL) 그대로. 뮤테이션
+  // 표적: setAccountLabel을 conn.account_label ?? conn.account_id로 되돌리면 이
+  // 테스트가 RED(전체 URL이 그대로 서게 됨).
+  it('⭐AC9 — webhook류(account_id가 URL)도 폴백이 짧은 꼬리만 보이고 URL 전체를 노출하지 않는다', async () => {
+    // stubFetch의 connections mock은 channel을 항상 'threads' 고정 실어 — webhook
+    // 케이스를 재현하려면 fetch mock을 여기서 직접 짠다(stubFetch 재사용 안 함).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}`) {
+          return { ok: true, status: 200, json: async () => ({ data: { ...DRAFT_DETAIL, channel: 'webhook' }, error: null, meta: null }) };
+        }
+        if (url === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}/versions`) {
+          return { ok: true, status: 200, json: async () => ({ data: [VERSION_1], error: null, meta: null }) };
+        }
+        if (url === `/api/organizations/${ORG_ID}/channel-connections`) {
+          return {
+            ok: true, status: 200,
+            json: async () => ({
+              data: [{
+                id: 'c1', channel: 'webhook', max_text_length: 500, account_label: null,
+                account_id: 'https://example.com/webhook/callback?token=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_extra_padding_to_reach_139_chars_xxxxxxxxxxxxxxxxxxxxxxxxx',
+                can_unpublish: true, unpublish_blocked_reason: null, status: 'active',
+                image_formats: [], image_max_bytes: 0, image_aspect_max: 10, image_aspect_min: 0,
+                image_width_min: 0, image_width_max: 0, image_color_space: 'sRGB', image_max_count: 0,
+                image_required: false, video_max_bytes: 0, video_max_seconds: 0, video_min_seconds: 0,
+                video_aspect_target: 0, video_aspect_tolerance: 0, video_codecs: [],
+              }],
+              error: null, meta: null,
+            }),
+          };
+        }
+        return { ok: true, status: 200, json: async () => ({ data: null, error: null, meta: null }) };
+      }),
+    );
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    const label = container.querySelector('[data-testid="channel-post-account-label"]')?.textContent;
+    expect(label).not.toContain('https://example.com');
+    expect(label).toContain('…');
   });
 
   it('⭐AC7 — 한도 잔량 조회 성공 시 남은 게시 수를 보인다', async () => {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -9,7 +9,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { fetchWithAuth } from '@/lib/db/client';
-import { channelLabel } from '@/lib/channel-label';
+import { channelLabel, channelConnectionIdentityLabel } from '@/lib/channel-label';
 import { channelTextLength } from '@/components/content/channel-text-length';
 import { parseSitePostApiError, type SitePostApiErrorInfo } from '@/components/content/api-error';
 import { deriveChannelPostView, type ChannelPublicationStatus } from '@/components/content/channel-post-status';
@@ -175,6 +175,10 @@ interface ChannelPostImageResponse {
 
 interface ChannelConnectionInfo {
   id: string;
+  // story #3671(3661 클래스 잔여, 페드루 PO 確定 2026-09-07) — channelConnectionIdentityLabel
+  // (lib/channel-label.ts)이 폴백 문구를 짓는 데 필요(BE 응답엔 원래 있던 필드, 이 인터페이스가
+  // 안 읽고 있었을 뿐).
+  channel: string;
   max_text_length: number | null;
   // story #3402 ④(AC9) — 나가는 계정을 승인 카드에 적는다. 없으면 account_id로 폴백
   // (지어내지 않는다, doc §3-4).
@@ -890,8 +894,10 @@ export default function ChannelPostEditPage() {
             // AC6 — 계약 필드 자체가 없거나 연결을 못 찾으면 "모른다"(undefined)로 남긴다.
             // 값이 명시적으로 null이면 "선언 안 함"(한도 미확認)으로 구별한다.
             setMaxTextLength(conn ? conn.max_text_length : undefined);
-            // AC9 — account_label 없으면 account_id로 폴백(지어내지 않는다).
-            if (conn) setAccountLabel(conn.account_label ?? conn.account_id);
+            // AC9 — account_label 없으면 폴백(지어내지 않는다). story #3671(3661 후속) —
+            // account_id를 그대로 쓰면 webhook류가 139자 URL로 문장을 무너뜨린다
+            // (channel-label.ts::channelConnectionIdentityLabel, 3661과 동형 처방).
+            if (conn) setAccountLabel(channelConnectionIdentityLabel(conn, t));
             // story #3426 — can_unpublish/unpublish_blocked_reason은 draft가 아니라
             // 이 연결 응답에 실린다(그라운딩 확認) — 새 왕복을 만들지 않고 같은 응답에서 읽는다.
             if (conn) {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/calendar/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/calendar/page.test.tsx
@@ -105,6 +105,28 @@ describe('ChannelPostCalendarPage (story #3422 ③)', () => {
     expect(container.querySelectorAll('[data-testid="channel-post-calendar-card"]').length).toBe(1);
   });
 
+  // story #3671(3661 클래스 잔여, 페드루 PO 確定 2026-09-07) — account_label 없는
+  // 연결의 필터 칩 라벨이 account_id로 폴백했다(webhook류는 그 값이 139자 URL이라
+  // 칩 문구를 무너뜨린다, 3661과 동형 결함). 채널명+연결 id 짧은 꼬리로 폴백한다
+  // (channelConnectionIdentityLabel, 새 낱말 0). 뮤테이션 표적: label을
+  // c.account_label ?? c.account_id로 되돌리면 이 테스트가 RED(전체 URL 노출).
+  it('⭐account_label이 없는 연결은 필터 칩에 「채널명(…짧은 꼬리)」로 폴백하고 URL 전체를 노출하지 않는다', async () => {
+    stubFetch({
+      connections: [{
+        id: 'conn-webhook-1', channel: 'webhook', account_label: null,
+        account_id: 'https://example.com/webhook/callback?token=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_extra_padding_to_reach_139_chars_xxxxxxxxxxxxxxxxxxxxxxxxx',
+      }],
+      scheduled: [],
+    });
+    await act(async () => {
+      root.render(wrap(<ChannelPostCalendarPage />));
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="channel-post-calendar-grid"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('https://example.com');
+    expect(container.textContent).toContain('…');
+  });
+
   it('「날짜 미정」 항목은 레인에 뜨고 격자 셀에는 안 나온다', async () => {
     stubFetch({
       connections: [{ id: 'c1', account_label: 'Marketing Bot', account_id: 'acct-1' }],

--- a/apps/web/src/app/(authenticated)/content/channel-posts/calendar/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/calendar/page.tsx
@@ -12,6 +12,7 @@ import { CalendarGrid, type CalendarChannel } from '@/components/content/calenda
 import { UnscheduledLane } from '@/components/content/unscheduled-lane';
 import { CalendarRangeControls } from '@/components/content/calendar-range-controls';
 import { defaultCalendarRange, resolveDisplayTimezone } from '@/components/content/schedule-format';
+import { channelConnectionIdentityLabel } from '@/lib/channel-label';
 
 /**
  * story #3422(Phase1·마케팅운영, doc §11 T8/T9) — 채널 포스트 캘린더. ③ 조립 조각 —
@@ -27,6 +28,9 @@ import { defaultCalendarRange, resolveDisplayTimezone } from '@/components/conte
  */
 interface ChannelConnectionSummary {
   id: string;
+  // story #3671(3661 클래스 잔여, 페드루 PO 確定 2026-09-07) — channelConnectionIdentityLabel
+  // 폴백 문구에 필요(BE 응답엔 원래 있던 필드).
+  channel: string;
   account_label: string | null;
   account_id: string;
 }
@@ -70,8 +74,8 @@ export default function ChannelPostCalendarPage() {
   }, [orgId]);
 
   const channels: CalendarChannel[] = useMemo(
-    () => connections.map((c) => ({ connectionId: c.id, label: c.account_label ?? c.account_id })),
-    [connections],
+    () => connections.map((c) => ({ connectionId: c.id, label: channelConnectionIdentityLabel(c, t) })),
+    [connections, t],
   );
 
   return (


### PR DESCRIPTION
Stacked on #4017 — base는 착지 뒤 develop으로 재지정 예정(diff는 이 브랜치만의 변경분).

3661(mismatch Alert)이 잡은 결함(webhook류 `account_id`=139자 URL로 문장 무너짐)과 같은 패턴이 develop 전체에 2곳 더 남아 있었다(3661 스토리 범위 밖으로 확認된 잔여):

1. `content/channel-posts/[draftId]/page.tsx:878` `setAccountLabel` — 승인 카드의 계정 라벨.
2. `content/channel-posts/calendar/page.tsx:73` — 연결 필터 칩 label.

둘 다 `channelConnectionIdentityLabel`(`channel-label.ts`, #4017/3661이 신설)로 교체 — `account_label` 없으면 「채널명(…연결id 짧은 꼬리)」로 폴백(새 낱말 0). BE 응답엔 이미 있던 `channel` 필드를 두 인터페이스(`ChannelConnectionInfo`·`ChannelConnectionSummary`)가 안 읽고 있었을 뿐이라 additive로 추가.

`organization/channels/page.tsx`의 나머지 3자리는 #4017/#4021 몫(이 스토리 범위 밖, develop 전체 grep으로 확認).

## Test plan
- [x] 기존 AC9 테스트(account_id 그대로 기대하던 것)를 새 폴백 문구로 갱신
- [x] webhook 139자 URL 재현 신규 2건(3661 원 시나리오와 동형, `[draftId]`) + calendar 페이지 신규 1건
- [x] 라이브 뮤테이션(두 자리 다 원래 `?? account_id`로 되돌림) — 3건 FAIL 재현 확認 후 원복
- [x] i18n 가드 클린(새 낱말 0)
- [x] AC4 — `git grep -F 'account_label ??' apps/web/src`는 `channel-label.ts`(정본 구현)·`organization/channels/page.tsx`(#4017/#4021 몫, 이 PR 범위 밖)만 남음

story #3671

🤖 Generated with [Claude Code](https://claude.com/claude-code)