### PR TITLE
[SID:3679] feat(BE·FE): hook_key 읽기 왕복 — GET 응답+초안 상세 표시

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2636,6 +2636,7 @@
     "generationBudgetAmountKrw": "₩{amount}",
     "generationBudgetAmountUsd": "${amount}",
     "channelPostsApprovalLinkPreviewLabel": "Link that will be attached",
+    "channelPostsApprovalHookLabel": "Hook",
     "channelPostsExternalIdLabel": "Post ID",
     "channelPostsPartialSuccessNotice": "The container was created but not yet published — continue publishing it. Starting over could post the same content twice.",
     "channelPostsImageAttachLabel": "Attach image",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2636,6 +2636,7 @@
     "generationBudgetAmountKrw": "{amount}원",
     "generationBudgetAmountUsd": "${amount}",
     "channelPostsApprovalLinkPreviewLabel": "발행 시 붙는 링크",
+    "channelPostsApprovalHookLabel": "훅",
     "channelPostsExternalIdLabel": "게시 ID",
     "channelPostsPartialSuccessNotice": "컨테이너는 생성됐지만 아직 게시되지 않았습니다 — 이어서 발행하세요. 처음부터 다시 발행하면 같은 글이 두 번 나갈 수 있습니다.",
     "channelPostsImageAttachLabel": "이미지 첨부",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -106,6 +106,7 @@ const DRAFT_DETAIL = {
 const VERSION_1 = {
   version_id: 'v1', version: 1, draft_id: DRAFT_ID, text: '초안 본문입니다', link_url: null,
   body_sha256: 'h1', author_kind: 'agent', created_at: '2026-09-03T03:50:00+00:00', tagged_link_preview: null,
+  hook_key: null as string | null,
 };
 
 function stubFetch(opts: {
@@ -870,6 +871,27 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     });
     await flush();
     expect(container.querySelector('[data-testid="channel-post-tagged-link-preview"]')).toBeNull();
+  });
+
+  // story #3679(3656 후속) — 훅 축은 tagged_link_preview와 달리 값이 없어도 줄 자체는
+  // 항상 그린다(insights-board group-rows와 같은 사실 표현, 뮤테이션 표적).
+  it('⭐3679 — hook_key가 있으면 그 값이 보인다', async () => {
+    stubFetch({ versions: [{ ...VERSION_1, hook_key: 'hook-A' }] });
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="channel-post-hook-key"]')?.textContent).toBe('hook-A');
+  });
+
+  it('⭐3679 — hook_key가 null이면 insights-board와 같은 미태깅 낱말(「미분류」)이 보인다', async () => {
+    stubFetch({ versions: [{ ...VERSION_1, hook_key: null }] });
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="channel-post-hook-key"]')?.textContent)
+      .toBe(koMessages.docs.indexCategoryUncategorized);
   });
 
   // story #3402 PR2(T7/T9) — 발행됨/부분성공/실패 표시(발행 버튼 배선은 다음 조각).

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -152,6 +152,10 @@ interface ChannelPostVersion {
   author_kind: 'agent' | 'human';
   created_at: string;
   tagged_link_preview: string | null;
+  // story #3679(3656 후속) — BE additive(ChannelPostVersionHistoryItem). null=미태깅
+  // (insights-board group-rows와 같은 낱말 「미분류」로 표시 — docs 네임스페이스 재사용,
+  // 새 낱말 0).
+  hook_key: string | null;
 }
 
 // story #3550(Phase2·풀스택, BE 2/2 #3910 계약, 페드루 PO 確定 2026-09-06) — 캐러셀
