### PR TITLE
[SID:3676] fix(FE): AlertDescription 부모 불투명도 제거 — Alert 안 muted 라이트 AA 미달 근절

### DIFF
--- a/apps/web/src/components/ui/alert.test.tsx
+++ b/apps/web/src/components/ui/alert.test.tsx
@@ -144,6 +144,19 @@ describe('Alert variant 라이트 대비 통일 (story #2513)', () => {
     expect(container.firstElementChild?.className).not.toContain('border-l-2');
   });
 
+  // story #3676(유나 실측 2026-09-07) — AlertDescription 자체가 부모 opacity를
+  // 가지면 그 안의 text-muted-foreground가 자식에 opacity-100을 줘도 안 풀리는
+  // 채로 배경과 합성돼 틴트 4종 전부 라이트 AA 미달로 떨어진다(4.15~4.34). 이
+  // 컴포넌트 층에 opacity 클래스가 다시 안 생기는지 고정 — 뮤테이션 대상.
+  it('AlertDescription 자신은 opacity 클래스를 갖지 않는다(부모 opacity 재발 방지)', async () => {
+    await act(async () => {
+      root.render(<Alert variant="destructive"><AlertDescription>메시지</AlertDescription></Alert>);
+    });
+    const description = container.querySelectorAll('p')[0];
+    const classes = (description?.className ?? '').split(/\s+/);
+    expect(classes.some((c) => /^opacity-/.test(c))).toBe(false);
+  });
+
   // 글자만 foreground로 통일됐을 뿐 variant 구분(색 정체성) 자체는 border/tint로 남아야
   // 한다 — 넷이 서로 다른 border-*-border/bg-*-tint를 갖는지 직접 대조.
   it('variant별 색 정체성(border·tint)은 서로 다르게 유지된다(글자 통일이 구분을 지우지 않는다)', async () => {

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -74,13 +74,21 @@ const AlertTitle = React.forwardRef<
 ));
 AlertTitle.displayName = 'AlertTitle';
 
+// story #3676(유나 실측 2026-09-07, PR #4025 판정 中 발견) — 이 자리에 부모
+// 불투명도 클래스(90%)가 있었다. 부모 opacity는 자식 색과 합성돼(자식에
+// opacity-100을 줘도 안 풀림) 안의
+// text-muted-foreground를 틴트 4종 전부 라이트 AA 미달(4.15~4.34)로 떨어뜨렸다
+// — 제거 뒤에도 다크 테마 muted는 여유가 0.3~0.4뿐이라, 이 컴포넌트 안에서
+// **12px 미만 글자에는 text-muted-foreground를 쓰지 않는다**(그 자리는
+// text-foreground) — 지금 이대로도 이미 얇은 마진이라, 폰트가 더 작아지면
+// 미달로 넘어간다.
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn('col-start-2 text-xs leading-relaxed opacity-90 [overflow-wrap:anywhere]', className)}
+    className={cn('col-start-2 text-xs leading-relaxed [overflow-wrap:anywhere]', className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## 근거(유나 실측 · 2026-09-07 19:17Z · PR #4025 판정 中 발견)

`AlertDescription`이 90% 불투명도 클래스를 갖고 있어 그 안의 `text-muted-foreground`는 배경과 합성된다(자식에 `opacity-100`을 줘도 상쇄되지 않는다 — 합성은 부모 층) — 라이트에서 destructive 4.150 / info 4.172 / success 4.244 / warning 4.336(하한 4.5) 전부 미달.

## 처방 — PO 決定 ⓐ 기제 층에서 걷는다

`components/ui/alert.tsx`의 `AlertDescription`에서 그 불투명도 클래스를 제거. 사용처마다 `text-foreground`를 덧대는 처방(ⓑ)은 채택하지 않음 — 막는 쪽과 하는 쪽이 다른 것을 보는 구조라, 다음 사용처가 또 muted를 쓰면 같은 미달이 조용히 재발한다.

제거 뒤에도 다크 테마 muted 여유가 0.3~0.4뿐(유나 "재기 前 계산")이라, 이 컴포넌트 안에서 **12px 미만 글자에는 muted 금지** — alert.tsx 주석 한 줄로 박음.

## 영향

`generation-budget-exceeded-banner.tsx`의 기존 muted 5자리(이 PR이 만든 것 아님) — 코드 변경 0, 부모 opacity 제거로 대비만 자동 상승. 다른 상시 opacity 글자 wrapper는 디디 grep(2026-09-07)으로 0건 확認됨(알파 전경 클래스는 별건 story #3677).

## 테스트

`alert.test.tsx`에 "AlertDescription 자신은 opacity 클래스를 갖지 않는다" 회귀가드 1건 추가 — 뮤테이션(불투명도 클래스 재삽입)으로 정확히 그 테스트만 RED 확認 후 복구. 기존 21건(story #2149/#2513/#2969) 무회귀. `tsc --noEmit`/eslint 클린.

시각 회귀(픽셀 실측)는 유나 배포 뒤 검증 축(AC4) — 이 PR 스코프 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA