### PR TITLE
[SID:3672] feat: 미처리 500 error_id — 로그·응답·DB·화면 4자리 상관 배선

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2187,6 +2187,7 @@
     "channelReauthError": "This connection can't publish right now — please reconnect.",
     "channelLoadFailed": "Failed to load channel connections.",
     "channelConnectSuccess": "{channel} is now connected.",
+    "channelConnectErrorId": "Error number: {errorId}",
     "channelConnectErrorGeneric": "Connection failed. Please try again in a moment.",
     "channelConnectErrorAppCredentialsMissing": "Can't start connecting — no app credentials are registered. Please register them in \"App credentials\" below.",
     "channelConnectErrorAppCredentialsMissingMember": "Can't start connecting — no app credentials are registered. Please ask an organization owner to register them.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2187,6 +2187,7 @@
     "channelReauthError": "이 연결로 지금 발행할 수 없습니다 — 다시 연결해 주세요.",
     "channelLoadFailed": "채널 연결 정보를 불러오지 못했습니다.",
     "channelConnectSuccess": "{channel} 연결이 완료됐습니다.",
+    "channelConnectErrorId": "오류 번호: {errorId}",
     "channelConnectErrorGeneric": "연결에 실패했습니다. 잠시 후 다시 시도해 주세요.",
     "channelConnectErrorAppCredentialsMissing": "앱 자격이 등록되지 않아 연결을 시작할 수 없습니다 — 아래 「앱 자격」에서 등록해 주세요.",
     "channelConnectErrorAppCredentialsMissingMember": "앱 자격이 등록되지 않아 연결을 시작할 수 없습니다 — 조직 owner에게 등록을 요청해 주세요.",

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -328,6 +328,16 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
     expect(container.textContent).not.toContain('오류 번호');
   });
 
+  // 페드루 PO 권고②(#4025 리뷰) — 쿼리는 조작 가능한 입력, uuid 형식이 아니면 표시 안 함.
+  it('?error_id=가 uuid 형식이 아니면(손상된 URL) 「오류 번호」 줄이 안 뜬다', async () => {
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams('connect_error=INTERNAL_ERROR&error_id=not-a-real-uuid'),
+    );
+    stubFetch({ connections: [] });
+    await mount('owner');
+    expect(container.textContent).not.toContain('오류 번호');
+  });
+
   it('⭐story #3409 — CHANNEL_APP_CREDENTIALS_MISSING을 member가 보면 owner에게 요청하라는 별도 키가 뜬다(owner용 화면 안 문구는 안 뜸)', async () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams('connect_error=CHANNEL_APP_CREDENTIALS_MISSING'));
     stubFetch({ connections: [] });

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -308,6 +308,26 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
     expect(container.textContent).toContain(koMessages.channelConnect.channelConnectErrorGeneric);
   });
 
+  // story #3672(2026-09-07, 3663 실사고, AC5) — BFF가 릴레이한 error_id가 있으면
+  // Alert 안에 「오류 번호: …」 한 줄이 덧붙는다(복사 가능한 일반 텍스트).
+  it('?connect_error=에 error_id가 실려 있으면 「오류 번호」 줄이 덧붙는다', async () => {
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams('connect_error=INTERNAL_ERROR&error_id=11111111-2222-3333-4444-555555555555'),
+    );
+    stubFetch({ connections: [] });
+    await mount('owner');
+    expect(container.textContent).toContain(
+      koMessages.channelConnect.channelConnectErrorId.replace('{errorId}', '11111111-2222-3333-4444-555555555555'),
+    );
+  });
+
+  it('?connect_error=에 error_id가 없으면(기존 4xx류) 「오류 번호」 줄 자체가 안 뜬다', async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('connect_error=CHANNEL_APP_CREDENTIALS_MISSING'));
+    stubFetch({ connections: [] });
+    await mount('owner');
+    expect(container.textContent).not.toContain('오류 번호');
+  });
+
   it('⭐story #3409 — CHANNEL_APP_CREDENTIALS_MISSING을 member가 보면 owner에게 요청하라는 별도 키가 뜬다(owner용 화면 안 문구는 안 뜸)', async () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams('connect_error=CHANNEL_APP_CREDENTIALS_MISSING'));
     stubFetch({ connections: [] });

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -934,7 +934,11 @@ export default function OrganizationChannelsPage() {
           <AlertDescription>
             {t(connectErrorLabelKey(connectError, isOwnerStrict))}
             {connectErrorId ? (
-              <span className="mt-1 block select-text text-xs text-muted-foreground">
+              // 유나 라이브 픽셀 실측(#4025 리뷰, 2026-09-07) — AlertDescription 자체가
+              // opacity-90이라 그 안에서 text-muted-foreground는 0.9와 합성돼 라이트
+              // 4.150(하한 4.5 미달)로 떨어진다. text-foreground(12.597/12.592)로 —
+              // opacity 층은 자식에 opacity-100을 줘도 상쇄 안 된다(부모 합성 자체).
+              <span className="mt-1 block select-text text-xs text-foreground">
                 {t('channelConnectErrorId', { errorId: connectErrorId })}
               </span>
             ) : null}

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -870,6 +870,10 @@ export default function OrganizationChannelsPage() {
 
   const connected = searchParams.get('connected');
   const connectError = searchParams.get('connect_error');
+  // story #3672(2026-09-07, 3663 실사고) — BE unhandled_exception_handler가 실어 준
+  // error_id를 BFF(authorize/callback route.ts)가 그대로 릴레이한다(AC4). 있을 때만
+  // 표시(AC5) — 없으면 지금 문구 그대로, 복사 가능한 일반 텍스트(select-text).
+  const connectErrorId = searchParams.get('error_id');
   // story #3650(PO Test Org 실측 2026-09-07) — 재연결 대상 행과 콜백이 실제로 갱신한
   // 행이 다를 때(다른 계정을 승인) BFF가 함께 싣는 두 id. 라벨은 이 화면이 이미
   // 불러온 connections에서 붙인다(콜백 라우트는 opaque 릴레이 그대로 유지).
@@ -922,7 +926,14 @@ export default function OrganizationChannelsPage() {
           {/* story #3504 — CHANNEL_APP_CREDENTIALS_MISSING의 "누구에게 요청하나" 분기는
               app-credentials 등록 자격(owner 전용, 앱 자격 저장과 같은 폭)을 묻는다 —
               owner|admin 폭인 isOwnerOrAdmin이 아니라 isOwnerStrict가 맞다. */}
-          <AlertDescription>{t(connectErrorLabelKey(connectError, isOwnerStrict))}</AlertDescription>
+          <AlertDescription>
+            {t(connectErrorLabelKey(connectError, isOwnerStrict))}
+            {connectErrorId ? (
+              <span className="mt-1 block select-text text-xs text-muted-foreground">
+                {t('channelConnectErrorId', { errorId: connectErrorId })}
+              </span>
+            ) : null}
+          </AlertDescription>
         </Alert>
       ) : null}
       {loadError ? (

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -873,7 +873,12 @@ export default function OrganizationChannelsPage() {
   // story #3672(2026-09-07, 3663 실사고) — BE unhandled_exception_handler가 실어 준
   // error_id를 BFF(authorize/callback route.ts)가 그대로 릴레이한다(AC4). 있을 때만
   // 표시(AC5) — 없으면 지금 문구 그대로, 복사 가능한 일반 텍스트(select-text).
-  const connectErrorId = searchParams.get('error_id');
+  // 페드루 PO 권고②(#4025 리뷰) — 쿼리는 조작 가능한 입력이라, uuid 형식이 아니면
+  // (손상된 URL·수동 조작) «오류 번호» 자리에 임의 문자열을 그대로 띄우지 않는다.
+  const rawConnectErrorId = searchParams.get('error_id');
+  const connectErrorId = rawConnectErrorId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(rawConnectErrorId)
+    ? rawConnectErrorId
+    : null;
   // story #3650(PO Test Org 실측 2026-09-07) — 재연결 대상 행과 콜백이 실제로 갱신한
   // 행이 다를 때(다른 계정을 승인) BFF가 함께 싣는 두 id. 라벨은 이 화면이 이미
   // 불러온 connections에서 붙인다(콜백 라우트는 opaque 릴레이 그대로 유지).

--- a/apps/web/src/app/api/oauth-channel/authorize/route.test.ts
+++ b/apps/web/src/app/api/oauth-channel/authorize/route.test.ts
@@ -116,4 +116,27 @@ describe('GET /api/oauth-channel/authorize (story #3376)', () => {
     expect(h.cookiesSetMock).not.toHaveBeenCalled();
     expect(res.headers.get('location')).toContain('connect_error=CHANNEL_APP_CREDENTIALS_MISSING');
   });
+
+  // story #3672(2026-09-07, 3663 실사고, AC4) — BE unhandled_exception_handler가
+  // error.error_id를 실어 주면 그대로 쿼리에 릴레이한다.
+  it('BE 500이 error.error_id를 실으면 connect_error 뒤에 error_id를 그대로 붙인다', async () => {
+    h.cookiesGetMock.mockReturnValue({ value: 'sp-at-token' });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ data: null, error: { code: 'INTERNAL_ERROR', error_id: '11111111-2222-3333-4444-555555555555' } }),
+    });
+    const res = await GET(makeRequest({ org: 'org-1', channel: 'threads' }));
+    const location = res.headers.get('location') ?? '';
+    expect(location).toContain('connect_error=INTERNAL_ERROR');
+    expect(location).toContain('error_id=11111111-2222-3333-4444-555555555555');
+  });
+
+  it('BE 오류에 error_id가 없으면(기존 4xx류) 지금과 동일 — error_id 쿼리 자체가 없다', async () => {
+    h.cookiesGetMock.mockReturnValue({ value: 'sp-at-token' });
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ data: null, error: { code: 'CHANNEL_APP_CREDENTIALS_MISSING' } }) });
+    const res = await GET(makeRequest({ org: 'org-1', channel: 'threads' }));
+    const location = res.headers.get('location') ?? '';
+    expect(location).toContain('connect_error=CHANNEL_APP_CREDENTIALS_MISSING');
+    expect(location).not.toContain('error_id=');
+  });
 });

