### PR TITLE
[SID:3678] fix(ci·핫픽스): FE-only PR의 Backend pytest가 shard 산출물 누락으로 오탐 RED

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1179,9 +1179,9 @@ jobs:
       # 나머지 스텝을 건너뛴다) — result!=success(실패/타임아웃)면 그 샤드의 실측
       # 데이터가 원천적으로 없어 "센다"가 불가능하니 ::warning만(exit 0, 원칙 그대로
       # CI를 안 죽인다).
-      - name: Audit shard durations vs weights.json (story #3558+#3642+#3653)
+      - name: Audit shard durations vs weights.json (story #3558+#3642+#3653+#3678)
         working-directory: backend
-        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations --drift-state /tmp/weights-drift-streak.json --run-id "${{ github.run_id }}" --shard-count 8 --shard-result "${{ needs.backend-test-destructive.result }}"
+        run: uv run python scripts/shard_destructive_tests.py --audit-durations /tmp/shard-durations --drift-state /tmp/weights-drift-streak.json --run-id "${{ github.run_id }}" --shard-count 8 --shard-result "${{ needs.backend-test-destructive.result }}" --backend-relevant "${{ needs.detect-changed-scope.outputs.backend_relevant }}"
 
       - name: Save weights-drift streak state (story #3642)
         if: always()

--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -357,6 +357,7 @@ def load_duration_artifacts(artifact_dir: Path) -> dict[str, float]:
 def _audit_durations_mode(
     artifact_dir: Path, *, drift_state_path: Path | None = None, run_id: str | None = None,
     expected_shard_count: int | None = None, shard_result: str | None = None,
+    backend_relevant: str | None = None,
 ) -> int:
     """story #3558 AC2 — 원칙은 경고 전용(CI를 절대 안 죽인다). 산출물 디렉터리가
     없거나 비어 있어도(backend-irrelevant PR이라 샤드 자체가 스킵된 경우) 조용히
@@ -388,6 +389,20 @@ def _audit_durations_mode(
       실측 데이터가 원천적으로 없어(타임아웃이 파일 루프 중간을 끊으면 부분 기록도
       없다) "센다"가 물리적으로 불가능하다 — `::warning::`으로 "N개는 집계 밖"만
       선언(exit 0, 기존 경고-전용 원칙 그대로).
+
+    story #3678(CI·핫픽스, 페드루 PO 確定 2026-09-07) — 위 `shard_result == "success"`
+    분기가 놓친 세 번째 세계: FE-only PR은 `detect-changed-scope`가 backend_relevant=
+    false를 내고, 그러면 ci.yml의 「Upload shard durations」 스텝 자체가 스킵된다
+    (`if: ... && backend_relevant != 'false'`) — 8개 shard 잡은 각자 내부 스텝을 전부
+    건너뛰고도 잡 자체는 `if: always()`라 "success"로 끝난다(스킵을 미실행이 아니라
+    통과로 잡히게 하려는 의도된 설계, 위 주석 §3653 참고). 그 결과 "shard_result=
+    success인데 산출물 8개 다 없다"가 **정상 경로**로 발생하는데, 위 분기는 이걸
+    "업로드 파이프라인이 무산됐다"와 구분하지 못하고 그대로 ::error+exit 1을 낸다
+    (실물: PR #4021 run 34160408234 잡 101860994039 — FE-only인데 Backend pytest
+    전체가 이걸로 빨갛다). `backend_relevant`(ci.yml이 `needs.detect-changed-scope.
+    outputs.backend_relevant`를 그대로 넘긴다)가 `"false"`면 shard_result·missing과
+    무관하게 "스코프 밖·집계 대상 아님"만 선언하고 exit 0 — backend_relevant가
+    `"false"`가 아닌 한(진짜 관련 PR) 위 §3653 판정은 그대로다(회귀 0).
 
     카디르 qa:changes(PR #4005, 2026-09-07, codex 발견) — 예전엔 `artifact_dir.exists()`
     가 이 shard_result 분기보다 **먼저** 서서, 디렉터리 자체가 통째로 없으면(업로드가
@@ -434,7 +449,14 @@ def _audit_durations_mode(
     if expected_shard_count is not None:
         missing = missing_shards(load_present_shard_numbers(artifact_dir), expected_count=expected_shard_count)
         if missing:
-            if shard_result == "success":
+            if backend_relevant == "false":
+                print(
+                    f"OK: shard {len(missing)}개 산출물 없음(story #3678): {missing} — backend_relevant="
+                    "false(FE-only 등 백엔드-무관 PR)라 8개 shard 모두 내부 스텝을 스킵하고 업로드 자체를 "
+                    "안 했다(잡은 always()라 result=success로 끝나지만 그건 스킵의 「통과」일 뿐) — "
+                    "스코프 밖·집계 대상 아님, 실패 아님."
+                )
+            elif shard_result == "success":
                 print(
                     f"::error::shard 산출물 누락(story #3653): {missing} — backend-test-destructive.result="
                     "success인데 산출물이 없다(코드 결함 아님 — 업로드 파이프라인이 조용히 무산됐다는 뜻, "
@@ -594,6 +616,15 @@ def main() -> int:
              "짝을 이뤄 «성공인데 산출물이 빈 shard」(업로드 결함, ::error+exit 1)와 "
              "「실패/타임아웃이라 원천적으로 못 세는 shard」(::warning만)를 가른다.",
     )
+    ap.add_argument(
+        "--backend-relevant", type=str, default=None,
+        help="story #3678 — --audit-durations와 함께 쓴다(ci.yml이 "
+             "needs.detect-changed-scope.outputs.backend_relevant를 그대로 넘긴다). "
+             "'false'면 --shard-result와 무관하게 산출물 누락을 «스코프 밖»으로 선언하고 "
+             "exit 0 — FE-only PR은 8개 shard 모두 업로드 자체를 스킵하는데도 잡은 "
+             "always()라 result=success로 끝나, --shard-result만으로는(§3653) 이 케이스가 "
+             "업로드 결함과 구분이 안 됐다.",
+    )
     args = ap.parse_args()
 
     if args.check_elapsed is not None:
@@ -611,6 +642,7 @@ def main() -> int:
         return _audit_durations_mode(
             args.audit_durations, drift_state_path=args.drift_state, run_id=args.run_id,
             expected_shard_count=args.shard_count, shard_result=args.shard_result,
+            backend_relevant=args.backend_relevant,
         )
 
     if args.shard_index is None or args.shard_count is None:

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -840,3 +840,58 @@ def test_mutation_removing_shard_presence_diff_silences_missing_shard_warning(tm
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "::warning::shard" not in captured.out, "뮤테이션이 걸리지 않았다(경고가 여전히 뜬다)"
+
+
+def test_audit_durations_mode_backend_irrelevant_success_missing_all_is_ok_not_error(capsys, tmp_path):
+    """selftest 4(story #3678) — 실물 재현(PR #4021 run 34160408234): FE-only PR이라
+    backend_relevant=false, 8개 shard가 전부 내부 스텝을 스킵해 업로드 자체가 없는데도
+    잡은 always()라 shard_result="success"로 끝난다. §3653만으로는 이걸 "업로드
+    파이프라인 무산"(selftest 3)과 구분 못 해 ::error+exit 1을 냈다 — backend_relevant
+    가 이 케이스를 갈라 exit 0."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"  # 만들지 않음 — 업로드 자체가 스킵됐다.
+    exit_code = mod._audit_durations_mode(
+        artifact_dir, expected_shard_count=8, shard_result="success", backend_relevant="false",
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "::error::" not in captured.out
+    assert "OK: shard 8개 산출물 없음(story #3678)" in captured.out
+    assert "[0, 1, 2, 3, 4, 5, 6, 7]" in captured.out
+
+
+def test_audit_durations_mode_backend_relevant_true_success_missing_still_errors(capsys, tmp_path):
+    """양성대조 — backend_relevant="true"(진짜 관련 PR)면 §3653 판정이 그대로다(selftest
+    3과 동일 시나리오, backend_relevant 인자만 추가). backend_relevant 도입이 §3653의
+    실제 결함 탐지력을 죽이지 않았음을 고정한다."""
+    mod = _load()
+    artifact_dir = tmp_path / "artifacts"
+    for n in range(7):  # shard 7만 빠짐 — 업로드 파이프라인이 조용히 무산된 형.
+        _write_shard_artifact(artifact_dir, n)
+    exit_code = mod._audit_durations_mode(
+        artifact_dir, expected_shard_count=8, shard_result="success", backend_relevant="true",
+    )
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "::error::shard 산출물 누락" in captured.out
+    assert "[7]" in captured.out
+
+
+def test_mutation_removing_backend_relevant_guard_reintroduces_false_positive(capsys, tmp_path, monkeypatch):
+    """뮤테이션 — backend_relevant 분기를 빼면(§3678 도입 前 코드 재현) FE-only PR의 정상
+    스킵이 다시 ::error+exit 1로 잘못 뜨는 것을 고정한다(이 가드가 실제로 그 결함을
+    막는다는 증거, story #3653의 뮤테이션 관례와 동형)."""
+    mod = _load()
+    original = mod._audit_durations_mode
+
+    def _without_backend_relevant_guard(artifact_dir, **kwargs):
+        kwargs.pop("backend_relevant", None)
+        return original(artifact_dir, **kwargs)
+
+    monkeypatch.setattr(mod, "_audit_durations_mode", _without_backend_relevant_guard)
+
+    artifact_dir = tmp_path / "artifacts"
+    exit_code = mod._audit_durations_mode(
+        artifact_dir, expected_shard_count=8, shard_result="success", backend_relevant="false",
+    )
+    assert exit_code == 1, "뮤테이션이 걸리지 않았다(backend_relevant 무시하고도 exit 0이 나왔다)"


### PR DESCRIPTION
실물: PR #4021 run 34160408234 잡 101860994039 — FE-only PR인데 「Audit shard durations」 스텝이 "backend-test-destructive.result=success인데 산출물 8개 전부 없다"(story #3653 가드)로 `::error`+exit 1.

## 원인
`detect-changed-scope`가 `backend_relevant=false`를 내면 「Upload shard durations」 스텝(ci.yml)이 스킵되는데, 8개 shard 잡 자체는 `if: always()`라 내부 스텝을 전부 건너뛰고도 "success"로 끝난다 — §3653은 이 두 세계("정상 스킵" vs "업로드 파이프라인 무산")를 구분하지 못하고 똑같이 취급했다.

## 처방
`--backend-relevant`(ci.yml이 `needs.detect-changed-scope.outputs.backend_relevant`를 그대로 넘긴다) 플래그 추가 — `"false"`면 `shard_result`·missing과 무관하게 "스코프 밖·집계 대상 아님"만 선언하고 exit 0. `backend_relevant`가 `"false"`가 아니면(진짜 backend 관련 PR) §3653 판정은 그대로(회귀 0 — selftest+뮤테이션으로 고정).

## Test plan
- [x] selftest(FE-only 정상 스킵 → exit 0)
- [x] 양성대조(backend 관련 PR의 실제 업로드 무산은 여전히 exit 1)
- [x] 뮤테이션(분기 제거 시 RED 재현 확認 후 원복)
- [x] 로컬 65 passed · py_compile 클린 · ci.yml YAML 파싱 확認 · CLI 실물 재현(빈 디렉터리+success+backend-relevant=false → exit 0)

story #3678(최우선 핫픽스) — PR #4021/#4022/#4024가 이 결함으로 막혀 있었음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)