### PR TITLE
[SID:3685] feat(BE): 에이전트 run을 지침이 아니라 메커니즘으로 기록

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -2630,6 +2630,27 @@ async def update_story_status(
         except Exception:  # noqa: BLE001
             pass
 
+    # story #3685(Trust·customer-zero, 페드루 PO 確定 2026-09-07) — run을 "지침"이 아니라
+    # "메커니즘"으로 기록한다. 위 participation 보장과 같은 트리거(in-progress 진입)·같은
+    # fail-open 규율(agent_run_tracking.py 내부가 이미 try/except — 여기선 추가로 감싸지
+    # 않는다, 이중 삼킴 불필요). 에이전트가 착수한 것만(사람은 agent_run 개념 밖).
+    if (
+        story_before is not None and old_status != "in-progress" and body.status == "in-progress"
+        and _line_actor_id is not None and _line_actor_type == "agent"
+    ):
+        from app.services.agent_run_tracking import ensure_agent_run_started
+        await ensure_agent_run_started(
+            db, org_id=repo.org_id, project_id=story_before.project_id,
+            agent_id=_line_actor_id, story_id=id,
+        )
+
+    # story #3685 — in-review/done 전이는 "닫는 행위자"와 무관하게 그 story의 열린 run을
+    # 닫는다(사람이 PR을 머지해 done으로 옮겨도 그 안에서 일한 에이전트의 run은 끝난 게
+    # 맞다 — agent_id 미지정, close_agent_runs_for_story의 no-op 멱등이 반복 전이를 감당).
+    if story_before is not None and body.status in ("in-review", "done"):
+        from app.services.agent_run_tracking import close_agent_runs_for_story
+        await close_agent_runs_for_story(db, story_id=id, status="completed")
+
     # E-DG S7: agent-handoff relay — status 적용 후 같은 트랜잭션에서 dispatch(commit=False)·step_run
     # delivery 기록(원자). wake/CC delivery 는 commit(아래) 후 recipient_seq 확정 후 발화(P1-2 불변식).
     # relay 실패도 전이 비차단(fail-open).

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -743,6 +743,15 @@ async def claim_story(
     from app.services.participation_helpers import ensure_implementation_participation
     participation_ensured = await ensure_implementation_participation(session, org_id, body.story_id, id)
 
+    # story #3685(Trust·customer-zero, 페드루 PO 確定 2026-09-07) — run을 "지침"이 아니라
+    # "메커니즘"으로 기록한다. claim=착수(사람은 agent_run 개념 밖 — member.type=="agent"만).
+    if member.type == "agent":
+        from app.services.agent_run_tracking import ensure_agent_run_started
+        await ensure_agent_run_started(
+            session, org_id=org_id, project_id=effective_project_id,
+            agent_id=id, story_id=body.story_id,
+        )
+
     # story 8b7e52d6(PO 재정의, 2026-09-04) — "신호 보정": claim_story의 실제 동작(위)은
     # story 3414b6d7 결정 그대로 assignee/board를 절대 안 건드린다 — 그런데 기존 응답
     # `{"claimed": True}` 한 줄만으로는 호출자가 "claim=내 것이 됨(assignee·board 반영)"
@@ -801,12 +810,23 @@ async def unclaim_story(
 
     await assert_caller_is_member(id, auth, session, org_id, detail="Cannot unclaim as another member")
 
+    # story #3685 — active_story_id를 null로 지우기 前에 캡처(그 값이 사라지면 어느 run을
+    # 닫을지 알 방법이 없다).
+    prior_active_story_id = member.active_story_id
+
     # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.
     from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, active_story_id=None)
     # AC7: unclaim 시 해당 멤버의 모든 file lock 해제
     from app.routers.file_locks import release_all_file_locks
     await release_all_file_locks(session, id)
+
+    # story #3685(Trust·customer-zero, 페드루 PO 確定 2026-09-07) — unclaim=포기. claim과
+    # 대칭(사람은 agent_run 개념 밖).
+    if member.type == "agent" and prior_active_story_id is not None:
+        from app.services.agent_run_tracking import close_agent_runs_for_story
+        await close_agent_runs_for_story(session, story_id=prior_active_story_id, status="abandoned", agent_id=id)
+
     return {"unclaimed": True}
 
 

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -469,6 +469,18 @@ async def _process_webhook_event(
     org_id = rl.org_id  # app=입력 org·legacy=story.org_id(resolver 검증). 단일 진실원.
     delivery.org_id = org_id
 
+    # story #3685(Trust·customer-zero, 페드루 PO 確定 2026-09-07) — PR 머지도 run을 닫는
+    # 생애주기 이벤트. 이 함수의 기존 verdict/게이트 로직과 완전히 독립된 자리(별도
+    # try/except, 실패해도 아래 어떤 처리도 안 건드린다) — close_agent_runs_for_story
+    # 자체가 이미 best-effort지만, resolve_story_for_pr 이후 이 시점의 다른 side effect와
+    # 절대 안 얽히도록 한 번 더 감싼다.
+    if merged:
+        try:
+            from app.services.agent_run_tracking import close_agent_runs_for_story
+            await close_agent_runs_for_story(session, story_id=story_id, status="completed")
+        except Exception:  # noqa: BLE001
+            logger.warning("PR 머지 agent_run 자동 종료 실패(비차단) story_id=%s", story_id, exc_info=True)
+
     # story #3039(2026-08-25, PO 판정) — resolve_story_for_pr()의 SID/auto_match/text 해소는
     # 매 호출 휘발성(반환만·미영속)이다. pull_request류 이벤트는 payload에 title/body가
     # 있어(_candidate_texts) 매번 SID 텍스트로 재해소되지만, check_suite/workflow_run/status

--- a/backend/app/services/agent_run_tracking.py
+++ b/backend/app/services/agent_run_tracking.py
@@ -1,0 +1,85 @@
+"""story #3685(Trust·customer-zero, 페드루 PO 確定 2026-09-07) — 에이전트 run을
+"지침"이 아니라 "메커니즘"으로 기록한다.
+
+3683 그라운딩(코드 X) — run 생성 경로는 전수 1곳(`POST /api/v2/agent-runs`)뿐이고,
+"왜 안 찍히나"의 실체는 코드가 막은 게 아니라 fleet 아무도 착수/PR/완료 어디서도
+그 경로(MCP `sprintable_emit_event`/`update_run_status`)를 부른 적이 없었다는
+것이었다. PO 確定 — 지침(AGENTS.md 한 줄)은 "잊으면 다시 0행"이라 거부하고,
+플랫폼이 이미 보는 생애주기 이벤트(claim_story·in-progress 전이·in-review/done
+전이·PR 머지)에서 run을 자동 유도한다.
+
+이 파일의 두 함수는 그 생애주기 훅들이 공유하는 유일한 쓰기 지점이다(중복 재발명
+금지). 둘 다 **best-effort** — 예외를 삼키고 로그만 남긴다: run 기록 실패가 스토리
+전이·웹훅 처리·claim/unclaim을 막으면 "일을 못 한다"는 새 결함이 "run이 안
+찍힌다"는 원 결함보다 나쁘다."""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_run import AgentRun
+from app.services.agent_run_lifecycle import AGENT_RUN_TIMEOUT_HOURS
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_agent_run_started(
+    session: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID,
+    agent_id: uuid.UUID, story_id: uuid.UUID, trigger: str = "story_lifecycle",
+) -> None:
+    """(agent_id, story_id)에 열린 run(`finished_at IS NULL`)이 이미 있으면 그대로 둔다 —
+    이 dedupe 축이 emit_event로 외부 런타임이 직접 만든 run과의 중복도 함께 막는다(같은
+    축이라 새 판정 로직 0). 없으면 새로 연다. `deadline_at`은 `POST /api/v2/agent-runs`
+    라우터와 동일하게 지금부터 `AGENT_RUN_TIMEOUT_HOURS` 뒤로 잡아, 이 메커니즘이 연 run도
+    리퍼(sweep_expired_agent_runs)의 자가회수 대상이 되게 한다(완료 훅이 어떤 이유로든
+    한 번 새도 영구 stuck 'running'으로 안 남는다)."""
+    try:
+        existing = (await session.execute(
+            select(AgentRun.id).where(
+                AgentRun.agent_id == agent_id, AgentRun.story_id == story_id,
+                AgentRun.finished_at.is_(None),
+            ).limit(1)
+        )).scalar_one_or_none()
+        if existing is not None:
+            return
+        run = AgentRun(
+            org_id=org_id, project_id=project_id, agent_id=agent_id, story_id=story_id,
+            trigger=trigger, status="running",
+            deadline_at=datetime.now(timezone.utc) + timedelta(hours=AGENT_RUN_TIMEOUT_HOURS),
+        )
+        session.add(run)
+        await session.flush()
+    except Exception:  # noqa: BLE001 — best-effort(위 docstring).
+        logger.warning(
+            "agent_run 자동 시작 실패(비차단) agent_id=%s story_id=%s", agent_id, story_id, exc_info=True,
+        )
+
+
+async def close_agent_runs_for_story(
+    session: AsyncSession, *, story_id: uuid.UUID, status: str, agent_id: uuid.UUID | None = None,
+) -> None:
+    """그 story_id의 열린 run을 닫는다. `agent_id`를 주면 그 에이전트 것만(unclaim처럼
+    "누구를" 이미 아는 호출부용) — 생략하면 그 스토리의 열린 run 전부(in-review/done
+    전이·PR 머지처럼 "닫는 행위자"와 "run의 주인"이 다를 수 있는 호출부용 — 사람이
+    PR을 머지해도 그 안에서 일한 에이전트의 run은 끝난 게 맞다). 열린 run이 없으면
+    조용히 no-op(멱등 — 같은 전이가 두 번 와도 안전)."""
+    try:
+        q = select(AgentRun).where(AgentRun.story_id == story_id, AgentRun.finished_at.is_(None))
+        if agent_id is not None:
+            q = q.where(AgentRun.agent_id == agent_id)
+        rows = list((await session.execute(q)).scalars().all())
+        if not rows:
+            return
+        now = datetime.now(timezone.utc)
+        for run in rows:
+            run.status = status
+            run.finished_at = now
+        await session.flush()
+    except Exception:  # noqa: BLE001 — best-effort(위 docstring).
+        logger.warning(
+            "agent_run 자동 종료 실패(비차단) story_id=%s status=%s", story_id, status, exc_info=True,
+        )

--- a/backend/app/services/agent_run_tracking.py
+++ b/backend/app/services/agent_run_tracking.py
@@ -11,7 +11,16 @@
 이 파일의 두 함수는 그 생애주기 훅들이 공유하는 유일한 쓰기 지점이다(중복 재발명
 금지). 둘 다 **best-effort** — 예외를 삼키고 로그만 남긴다: run 기록 실패가 스토리
 전이·웹훅 처리·claim/unclaim을 막으면 "일을 못 한다"는 새 결함이 "run이 안
-찍힌다"는 원 결함보다 나쁘다."""
+찍힌다"는 원 결함보다 나쁘다.
+
+페드루 PO CHANGES(2026-09-07) — 최초 버전은 이 쓰기를 바깥 세션의 트랜잭션
+그대로에 `session.add`+`flush`만 try/except로 감쌌다. flush가 DB 오류(제약·연결)로
+터지면 예외는 삼켜져도 **세션 자체**가 실패 상태(SQLAlchemy가 트랜잭션을 이미
+invalidate)로 남아, 바로 뒤 호출부(스토리 전이·웹훅 처리)의 commit이
+"transaction has been rolled back"으로 터진다 — "run 실패가 일을 막는다"는 이
+파일이 막으려던 바로 그 결함의 새 버전이었다(SAVEPOINT fail-open 세션 poison
+클래스). `session.begin_nested()`(SAVEPOINT)로 격리해 이 함수 안의 실패가
+SAVEPOINT만 롤백시키고 바깥 트랜잭션은 그대로 살게 한다."""
 from __future__ import annotations
 
 import logging
@@ -37,23 +46,31 @@ async def ensure_agent_run_started(
     라우터와 동일하게 지금부터 `AGENT_RUN_TIMEOUT_HOURS` 뒤로 잡아, 이 메커니즘이 연 run도
     리퍼(sweep_expired_agent_runs)의 자가회수 대상이 되게 한다(완료 훅이 어떤 이유로든
     한 번 새도 영구 stuck 'running'으로 안 남는다)."""
+    run: AgentRun | None = None
     try:
-        existing = (await session.execute(
-            select(AgentRun.id).where(
-                AgentRun.agent_id == agent_id, AgentRun.story_id == story_id,
-                AgentRun.finished_at.is_(None),
-            ).limit(1)
-        )).scalar_one_or_none()
-        if existing is not None:
-            return
-        run = AgentRun(
-            org_id=org_id, project_id=project_id, agent_id=agent_id, story_id=story_id,
-            trigger=trigger, status="running",
-            deadline_at=datetime.now(timezone.utc) + timedelta(hours=AGENT_RUN_TIMEOUT_HOURS),
-        )
-        session.add(run)
-        await session.flush()
+        async with session.begin_nested():
+            existing = (await session.execute(
+                select(AgentRun.id).where(
+                    AgentRun.agent_id == agent_id, AgentRun.story_id == story_id,
+                    AgentRun.finished_at.is_(None),
+                ).limit(1)
+            )).scalar_one_or_none()
+            if existing is not None:
+                return
+            run = AgentRun(
+                org_id=org_id, project_id=project_id, agent_id=agent_id, story_id=story_id,
+                trigger=trigger, status="running",
+                deadline_at=datetime.now(timezone.utc) + timedelta(hours=AGENT_RUN_TIMEOUT_HOURS),
+            )
+            session.add(run)
+            await session.flush()
     except Exception:  # noqa: BLE001 — best-effort(위 docstring).
+        # SAVEPOINT 롤백은 DB측 변경만 되돌린다 — 방금 session.add()한 pending 객체가
+        # 세션 identity map에 남아 있으면 바깥 호출부의 다음 flush/commit이 이 죽은
+        # 객체를 다시 밀어보려다 또 실패한다(같은 poison 클래스, 격리만 하고 안 지우면
+        # 재발). expunge로 완전히 떼어낸다.
+        if run is not None:
+            session.expunge(run)
         logger.warning(
             "agent_run 자동 시작 실패(비차단) agent_id=%s story_id=%s", agent_id, story_id, exc_info=True,
         )
@@ -68,18 +85,22 @@ async def close_agent_runs_for_story(
     PR을 머지해도 그 안에서 일한 에이전트의 run은 끝난 게 맞다). 열린 run이 없으면
     조용히 no-op(멱등 — 같은 전이가 두 번 와도 안전)."""
     try:
-        q = select(AgentRun).where(AgentRun.story_id == story_id, AgentRun.finished_at.is_(None))
-        if agent_id is not None:
-            q = q.where(AgentRun.agent_id == agent_id)
-        rows = list((await session.execute(q)).scalars().all())
-        if not rows:
-            return
-        now = datetime.now(timezone.utc)
-        for run in rows:
-            run.status = status
-            run.finished_at = now
-        await session.flush()
-    except Exception:  # noqa: BLE001 — best-effort(위 docstring).
+        async with session.begin_nested():
+            q = select(AgentRun).where(AgentRun.story_id == story_id, AgentRun.finished_at.is_(None))
+            if agent_id is not None:
+                q = q.where(AgentRun.agent_id == agent_id)
+            rows = list((await session.execute(q)).scalars().all())
+            if not rows:
+                return
+            now = datetime.now(timezone.utc)
+            for run in rows:
+                run.status = status
+                run.finished_at = now
+            await session.flush()
+    except Exception:  # noqa: BLE001 — best-effort(위 docstring). rows는 기존 추적 중이던
+        # 행이라(신규 add 아님) SAVEPOINT 롤백이 그 in-memory 속성 변경도 되돌린다 —
+        # ensure_agent_run_started와 달리 expunge 대상이 없다(새로 만든 pending 객체가
+        # 아니라 이미 세션이 알던 행일 뿐).
         logger.warning(
             "agent_run 자동 종료 실패(비차단) story_id=%s status=%s", story_id, status, exc_info=True,
         )

--- a/backend/app/services/agent_run_tracking.py
+++ b/backend/app/services/agent_run_tracking.py
@@ -65,11 +65,13 @@ async def ensure_agent_run_started(
             session.add(run)
             await session.flush()
     except Exception:  # noqa: BLE001 — best-effort(위 docstring).
-        # SAVEPOINT 롤백은 DB측 변경만 되돌린다 — 방금 session.add()한 pending 객체가
-        # 세션 identity map에 남아 있으면 바깥 호출부의 다음 flush/commit이 이 죽은
-        # 객체를 다시 밀어보려다 또 실패한다(같은 poison 클래스, 격리만 하고 안 지우면
-        # 재발). expunge로 완전히 떼어낸다.
-        if run is not None:
+        # begin_nested()의 SAVEPOINT 롤백은 그 SAVEPOINT 안에서 session.add()한 pending
+        # 객체를 SQLAlchemy가 이미 자동으로 세션에서 떼어낸다(실측 확認 — CHECK 위반
+        # 재현 중 session.expunge(run)이 "Instance is not present in this Session"으로
+        # 터졌다) — 그래서 `run in session`으로 아직 붙어 있는 경우만 방어적으로
+        # expunge한다(SAVEPOINT 실패 전, 예: 데드록/타임아웃처럼 flush 자체가 SAVEPOINT
+        # 밖에서 실패하는 다른 예외 경로를 위한 안전망).
+        if run is not None and run in session:
             session.expunge(run)
         logger.warning(
             "agent_run 자동 시작 실패(비차단) agent_id=%s story_id=%s", agent_id, story_id, exc_info=True,

--- a/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
+++ b/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
@@ -318,33 +318,20 @@ async def test_mutation_removing_claim_hook_leaves_zero_runs(monkeypatch):
         await engine.dispose()
 
 
-async def _seed_duplicate_id_collision(session, *, org_id, project_id, agent_id):
-    """AgentRun 생성 시 이미 DB에 있는 id로 강제해 flush에서 실 Postgres PK 위반
-    (IntegrityError)이 나게 한다 — 순수 Python 예외(예: TypeError)는 SQL을 한 번도 안
-    태워 세션/트랜잭션을 전혀 안 건드리므로 SAVEPOINT 유무 차이가 안 드러난다. 이
-    헬퍼는 «진짜 DB 오류가 세션을 poison하는가」를 실측하기 위해 실 제약 위반을 쓴다
-    (ORM 서브클래싱 없이 — 같은 파일 안에서 mapped class를 재정의하면 SQLAlchemy
-    string-lookup 레지스트리가 매 테스트 재정의를 경고하며 불안정해진다, 실측 확認)."""
-    from datetime import datetime, timedelta, timezone
-
-    from app.models.agent_run import AgentRun
-
-    collision_id = uuid.uuid4()
-    other_story_id = uuid.uuid4()  # 다른 story_id — dedupe 축(agent_id+story_id)과 안 겹침.
-    session.add(AgentRun(
-        id=collision_id, org_id=org_id, project_id=project_id, agent_id=agent_id,
-        story_id=other_story_id, trigger="manual", status="running",
-        deadline_at=datetime.now(timezone.utc) + timedelta(hours=1),
-    ))
-    await session.commit()
-    return collision_id
-
-
-def _install_id_colliding_agent_run(monkeypatch, mod, collision_id):
+def _install_check_violating_agent_run(monkeypatch, mod):
+    """CHANGES(페드루 PO, 2026-09-07) — PK 충돌은 SQLAlchemy identity map이 SQL을 내보내기
+    前에 ORM 층에서 먼저 잡아버려(식별맵에 같은 키가 있으면) 실제로 Postgres에 SQL이
+    한 번도 안 나가고, 그래서 asyncpg 트랜잭션도 안 깨지고 세션도 PendingRollback이 안
+    된다 — 내 첫 시도(PK 충돌)가 SAVEPOINT 유무 차이를 못 드러낸 이유가 이것이었다.
+    세션이 진짜 poison되려면 SQL 자체가 Postgres까지 나가서 거부돼야 한다 —
+    `agent_runs_status_check`(alembic 0207) CHECK 제약을 어기는 status 값으로 강제하면
+    INSERT가 실제로 Postgres에 도달해 CHECK 위반(asyncpg IntegrityError)으로 터지고,
+    그 순간 PG가 트랜잭션을 abort한다(SAVEPOINT 없으면 그 뒤 같은 세션의 어떤 SQL도
+    실패)."""
     from app.models.agent_run import AgentRun as RealAgentRun
 
     def _factory(**kwargs):
-        kwargs["id"] = collision_id  # 이미 있는 PK로 강제 — flush에서 UniqueViolation.
+        kwargs["status"] = "bogus"  # agent_runs_status_check가 거부하는 값 — 실 CHECK 위반.
         return RealAgentRun(**kwargs)
 
     monkeypatch.setattr(mod, "AgentRun", _factory)
@@ -353,43 +340,46 @@ def _install_id_colliding_agent_run(monkeypatch, mod, collision_id):
 @pytest.mark.anyio
 async def test_run_write_failure_does_not_poison_story_transition_commit(monkeypatch):
     """CHANGES(페드루 PO, 2026-09-07) — ensure_agent_run_started 안에서 flush가 실 DB
-    오류(PK 위반)로 터져도 스토리 in-progress 전이 자체는 여전히 커밋돼야 한다(SAVEPOINT
-    격리가 실제로 바깥 트랜잭션을 살린다는 증거) — run은 0행(PK 위반 행은 롤백됐다)."""
+    오류(CHECK 위반, PG가 트랜잭션을 실제로 abort)로 터져도 스토리 in-progress 전이
+    자체는 여전히 커밋돼야 한다(SAVEPOINT 격리가 실제로 바깥 트랜잭션을 살린다는
+    증거) — 응답 200이 아니라(라우터가 다른 예외 경로로 200을 낼 수도 있어 그 자체는
+    약한 신호) 새 세션 SELECT로 story.status가 실제로 영속됐는지를 본다."""
     import app.services.agent_run_tracking as mod
 
+    _install_check_violating_agent_run(monkeypatch, mod)
+
     from app.main import app
+    from app.models.pm import Story
 
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
             seeded = await _seed(s)
-            collision_id = await _seed_duplicate_id_collision(
-                s, org_id=seeded["org_id"], project_id=seeded["project_id"], agent_id=seeded["agent_id"],
-            )
-        _install_id_colliding_agent_run(monkeypatch, mod, collision_id)
         await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
         client = _client_for(app)
         try:
             resp = await client.patch(
                 f"/api/v2/stories/{seeded['story_id']}/status", json={"status": "in-progress"},
             )
-            # 핵심 단언 — run 기록이 안에서 터져도 스토리 전이 자체는 500이 아니라 200.
             assert resp.status_code == 200, resp.text
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
 
         async with Session() as s:
-            from app.models.pm import Story
-
             story = (await s.execute(
                 select(Story).where(Story.id == seeded["story_id"])
             )).scalar_one()
             assert story.status == "in-progress", "run 실패가 스토리 전이 자체를 오염시켰다(세션 poison)"
             runs = await _agent_runs_for(s, agent_id=seeded["agent_id"], story_id=seeded["story_id"])
-            assert len(runs) == 0
+            assert len(runs) == 0, "CHECK 위반 행이 커밋됐다(있을 수 없음 — DB가 거부했어야)"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+# 뮤테이션(begin_nested 제거) 테스트는 두 번 시도(PK 충돌·CHECK 위반) 다 이
+# SQLAlchemy/asyncpg 조합에서 SAVEPOINT 유무 차이를 못 드러냈다(둘 다 여전히
+# 200+영속) — 채널에 실측 그대로 보고, 신뢰성 없는 RED를 위한 RED 테스트는
+# 안 남긴다. SAVEPOINT 자체(코드)는 이 결함 클래스의 확립된 정공법이라 유지.
 
 

--- a/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
+++ b/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
@@ -316,3 +316,80 @@ async def test_mutation_removing_claim_hook_leaves_zero_runs(monkeypatch):
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+async def _seed_duplicate_id_collision(session, *, org_id, project_id, agent_id):
+    """AgentRun 생성 시 이미 DB에 있는 id로 강제해 flush에서 실 Postgres PK 위반
+    (IntegrityError)이 나게 한다 — 순수 Python 예외(예: TypeError)는 SQL을 한 번도 안
+    태워 세션/트랜잭션을 전혀 안 건드리므로 SAVEPOINT 유무 차이가 안 드러난다. 이
+    헬퍼는 «진짜 DB 오류가 세션을 poison하는가」를 실측하기 위해 실 제약 위반을 쓴다
+    (ORM 서브클래싱 없이 — 같은 파일 안에서 mapped class를 재정의하면 SQLAlchemy
+    string-lookup 레지스트리가 매 테스트 재정의를 경고하며 불안정해진다, 실측 확認)."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.agent_run import AgentRun
+
+    collision_id = uuid.uuid4()
+    other_story_id = uuid.uuid4()  # 다른 story_id — dedupe 축(agent_id+story_id)과 안 겹침.
+    session.add(AgentRun(
+        id=collision_id, org_id=org_id, project_id=project_id, agent_id=agent_id,
+        story_id=other_story_id, trigger="manual", status="running",
+        deadline_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    ))
+    await session.commit()
+    return collision_id
+
+
+def _install_id_colliding_agent_run(monkeypatch, mod, collision_id):
+    from app.models.agent_run import AgentRun as RealAgentRun
+
+    def _factory(**kwargs):
+        kwargs["id"] = collision_id  # 이미 있는 PK로 강제 — flush에서 UniqueViolation.
+        return RealAgentRun(**kwargs)
+
+    monkeypatch.setattr(mod, "AgentRun", _factory)
+
+
+@pytest.mark.anyio
+async def test_run_write_failure_does_not_poison_story_transition_commit(monkeypatch):
+    """CHANGES(페드루 PO, 2026-09-07) — ensure_agent_run_started 안에서 flush가 실 DB
+    오류(PK 위반)로 터져도 스토리 in-progress 전이 자체는 여전히 커밋돼야 한다(SAVEPOINT
+    격리가 실제로 바깥 트랜잭션을 살린다는 증거) — run은 0행(PK 위반 행은 롤백됐다)."""
+    import app.services.agent_run_tracking as mod
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            collision_id = await _seed_duplicate_id_collision(
+                s, org_id=seeded["org_id"], project_id=seeded["project_id"], agent_id=seeded["agent_id"],
+            )
+        _install_id_colliding_agent_run(monkeypatch, mod, collision_id)
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{seeded['story_id']}/status", json={"status": "in-progress"},
+            )
+            # 핵심 단언 — run 기록이 안에서 터져도 스토리 전이 자체는 500이 아니라 200.
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            from app.models.pm import Story
+
+            story = (await s.execute(
+                select(Story).where(Story.id == seeded["story_id"])
+            )).scalar_one()
+            assert story.status == "in-progress", "run 실패가 스토리 전이 자체를 오염시켰다(세션 poison)"
+            runs = await _agent_runs_for(s, agent_id=seeded["agent_id"], story_id=seeded["story_id"])
+            assert len(runs) == 0
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+

--- a/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
+++ b/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
@@ -1,0 +1,318 @@
+"""story #3685(Trust·customer-zero, 페드루 PO 確定 2026-09-07) — 에이전트 run을 "지침"이
+아니라 "메커니즘"으로 기록한다. claim_story/in-progress 전이에서 자동 시작, in-review/
+done 전이·unclaim에서 자동 종료 realdb 검증.
+
+3683 그라운딩 — run 생성 경로는 전수 1곳(POST /api/v2/agent-runs)뿐이고 fleet 아무도
+착수/PR/완료 어디서도 그 경로(MCP emit_event/update_run_status)를 부른 적이 없었다.
+이 스토리는 코드가 아니라 지침 의존이던 그 배선을 claim_story/status 전이 훅으로
+대체한다 — 여기서는 그 훅들이 실제로 agent_runs 행을 쓰는지 HTTP 계층째로 검증한다.
+
+세팅은 test_2266_story_backlinks_realdb.py(_session_factory/_client_for)·
+test_agent_runs_story_id_filter_realdb.py(Member type="agent" + ProjectAccess 시드
+패턴) 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2266_story_backlinks_realdb import _client_for, _session_factory
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed(session):
+    """org+project+agent(team_member)+story. participation 기본 role도 심어(claim_story의
+    ensure_implementation_participation이 best-effort로 스킵돼도 이 스토리의 관심사(run)와
+    무관 — 그래도 실물과 같은 모양으로 시드해 둔다)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.participation import ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.flush()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    ))
+    session.add(ParticipationRole(
+        id=uuid.uuid4(), org_id=org.id, key="implementation", label="구현", is_default=True,
+    ))
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="backlog")
+    session.add(story)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id, "story_id": story.id}
+
+
+async def _setup_app_agent(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _agent_runs_for(session, *, agent_id, story_id):
+    from app.models.agent_run import AgentRun
+
+    return list((await session.execute(
+        select(AgentRun).where(AgentRun.agent_id == agent_id, AgentRun.story_id == story_id)
+    )).scalars().all())
+
+
+@pytest.mark.anyio
+async def test_claim_story_creates_running_agent_run():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/team-members/{seeded['agent_id']}/claim",
+                json={"story_id": str(seeded["story_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            runs = await _agent_runs_for(s, agent_id=seeded["agent_id"], story_id=seeded["story_id"])
+            assert len(runs) == 1
+            assert runs[0].status == "running"
+            assert runs[0].finished_at is None
+            assert runs[0].project_id == seeded["project_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_status_to_in_review_closes_run_as_completed():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            claim_resp = await client.post(
+                f"/api/v2/team-members/{seeded['agent_id']}/claim",
+                json={"story_id": str(seeded["story_id"])},
+            )
+            assert claim_resp.status_code == 200, claim_resp.text
+            # 착수 표시 — claim만으로는 story.status가 안 바뀐다(3414b6d7 결정, board 무변경).
+            for target in ("in-progress", "in-review"):
+                status_resp = await client.patch(
+                    f"/api/v2/stories/{seeded['story_id']}/status", json={"status": target},
+                )
+                assert status_resp.status_code == 200, status_resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            runs = await _agent_runs_for(s, agent_id=seeded["agent_id"], story_id=seeded["story_id"])
+            assert len(runs) == 1
+            assert runs[0].status == "completed"
+            assert runs[0].finished_at is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reclaim_does_not_duplicate_run():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            for _ in range(2):
+                resp = await client.post(
+                    f"/api/v2/team-members/{seeded['agent_id']}/claim",
+                    json={"story_id": str(seeded["story_id"])},
+                )
+                assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            runs = await _agent_runs_for(s, agent_id=seeded["agent_id"], story_id=seeded["story_id"])
+            assert len(runs) == 1, "재claim이 중복 run을 냈다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_preexisting_emit_event_run_deduped_by_claim():
+    """emit_event(MCP)로 이미 만들어진 열린 run이 있으면 claim_story가 새로 안 만든다 —
+    (agent_id, story_id)+finished_at IS NULL 축이 두 생성 경로를 하나로 묶는다."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.main import app
+    from app.models.agent_run import AgentRun
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            # emit_event가 직접 만든 것과 동형 — trigger="manual"(POST /api/v2/agent-runs 기본값).
+            pre_existing = AgentRun(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                agent_id=seeded["agent_id"], story_id=seeded["story_id"], trigger="manual",
+                status="running", deadline_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+            s.add(pre_existing)
+            await s.commit()
+            pre_existing_id = pre_existing.id
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/team-members/{seeded['agent_id']}/claim",
+                json={"story_id": str(seeded["story_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            runs = await _agent_runs_for(s, agent_id=seeded["agent_id"], story_id=seeded["story_id"])
+            assert len(runs) == 1, "emit_event 선행 run과 claim_story가 중복을 냈다"
+            assert runs[0].id == pre_existing_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unclaim_marks_run_abandoned():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            claim_resp = await client.post(
+                f"/api/v2/team-members/{seeded['agent_id']}/claim",
+                json={"story_id": str(seeded["story_id"])},
+            )
+            assert claim_resp.status_code == 200, claim_resp.text
+            unclaim_resp = await client.post(f"/api/v2/team-members/{seeded['agent_id']}/unclaim")
+            assert unclaim_resp.status_code == 200, unclaim_resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            runs = await _agent_runs_for(s, agent_id=seeded["agent_id"], story_id=seeded["story_id"])
+            assert len(runs) == 1
+            assert runs[0].status == "abandoned"
+            assert runs[0].finished_at is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_removing_claim_hook_leaves_zero_runs(monkeypatch):
+    """뮤테이션 — claim_story의 ensure_agent_run_started 호출을 무력화하면(옛 사각지대
+    재현) claim이 성공해도 agent_runs가 0건인 것을 고정(이 훅이 실제로 값을 만든다는
+    증거)."""
+    import app.services.agent_run_tracking as mod
+
+    async def _noop_start(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mod, "ensure_agent_run_started", _noop_start)
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/team-members/{seeded['agent_id']}/claim",
+                json={"story_id": str(seeded["story_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            runs = await _agent_runs_for(s, agent_id=seeded["agent_id"], story_id=seeded["story_id"])
+            assert len(runs) == 0, "뮤테이션이 걸리지 않았다(훅을 지웠는데도 run이 생겼다)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
+++ b/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
@@ -318,7 +318,7 @@ async def test_mutation_removing_claim_hook_leaves_zero_runs(monkeypatch):
         await engine.dispose()
 
 
-def _install_check_violating_agent_run(monkeypatch, mod):
+def _install_check_violating_agent_run(monkeypatch):
     """CHANGES(페드루 PO, 2026-09-07) — PK 충돌은 SQLAlchemy identity map이 SQL을 내보내기
     前에 ORM 층에서 먼저 잡아버려(식별맵에 같은 키가 있으면) 실제로 Postgres에 SQL이
     한 번도 안 나가고, 그래서 asyncpg 트랜잭션도 안 깨지고 세션도 PendingRollback이 안
@@ -328,13 +328,18 @@ def _install_check_violating_agent_run(monkeypatch, mod):
     INSERT가 실제로 Postgres에 도달해 CHECK 위반(asyncpg IntegrityError)으로 터지고,
     그 순간 PG가 트랜잭션을 abort한다(SAVEPOINT 없으면 그 뒤 같은 세션의 어떤 SQL도
     실패)."""
-    from app.models.agent_run import AgentRun as RealAgentRun
+    from app.models.agent_run import AgentRun
 
-    def _factory(**kwargs):
+    # mod.AgentRun 자체(모듈-레벨 이름)를 바꾸면 dedupe SELECT의 `AgentRun.id`(클래스
+    # 속성 접근)도 같이 깨진다(함수엔 .id가 없다) — 생성자(__init__)만 패치해 SELECT는
+    # 그대로 두고 INSERT할 인스턴스만 status를 강제로 위반값으로 바꾼다.
+    original_init = AgentRun.__init__
+
+    def _init_with_bogus_status(self, **kwargs):
         kwargs["status"] = "bogus"  # agent_runs_status_check가 거부하는 값 — 실 CHECK 위반.
-        return RealAgentRun(**kwargs)
+        original_init(self, **kwargs)
 
-    monkeypatch.setattr(mod, "AgentRun", _factory)
+    monkeypatch.setattr(AgentRun, "__init__", _init_with_bogus_status)
 
 
 @pytest.mark.anyio
@@ -346,7 +351,7 @@ async def test_run_write_failure_does_not_poison_story_transition_commit(monkeyp
     약한 신호) 새 세션 SELECT로 story.status가 실제로 영속됐는지를 본다."""
     import app.services.agent_run_tracking as mod
 
-    _install_check_violating_agent_run(monkeypatch, mod)
+    _install_check_violating_agent_run(monkeypatch)
 
     from app.main import app
     from app.models.pm import Story
@@ -377,9 +382,97 @@ async def test_run_write_failure_does_not_poison_story_transition_commit(monkeyp
         app.dependency_overrides.clear()
         await engine.dispose()
 
-# 뮤테이션(begin_nested 제거) 테스트는 두 번 시도(PK 충돌·CHECK 위반) 다 이
-# SQLAlchemy/asyncpg 조합에서 SAVEPOINT 유무 차이를 못 드러냈다(둘 다 여전히
-# 200+영속) — 채널에 실측 그대로 보고, 신뢰성 없는 RED를 위한 RED 테스트는
-# 안 남긴다. SAVEPOINT 자체(코드)는 이 결함 클래스의 확립된 정공법이라 유지.
+
+@pytest.mark.anyio
+async def test_run_write_failure_does_not_lose_uncommitted_sibling_write(monkeypatch):
+    """페드루 PO 3차 지적(2026-09-07, 서비스 층 직접) — API 경로에선 차이가 안 드러난
+    이유는 «잃을 미커밋 형제 쓰기가 없어서»였다: SQLAlchemy 2.0은 flush 실패 시
+    세션을 poison(못 쓰게)시키는 게 아니라 루트 트랜잭션을 통째로 롤백하고 다음
+    사용에 새 트랜잭션을 autobegin한다 — 실제 증상은 «세션이 죽는다」가 아니라
+    «그 앞의 미커밋 쓰기가 조용히 사라진다」. 이 테스트는 서비스 함수를 API 없이
+    직접 호출해 그 증상을 정확히 겨냥한다: 같은 세션에서 ① 형제 쓰기(story.title,
+    flush 안 함=pending) → ② ensure_agent_run_started를 CHECK 위반으로 실패시킴
+    → ③ session.commit() → ④ 새 세션 SELECT로 ①이 살아남았는지."""
+    import app.services.agent_run_tracking as mod
+    from app.models.pm import Story
+
+    _install_check_violating_agent_run(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        async with Session() as s:
+            story = (await s.execute(
+                select(Story).where(Story.id == seeded["story_id"])
+            )).scalar_one()
+            story.title = "형제쓰기-생존확인"  # flush 안 함 — 세션에 pending 상태로만 존재.
+
+            await mod.ensure_agent_run_started(
+                s, org_id=seeded["org_id"], project_id=seeded["project_id"],
+                agent_id=seeded["agent_id"], story_id=seeded["story_id"],
+            )
+            await s.commit()
+
+        async with Session() as s2:
+            story2 = (await s2.execute(
+                select(Story).where(Story.id == seeded["story_id"])
+            )).scalar_one()
+            assert story2.title == "형제쓰기-생존확인", (
+                "형제의 미커밋 쓰기가 사라졌다 — run 기록 실패가 세션을 poison시켰다"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_removing_savepoint_loses_sibling_write(monkeypatch):
+    """뮤테이션 — begin_nested() 격리를 빼면(옛 결함 재현) 위 테스트와 똑같은 시나리오에서
+    형제의 미커밋 쓰기가 루트 트랜잭션 롤백에 휩쓸려 사라지는 것을 고정(위 테스트가
+    실제로 SAVEPOINT 격리를 지키고 있다는 증거)."""
+
+    class _AsyncNullContext:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False  # 예외를 그대로 전파(=SAVEPOINT 없음과 동형).
+
+    import app.services.agent_run_tracking as mod
+    from app.models.pm import Story
+
+    _install_check_violating_agent_run(monkeypatch)
+    monkeypatch.setattr(mod.AsyncSession, "begin_nested", lambda self: _AsyncNullContext())
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        async with Session() as s:
+            story = (await s.execute(
+                select(Story).where(Story.id == seeded["story_id"])
+            )).scalar_one()
+            story.title = "형제쓰기-생존확인"
+
+            await mod.ensure_agent_run_started(
+                s, org_id=seeded["org_id"], project_id=seeded["project_id"],
+                agent_id=seeded["agent_id"], story_id=seeded["story_id"],
+            )
+            try:
+                await s.commit()
+            except Exception:  # noqa: BLE001 — SAVEPOINT 없으면 commit 자체가 터질 수도 있다.
+                await s.rollback()
+
+        async with Session() as s2:
+            story2 = (await s2.execute(
+                select(Story).where(Story.id == seeded["story_id"])
+            )).scalar_one()
+            assert story2.title != "형제쓰기-생존확인", (
+                "뮤테이션이 걸리지 않았다(SAVEPOINT 없이도 형제 쓰기가 살아남았다)"
+            )
+    finally:
+        await engine.dispose()
 
 

--- a/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
+++ b/backend/tests/test_3685_agent_run_lifecycle_mechanism_realdb.py
@@ -79,7 +79,7 @@ async def _seed(session):
 
 async def _setup_app_agent(app, Session, agent_id, org_id):
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -96,7 +96,9 @@ async def _setup_app_agent(app, Session, agent_id, org_id):
             claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
         )
 
-    app.dependency_overrides[get_db] = _db
+    # story #2451(§6 Phase3) CI 가드 — get_db만 걸고 get_read_db를 놓치는 클래스(A1/A2
+    # 재발 이력). override_db_and_read()가 두 key를 구조적으로 함께 건다.
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
 
 


### PR DESCRIPTION
3683 그라운딩(코드 X) — run 생성 경로는 전수 1곳(`POST /api/v2/agent-runs`)뿐이고, "왜 안 찍히나"의 실체는 코드가 막은 게 아니라 fleet 아무도 착수/PR/완료 어디서도 그 경로(MCP `emit_event`/`update_run_status`)를 부른 적이 없었다는 것이었다.

## PO 確定 — 지침이 아니라 메커니즘
지침(AGENTS.md 한 줄)은 "잊으면 다시 0행"이라 거부, 플랫폼이 이미 보는 생애주기 이벤트에서 run을 자동 유도한다.

## 변경
- `claim_story`(team_members.py) — 에이전트 assignee가 claim하면 (agent_id, story_id)에 열린 run이 없으면 새로 연다(running). `emit_event`로 이미 열려 있으면 그대로 재사용(dedupe 축 공유).
- `unclaim_story` — 캡처해 둔 이전 `active_story_id`의 열린 run을 abandoned로.
- `update_story_status`(stories.py) — in-progress 전이(에이전트 actor)에서 시작, in-review/done 전이에서 그 story의 열린 run 전부를 completed로(닫는 행위자와 무관).
- `github_webhook`(verdict_capture.py) — PR 머지 이벤트에서도 같은 방식으로 닫는다(기존 verdict/게이트 로직과 완전 독립된 자리).
- 공유 서비스 `agent_run_tracking.py`(`ensure_agent_run_started`·`close_agent_runs_for_story`) — 둘 다 best-effort(예외를 삼키고 로그만). `deadline_at`도 동일하게 잡아 리퍼 자가회수 대상이 되게 한다.

## Test plan
- [x] 6건: claim→running·in-review→completed·재claim 중복 0·emit_event 선행 시 dedupe·unclaim→abandoned·뮤테이션
- [x] 라이브 뮤테이션 2건(claim 훅·in-review 훅) RED 확認 후 원복
- [x] 기존 회귀 스윕 83 passed(claim/unclaim·참여 갭·webhook·stories 라우터 전체)
- [x] py_compile 클린

AGENTS.md 「자동 기록됨」 한 줄은 PO 몫(이 PR 범위 밖).

story #3685

🤖 Generated with [Claude Code](https://claude.com/claude-code)