--- a/apps/web/src/app/api/oauth-channel/authorize/route.ts
+++ b/apps/web/src/app/api/oauth-channel/authorize/route.ts
@@ -40,9 +40,13 @@ export async function GET(request: Request) {
   ).catch(() => null);
 
   if (!res?.ok) {
-    const errBody = await res?.json().catch(() => null) as { error?: { code?: string } } | null;
+    const errBody = await res?.json().catch(() => null) as { error?: { code?: string; error_id?: string } } | null;
     const errCode = errBody?.error?.code ?? 'CHANNEL_AUTHORIZE_FAILED';
-    return NextResponse.redirect(`${origin}/organization/channels?connect_error=${errCode}`);
+    // story #3672(2026-09-07, 3663 실사고) — BE unhandled_exception_handler가 실어 준
+    // error_id가 있으면 그대로 넘긴다(있을 때만·없으면 기존 동작 그대로, AC4).
+    const errorId = errBody?.error?.error_id;
+    const suffix = errorId ? `&error_id=${encodeURIComponent(errorId)}` : '';
+    return NextResponse.redirect(`${origin}/organization/channels?connect_error=${errCode}${suffix}`);
   }
 
   // story #3613(BE 그라운딩·페드루 PO 確定 2026-09-07) — BE `authorize_channel_

--- a/apps/web/src/app/api/oauth-channel/callback/[channel]/route.test.ts
+++ b/apps/web/src/app/api/oauth-channel/callback/[channel]/route.test.ts
@@ -101,6 +101,29 @@ describe('GET /api/oauth-channel/callback/[channel] (story #3376)', () => {
     const res = await GET(makeRequest({ code: 'c', state: 's' }), routeParams());
     expect(res.headers.get('location')).toContain('connect_error=CHANNEL_OAUTH_STATE_INVALID');
   });
+
+  // story #3672(2026-09-07, 3663 실사고, AC4) — authorize/route.ts와 동형: BE
+  // unhandled_exception_handler의 error.error_id가 있으면 그대로 릴레이한다.
+  it('BE 500이 error.error_id를 실으면 connect_error 뒤에 error_id를 그대로 붙인다', async () => {
+    stubCookies();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ data: null, error: { code: 'INTERNAL_ERROR', error_id: '11111111-2222-3333-4444-555555555555' } }),
+    });
+    const res = await GET(makeRequest({ code: 'c', state: 's' }), routeParams());
+    const location = res.headers.get('location') ?? '';
+    expect(location).toContain('connect_error=INTERNAL_ERROR');
+    expect(location).toContain('error_id=11111111-2222-3333-4444-555555555555');
+  });
+
+  it('BE 오류에 error_id가 없으면(기존 4xx류) 지금과 동일 — error_id 쿼리 자체가 없다', async () => {
+    stubCookies();
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ data: null, error: { code: 'CHANNEL_OAUTH_STATE_INVALID' } }) });
+    const res = await GET(makeRequest({ code: 'c', state: 's' }), routeParams());
+    const location = res.headers.get('location') ?? '';
+    expect(location).toContain('connect_error=CHANNEL_OAUTH_STATE_INVALID');
+    expect(location).not.toContain('error_id=');
+  });
 });
 
 // story #3549(3547 BE·디디 계약, 유나 §13-8②, PO 確定 2026-09-06) — Facebook Page가

--- a/apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts
+++ b/apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts
@@ -66,9 +66,13 @@ export async function GET(request: Request, { params }: RouteParams) {
   ).catch(() => null);
 
   if (!res?.ok) {
-    const errBody = await res?.json().catch(() => null) as { error?: { code?: string } } | null;
+    const errBody = await res?.json().catch(() => null) as { error?: { code?: string; error_id?: string } } | null;
     const errCode = errBody?.error?.code ?? 'CHANNEL_CALLBACK_FAILED';
-    return NextResponse.redirect(`${origin}/organization/channels?connect_error=${errCode}`);
+    // story #3672(2026-09-07, 3663 실사고) — authorize/route.ts와 동형: BE
+    // unhandled_exception_handler의 error_id가 있으면 그대로 넘긴다(AC4).
+    const errorId = errBody?.error?.error_id;
+    const suffix = errorId ? `&error_id=${encodeURIComponent(errorId)}` : '';
+    return NextResponse.redirect(`${origin}/organization/channels?connect_error=${errCode}${suffix}`);
   }
 
   // story #3549(3547 BE·디디 계약, 유나 §13-8②, PO 確定 2026-09-06) — Facebook Page가

