### PR TITLE
[SID:3673] fix(FE): 초안 상세 두 화면 오류 Alert a11y 층 통일 — 재선언 0

### DIFF
--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -779,6 +779,22 @@ describe('ContentPostEditPage — story #3662(로드 실패 문구 3갈래)', ()
     expect(backLink?.textContent).toBe(koMessages.content.channelPostsCalendarBackToListCta);
   });
 
+  // story #3673(유나 #4016 적기만 ①) — 이 화면은 이미 role/aria-live/aria-atomic을
+  // 문자열로 재선언했었다(#3673에서 그 재선언을 걷고 Alert 기본값에 맡김) — 결과
+  // 값은 무변, channel-posts/[draftId]와 같은 층임을 여기서도 고정.
+  it('로드 실패(404) — 오류 Alert가 role=alert·aria-live=assertive·aria-atomic=true를 갖는다', async () => {
+    stubFetchWithVersions([], undefined, undefined, { versionsStatus: 404 });
+    await act(async () => {
+      root.render(wrap(<ContentPostEditPage />));
+    });
+    await flush();
+
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl).not.toBeNull();
+    expect(alertEl?.getAttribute('aria-live')).toBe('assertive');
+    expect(alertEl?.getAttribute('aria-atomic')).toBe('true');
+  });
+
   it('로드 실패(403) — 「볼 권한이 없습니다」+목록으로 나가는 링크', async () => {
     stubFetchWithVersions([], undefined, undefined, { versionsStatus: 403 });
     await act(async () => {

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -1012,10 +1012,15 @@ export default function ContentPostEditPage() {
     );
   }
 
+  // story #3673(유나 #4016 적기만 ①) — role/aria-live/aria-atomic 문자열 복붙을
+  // 걷는다. Alert(components/ui/alert.tsx)가 variant="destructive"면 이미
+  // role="alert" aria-live="assertive" aria-atomic="true"를 기본 유도한다
+  // (getAlertRole/getAlertAriaLive) — 여기서 재선언하면 그 기본값과 화면별
+  // 재선언이 언젠가 갈라질 수 있는 여지만 남는다(AC2, "화면별 재선언 0").
   if (notFound) {
     return (
       <div className="mx-auto w-full max-w-3xl space-y-3 p-6">
-        <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
+        <Alert variant="destructive">
           <AlertDescription>{t('editNotFound')}</AlertDescription>
         </Alert>
         {/* story #3667(3662 후속, 유나 #4016 적기만 ②) — 링크로 들어와 404/403을
@@ -1030,7 +1035,7 @@ export default function ContentPostEditPage() {
   if (forbidden) {
     return (
       <div className="mx-auto w-full max-w-3xl space-y-3 p-6">
-        <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
+        <Alert variant="destructive">
           <AlertDescription>{t('editForbidden')}</AlertDescription>
         </Alert>
         <Link href="/content" className="text-sm font-medium text-primary underline">
@@ -1042,7 +1047,7 @@ export default function ContentPostEditPage() {
   if (loadError || !latest) {
     return (
       <div className="mx-auto w-full max-w-3xl p-6">
-        <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
+        <Alert variant="destructive">
           <AlertDescription>{t('editLoadFailed')}</AlertDescription>
         </Alert>
       </div>

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -2028,6 +2028,22 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     expect(backLink?.textContent).toBe(koMessages.content.channelPostsCalendarBackToListCta);
   });
 
+  // story #3673(유나 #4016 적기만 ① — content/[draftId]와 같은 a11y 층) — role=alert
+  // aria-live=assertive aria-atomic=true 셋 다 이 화면 오류 Alert에도 있어야 한다.
+  // Alert 컴포넌트 기본 유도값이므로 화면이 문자열로 재선언하지 않아도 된다(AC2).
+  it('로드 실패(404) — 오류 Alert가 role=alert·aria-live=assertive·aria-atomic=true를 갖는다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })));
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl).not.toBeNull();
+    expect(alertEl?.getAttribute('aria-live')).toBe('assertive');
+    expect(alertEl?.getAttribute('aria-atomic')).toBe('true');
+  });
+
   it('로드 실패(403) — 「볼 권한이 없습니다」+목록으로 나가는 링크', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 403, json: async () => ({}) })));
     await act(async () => {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1737,10 +1737,16 @@ export default function ChannelPostEditPage() {
   if (loading) {
     return <div className="mx-auto w-full max-w-2xl space-y-4 p-6" data-testid="channel-post-edit-loading" />;
   }
+  // story #3673(유나 #4016 적기만 ①) — role/aria-live/aria-atomic을 여기서
+  // 재선언하지 않는다. Alert(components/ui/alert.tsx)가 variant="destructive"
+  // 이면 이미 role="alert" aria-live="assertive" aria-atomic="true"를 기본
+  // 유도한다(getAlertRole/getAlertAriaLive) — content/[draftId]가 이 셋을
+  // 문자열로 복붙해 온 것과 이 화면이 role만 붙인 것 둘 다 "화면별 재선언"이라
+  // AC2 위반. 공용 컴포넌트의 기본값 하나로 두 화면이 저절로 같은 층이 된다.
   if (notFound) {
     return (
       <div className="mx-auto w-full max-w-2xl space-y-3 p-6">
-        <Alert variant="destructive" role="alert">
+        <Alert variant="destructive">
           <AlertDescription>{t('editNotFound')}</AlertDescription>
         </Alert>
         {/* story #3667(3662 후속, 유나 #4016 적기만 ②) — 링크로 들어와 404/403을
@@ -1755,7 +1761,7 @@ export default function ChannelPostEditPage() {
   if (forbidden) {
     return (
       <div className="mx-auto w-full max-w-2xl space-y-3 p-6">
-        <Alert variant="destructive" role="alert">
+        <Alert variant="destructive">
           <AlertDescription>{t('editForbidden')}</AlertDescription>
         </Alert>
         <Link href="/content/channel-posts" className="text-sm font-medium text-primary underline">
@@ -1767,7 +1773,7 @@ export default function ChannelPostEditPage() {
   if (loadError || !draft) {
     return (
       <div className="mx-auto w-full max-w-2xl p-6">
-        <Alert variant="destructive" role="alert">
+        <Alert variant="destructive">
           <AlertDescription>{t('editLoadFailed')}</AlertDescription>
         </Alert>
       </div>


### PR DESCRIPTION
## 배경

유나 #4016(3662) 판정 「적기만 ①」 — `content/[draftId]`의 오류 Alert는 `role="alert" aria-live="assertive" aria-atomic="true"`를 문자열로 재선언하고, `channel-posts/[draftId]`는 `role="alert"`만 붙였다.

두 화면 다 `variant="destructive"`라 실제로는 `Alert`(`components/ui/alert.tsx`)의 기본 유도(`getAlertRole`/`getAlertAriaLive`, `aria-atomic` 기본값 `'true'`)로 이미 같은 값이 나온다 — **렌더 결과는 애초에 같았지만 소스가 갈려 있었던 것**.

## 처방(AC2 — 공용 컴포넌트가 이미 가진 속성을 재선언하지 않는다)

두 화면 6곳(notFound·forbidden·loadError × 2파일) 전부에서 `role`/`aria-live`/`aria-atomic` 명시를 걷어내고 `Alert` 기본값에 맡긴다. "사용처 문자열 복붙을 늘리는" 반대 방향은 채택하지 않음 — 재선언 자체를 0으로 줄여, 공용 컴포넌트 값 하나가 두 화면을 저절로 같은 층으로 만들게 한다.

## 테스트

두 파일에 "role=alert·aria-live=assertive·aria-atomic=true" 3속성 단언 1건씩 추가(AC3) — 뮤테이션(속성 값 변조) 각 1건으로 정확히 그 테스트만 RED 확認 후 복구. 기존 315건(두 파일 합) 무회귀. `tsc --noEmit`/eslint 클린(신규 경고 0). i18n 가드 클린(새 낱말 0).

유나 실픽셀(VoiceOver 낭독 층)은 다음 배포 회차(AC4) — 이 PR 스코프 밖.

## 브랜치 규율

PR #4022(3667·#4016 위 stacked, 아직 미착지) 위에 스택하지 않고 develop 기준으로 새로 판다(3중 스택 금지) — #4022 착지 뒤 rebase 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYnh32vxWmgSM7Fax3fUA