### PR TITLE
[SID:3677] fix(FE·대비): text-destructive/80 상시 2자리 AA 미달 — 알파 제거

### DIFF
--- a/apps/web/scripts/verify-no-new-md-breakpoint.ts
+++ b/apps/web/scripts/verify-no-new-md-breakpoint.ts
@@ -18,6 +18,9 @@ import path from 'node:path';
 // GNB(components/ui/sidebar.tsx·components/nav/top-bar.tsx)는 이번 스토리에서 lg:로
 // 전환 완료돼 있어야 하므로 의도적으로 목록에 없다(재도입 시 이 스크립트가 잡는다).
 export const ALLOWLIST = new Set([
+  // story #3677 — InlineSaveIndicator를 page.tsx에서 이 형제 모듈로 이사(바이트
+  // 그대로, md:max-w-none 신규 분기 0) — grandfather 취지 그대로 옮김.
+  'app/(authenticated)/[ws]/[proj]/docs/[slug]/inline-save-indicator.tsx',
   'app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx',
   'app/(authenticated)/[ws]/[proj]/mockups/page.tsx',
   'app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx',

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/inline-save-indicator.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/inline-save-indicator.test.tsx
@@ -3,12 +3,14 @@
 // story #3677(FE·대비·確定, 2026-09-07) — InlineSaveIndicator의 status='error' 칩이
 // hover:text-destructive/80(resting state보다 대비를 낮추는 방향)을 썼다 — hover는
 // underline으로 피드백을 표현하고 색은 그대로(text-destructive, 알파 없음) 두도록
-// 교체. page.tsx 전체를 마운트하지 않고 이 하위 컴포넌트만 직접 렌더(export 추가,
-// 동작 무변 — page.test.tsx 부재라 이 파일이 유일한 회귀가드).
+// 교체. page.tsx 전체를 마운트하지 않고 이 하위 컴포넌트만 직접 렌더(카디르 CI
+// 지적: app-router page.tsx는 named export가 있으면 build type check가 깨져
+// 형제 모듈 inline-save-indicator.tsx로 분리 — page.test.tsx 부재라 이 파일이
+// 유일한 회귀가드).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { InlineSaveIndicator } from './page';
+import { InlineSaveIndicator } from './inline-save-indicator';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/inline-save-indicator.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/inline-save-indicator.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+//
+// story #3677(FE·대비·確定, 2026-09-07) — InlineSaveIndicator의 status='error' 칩이
+// hover:text-destructive/80(resting state보다 대비를 낮추는 방향)을 썼다 — hover는
+// underline으로 피드백을 표현하고 색은 그대로(text-destructive, 알파 없음) 두도록
+// 교체. page.tsx 전체를 마운트하지 않고 이 하위 컴포넌트만 직접 렌더(export 추가,
+// 동작 무변 — page.test.tsx 부재라 이 파일이 유일한 회귀가드).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { InlineSaveIndicator } from './page';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const t = ((key: string) => key) as unknown as Parameters<typeof InlineSaveIndicator>[0]['t'];
+
+describe('InlineSaveIndicator — status=error (story #3677 대비 뮤테이션가드)', () => {
+  it('hover 클래스가 text-destructive/80이 아니라 underline이다(resting 대비를 낮추지 않음)', async () => {
+    await act(async () => {
+      root.render(<InlineSaveIndicator status="error" onAction={() => {}} t={t} />);
+    });
+    const button = container.querySelector('button');
+    expect(button).not.toBeNull();
+    const className = button?.getAttribute('class') ?? '';
+    expect(className).toContain('text-destructive');
+    expect(className).toContain('hover:underline');
+    expect(className).not.toContain('text-destructive/80');
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/inline-save-indicator.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/inline-save-indicator.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2, XCircle } from 'lucide-react';
+import type { SaveStatus } from '@/components/docs/use-doc-sync';
+
+// story #3677(FE·대비·確定) — page.tsx(App Router page 파일)는 default export+정해진
+// config export만 허용돼 named export가 있으면 Next build type check가 깨진다(카디르
+// CI 실물). 테스트 격리를 위해 이 형제 모듈로 분리 — page.tsx는 import만.
+export function InlineSaveIndicator({
+  status,
+  onAction,
+  t,
+}: {
+  status: SaveStatus;
+  onAction: () => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const [show, setShow] = useState(false);
+  const [fading, setFading] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (status === 'idle') { setShow(false); setFading(false); return; }
+    setShow(true);
+    setFading(false);
+    if (status !== 'saved') return;
+    const t1 = setTimeout(() => setFading(true), 200);
+    const t2 = setTimeout(() => setShow(false), 1600);
+    return () => { clearTimeout(t1); clearTimeout(t2); };
+  }, [status]);
+
+  if (!show) return null;
+
+  if (status === 'saving') {
+    return (
+      <span aria-label={t('statusSaving')} title={t('statusSaving')} className="flex items-center">
+        <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+      </span>
+    );
+  }
+  if (status === 'saved') {
+    return (
+      <span aria-label={t('statusSaved')} title={t('statusSaved')} className={`flex items-center transition-opacity duration-[1400ms] ${fading ? 'opacity-0' : 'opacity-100'}`}>
+        <span className="size-2 rounded-full bg-success" />
+      </span>
+    );
+  }
+  if (status === 'unsaved') {
+    return (
+      <span aria-label={t('statusUnsaved')} title={t('statusUnsaved')} className="flex items-center">
+        <span className="size-2 rounded-full bg-warning" />
+      </span>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <button type="button" onClick={onAction}
+        aria-label={`${t('statusError')} · ${t('retry')}`}
+        title={`${t('statusError')} · ${t('retry')}`}
+        // story #3677(FE·대비·確定) — hover:text-destructive/80은 resting state(text-
+        // destructive, 알파 없음)보다 대비를 "낮추는" 방향이라 새 규칙 위반. 색은
+        // 그대로 두고 underline으로 hover 피드백을 표현(대비 하락 0).
+        className="flex max-w-[120px] items-center gap-1 truncate text-xs text-destructive hover:underline md:max-w-none"
+      >
+        <XCircle className="size-3.5 shrink-0" />
+        <span className="truncate">{t('statusError')} · {t('retry')}</span>
+      </button>
+    );
+  }
+  // conflict / remote-changed are surfaced by DocSyncBanner (the off-ramp), not this
+  // status chip — keeping a chip here too would double-surface and re-expose the
+  // dead-end onAction. (fc4d4264 FIX-4)
+  return null;
+}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
@@ -9,10 +9,11 @@ import { DocUrlChip } from '@/components/docs/doc-url-chip';
 import { DocUrlDialog, type SlugSubmitResult } from '@/components/docs/doc-url-dialog';
 import { slugifyDocTitle, isUntitledSlug } from '@/components/docs/lib/doc-slug';
 import { docsListUrl, docUrl } from '@/components/docs/lib/doc-project-url';
-import { useDocSync, unwrapDocResponse, type SaveStatus } from '@/components/docs/use-doc-sync';
+import { useDocSync, unwrapDocResponse } from '@/components/docs/use-doc-sync';
 import { htmlToMarkdown } from '@/components/docs/lib/content-converter';
 import Link from 'next/link';
-import { Check, Copy, Eye, Link2, Loader2, MoreHorizontal, Share2, Trash2, XCircle } from 'lucide-react';
+import { Check, Copy, Eye, Link2, MoreHorizontal, Share2, Trash2 } from 'lucide-react';
+import { InlineSaveIndicator } from './inline-save-indicator';
 import { DocShareDialog } from '@/components/docs/doc-share-dialog';
 import { DocSyncBanner } from '@/components/docs/doc-sync-banner';
 import {
@@ -53,76 +54,6 @@ interface DocDetail {
   // #1691 payload enrich(이중 fetch 제거·additive·nullable): 담당자 요약 + 수정이력 요약 동봉.
   assignee?: { id: string; name: string; avatar_url?: string | null } | null;
   revisions?: { count: number; latest_at?: string | null } | null;
-}
-
-// story #3677(FE·대비·確定) — export만 추가(테스트 격리용, 동작 무변) — 렌더 테스트가
-// 이 하위 컴포넌트만 직접 마운트해 hover 클래스를 검증한다(page.tsx 전체를 마운트하면
-// useParams/fetch 등 무관한 의존성까지 다 갖춰야 해 이 1pt 스토리 범위를 넘는다).
-export function InlineSaveIndicator({
-  status,
-  onAction,
-  t,
-}: {
-  status: SaveStatus;
-  onAction: () => void;
-  t: ReturnType<typeof useTranslations>;
-}) {
-  const [show, setShow] = useState(false);
-  const [fading, setFading] = useState(false);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (status === 'idle') { setShow(false); setFading(false); return; }
-    setShow(true);
-    setFading(false);
-    if (status !== 'saved') return;
-    const t1 = setTimeout(() => setFading(true), 200);
-    const t2 = setTimeout(() => setShow(false), 1600);
-    return () => { clearTimeout(t1); clearTimeout(t2); };
-  }, [status]);
-
-  if (!show) return null;
-
-  if (status === 'saving') {
-    return (
-      <span aria-label={t('statusSaving')} title={t('statusSaving')} className="flex items-center">
-        <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
-      </span>
-    );
-  }
-  if (status === 'saved') {
-    return (
-      <span aria-label={t('statusSaved')} title={t('statusSaved')} className={`flex items-center transition-opacity duration-[1400ms] ${fading ? 'opacity-0' : 'opacity-100'}`}>
-        <span className="size-2 rounded-full bg-success" />
-      </span>
-    );
-  }
-  if (status === 'unsaved') {
-    return (
-      <span aria-label={t('statusUnsaved')} title={t('statusUnsaved')} className="flex items-center">
-        <span className="size-2 rounded-full bg-warning" />
-      </span>
-    );
-  }
-  if (status === 'error') {
-    return (
-      <button type="button" onClick={onAction}
-        aria-label={`${t('statusError')} · ${t('retry')}`}
-        title={`${t('statusError')} · ${t('retry')}`}
-        // story #3677(FE·대비·確定) — hover:text-destructive/80은 resting state(text-
-        // destructive, 알파 없음)보다 대비를 "낮추는" 방향이라 새 규칙 위반. 색은
-        // 그대로 두고 underline으로 hover 피드백을 표현(대비 하락 0).
-        className="flex max-w-[120px] items-center gap-1 truncate text-xs text-destructive hover:underline md:max-w-none"
-      >
-        <XCircle className="size-3.5 shrink-0" />
-        <span className="truncate">{t('statusError')} · {t('retry')}</span>
-      </button>
-    );
-  }
-  // conflict / remote-changed are surfaced by DocSyncBanner (the off-ramp), not this
-  // status chip — keeping a chip here too would double-surface and re-expose the
-  // dead-end onAction. (fc4d4264 FIX-4)
-  return null;
 }
 
 export default function DocSlugPage() {

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
@@ -55,7 +55,10 @@ interface DocDetail {
   revisions?: { count: number; latest_at?: string | null } | null;
 }
 
-function InlineSaveIndicator({
+// story #3677(FE·대비·確定) — export만 추가(테스트 격리용, 동작 무변) — 렌더 테스트가
+// 이 하위 컴포넌트만 직접 마운트해 hover 클래스를 검증한다(page.tsx 전체를 마운트하면
+// useParams/fetch 등 무관한 의존성까지 다 갖춰야 해 이 1pt 스토리 범위를 넘는다).
+export function InlineSaveIndicator({
   status,
   onAction,
   t,
@@ -106,7 +109,10 @@ function InlineSaveIndicator({
       <button type="button" onClick={onAction}
         aria-label={`${t('statusError')} · ${t('retry')}`}
         title={`${t('statusError')} · ${t('retry')}`}
-        className="flex max-w-[120px] items-center gap-1 truncate text-xs text-destructive hover:text-destructive/80 md:max-w-none"
+        // story #3677(FE·대비·確定) — hover:text-destructive/80은 resting state(text-
+        // destructive, 알파 없음)보다 대비를 "낮추는" 방향이라 새 규칙 위반. 색은
+        // 그대로 두고 underline으로 hover 피드백을 표현(대비 하락 0).
+        className="flex max-w-[120px] items-center gap-1 truncate text-xs text-destructive hover:underline md:max-w-none"
       >
         <XCircle className="size-3.5 shrink-0" />
         <span className="truncate">{t('statusError')} · {t('retry')}</span>

--- a/apps/web/src/components/agents/agent-run-detail.test.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.test.tsx
@@ -66,3 +66,62 @@ describe('AgentRunDetail — 실패 배너 아이콘 색 유지 (story #2513 회
     expect(icon?.getAttribute('class')).toContain('text-destructive');
   });
 });
+
+// story #3677(FE·대비·確定, 유나 표① 2026-09-07) — text-destructive/80 상시 2자리가
+// 두 테마 다 AA 미달(3.76 타임라인 카드·3.82 이중 알파 bg-white/3 카드)이었다. 알파를
+// 뺀 text-destructive로 교체 — 뮤테이션 표적(디디 자체 검증): /80을 되돌리면 이
+// 테스트가 RED.
+function failedRunWithErrorsResponse() {
+  return {
+    ok: true,
+    json: async () => ({
+      data: {
+        id: 'run-1', agent_id: 'agent-1', agent_name: '테스트 에이전트', deployment_id: null,
+        session_id: null, memo_id: null, story_id: null, trigger: 'manual', model: null,
+        llm_provider: null, llm_provider_key: null, status: 'failed', duration_ms: 1000,
+        llm_call_count: 1, input_tokens: null, output_tokens: null, cost_usd: null,
+        computed_cost_cents: 0, per_run_cap_cents: null, billing_notes: [],
+        result_summary: null, error_message: '실패했습니다', last_error_code: 'E1',
+        retry_count: 0, max_retries: 3, next_retry_at: null, failure_disposition: null,
+        tool_call_history: [
+          { type: 'tool', toolName: 'search', error: '타임라인 카드 에러' },
+        ],
+        tool_audit_trail: [
+          {
+            id: 'audit-1', run_id: 'run-1', session_id: null, event_type: 'tool.denied',
+            severity: 'error', summary: '거부됨', payload: { error: '감사 카드 에러' },
+            created_by: null, created_at: '2026-08-07T00:00:00Z', actor_name: null,
+          },
+        ],
+        continuity_debug: null, memory_compaction_policy: null,
+        started_at: null, finished_at: null, created_at: '2026-08-07T00:00:00Z',
+      },
+    }),
+  };
+}
+
+describe('AgentRunDetail — text-destructive 알파 제거(story #3677 AA 미달 픽스)', () => {
+  it('타임라인 카드·도구 감사 카드의 에러 문구 둘 다 text-destructive/80이 아니라 text-destructive다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => failedRunWithErrorsResponse()));
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <AgentRunDetail runId="run-1" locale="ko" onBack={() => {}} />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('타임라인 카드 에러');
+    expect(container.textContent).toContain('감사 카드 에러');
+
+    const allClassNames = Array.from(container.querySelectorAll('[class]'))
+      .map((el) => el.getAttribute('class') ?? '');
+    const destructiveTextEls = allClassNames.filter((c) => /\btext-destructive\b/.test(c));
+    expect(destructiveTextEls.length).toBeGreaterThan(0);
+    expect(allClassNames.some((c) => c.includes('text-destructive/80'))).toBe(false);
+  });
+});

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -499,7 +499,13 @@ export function AgentRunDetail({
                             )}
                           </div>
                           {hasError && (
-                            <div className="mt-1 space-y-1 text-xs text-destructive/80">
+                            // story #3677(FE·대비·確定, 유나 표① 2026-09-07) — text-destructive/80
+                            // 이 이 카드 배경 위에서 두 테마 다 AA 미달(3.76/3.82)이었다. 알파
+                            // 제거 규칙: 시맨틱 색(destructive/muted/foreground 등) 알파 수정자는
+                            // /60 이상만·hover는 그 resting state보다 대비를 낮추지 않음·이중 알파
+                            // (반투명 배경 위에 알파 전경, 예 bg-white/3 위 text-*/N)는 픽셀 실측
+                            // 없이는 통과로 간주하지 않는다(유나 표 대조 필수).
+                            <div className="mt-1 space-y-1 text-xs text-destructive">
                               <p>{display.error}</p>
                               {display.userReason ? <p>{display.userReason}</p> : null}
                               {display.nextAction ? <p>{display.nextAction}</p> : null}
@@ -592,7 +598,10 @@ export function AgentRunDetail({
                           </div>
                         ) : null}
                         {error ? (
-                          <p className="mt-3 text-sm text-destructive/80">{error}</p>
+                          // story #3677(FE·대비·確定, 유나 표① 2026-09-07) — bg-white/3(이 카드
+                          // 자체가 이미 반투명) 위 text-destructive/80은 이중 알파라 AA 미달
+                          // (3.82) — 알파 제거(규칙 근거는 위 hasError 블록 주석 참고).
+                          <p className="mt-3 text-sm text-destructive">{error}</p>
                         ) : null}
                         {!operatorReason && !userReason && !nextAction && detailSummary ? (
                           <p className="mt-3 text-sm text-muted-foreground">{detailSummary}</p>


### PR DESCRIPTION
유나 표①(2026-09-07) — 알파 전경 클래스 전수 grep 48자리 중 46자리는 통과, 이 2자리(`agent-run-detail.tsx`)만 두 테마 다 미달:
- `:502` 타임라인 카드 위 `text-xs` — 3.76
- `:595` `bg-white/3`(이미 반투명) 카드 위 `text-sm` — 이중 알파라 3.82

## 처방
알파 제거(`text-destructive/80` → `text-destructive`). 규칙 주석 인라인 — 시맨틱 색 알파 수정자는 `/60` 이상만·hover는 resting state보다 대비를 낮추지 않음·이중 알파(반투명 배경 위 알파 전경)는 픽셀 실측 없이는 통과로 간주 안 함.

`docs/[slug]/page.tsx:109`의 `hover:text-destructive/80`은 이 스토리의 "미달 2자리" 목록 밖(범위 밖 — 새 규칙과 어긋나 보이면 PO 별건 판단).

## Test plan
- [x] 타임라인+도구감사 카드 둘 다 `text-destructive`(알파 없음)를 렌더하고 `text-destructive/80`이 DOM 전체에 0건임을 단언(story #2513 회귀가드 옆에 추가)
- [x] 라이브 뮤테이션(`/80` 복원) — RED 재현 확認 후 원복
- [x] `tsc --noEmit` 그린 · `eslint` 그린

story #3677

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 정정(디디, 후속 커밋) — AC②를 첫 커밋에서 범위 밖으로 잘못 읽음

스토리 確定 AC②(`docs/[slug]:109`의 `hover:text-destructive/80` → hover에서 대비를 낮추지 않는 형)를 첫 커밋에서 "미달 2자리" 목록 밖으로 잘못 취급했습니다 — 실제로는 확定 AC에 명시된 3번째 자리입니다. 추가 커밋으로 반영:

- `hover:text-destructive/80` → `hover:underline`(색은 `text-destructive` 그대로, 대비 하락 0).
- `InlineSaveIndicator` export(테스트 격리용, 동작 무변) + 렌더 테스트 1건.
- 라이브 뮤테이션(되돌림) RED 재현 확認 후 원복.

head 3e5b954d5b36abfabbeb063f09bb02532dcb2b59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