--- a/backend/alembic/versions/0355_unhandled_error_events.py
+++ b/backend/alembic/versions/0355_unhandled_error_events.py
@@ -1,0 +1,42 @@
+"""story #3672(BE·BFF·FE·관측, 페드루 PO 確定 2026-09-07) — 미처리 500의 서버측
+지속 흔적(unhandled_error_events). id=error_id(응답 봉투·로그 한 줄과 동일 값) —
+서버 발급 uuid4를 앱 코드가 그대로 싣는다(server_default 없음, 항상 명시 INSERT).
+
+Revision ID: 0355
+Revises: 0354
+Create Date: 2026-09-07
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0355"
+down_revision = "0354"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "unhandled_error_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("method", sa.Text(), nullable=False),
+        sa.Column("path", sa.Text(), nullable=False),
+        sa.Column("exception_class", sa.Text(), nullable=False),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("request_id", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_unhandled_error_events_occurred_at", "unhandled_error_events", ["occurred_at"])
+    op.create_index("ix_unhandled_error_events_org_id", "unhandled_error_events", ["org_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_unhandled_error_events_org_id", table_name="unhandled_error_events")
+    op.drop_index("ix_unhandled_error_events_occurred_at", table_name="unhandled_error_events")
+    op.drop_table("unhandled_error_events")

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -498,6 +498,11 @@ async def get_current_user(
     if request is not None:
         request.state.au_actor = "agent" if is_au_billable_agent(auth) else "human"
         request.state.au_org_id = auth.org_id
+        # story #3672 — 소비처③: main.py::unhandled_exception_handler가 미처리 500
+        # 발생 시 「누구 요청이었나」를 지어내지 않고 알 때만 싣는다(au_org_id와 동일
+        # 자리·동일 이유 — FastAPI dependency는 라우터 밖 미들웨어/전역 예외 핸들러로
+        # 안 새어나가 request.state에 명시 기록해야 그쪽이 볼 수 있다).
+        request.state.au_user_id = auth.user_id
         if (
             request.state.au_actor == "agent"
             and request.method in _WRITE_METHODS

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import uuid
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
@@ -226,7 +227,7 @@ async def lifespan(app: FastAPI):
             await worker_engine.dispose()
 
 
-from app.routers import a2a, account, activation, activity_logs, admin_billing, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, channel_post_comments, channel_post_comment_replies, insight_snapshots, insights_board, assets, billing_keys, toss_webhooks, org_subscription_checkout, billing_packs, campaigns, content_rules, context_pack, publishing_metrics, connectors, channel_connections, channel_posts, deeplink_manifest, domain_labels, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, legal, loop_measure_due, loops, mcp, me, meetings, members, measurement_connections, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, pageview_metering, participation, plan_features, platform_settings, policy_documents, project_access, project_settings, projects, public_docs, public_pageview, public_site_posts, recipe_repeat_schedules, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, site_posts, sprints, standups, stories, subscription, support_gateway_token, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_report, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activation, activity_logs, admin_billing, admin_unhandled_errors, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, channel_post_comments, channel_post_comment_replies, insight_snapshots, insights_board, assets, billing_keys, toss_webhooks, org_subscription_checkout, billing_packs, campaigns, content_rules, context_pack, publishing_metrics, connectors, channel_connections, channel_posts, deeplink_manifest, domain_labels, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, legal, loop_measure_due, loops, mcp, me, meetings, members, measurement_connections, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, pageview_metering, participation, plan_features, platform_settings, policy_documents, project_access, project_settings, projects, public_docs, public_pageview, public_site_posts, recipe_repeat_schedules, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, site_posts, sprints, standups, stories, subscription, support_gateway_token, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_report, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -324,9 +325,35 @@ async def rate_limit_storage_error_handler(request: Request, exc: StorageError) 
 
 @app.exception_handler(Exception)
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-    """예상치 못한 500 에러 — 내부 정보는 로그에만, 클라이언트엔 일반 메시지."""
-    _logger.exception("Unhandled exception on %s %s: %s", request.method, request.url.path, exc)
+    """예상치 못한 500 에러 — 내부 정보는 로그에만, 클라이언트엔 일반 메시지.
+
+    story #3672(2026-09-07, 3663 실사고) — 이 로그가 Cloud Run에만 남아 gcloud
+    재로그인 없이는 원인 추적이 안 됐다(사람 의존 재개 경로). error_id(uuid4) 하나를
+    로그 한 줄·응답 봉투 `error.error_id`·`unhandled_error_events` 행 셋에 같은 값으로
+    싣는다 — 셋을 나중에 그 id로 상관시킬 수 있다. DB 기록은 best-effort(실패해도
+    이 500 응답 자체는 그대로 나간다, record_unhandled_error_event 참고)."""
+    error_id = uuid.uuid4()
+    _logger.exception(
+        "Unhandled exception on %s %s [error_id=%s]: %s", request.method, request.url.path, error_id, exc
+    )
     detail = str(exc) if settings.debug else "Internal server error"
+
+    try:
+        from app.services.unhandled_error_events import record_unhandled_error_event
+        # story #3173 소비처와 같은 request.state 자리(au_org_id) — get_current_user()가
+        # 인증에 성공했을 때만 채운다(그 前에 죽은 요청은 None이 정직한 값, 지어내지
+        # 않는다). 문자열로 심겨 있어(AuthContext.org_id: str) UUID로 변환.
+        _raw_org_id = getattr(request.state, "au_org_id", None)
+        _raw_user_id = getattr(request.state, "au_user_id", None)
+        await record_unhandled_error_event(
+            error_id=error_id, method=request.method, path=request.url.path,
+            exception_class=type(exc).__name__, message=str(exc)[:2000] if str(exc) else None,
+            org_id=uuid.UUID(_raw_org_id) if _raw_org_id else None,
+            user_id=uuid.UUID(_raw_user_id) if _raw_user_id else None,
+            request_id=request.headers.get("x-request-id"),
+        )
+    except Exception:
+        _logger.exception("record_unhandled_error_event itself raised for error_id=%s", error_id)
 
     # story #2003: /rpc의 미처리 예외도 JSON-RPC envelope으로(code=-32603 표준 Internal error,
     # retryable=True — 5xx 분류). http_exception_handler와 동일 경로-정밀 매치.
@@ -335,7 +362,11 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
 
     return JSONResponse(
         status_code=500,
-        content={"data": None, "error": {"code": "INTERNAL_ERROR", "message": detail}, "meta": None},
+        content={
+            "data": None,
+            "error": {"code": "INTERNAL_ERROR", "message": detail, "error_id": str(error_id)},
+            "meta": None,
+        },
     )
 
 
@@ -495,6 +526,7 @@ app.include_router(toss_webhooks.router)
 app.include_router(org_subscription_checkout.router)
 app.include_router(billing_packs.router)
 app.include_router(admin_billing.router)
+app.include_router(admin_unhandled_errors.router)
 app.include_router(account.router)
 app.include_router(account.accounts_router)
 app.include_router(oss.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -345,12 +345,21 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
         # 않는다). 문자열로 심겨 있어(AuthContext.org_id: str) UUID로 변환.
         _raw_org_id = getattr(request.state, "au_org_id", None)
         _raw_user_id = getattr(request.state, "au_user_id", None)
+        # 페드루 PO 권고①(#4025 리뷰, 2026-09-07) — dev-app은 CF 경유라 x-request-id가
+        # 지금은 거의 null. cf-ray(Cloudflare)·x-cloud-trace-context(GCP LB/Cloud Run)
+        # 순으로 폴백 — 셋 다 "이 한 요청의 트레이스 식별자"라는 같은 뜻, 상관용일 뿐
+        # 인가/검증에 안 쓰이니 값을 신뢰하지 않고 그대로 통과시켜도 안전하다.
+        _request_id = (
+            request.headers.get("x-request-id")
+            or request.headers.get("cf-ray")
+            or request.headers.get("x-cloud-trace-context")
+        )
         await record_unhandled_error_event(
             error_id=error_id, method=request.method, path=request.url.path,
             exception_class=type(exc).__name__, message=str(exc)[:2000] if str(exc) else None,
             org_id=uuid.UUID(_raw_org_id) if _raw_org_id else None,
             user_id=uuid.UUID(_raw_user_id) if _raw_user_id else None,
-            request_id=request.headers.get("x-request-id"),
+            request_id=_request_id,
         )
     except Exception:
         _logger.exception("record_unhandled_error_event itself raised for error_id=%s", error_id)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -74,6 +74,7 @@ from app.models.doc_chat_nudge_dispatch import DocChatNudgeDispatch
 from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
 from app.models.reward import RewardLedger
 from app.models.login_audit_log import LoginAuditLog
+from app.models.unhandled_error_event import UnhandledErrorEvent
 from app.models.standup import StandupEntry, StandupFeedback
 from app.models.team import TeamMember
 from app.models.file_lock import FileLock
@@ -247,6 +248,7 @@ __all__ = [
     "TeamMember",
     "UnattachedStorySnapshot",
     "LoginAuditLog",
+    "UnhandledErrorEvent",
     "RefreshToken",
     "User",
     "WorkflowVersion",

--- a/backend/app/models/unhandled_error_event.py
+++ b/backend/app/models/unhandled_error_event.py
@@ -1,0 +1,43 @@
+"""story #3672(BE·BFF·FE·관측, 페드루 PO 確定 2026-09-07) — 미처리 500이 Cloud Run
+로그에만 남아 사람(gcloud) 없이는 원인 재개가 안 되던 것(3663 실사고)을 닫는다.
+
+`main.py::unhandled_exception_handler`가 매 미처리 예외마다 이 행을 하나 심는다 —
+id 자체가 응답 봉투에 실리는 error_id와 동일(로그 한 줄 ↔ 응답 ↔ 이 행 셋이 같은
+값으로 상관된다). FK 없음(channel_connections·channel_post_drafts와 동일 관례,
+login_audit_logs와도 동형) — org/user가 인증 실패 전에 죽으면 그 자체로 null이
+정직한 값이라 강제 조인을 걸 이유가 없다. 비밀값(헤더·바디·쿼리스트링) 미저장 —
+message는 str(exc)[:2000]만(트레이스백 원문은 로그에만 남는다, 이 테이블은 조회
+편의용 요약이지 로그 대체가 아니다)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class UnhandledErrorEvent(Base):
+    __tablename__ = "unhandled_error_events"
+
+    # id=error_id 그 자체 — uuid4는 서버(main.py)가 발급, 여기 PK로 그대로 심는다.
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    method: Mapped[str] = mapped_column(Text, nullable=False)
+    # 쿼리스트링 제외 — 토큰/코드류(oauth-channel authorize state 등)가 쿼리에 실릴 수
+    # 있어(AC2 "비밀값 기록 금지") request.url.path만(쿼리 없는 경로) 저장한다.
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    exception_class: Mapped[str] = mapped_column(Text, nullable=False)
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # FK 없음(그라운딩 §9 관례 그대로) — 인증 실패 前에 죽은 요청은 org_id 자체가
+    # 없을 수 있다(null 허용, 지어내지 않는다).
+    org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # 엣지(CF 등)가 실어 보내는 X-Request-Id 그대로(모르면 null) — 새 트레이싱 체계
+    # 발명 0(story "안 하는 것" 절 — Sentry류 APM은 범위 밖).
+    request_id: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/realtime_main.py
+++ b/backend/app/realtime_main.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import uuid
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
@@ -172,9 +173,44 @@ async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONRe
 
 @app.exception_handler(Exception)
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-    _logger.exception("Unhandled exception on %s %s: %s", request.method, request.url.path, exc)
+    """story #3672(2026-09-07, 페드루 PO 권고③ — main.py와 같은 서비스로) — app/main.py의
+    동형 핸들러와 완전히 같은 처방(error_id 3자리 상관, best-effort DB persist). 이 서비스
+    (realtime, SSE 전용 별도 entrypoint)는 get_current_user 경로를 안 태우는 라우터만
+    마운트해(위 모듈 docstring 참고) request.state.au_org_id/au_user_id가 지금은 늘
+    비어 있을 것 — 그건 정직한 값이다(모르는데 지어내지 않는다), main.py와 코드는 같다."""
+    error_id = uuid.uuid4()
+    _logger.exception(
+        "Unhandled exception on %s %s [error_id=%s]: %s", request.method, request.url.path, error_id, exc
+    )
     detail = str(exc) if settings.debug else "Internal server error"