@@ -381,6 +385,10 @@ export default function ChannelPostEditPage() {
   const params = useParams();
   const draftId = String(params.draftId);
   const t = useTranslations('content');
+  // story #3679 — 훅 미태깅 라벨은 새 낱말을 안 만들고 insights-board가 이미 재사용
+  // 중인 docs 네임스페이스 키(indexCategoryUncategorized, 「미분류」)를 그대로 쓴다
+  // (같은 사실=같은 낱말, 유나 §3656 확定과 동형).
+  const tDocs = useTranslations('docs');
   // story #3641(유나 전수·PO 채택) — 확認 다이얼로그 취소 버튼: 버릴 게 있으면 「취소」,
   // 이미 끝났으면 「닫기」. 재시도/회수 확認은 취소하면 "그 시도 자체를 버리는" 것이라
   // 「취소」가 맞다(형제 발행 취소 확認·:1351이 이미 「취소」인데 재시도/회수만 어긋나
@@ -2018,6 +2026,15 @@ export default function ChannelPostEditPage() {
             </p>
           </div>
         ) : null}
+        {/* story #3679(3656 후속) — 링크 미리보기와 달리 이 줄은 항상 그린다(값이
+            없어도 「미분류」로 — 훅 축은 "있으면만 보인다"가 아니라 "항상 있는 축인데
+            안 태깅된 상태"가 있는 것, insights-board와 같은 사실 표현). */}
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">{t('channelPostsApprovalHookLabel')}</span>
+          <span data-testid="channel-post-hook-key">
+            {versions[versions.length - 1]?.hook_key ?? tDocs('indexCategoryUncategorized')}
+          </span>
+        </div>
         {/* story #3428(T5-M·§17-14) — 썸네일 + 자동 변환 배지. was_converted=false면
             원본=최종이라 배지 자체를 안 그린다(값은 서버가 낸 것만, 문구 조립만 화면
             몫 — 판정은 안 함). 이미지 없는 초안(thumbnail_url=null)은 이 블록 전체를

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -250,6 +250,11 @@ class ChannelPostDraftListItem(BaseModel):
     # _validate_text_length(422 검증)와 두 곳이 갈리지 않게 헬퍼 하나를 공유한다.
     text_preview: str
     text_length: int
+    # story #3679(3656 후속, 페드루 PO 確定 2026-09-07) — 최신 버전 hook_key(3645가 쓰기
+    # 경로에만 심어 두고 읽기 경로가 없었던 갭). additive — 없으면 null(3645 착지 前
+    # 초안·훅 미태깅 둘 다 이 값과 구별 안 됨, "모른다≠다르다" 원칙과 달리 여긴 순수
+    # "값 없음"만 표현한다).
+    hook_key: str | None = None
     # story #3394(AC1·AC3) — site_posts.SitePostDraftListItem(#3742)과 같은 이름·의미로
     # 미러. gate 없으면 전부 None("모른다≠다르다" — 아직 상신 전이라는 뜻).
     gate_status: str | None = None
@@ -373,6 +378,9 @@ class ChannelPostVersionHistoryItem(BaseModel):
     author_kind: str
     created_at: str
     tagged_link_preview: str | None = None
+    # story #3679(3656 후속, 페드루 PO 確定 2026-09-07) — 이 버전 자체의 hook_key(값은
+    # 버전별, ChannelPostDraftListItem.hook_key=최신 버전과 동일 소스).
+    hook_key: str | None = None
 
 
 class CreateChannelPostImageUploadUrlRequest(BaseModel):
@@ -1153,6 +1161,7 @@ def _to_draft_list_item(
         latest_author_kind=latest.author_kind, origin_author_kind=origin.author_kind,
         updated_at=latest.created_at.isoformat(),
         text_preview=build_text_preview(latest.text), text_length=text_char_count(latest.text),
+        hook_key=latest.hook_key,
         body_sha256=latest.body_sha256,
         gate_status=gate.status if gate else None,
         reapproval_required=gate.reapproval_required if gate else None,
@@ -1402,6 +1411,7 @@ async def list_channel_post_draft_version_history(
                 build_tagged_link(channel=draft.channel, link_url=v.link_url, draft_id=draft.id, utm_rules=utm_rules)
                 if v.link_url else None
             ),
+            hook_key=v.hook_key,
         )
         for v in versions
     ]

--- a/backend/tests/test_3679_hook_key_read_round_trip.py
+++ b/backend/tests/test_3679_hook_key_read_round_trip.py
@@ -1,0 +1,167 @@
+"""story #3679(3656 후속, 페드루 PO 確定 2026-09-07) — hook_key 왕복.
+
+실물(2026-09-07 21:38Z) — `POST drafts`는 hook_key를 받고 201 응답(ChannelPost
+DraftVersionResponse)에 에코하지만, `GET drafts/{id}`(ChannelPostDraftListItem)와
+`GET drafts/{id}/versions`(ChannelPostVersionHistoryItem) 응답엔 hook_key가 없어
+쓰고 나면 보드 묶음 말고는 어디서도 못 읽었다. `ChannelPostDraftVersion.hook_key`
+컬럼은 story #3645부터 이미 있다(신규 마이그레이션 0) — 이 스토리는 순수 읽기
+경로 additive 배선이다.
+
+세팅 헬퍼는 test_620beefc_channel_post_image_upload.py 재사용(중복 재발명 금지,
+test_3645_evidence_asset_hook_keys.py와 동형 관례)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_620beefc_channel_post_image_upload import (
+    _client_for,
+    _seed_connection,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _setup(text: str, hook_key: str | None):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    async with Session() as s:
+        org_id, project_id = await _seed_org(s)
+        user_id = await _seed_human(s, org_id, project_id)
+        story_id = await _seed_story(s, org_id, project_id)
+        conn_id = await _seed_connection(s, org_id, channel="sandbox")
+
+    app.dependency_overrides.clear()
+    _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+    return engine, app, org_id, story_id, conn_id
+
+
+@pytest.mark.anyio
+async def test_get_draft_detail_includes_hook_key_when_tagged():
+    engine, app, org_id, story_id, conn_id = await _setup("훅 왕복 테스트", "hook-A")
+    try:
+        async with _client_for(app) as c:
+            create_res = await c.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json={
+                    "work_item_id": str(story_id), "connection_id": str(conn_id),
+                    "text": "훅 왕복 테스트", "hook_key": "hook-A",
+                },
+            )
+            assert create_res.status_code == 201, create_res.text
+            draft_id = create_res.json()["draft_id"]
+
+            detail_res = await c.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert detail_res.status_code == 200, detail_res.text
+            assert detail_res.json()["hook_key"] == "hook-A"
+
+            list_res = await c.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+            assert list_res.status_code == 200, list_res.text
+            [row] = [r for r in list_res.json() if r["draft_id"] == draft_id]
+            assert row["hook_key"] == "hook-A"
+
+            versions_res = await c.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/versions")
+            assert versions_res.status_code == 200, versions_res.text
+            versions = versions_res.json()
+            assert len(versions) == 1
+            assert versions[0]["hook_key"] == "hook-A"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_draft_detail_hook_key_null_when_untagged():
+    """AC4(호환) — hook_key 없이 만든 초안은 지금과 같이 null·거부 없음."""
+    engine, app, org_id, story_id, conn_id = await _setup("훅 없는 초안", None)
+    try:
+        async with _client_for(app) as c:
+            create_res = await c.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json={"work_item_id": str(story_id), "connection_id": str(conn_id), "text": "훅 없는 초안"},
+            )
+            assert create_res.status_code == 201, create_res.text
+            draft_id = create_res.json()["draft_id"]
+            assert create_res.json()["hook_key"] is None
+
+            detail_res = await c.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert detail_res.status_code == 200, detail_res.text
+            assert detail_res.json()["hook_key"] is None
+
+            versions_res = await c.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/versions")
+            assert versions_res.status_code == 200, versions_res.text
+            assert versions_res.json()[0]["hook_key"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_removing_hook_key_from_list_item_loses_it_on_read(monkeypatch):
+    """뮤테이션 — `_to_draft_list_item()`이 hook_key를 안 실으면(옛 사각지대 재현)
+    GET draft detail이 값을 잃는 것을 고정한다(이 배선이 실제로 값을 옮긴다는 증거)."""
+    import app.routers.channel_posts as mod
+
+    original = mod._to_draft_list_item
+
+    def _without_hook_key(*args, **kwargs):
+        item = original(*args, **kwargs)
+        return item.model_copy(update={"hook_key": None})
+
+    monkeypatch.setattr(mod, "_to_draft_list_item", _without_hook_key)
+
+    engine, app, org_id, story_id, conn_id = await _setup("뮤테이션", "hook-A")
+    try:
+        async with _client_for(app) as c:
+            create_res = await c.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json={
+                    "work_item_id": str(story_id), "connection_id": str(conn_id),
+                    "text": "뮤테이션", "hook_key": "hook-A",
+                },
+            )
+            draft_id = create_res.json()["draft_id"]
+            detail_res = await c.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert detail_res.json()["hook_key"] is None, "뮤테이션이 걸리지 않았다(hook_key가 여전히 읽힌다)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1522,6 +1522,11 @@
       "file": "tests/test_3666_channel_post_image_import.py",
       "sec": 22.0,
       "source": "story-3666-channel-post-image-import(PR 개설 前 선제 등재 — 로컬 raw pytest 4건 3.68s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 22s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3679_hook_key_read_round_trip.py",
+      "sec": 20.0,
+      "source": "story-3679-hook-key-read-round-trip(PR 개설 前 선제 등재 — 로컬 raw pytest 3건 3.33s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
실물(2026-09-07 21:38Z) — `hook_key`는 `POST drafts`에서 받고 201 응답에 에코되지만 `GET drafts/{id}`(ChannelPostDraftListItem)·`GET .../versions`(ChannelPostVersionHistoryItem) 응답엔 없어 쓰고 나면 보드 묶음 말고는 어디서도 못 읽었다. `ChannelPostDraftVersion.hook_key` 컬럼은 #3645부터 이미 있다 — 신규 마이그레이션 0, 순수 읽기 경로 additive 배선.

## 변경
- **BE**: `ChannelPostDraftListItem`·`ChannelPostVersionHistoryItem` 둘 다 `hook_key: str | None` 추가, `_to_draft_list_item()`·versions 엔드포인트 둘 다 `latest`/`v.hook_key` 그대로 실어보낸다.
- **FE**: 초안 상세 승인 카드에 「훅: {값}」 줄 — `tagged_link_preview`와 달리 값이 없어도 줄 자체는 항상 그린다(insights-board group-rows와 같은 미태깅 낱말 「미분류」, `docs` 네임스페이스 재사용 — 새 낱말 0).
- 플러그인 쪽(`create_channel_post_draft` 인자)은 이미 #46(3645 AC2)에서 완료 — skill 문서 한 줄만 sprintable-agent-plugins#48로 별도.

## Test plan
- [x] BE 3건(값 왕복·null 호환·뮤테이션) — 표본과 같은 시나리오로 라이브 재현
- [x] FE 2건(값 표시/미태깅 표시) — 라이브 뮤테이션 RED 확認 후 원복
- [x] destructive weights.json 등재(story-3679)
- [x] tsc·eslint 클린 · 기존 3645/620beefc(22)·`[draftId]` 페이지 전체(237) 회귀 0

## AC 대조
1. [제품·API] ✅ GET drafts/{id}·GET versions에 hook_key
2. [제품·화면] ✅ 값 있으면 그대로, 없으면 「미분류」
3. [에이전트 도구] ✅ 완료(#46, 별건 PR)
4. [호환] ✅ hook_key 없이 만든 초안은 null·거부 없음

story #3679

🤖 Generated with [Claude Code](https://claude.com/claude-code)