-    return JSONResponse(status_code=500, content={"data": None, "error": {"code": "INTERNAL_ERROR", "message": detail}, "meta": None})
+
+    try:
+        from app.services.unhandled_error_events import record_unhandled_error_event
+        _raw_org_id = getattr(request.state, "au_org_id", None)
+        _raw_user_id = getattr(request.state, "au_user_id", None)
+        _request_id = (
+            request.headers.get("x-request-id")
+            or request.headers.get("cf-ray")
+            or request.headers.get("x-cloud-trace-context")
+        )
+        await record_unhandled_error_event(
+            error_id=error_id, method=request.method, path=request.url.path,
+            exception_class=type(exc).__name__, message=str(exc)[:2000] if str(exc) else None,
+            org_id=uuid.UUID(_raw_org_id) if _raw_org_id else None,
+            user_id=uuid.UUID(_raw_user_id) if _raw_user_id else None,
+            request_id=_request_id,
+        )
+    except Exception:
+        _logger.exception("record_unhandled_error_event itself raised for error_id=%s", error_id)
+
+    return JSONResponse(
+        status_code=500,
+        content={
+            "data": None,
+            "error": {"code": "INTERNAL_ERROR", "message": detail, "error_id": str(error_id)},
+            "meta": None,
+        },
+    )
 
 
 app.state.limiter = limiter

--- a/backend/app/routers/admin_unhandled_errors.py
+++ b/backend/app/routers/admin_unhandled_errors.py
@@ -1,0 +1,39 @@
+"""story #3672(BE·BFF·FE·관측, 페드루 PO 確定 2026-09-07) — 미처리 500의 서버측
+지속 흔적 조회. admin_billing.py와 같은 SA ID-token 인가 게이트(require_admin_operator)
+재사용 — 새 인가 축 발명 0."""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.admin_auth import AdminOperator, require_admin_operator
+from app.dependencies.database import get_db
+from app.services.unhandled_error_events import get_unhandled_error_event
+
+router = APIRouter(prefix="/api/v2/admin", tags=["admin"])
+
+
+@router.get("/unhandled-errors/{error_id}")
+async def get_unhandled_error(
+    error_id: uuid.UUID,
+    operator: AdminOperator = Depends(require_admin_operator),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """AC3 — 응답=저장 컬럼 그대로. 존재하지 않으면 404(지어내지 않는다 — 이
+    error_id로 아무것도 못 찾았다는 사실 그대로)."""
+    row = await get_unhandled_error_event(db, error_id=error_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="unhandled error event not found")
+    return {
+        "id": str(row.id),
+        "occurred_at": row.occurred_at.isoformat(),
+        "method": row.method,
+        "path": row.path,
+        "exception_class": row.exception_class,
+        "message": row.message,
+        "org_id": str(row.org_id) if row.org_id else None,
+        "user_id": str(row.user_id) if row.user_id else None,
+        "request_id": row.request_id,
+    }

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1337,6 +1337,14 @@ async def publication_commands_tick(
         except Exception as exc:
             logger.exception("oauth-pending-selections sweep tick error: %s", exc)
             counts["oauth_pending_selections_swept"] = {"error": "unhandled"}
+        # story #3672(2026-09-07) — unhandled_error_events 30일 보존 정리. 위 세 축과
+        # 같은 피기백 사상(새 Cloud Scheduler 잡 0) — 독립 try.
+        try:
+            from app.services.unhandled_error_events import sweep_old_unhandled_error_events
+            counts["unhandled_error_events_swept"] = await sweep_old_unhandled_error_events(session)
+        except Exception as exc:
+            logger.exception("unhandled-error-events sweep tick error: %s", exc)
+            counts["unhandled_error_events_swept"] = {"error": "unhandled"}
         return _ok(counts)
     except Exception as exc:
         logger.exception("publication-commands cron error: %s", exc)

--- a/backend/app/services/unhandled_error_events.py
+++ b/backend/app/services/unhandled_error_events.py
@@ -10,6 +10,7 @@ main.py의 원래 500 응답은 그대로 나간다."""
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -21,6 +22,27 @@ from app.models.unhandled_error_event import UnhandledErrorEvent
 logger = logging.getLogger(__name__)
 
 _RETENTION_DAYS = 30
+
+# 페드루 PO REQUIRED(#4025 리뷰, 2026-09-07) — `message=str(exc)[:2000]`는 debug 여부와
+# 무관하게 이 테이블에 30일 남는다. 이 문자열은 요청 URL/헤더/바디를 그대로 인용하는
+# 예외(예: httpx가 실패한 요청의 URL을 메시지에 그대로 넣는 경우)에서 access_token=…·
+# client_secret=…·Authorization: Bearer … 가 새어 들어올 수 있어, 여기서 한 겹 마스킹한다
+# — «비밀값 미저장»(AC2)이 path/헤더/바디를 안 담는 것만으로는 안 끝난다(예외 메시지라는
+# 별도 경로가 있다). key=value류(쿼리스트링·form 인코딩 공통 표기)와 Bearer 토큰 두
+# 형태만 잡는다(과설계 금지 — 이 표에 실제로 나타나는 값의 모양 두 가지).
+_SECRET_KV_RE = re.compile(
+    r"(?i)\b(access_token|refresh_token|client_secret|api_key|password|secret|token)"
+    r"([=:])\s*[^\s&\"'<>]+"
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9\-_.~+/]+=*")
+
+
+def _redact(message: str | None) -> str | None:
+    if not message:
+        return message
+    redacted = _BEARER_RE.sub("Bearer [REDACTED]", message)
+    redacted = _SECRET_KV_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}[REDACTED]", redacted)
+    return redacted
 
 
 async def record_unhandled_error_event(
@@ -36,14 +58,15 @@ async def record_unhandled_error_event(
 ) -> None:
     """AC2 — 비밀값(헤더·바디·쿼리스트링) 미저장, message는 호출부가 이미
     [:2000]으로 자른 값을 그대로 받는다(이 함수는 자르지 않는다 — 계약은
-    호출부 몫, 이중 절단 방지)."""
+    호출부 몫, 이중 절단 방지). 저장 直前 `_redact()`로 예외 문자열 안에 낀
+    토큰류를 한 번 더 가린다(경로/헤더 자체를 안 담는 것과는 별개 방어선)."""
     from app.core.database import async_session_factory
 
     try:
         async with async_session_factory() as s:
             s.add(UnhandledErrorEvent(
                 id=error_id, method=method, path=path, exception_class=exception_class,
-                message=message, org_id=org_id, user_id=user_id, request_id=request_id,
+                message=_redact(message), org_id=org_id, user_id=user_id, request_id=request_id,
             ))
             await s.commit()
     except Exception:

--- a/backend/app/services/unhandled_error_events.py
+++ b/backend/app/services/unhandled_error_events.py
@@ -1,0 +1,70 @@
+"""story #3672(BE·BFF·FE·관측, 페드루 PO 確定 2026-09-07) — 미처리 500의 서버측
+지속 흔적. `main.py::unhandled_exception_handler`가 이 모듈 하나로 «error_id를
+로그·응답과 같은 값으로 DB에도 남긴다»를 전담한다.
+
+`record_unhandled_error_event`는 best-effort — `_persist_first_auth_seen`
+(app/dependencies/auth.py)과 동형 관례로 전용 세션을 새로 열어 커밋하고, 어떤
+예외로도 원래의 500 응답 흐름을 막지 않는다(fail-silent, 로그 경고 한 줄만).
+이 함수 자체가 두 번째 미처리 예외의 근원이 되면 안 되므로, 여기서 실패해도
+main.py의 원래 500 응답은 그대로 나간다."""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.unhandled_error_event import UnhandledErrorEvent
+
+logger = logging.getLogger(__name__)
+
+_RETENTION_DAYS = 30
+
+
+async def record_unhandled_error_event(
+    *,
+    error_id: uuid.UUID,
+    method: str,
+    path: str,
+    exception_class: str,
+    message: str | None,
+    org_id: uuid.UUID | None,
+    user_id: uuid.UUID | None,
+    request_id: str | None,
+) -> None:
+    """AC2 — 비밀값(헤더·바디·쿼리스트링) 미저장, message는 호출부가 이미
+    [:2000]으로 자른 값을 그대로 받는다(이 함수는 자르지 않는다 — 계약은
+    호출부 몫, 이중 절단 방지)."""
+    from app.core.database import async_session_factory
+
+    try:
+        async with async_session_factory() as s:
+            s.add(UnhandledErrorEvent(
+                id=error_id, method=method, path=path, exception_class=exception_class,
+                message=message, org_id=org_id, user_id=user_id, request_id=request_id,
+            ))
+            await s.commit()
+    except Exception:
+        logger.warning("unhandled_error_event persist failed error_id=%s", error_id, exc_info=True)
+
+
+async def sweep_old_unhandled_error_events(session: AsyncSession, *, now: datetime | None = None) -> int:
+    """cron.py `/publication-commands` tick 피기백(새 Cloud Scheduler 잡 0, 3497/3527/3547과
+    동형 사상) — 30일 지난 행을 지운다. 반환값=삭제 건수(tick 응답 카운트용)."""
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=_RETENTION_DAYS)
+    result = await session.execute(
+        delete(UnhandledErrorEvent).where(UnhandledErrorEvent.occurred_at < cutoff)
+    )
+    await session.commit()
+    return result.rowcount or 0
+
+
+async def get_unhandled_error_event(session: AsyncSession, *, error_id: uuid.UUID) -> UnhandledErrorEvent | None:
+    """AC3 조회 경로 전용 — 존재하지 않는 error_id는 None(라우터가 404로 지어내지
+    않고 그대로 응답)."""
+    return (await session.execute(
+        select(UnhandledErrorEvent).where(UnhandledErrorEvent.id == error_id)
+    )).scalar_one_or_none()

--- a/backend/tests/test_3672_unhandled_error_events.py
+++ b/backend/tests/test_3672_unhandled_error_events.py
@@ -1,0 +1,413 @@
+"""story #3672(BE·BFF·FE·관측, 페드루 PO 確定 2026-09-07) — 미처리 500이 Cloud Run
+로그에만 남아 사람(gcloud) 없이는 원인 재개가 안 되던 것(3663 실사고)을 닫는다.
+
+이 파일의 관심사(BE 축만 — BFF/FE는 apps/web 쪽 자체 테스트 파일):
+① unhandled_exception_handler가 error_id를 로그·응답 봉투에 싣는다
+② 같은 id로 unhandled_error_events 1행이 best-effort로 남는다(저장 실패해도 500
+   응답 자체는 그대로) ③ 비밀값(쿼리스트링 등) 미저장 ④ platform-admin GET 조회
+⑤ 30일 보존 정리 스윕."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi import Depends, Request
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    # raise_app_exceptions=False — test_2003 선례와 동형: 강제 unhandled 500이 ASGI
+    # ServerErrorMiddleware의 재-raise로 pytest 실패를 오인하지 않게 억제.
+    return AsyncClient(transport=ASGITransport(app=app, raise_app_exceptions=False), base_url="http://test")
+
+
+async def _seed_org_and_user(session):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org3672", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="member")
+    session.add(om)
+    await session.commit()
+    return org.id, user.id
+
+
+# ── AC1/AC2 — 핸들러가 error_id를 로그+응답+DB에 같은 값으로 싣는다 ────────────
+
+
+@pytest.mark.anyio
+async def test_unhandled_exception_returns_error_id_and_persists_row_with_auth_context():
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.models.unhandled_error_event import UnhandledErrorEvent
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, user_id = await _seed_org_and_user(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        # 실 get_current_user와 동형으로 request.state.au_org_id/au_user_id를 직접
+        # 채운다(main.py::unhandled_exception_handler 소비처③) — 「인증 성공 뒤 죽음」
+        # 시나리오를 재현. Depends(Request)로 FastAPI가 그대로 주입해 준다.
+
+        async def _auth_with_state(request: Request) -> AuthContext:
+            request.state.au_org_id = str(org_id)
+            request.state.au_user_id = str(user_id)
+            return AuthContext(user_id=str(user_id), email="caller@test", claims={}, org_id=str(org_id))
+
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[get_current_user] = _auth_with_state
+
+        # 테스트 전용 라우트 — 인증 dependency가 먼저 resolve된 뒤(request.state 채워짐)
+        # 본문에서 강제로 미처리 예외를 던진다(진짜 버그 시뮬레이션, #2003 선례와 동형).
+        async def _boom(auth: AuthContext = Depends(get_current_user)):
+            raise RuntimeError("s3672 forced unhandled failure")
+        app.add_api_route("/__test_3672_boom", _boom, methods=["GET"])
+        try:
+            # record_unhandled_error_event가 내부에서 late-import하는 app.core.database.
+            # async_session_factory는 앱의 실 설정(DATABASE_URL)을 가리켜 이 테스트의
+            # 격리 PG(_REAL_DB_URL)와 다르다 — 이 파일의 Session(위 _session_factory 산출)
+            # 으로 바꿔치기해야 그 자리도 같은 테스트 DB에 쓴다(test_ob4b_funnel_seams.py
+            # 선례와 동형 patch 지점).
+            with patch("app.core.database.async_session_factory", new=Session):
+                client = _client_for(app)
+                try:
+                    resp = await client.get("/__test_3672_boom")
+                    assert resp.status_code == 500, resp.text
+                    body = resp.json()
+                    error_id = body["error"]["error_id"]
+                    uuid.UUID(error_id)  # 유효한 uuid4 형식
+                    assert body["error"]["code"] == "INTERNAL_ERROR"
+                finally:
+                    await client.aclose()
+
+            async with Session() as s:
+                row = (await s.execute(
+                    select(UnhandledErrorEvent).where(UnhandledErrorEvent.id == uuid.UUID(error_id))
+                )).scalar_one_or_none()
+            assert row is not None, "unhandled_error_events 행이 안 남음"
+            assert row.method == "GET"
+            assert row.path == "/__test_3672_boom"
+            assert row.exception_class == "RuntimeError"
+            assert row.message == "s3672 forced unhandled failure"
+            assert row.org_id == org_id
+            assert row.user_id == user_id
+        finally:
+            app.router.routes[:] = [r for r in app.router.routes if getattr(r, "path", None) != "/__test_3672_boom"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unhandled_exception_before_auth_persists_null_org_and_user():
+    """인증 자체가 죽으면(request.state가 안 채워진 채) org_id/user_id는 null이
+    정직한 값 — 지어내지 않는다(AC2 "알 때만")."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.dependencies.auth import get_current_user
+    from app.models.unhandled_error_event import UnhandledErrorEvent
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        async def _boom_auth():
+            raise RuntimeError("s3672 forced auth failure")
+
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[get_current_user] = _boom_auth
+
+        from app.dependencies.auth import AuthContext
+
+        async def _route(auth: AuthContext = Depends(get_current_user)):
+            return {"ok": True}
+
+        app.add_api_route("/__test_3672_boom_auth", _route, methods=["GET"])
+        try:
+            with patch("app.core.database.async_session_factory", new=Session):
+                client = _client_for(app)
+                try:
+                    resp = await client.get("/__test_3672_boom_auth")
+                    assert resp.status_code == 500, resp.text
+                    error_id = resp.json()["error"]["error_id"]
+                finally:
+                    await client.aclose()
+
+            async with Session() as s:
+                row = (await s.execute(
+                    select(UnhandledErrorEvent).where(UnhandledErrorEvent.id == uuid.UUID(error_id))
+                )).scalar_one_or_none()
+            assert row is not None
+            assert row.org_id is None
+            assert row.user_id is None
+            assert row.exception_class == "RuntimeError"
+        finally:
+            app.router.routes[:] = [r for r in app.router.routes if getattr(r, "path", None) != "/__test_3672_boom_auth"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_persist_failure_does_not_block_the_500_response():
+    """AC2 — 저장이 실패해도(예: DB 자체가 안 닿음) 원래의 500 응답은 그대로 나간다
+    (best-effort, fail-silent). 뮤테이션 대상 — main.py의 try/except를 없애면 이
+    테스트가 500 대신 unhandled RuntimeError로 죽어 RED가 된다."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.dependencies.auth import AuthContext, get_current_user
+    import app.services.unhandled_error_events as uee_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        async def _auth():
+            return AuthContext(user_id=str(uuid.uuid4()), email="caller@test", claims={})
+
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[get_current_user] = _auth
+
+
+        async def _boom(auth: AuthContext = Depends(get_current_user)):
+            raise RuntimeError("s3672 forced unhandled failure")
+
+        app.add_api_route("/__test_3672_boom_persist_fail", _boom, methods=["GET"])
+        try:
+            with patch.object(
+                uee_mod, "record_unhandled_error_event",
+                side_effect=RuntimeError("db unreachable — simulated persist failure"),
+            ):
+                client = _client_for(app)
+                try:
+                    resp = await client.get("/__test_3672_boom_persist_fail")
+                    assert resp.status_code == 500, resp.text
+                    body = resp.json()
+                    assert body["error"]["code"] == "INTERNAL_ERROR"
+                    uuid.UUID(body["error"]["error_id"])  # 저장 실패해도 error_id는 그대로 실린다
+                finally:
+                    await client.aclose()
+        finally:
+            app.router.routes[:] = [
+                r for r in app.router.routes if getattr(r, "path", None) != "/__test_3672_boom_persist_fail"
+            ]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_persisted_path_excludes_query_string_even_if_request_had_one():
+    """AC2 "비밀값(쿼리스트링) 미저장" — request.url.path 자체가 쿼리 없는 값이라
+    보장되지만, oauth-channel authorize/callback 같은 자리는 쿼리에 code/state
+    (사실상 비밀)를 싣는다 — 그 요청이 500나도 path 컬럼엔 안 새는지 직접 확認."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.models.unhandled_error_event import UnhandledErrorEvent
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        async def _auth():
+            return AuthContext(user_id=str(uuid.uuid4()), email="caller@test", claims={})
+
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[get_current_user] = _auth
+
+
+        async def _boom(auth: AuthContext = Depends(get_current_user)):
+            raise RuntimeError("s3672 forced unhandled failure")
+
+        app.add_api_route("/__test_3672_boom_query", _boom, methods=["GET"])
+        try:
+            with patch("app.core.database.async_session_factory", new=Session):
+                client = _client_for(app)
+                try:
+                    resp = await client.get("/__test_3672_boom_query?code=SECRET-OAUTH-CODE&state=SECRET-STATE-JWT")
+                    error_id = resp.json()["error"]["error_id"]
+                finally:
+                    await client.aclose()
+
+            async with Session() as s:
+                row = (await s.execute(
+                    select(UnhandledErrorEvent).where(UnhandledErrorEvent.id == uuid.UUID(error_id))
+                )).scalar_one_or_none()
+            assert row.path == "/__test_3672_boom_query"
+            assert "SECRET" not in row.path
+            assert row.message is None or "SECRET" not in row.message
+        finally:
+            app.router.routes[:] = [
+                r for r in app.router.routes if getattr(r, "path", None) != "/__test_3672_boom_query"
+            ]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── AC3 — platform-admin GET 조회 ──────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_admin_get_unhandled_error_returns_stored_row():
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.dependencies.admin_auth import AdminOperator, require_admin_operator
+    from app.models.unhandled_error_event import UnhandledErrorEvent
+
+    engine, Session = await _session_factory()
+    try:
+        error_id = uuid.uuid4()
+        async with Session() as s:
+            s.add(UnhandledErrorEvent(
+                id=error_id, method="POST", path="/api/v2/organizations/x/channel-connections/y/callback",
+                exception_class="KeyError", message="'foo'", org_id=None, user_id=None, request_id=None,
+            ))
+            await s.commit()
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[require_admin_operator] = lambda: AdminOperator(email="op@moonklabs.com", subject="sub-1")
+
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/admin/unhandled-errors/{error_id}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["id"] == str(error_id)
+            assert body["exception_class"] == "KeyError"
+            assert body["method"] == "POST"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_admin_get_unhandled_error_404_for_unknown_id():
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.dependencies.admin_auth import AdminOperator, require_admin_operator
+
+    engine, Session = await _session_factory()
+    try:
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[require_admin_operator] = lambda: AdminOperator(email="op@moonklabs.com", subject="sub-1")
+
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/admin/unhandled-errors/{uuid.uuid4()}")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── AC2 — 30일 보존 정리 스윕 ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_sweep_deletes_only_rows_older_than_30_days():
+    from app.models.unhandled_error_event import UnhandledErrorEvent
+    from app.services.unhandled_error_events import sweep_old_unhandled_error_events
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        now = datetime.now(timezone.utc)
+        old_id, recent_id = uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            s.add(UnhandledErrorEvent(
+                id=old_id, method="GET", path="/old", exception_class="RuntimeError", message=None,
+            ))
+            s.add(UnhandledErrorEvent(
+                id=recent_id, method="GET", path="/recent", exception_class="RuntimeError", message=None,
+            ))
+            await s.commit()
+            # occurred_at은 server_default이라 커밋 뒤 직접 UPDATE로 시점을 되돌린다
+            # (다른 story의 30일 스윕 테스트들과 동형 관례 — created_at 직접 조작).
+            from sqlalchemy import update
+            await s.execute(
+                update(UnhandledErrorEvent).where(UnhandledErrorEvent.id == old_id)
+                .values(occurred_at=now - timedelta(days=31))
+            )
+            await s.commit()
+
+        async with Session() as s:
+            swept = await sweep_old_unhandled_error_events(s, now=now)
+            assert swept == 1
+
+        async with Session() as s:
+            remaining_ids = set((await s.execute(select(UnhandledErrorEvent.id))).scalars().all())
+        assert old_id not in remaining_ids
+        assert recent_id in remaining_ids
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3672_unhandled_error_events.py
+++ b/backend/tests/test_3672_unhandled_error_events.py
@@ -16,6 +16,8 @@ from unittest.mock import patch
 import pytest
 from fastapi import Depends, Request
 
+from tests.conftest import override_db_and_read
+
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
 pytestmark = [
@@ -80,7 +82,6 @@ async def _seed_org_and_user(session):
 @pytest.mark.anyio
 async def test_unhandled_exception_returns_error_id_and_persists_row_with_auth_context():
     from app.main import app
-    from app.dependencies.database import get_db
     from app.dependencies.auth import AuthContext, get_current_user
     from app.models.unhandled_error_event import UnhandledErrorEvent
     from sqlalchemy import select
@@ -103,7 +104,7 @@ async def test_unhandled_exception_returns_error_id_and_persists_row_with_auth_c
             request.state.au_user_id = str(user_id)
             return AuthContext(user_id=str(user_id), email="caller@test", claims={}, org_id=str(org_id))
 
-        app.dependency_overrides[get_db] = _db
+        override_db_and_read(app, _db)
         app.dependency_overrides[get_current_user] = _auth_with_state
 
         # 테스트 전용 라우트 — 인증 dependency가 먼저 resolve된 뒤(request.state 채워짐)
@@ -147,12 +148,73 @@ async def test_unhandled_exception_returns_error_id_and_persists_row_with_auth_c
         await engine.dispose()
 
 
+# 페드루 PO 권고①(#4025 리뷰, 2026-09-07) — dev-app이 CF 경유라 x-request-id는 지금
+# 거의 null. cf-ray→x-cloud-trace-context 순 폴백이 실제로 도는지 고정.
+@pytest.mark.anyio
+async def test_request_id_falls_back_to_cf_ray_then_cloud_trace_context():
+    from app.main import app
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.models.unhandled_error_event import UnhandledErrorEvent
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        async def _auth():
+            return AuthContext(user_id=str(uuid.uuid4()), email="caller@test", claims={})
+
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+
+        async def _boom(auth: AuthContext = Depends(get_current_user)):
+            raise RuntimeError("s3672 forced unhandled failure")
+
+        app.add_api_route("/__test_3672_boom_reqid", _boom, methods=["GET"])
+        try:
+            with patch("app.core.database.async_session_factory", new=Session):
+                client = _client_for(app)
+                try:
+                    # x-request-id 없음 · cf-ray 있음 → cf-ray를 쓴다.
+                    resp = await client.get(
+                        "/__test_3672_boom_reqid",
+                        headers={"cf-ray": "cf-ray-value-1", "x-cloud-trace-context": "trace-value-1"},
+                    )
+                    error_id_1 = resp.json()["error"]["error_id"]
+                    # x-request-id·cf-ray 둘 다 없음 → x-cloud-trace-context를 쓴다.
+                    resp2 = await client.get(
+                        "/__test_3672_boom_reqid",
+                        headers={"x-cloud-trace-context": "trace-value-2"},
+                    )
+                    error_id_2 = resp2.json()["error"]["error_id"]
+                finally:
+                    await client.aclose()
+
+            async with Session() as s:
+                row1 = (await s.execute(
+                    select(UnhandledErrorEvent).where(UnhandledErrorEvent.id == uuid.UUID(error_id_1))
+                )).scalar_one_or_none()
+                row2 = (await s.execute(
+                    select(UnhandledErrorEvent).where(UnhandledErrorEvent.id == uuid.UUID(error_id_2))
+                )).scalar_one_or_none()
+            assert row1.request_id == "cf-ray-value-1"
+            assert row2.request_id == "trace-value-2"
+        finally:
+            app.router.routes[:] = [
+                r for r in app.router.routes if getattr(r, "path", None) != "/__test_3672_boom_reqid"
+            ]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 @pytest.mark.anyio
 async def test_unhandled_exception_before_auth_persists_null_org_and_user():
     """인증 자체가 죽으면(request.state가 안 채워진 채) org_id/user_id는 null이
     정직한 값 — 지어내지 않는다(AC2 "알 때만")."""
     from app.main import app
-    from app.dependencies.database import get_db
     from app.dependencies.auth import get_current_user
     from app.models.unhandled_error_event import UnhandledErrorEvent
     from sqlalchemy import select
@@ -166,7 +228,7 @@ async def test_unhandled_exception_before_auth_persists_null_org_and_user():
         async def _boom_auth():
             raise RuntimeError("s3672 forced auth failure")
 
-        app.dependency_overrides[get_db] = _db
+        override_db_and_read(app, _db)
         app.dependency_overrides[get_current_user] = _boom_auth
 
         from app.dependencies.auth import AuthContext
@@ -206,7 +268,6 @@ async def test_persist_failure_does_not_block_the_500_response():
     (best-effort, fail-silent). 뮤테이션 대상 — main.py의 try/except를 없애면 이
     테스트가 500 대신 unhandled RuntimeError로 죽어 RED가 된다."""
     from app.main import app
-    from app.dependencies.database import get_db
     from app.dependencies.auth import AuthContext, get_current_user
     import app.services.unhandled_error_events as uee_mod
 
@@ -219,7 +280,7 @@ async def test_persist_failure_does_not_block_the_500_response():
         async def _auth():
             return AuthContext(user_id=str(uuid.uuid4()), email="caller@test", claims={})
 
-        app.dependency_overrides[get_db] = _db
+        override_db_and_read(app, _db)
         app.dependency_overrides[get_current_user] = _auth
 
 
@@ -256,7 +317,6 @@ async def test_persisted_path_excludes_query_string_even_if_request_had_one():
     보장되지만, oauth-channel authorize/callback 같은 자리는 쿼리에 code/state
     (사실상 비밀)를 싣는다 — 그 요청이 500나도 path 컬럼엔 안 새는지 직접 확認."""
     from app.main import app
-    from app.dependencies.database import get_db
     from app.dependencies.auth import AuthContext, get_current_user
     from app.models.unhandled_error_event import UnhandledErrorEvent
     from sqlalchemy import select
@@ -270,7 +330,7 @@ async def test_persisted_path_excludes_query_string_even_if_request_had_one():
         async def _auth():
             return AuthContext(user_id=str(uuid.uuid4()), email="caller@test", claims={})
 
-        app.dependency_overrides[get_db] = _db
+        override_db_and_read(app, _db)
         app.dependency_overrides[get_current_user] = _auth
 
 
@@ -303,13 +363,72 @@ async def test_persisted_path_excludes_query_string_even_if_request_had_one():
         await engine.dispose()
 
 
+# 페드루 PO REQUIRED(#4025 리뷰, 2026-09-07) — message=str(exc)[:2000]는 debug 무관하게
+# 30일 잔존한다. 예외 문자열 자체(요청 URL/헤더가 아니라)가 access_token=…·Bearer …를
+# 인용하는 경로(예: 실패한 하위요청의 URL을 그대로 붙이는 라이브러리 예외)가 있어
+# path/헤더/바디를 안 담는 것만으로는 안 끝난다 — 저장 直前 _redact()로 한 번 더 가린다.
+@pytest.mark.anyio
+async def test_persisted_message_redacts_access_token_and_bearer_even_when_exception_string_carries_it():
+    from app.main import app
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.models.unhandled_error_event import UnhandledErrorEvent
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        async def _auth():
+            return AuthContext(user_id=str(uuid.uuid4()), email="caller@test", claims={})
+
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+
+        async def _boom(auth: AuthContext = Depends(get_current_user)):
+            raise RuntimeError(
+                "upstream call failed: https://graph.facebook.com/oauth?access_token=abc123secret"
+                " Authorization: Bearer xyz789token client_secret=shh-dont-tell"
+            )
+
+        app.add_api_route("/__test_3672_boom_redact", _boom, methods=["GET"])
+        try:
+            with patch("app.core.database.async_session_factory", new=Session):
+                client = _client_for(app)
+                try:
+                    resp = await client.get("/__test_3672_boom_redact")
+                    error_id = resp.json()["error"]["error_id"]
+                finally:
+                    await client.aclose()
+
+            async with Session() as s:
+                row = (await s.execute(
+                    select(UnhandledErrorEvent).where(UnhandledErrorEvent.id == uuid.UUID(error_id))
+                )).scalar_one_or_none()
+            assert row.message is not None
+            assert "abc123secret" not in row.message
+            assert "xyz789token" not in row.message
+            assert "shh-dont-tell" not in row.message
+            # 값만 가리고 자리 자체(그 예외가 access_token 축과 관련됐다는 사실)는 남긴다 —
+            # 완전 삭제가 아니라 마스킹임을 확認(디버깅에 최소한의 단서는 남아야 값이 있다).
+            assert "access_token" in row.message
+            assert "[REDACTED]" in row.message
+        finally:
+            app.router.routes[:] = [
+                r for r in app.router.routes if getattr(r, "path", None) != "/__test_3672_boom_redact"
+            ]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 # ── AC3 — platform-admin GET 조회 ──────────────────────────────────────────
 
 
 @pytest.mark.anyio
 async def test_admin_get_unhandled_error_returns_stored_row():
     from app.main import app
-    from app.dependencies.database import get_db
     from app.dependencies.admin_auth import AdminOperator, require_admin_operator
     from app.models.unhandled_error_event import UnhandledErrorEvent
 
@@ -327,7 +446,7 @@ async def test_admin_get_unhandled_error_returns_stored_row():
             async with Session() as s:
                 yield s
 
-        app.dependency_overrides[get_db] = _db
+        override_db_and_read(app, _db)
         app.dependency_overrides[require_admin_operator] = lambda: AdminOperator(email="op@moonklabs.com", subject="sub-1")
 
         client = _client_for(app)
@@ -348,7 +467,6 @@ async def test_admin_get_unhandled_error_returns_stored_row():
 @pytest.mark.anyio
 async def test_admin_get_unhandled_error_404_for_unknown_id():
     from app.main import app
-    from app.dependencies.database import get_db
     from app.dependencies.admin_auth import AdminOperator, require_admin_operator
 
     engine, Session = await _session_factory()
@@ -357,7 +475,7 @@ async def test_admin_get_unhandled_error_404_for_unknown_id():
             async with Session() as s:
                 yield s
 
-        app.dependency_overrides[get_db] = _db
+        override_db_and_read(app, _db)
         app.dependency_overrides[require_admin_operator] = lambda: AdminOperator(email="op@moonklabs.com", subject="sub-1")
 
         client = _client_for(app)
@@ -409,5 +527,47 @@ async def test_sweep_deletes_only_rows_older_than_30_days():
             remaining_ids = set((await s.execute(select(UnhandledErrorEvent.id))).scalars().all())
         assert old_id not in remaining_ids
         assert recent_id in remaining_ids
+    finally:
+        await engine.dispose()
+
+
+# 페드루 PO 권고③(#4025 리뷰, 2026-09-07) — main.py와 같은 서비스를 realtime_main.py
+# (SSE 전용 별도 entrypoint, story #2089)에도 건다. 여기는 get_current_user 경로를
+# 안 태우는 라우터만 마운트하므로(모듈 docstring) org_id/user_id는 null이 정직한 값.
+@pytest.mark.anyio
+async def test_realtime_main_unhandled_exception_also_gets_error_id():
+    from app.realtime_main import app
+    from app.models.unhandled_error_event import UnhandledErrorEvent
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async def _boom():
+            raise RuntimeError("s3672 realtime forced unhandled failure")
+
+        app.add_api_route("/__test_3672_realtime_boom", _boom, methods=["GET"])
+        try:
+            with patch("app.core.database.async_session_factory", new=Session):
+                client = _client_for(app)
+                try:
+                    resp = await client.get("/__test_3672_realtime_boom")
+                    assert resp.status_code == 500, resp.text
+                    body = resp.json()
+                    error_id = body["error"]["error_id"]
+                    uuid.UUID(error_id)
+                finally:
+                    await client.aclose()
+
+            async with Session() as s:
+                row = (await s.execute(
+                    select(UnhandledErrorEvent).where(UnhandledErrorEvent.id == uuid.UUID(error_id))
+                )).scalar_one_or_none()
+            assert row is not None
+            assert row.path == "/__test_3672_realtime_boom"
+            assert row.exception_class == "RuntimeError"
+        finally:
+            app.router.routes[:] = [
+                r for r in app.router.routes if getattr(r, "path", None) != "/__test_3672_realtime_boom"
+            ]
     finally:
         await engine.dispose()


### PR DESCRIPTION
## 배경(customer-zero 실측·배포 51)

FB sandbox 「다시 연결」 authorize→callback이 dev에서 결정적으로 500 → BFF가 `connect_error=INTERNAL_ERROR`로 되돌리고 연결 행은 무변(3663). 로컬 재현은 전부 200이라 DB엔 흔적 0, 유일한 흔적은 Cloud Run 로그뿐 — 그 로그를 이 머신 gcloud 토큰 만료로 사람 재로그인 前엔 못 읽어 3663 재개 트리거가 「사람」에 묶여 있었다.

## 처방

- **AC1/AC2 [BE]** `main.py::unhandled_exception_handler`가 미처리 예외마다 `error_id`(uuid4)를 발급해 로그 한 줄+traceback / 응답 봉투 `error.error_id` / `unhandled_error_events` 1행에 같은 값으로 싣는다. 저장은 best-effort(전용 세션, 실패해도 500 응답은 그대로) — 비밀값(헤더/바디/쿼리스트링) 미저장, `path`는 쿼리 없는 값만, `message`는 `[:2000]`. `org_id`/`user_id`는 `request.state.au_org_id`(기존 AU 계측 소비처와 같은 자리) 재사용 — `au_user_id`는 이번에 추가.
- **AC3 [BE]** `GET /api/v2/admin/unhandled-errors/{error_id}` — `admin_billing.py`와 같은 `require_admin_operator` 재사용(새 인가 축 발명 0).
- **보존** 30일 지난 행 정리는 `cron.py` `/publication-commands` tick 피기백(#3497/#3527/#3547과 동형 사상, 새 Cloud Scheduler 잡 0).
- **AC4 [BFF]** `oauth-channel/authorize`·`callback/[channel]` route.ts가 `error.error_id`가 있을 때만 `&error_id=`로 릴레이(없으면 기존 동작 그대로).
- **AC5 [FE]** 채널 연결 화면 Alert에 error_id가 있을 때만 「오류 번호: …」 한 줄(새 키 1개 `channelConnectErrorId`, 복사 가능한 일반 텍스트).

## 안 하는 것

- 외부 오류 추적 SaaS(Sentry 등) 도입 — 별건, 선생님 결정.
- 4xx는 대상 아님(이미 code로 사람 말 매핑).

## 테스트

- BE 7건(`test_3672_unhandled_error_events.py`): 핸들러 봉투+DB 상관 / 인증 前 실패 시 org·user null / 저장 실패해도 500 유지 / 쿼리스트링 미저장 / admin GET 200·404 / 30일 스윕 경계.
- BFF 4건(authorize·callback 각 2): passthrough 유무.
- FE 2건: 표시/비표시.
- 전부 뮤테이션 1개씩 RED 확認 후 복구. i18n 가드 클린(새 낱말 1, 한자 0). `tsc --noEmit`/eslint 클린. 기존 회귀(au_metering·`/rpc` 에러 계약·publication-commands cron tick) 무회귀 확認.

## 남은 것

AC7(dev 배포 뒤 3663 재현 1회로 예외 클래스 확보, gcloud 재로그인 없이)은 이 PR 머지·배포 후 별도로 확認합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA