### PR TITLE
[SID:3687] fix(FE): @멘션 자동완성 project_id 없는 대화 org 스코프 폴백

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4443,6 +4443,7 @@
     "deliveryContractLevel_all": "All",
     "deliveryContractLevel_mentions": "Mentions only",
     "deliveryContractLevel_mute": "Off",
+    "mentionLoadFailed": "Couldn't load the member list.",
     "deliveryContractFreeResponseLabel": "Allow replies without a mention",
     "deliveryContractFreeResponseDesc": "When on, participants set to \"mentions only\" in this conversation also receive messages that don't mention them.",
     "deliveryContractReasonGapNote": "Why a message wasn't delivered (e.g. chain limit reached) isn't shown here yet.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4443,6 +4443,7 @@
     "deliveryContractLevel_all": "전체",
     "deliveryContractLevel_mentions": "멘션만",
     "deliveryContractLevel_mute": "끄기",
+    "mentionLoadFailed": "멤버 목록을 불러오지 못했습니다.",
     "deliveryContractFreeResponseLabel": "멘션 없이도 자유롭게 응답",
     "deliveryContractFreeResponseDesc": "켜면 이 대화에서 «멘션만» 설정한 참여자도 멘션 없는 메시지를 받습니다.",
     "deliveryContractReasonGapNote": "메시지가 전달되지 않은 이유(연쇄 한도 초과 등)는 아직 이 화면에서 바로 보이지 않습니다.",

--- a/apps/web/src/components/chat/chat-input.mention-org-scope.test.tsx
+++ b/apps/web/src/components/chat/chat-input.mention-org-scope.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+//
+// story #3687(3680 클래스) — @멘션 자동완성이 project_id 없는 대화(org-level DM 등)에서
+// /api/members(project_id 필수, Query(...))를 불러 매 요청 422 → r.ok 검사 없이 json()으로
+// 파싱 → data undefined → `?? []`로 조용히 0건. 처방: 기존 org-스코프 폴백을 이미 가진
+// /api/team-members(project_id 생략 시 org 전체, S:166051f0)로 갈아타고, 실패는 실패
+// 얼굴(mentionLoadFailed)로 드러낸다(실패≠0건).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ChatInput } from './chat-input';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function withIntl(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+let store: Map<string, string>;
+function stubLocalStorage() {
+  store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  stubLocalStorage();
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false } as MediaQueryList));
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function textarea(): HTMLTextAreaElement {
+  return container.querySelector('textarea') as HTMLTextAreaElement;
+}
+
+async function typeAt() {
+  const el = textarea();
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+  await act(async () => {
+    setter.call(el, '@');
+    el.selectionStart = 1;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  // effect의 fetch가 microtask 큐를 거친다 — 실 타이머 없이도 흘려보낸다.
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('ChatInput — @멘션 org-스코프 폴백(story #3687 AC①)', () => {
+  it('project_id 없는 대화에서도 team-members(org 스코프)로 멤버 ≥1건이 뜬다', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toContain('/api/team-members');
+      expect(url).not.toContain('project_id');
+      return new Response(JSON.stringify({ data: [{ id: 'm1', name: 'Alice', role: 'member' }] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} />));
+    });
+    await typeAt();
+
+    const listbox = container.querySelector('[role="listbox"][aria-label="멘션 후보"]');
+    expect(listbox).not.toBeNull();
+    expect(listbox!.textContent).toContain('Alice');
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('project_id 있는 대화는 여전히 project 스코프로 쿼리한다(회귀 방지)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      expect(url).toContain('project_id=p1');
+      return new Response(JSON.stringify({ data: [{ id: 'm1', name: 'Bob', role: 'member' }] }), { status: 200 });
+    }));
+
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" projectId="p1" onSend={vi.fn()} />));
+    });
+    await typeAt();
+
+    const listbox = container.querySelector('[role="listbox"][aria-label="멘션 후보"]');
+    expect(listbox!.textContent).toContain('Bob');
+  });
+});
+
+describe('ChatInput — @멘션 로드 실패 얼굴(story #3687 AC②, 실패≠0건)', () => {
+  it('BE가 422를 주면 빈 목록이 아니라 실패 문구를 보여준다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ detail: 'project_id required' }), { status: 422 })));
+
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} />));
+    });
+    await typeAt();
+
+    // 실패 상태 — 후보 목록(listbox)은 없고, 실패 문구(status role)가 대신 뜬다.
+    expect(container.querySelector('[role="listbox"][aria-label="멘션 후보"]')).toBeNull();
+    const status = container.querySelector('[role="status"]');
+    expect(status).not.toBeNull();
+    expect(status!.textContent).toBe(koMessages.chats.mentionLoadFailed);
+    // 실패는 실패다 — 후보가 "0건이라 안 뜬 것"과 구분되는 별도 상태(mentionLoadFailed)임을
+    // 렌더 결과로 고정. r.ok 검사를 빼는 뮤테이션(수동 검증, PR 설명 참조)이 이 assertion을
+    // 정확히 깨뜨린다 — 422 바디가 r.ok 없이 바로 파싱되면 data undefined→`?? []`로
+    // mentionMembers만 비고 mentionLoadFailed는 계속 false라 이 role="status" 자체가 안 뜬다.
+  });
+});

--- a/apps/web/src/components/chat/chat-input.mention-org-scope.test.tsx
+++ b/apps/web/src/components/chat/chat-input.mention-org-scope.test.tsx
@@ -2,9 +2,14 @@
 //
 // story #3687(3680 클래스) — @멘션 자동완성이 project_id 없는 대화(org-level DM 등)에서
 // /api/members(project_id 필수, Query(...))를 불러 매 요청 422 → r.ok 검사 없이 json()으로
-// 파싱 → data undefined → `?? []`로 조용히 0건. 처방: 기존 org-스코프 폴백을 이미 가진
-// /api/team-members(project_id 생략 시 org 전체, S:166051f0)로 갈아타고, 실패는 실패
-// 얼굴(mentionLoadFailed)로 드러낸다(실패≠0건).
+// 파싱 → data undefined → `?? []`로 조용히 0건.
+//
+// PO CHANGES(페드루, 2026-09-07) — 처음엔 /api/team-members(project_id 생략 시 org
+// 스코프 폴백, S:166051f0)로 갈아탔으나, 이건 회귀였다: /api/members는 canonical
+// SSOT(grant 휴먼·owner/admin 누락 없음)라 team-members(뷰 기반)로 바꾸면 project_id
+// 있는 대화에서도 grant 휴먼이 @멘션에서 사라진다(BFF route.ts 주석). 정정 — FE는
+// /api/members 그대로 두고, BE가 project_id 생략 시 org 스코프(grant 판정 불요) additive
+// 분기를 얻었다. 실패는 실패 얼굴(mentionLoadFailed)로 드러낸다(실패≠0건).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -74,9 +79,9 @@ async function typeAt() {
 }
 
 describe('ChatInput — @멘션 org-스코프 폴백(story #3687 AC①)', () => {
-  it('project_id 없는 대화에서도 team-members(org 스코프)로 멤버 ≥1건이 뜬다', async () => {
+  it('project_id 없는 대화에서도 members(org 스코프)로 멤버 ≥1건이 뜬다', async () => {
     const fetchMock = vi.fn(async (url: string) => {
-      expect(url).toContain('/api/team-members');
+      expect(url).toContain('/api/members');
       expect(url).not.toContain('project_id');
       return new Response(JSON.stringify({ data: [{ id: 'm1', name: 'Alice', role: 'member' }] }), { status: 200 });
     });

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -197,6 +197,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionMembers, setMentionMembers] = useState<MentionMember[]>([]);
   const [mentionIndex, setMentionIndex] = useState(0);
+  const [mentionLoadFailed, setMentionLoadFailed] = useState(false);
 
   // story #2264(C-6): 채팅 전용이던 entityQuery/entityResults/entityIndex + 검색 effect가
   // 참조 코어 hook으로 옮겨갔다 — 이 컴포넌트는 소비자일 뿐이다.
@@ -247,18 +248,33 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
   }, [prefillCommand]);
 
   useEffect(() => {
-    if (mentionQuery === null) { setMentionMembers([]); return; }
+    if (mentionQuery === null) { setMentionMembers([]); setMentionLoadFailed(false); return; }
     let cancelled = false;
-    fetchWithAuth(`/api/members?is_active=true${projectId ? `&project_id=${projectId}` : ''}`)
-      .then((r) => r.json())
+    // story #3687(3680 클래스) — project_id 없는 대화(org-level DM 등)는 project 스코프
+    // /api/members(project_id 필수, 없으면 422)가 원천적으로 못 닿는다. /api/team-members는
+    // project_id 생략 시 org 전체(휴먼+에이전트)로 이미 폴백하는 기존 엔드포인트라(S:166051f0)
+    // 여기서도 그대로 재사용 — project_id 있으면 기존과 동일하게 프로젝트 스코프 유지.
+    const params = new URLSearchParams({ is_active: 'true' });
+    if (projectId) params.set('project_id', projectId);
+    fetchWithAuth(`/api/team-members?${params.toString()}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`mention fetch ${r.status}`);
+        return r.json();
+      })
       .then((json) => {
         if (cancelled) return;
         const all: MentionMember[] = (json.data ?? []).map((m: { id: string; name: string; role?: string | null }) => ({ id: m.id, name: m.name, role: m.role }));
         const q = mentionQuery.toLowerCase();
         setMentionMembers(q ? all.filter((m) => m.name.toLowerCase().includes(q)) : all);
         setMentionIndex(0);
+        setMentionLoadFailed(false);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (cancelled) return;
+        // 실패≠0건 — 조용히 빈 목록으로 삼키지 않고 드롭다운에 실패 상태를 드러낸다(AC②).
+        setMentionMembers([]);
+        setMentionLoadFailed(true);
+      });
     return () => { cancelled = true; };
   }, [mentionQuery, projectId]);
 
@@ -765,6 +781,13 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
               </li>
             ))}
           </ul>
+        )}
+
+        {/* Mention dropdown 실패 상태 — story #3687: 조용한 0건과 구분되는 별도 얼굴. */}
+        {mentionQuery !== null && mentionLoadFailed && (
+          <div role="status" className="focus-inset absolute bottom-full left-8 z-50 mb-1 w-56 rounded-md border border-border bg-popover px-3 py-2 text-xs text-muted-foreground shadow-[var(--elev-overlay)]">
+            {t('mentionLoadFailed')}
+          </div>
         )}
 
         {/* Mention dropdown */}

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -250,13 +250,15 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
   useEffect(() => {
     if (mentionQuery === null) { setMentionMembers([]); setMentionLoadFailed(false); return; }
     let cancelled = false;
-    // story #3687(3680 클래스) — project_id 없는 대화(org-level DM 등)는 project 스코프
-    // /api/members(project_id 필수, 없으면 422)가 원천적으로 못 닿는다. /api/team-members는
-    // project_id 생략 시 org 전체(휴먼+에이전트)로 이미 폴백하는 기존 엔드포인트라(S:166051f0)
-    // 여기서도 그대로 재사용 — project_id 있으면 기존과 동일하게 프로젝트 스코프 유지.
+    // story #3687(3680 클래스) — project_id 없는 대화(org-level DM 등)는 project_id를 안
+    // 보냈었다(BE 필수→422). /api/members는 canonical SSOT(grant 휴먼·owner/admin 누락
+    // 없음, /api/team-members와 다른 계약 — BFF route.ts 주석)라 project_id가 있는 대화는
+    // 계속 이 엔드포인트를 써야 한다(team-members로 바꾸면 grant 휴먼이 사라지는 회귀,
+    // PO CHANGES 지적). 대신 BE가 project_id 없으면 org 스코프(grant 판정 불요)로
+    // additive 분기했다 — FE는 project_id 있으면 그대로, 없으면 생략만 하면 된다.
     const params = new URLSearchParams({ is_active: 'true' });
     if (projectId) params.set('project_id', projectId);
-    fetchWithAuth(`/api/team-members?${params.toString()}`)
+    fetchWithAuth(`/api/members?${params.toString()}`)
       .then((r) => {
         if (!r.ok) throw new Error(`mention fetch ${r.status}`);
         return r.json();

--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.team import TeamMember
+from app.repositories.team_member import TeamMemberRepository
 from app.services.project_auth import assert_target_in_caller_org, has_project_access
 
 router = APIRouter(prefix="/api/v2/members", tags=["members", "Organization"])
@@ -25,16 +26,37 @@ class MemberResponse(BaseModel):
 
 @router.get("", response_model=list[MemberResponse])
 async def list_members(
-    project_id: uuid.UUID = Query(...),
+    project_id: uuid.UUID | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[MemberResponse]:
-    """프로젝트 멤버 목록.
+    """멤버 목록 — canonical SSOT(휴먼: org_members+project_access grant, 에이전트: team_members
+    type=agent). team_members 뷰 기반 /api/v2/team-members와 달리 grant 휴먼·owner/admin
+    누락이 없다(BFF route.ts 주석과 동일 계약 — 이 계약을 지키는 게 이 엔드포인트의 존재
+    이유라 project_id 스코프에서 team-members로 대체하면 안 된다).
 
-    Human: org_members + project_access JOIN (grant 모델 — 레코드 있음 = 접근 허용).
-    Agent: team_members(type=agent) 그대로 유지.
+    story #3687(3680 클래스) — project_id 없는 대화(org-level DM 등)는 애초에 "프로젝트
+    접근권" 개념이 없다. 이 경우는 grant 판정 자체가 무의미한 **별도 분기**(project 스코프
+    "grant 모델이라 못 바꾼다"는 여기 해당 안 됨) — 휴먼은 org_members 전원(SSOT 직접 해소,
+    list_org_human_members·S:166051f0과 동일 방식, grant 무관 — DM 상대가 프로젝트 grant가
+    없어도 org 소속이면 멘션 가능해야 한다), 에이전트는 org의 team_members(type=agent) 전원
+    (프로젝트 무관, 이 org에서 일하는 모든 에이전트).
     """
+    if project_id is None:
+        result: list[MemberResponse] = []
+        repo = TeamMemberRepository(session, org_id)
+        for row in await repo.list_org_human_members():
+            result.append(MemberResponse(id=row["id"], name=row["name"], type="human", role=row["role"], is_active=True))
+
+        # team_members는 members⋈project_access VIEW(0088)라 project_id로 안 좁히면 grant
+        # 프로젝트 수만큼 같은 에이전트가 중복 행으로 나온다 — repo.list()가 이미 이 축(project_id
+        # 미필터 시 DISTINCT ON team_members.id)을 처리해 두어 그대로 재사용(중복 재발명 금지,
+        # team_members.py org-스코프 분기와 동일 패턴).
+        for agent in await repo.list(type="agent", is_active=True):
+            result.append(MemberResponse.model_validate(agent))
+        return result
+
     # E-SECURITY SEC-S6(story 54248174·까심 QA 부수발견 D): project_id가 caller org 소속인지
     # 대조한 적이 없어 타 org project_id로 그 org 멤버 로스터가 그대로 열거됐다(cross-org IDOR).
     # 존재/타org 둘 다 404(존재 비노출).

--- a/backend/tests/test_3687_members_org_scope_realdb.py
+++ b/backend/tests/test_3687_members_org_scope_realdb.py
@@ -1,0 +1,158 @@
+"""story #3687(3680 클래스, PO CHANGES 2026-09-07) — GET /api/v2/members가 project_id
+없이도(org-level 대화의 @멘션 등) 응답한다.
+
+PO 지적 — 처음 시도(FE를 /api/team-members로 전환)는 회귀였다: /api/v2/members는
+canonical SSOT(휴먼: org_members+project_access grant, 에이전트: team_members
+type=agent — BFF route.ts 주석: "team_members 뷰 기반 /api/v2/team-members와 달리
+grant 휴먼·owner/admin 누락이 없다")라 team-members로 바꾸면 project_id 있는 대화에서도
+grant 휴먼이 사라진다. 정정 — FE는 /api/members 그대로 두고, BE에 project_id 선택
+분기(없으면 org 스코프 — grant 판정 불요)를 additive로 얹는다.
+
+이 테스트의 핵심 양성대조(PO 지정) — team_members 행이 **없는**(project_access 자체가
+없는) org owner 휴먼 1명이 project_id 없이도 응답에 뜬다(team_members 뷰 기반이었다면
+못 뜬다 — 이 표본이 없으면 "team-members로 다시 바꿔도 통과"라 구별이 안 된다). 에이전트도
+1명 이상(다른 프로젝트에 grant된) 응답에 뜬다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_2266_story_backlinks_realdb import (
+    _client_for,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_org_owner_without_team_member_row(session, org_id):
+    """PO 지정 양성대조 표본 — org_members(role=owner)만 있고 members/project_access(=
+    team_members 뷰의 원천)가 전혀 없는 휴먼. team_members 뷰 기반 조회였다면 이 사람은
+    절대 안 뜬다(뷰가 project_access.member_id로 join하는데 애초에 project_access 행이
+    없다) — org_members SSOT 직접 해소(list_org_human_members)만이 이 사람을 잡는다."""
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="owner")
+    session.add(om)
+    await session.commit()
+    return om.id, user.id
+
+
+async def _make_agent_with_project_grant(session, org_id, project_id, name="Agent"):
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    agent = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name=name)
+    session.add(agent)
+    await session.flush()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=agent.id, permission="granted", role="member",
+    ))
+    await session.commit()
+    return agent.id
+
+
+@pytest.mark.anyio
+async def test_no_project_id_returns_org_owner_without_team_member_row_and_agent():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_member_id, owner_user_id = await _make_org_owner_without_team_member_row(s, org.id)
+            agent_id = await _make_agent_with_project_grant(s, org.id, project.id, name="Agent Alpha")
+
+        await _setup_app_human(app, Session, owner_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/members")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        ids = {row["id"] for row in body}
+        # team_members 뷰 기반이었다면 owner_member_id는 여기 없다(project_access 자체가 0건).
+        assert str(owner_member_id) in ids, "team_members 행이 없는 org owner가 org 스코프에서 빠졌다"
+        assert str(agent_id) in ids, "org의 에이전트가 org 스코프에서 빠졌다"
+        owner_row = next(row for row in body if row["id"] == str(owner_member_id))
+        assert owner_row["role"] == "owner"
+        assert owner_row["type"] == "human"
+        agent_row = next(row for row in body if row["id"] == str(agent_id))
+        assert agent_row["type"] == "agent"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_scope_unchanged_grant_human_still_required():
+    """회귀 방지 — project_id **있는** 호출은 여전히 grant 모델 그대로(org owner가 아닌
+    일반 org member는 그 프로젝트에 grant가 없으면 안 뜬다). 이 테스트가 없으면 org-스코프
+    분기 추가가 project-스코프 분기까지 실수로 느슨하게 만들었는지 구별이 안 된다."""
+    from app.main import app
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a = await _make_project(s, org.id, name="A")
+            project_b = await _make_project(s, org.id, name="B")
+            owner_member_id, owner_user_id = await _make_org_owner_without_team_member_row(s, org.id)
+            # project_b에만 grant된 일반 member(비-owner) — project_a 쿼리에는 안 뜨는 게 맞다.
+            user = User(id=uuid.uuid4(), email=f"m-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+            s.add(user)
+            await s.flush()
+            om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="member")
+            s.add(om)
+            await s.commit()
+
+        await _setup_app_human(app, Session, owner_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={project_a.id}")
+            assert resp.status_code == 200, resp.text
+            ids = {row["id"] for row in resp.json()}
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        # owner는 grant 없이도 항상 포함(S-MBR-03) — project 스코프에서도 여전히 성립.
+        assert str(owner_member_id) in ids
+        # project_b에만 grant된 member는 project_a 쿼리에 없다(grant 모델 무회귀).
+        assert str(om.id) not in ids
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_s33.py
+++ b/backend/tests/test_s33.py
@@ -242,12 +242,27 @@ async def test_members_list_200():
 
 
 @pytest.mark.anyio
-async def test_members_missing_project_id_422():
+async def test_members_missing_project_id_returns_org_scope_200():
+    """story #3687(PO CHANGES 2026-09-07) — project_id 없음은 더 이상 422가 아니다.
+    org-level 대화(@멘션 등)는 애초에 project 접근권 개념이 없어 grant 판정 자체가
+    무의미한 별도 분기(org 스코프) — 휴먼=org_members 전원, 에이전트=org의
+    team_members(type=agent) 전원. IDOR 축(다른 org 멤버 0건) 실측 검증은
+    test_3687_members_org_scope_realdb.py(실 PG)가 담당 — 이 파일은 mock 기반이라
+    "project_id 없으면 더 이상 422가 아니라 200"이라는 계약 자체만 고정한다."""
     client, session, app = await _client()
     try:
+        # 휴먼 분기(list_org_human_members) — raw SQL execute()를 직접 순회(row._mapping).
+        human_result = MagicMock()
+        human_result.__iter__ = MagicMock(return_value=iter([]))
+        # 에이전트 분기(repo.list) — select().scalars().all().
+        agent_result = MagicMock()
+        agent_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(side_effect=[human_result, agent_result])
+
         async with client as c:
             resp = await c.get("/api/v2/members")
 
-        assert resp.status_code == 422
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- story #3687(3680 클래스, 3686 그라운딩 신규 finding) — `chat-input.tsx`의 @멘션 자동완성이 `project_id` 없는 대화(org-level DM 등)에서 project 스코프 `/api/members`(`project_id` 필수)를 호출해 매 요청 422 → `.then(r=>r.json())`가 `r.ok` 검사 없이 파싱 → `data` undefined → `?? []`로 멘션 목록이 조용히 0건(#3680과 동일 시그니처).
- **CHANGES(페드루 PO) 반영** — 최초 시도는 FE를 `/api/team-members`로 전환했으나 회귀였다: `/api/members`는 canonical SSOT(grant 휴먼·owner/admin 누락 없음, BFF route.ts 주석)라 team-members(뷰 기반)로 바꾸면 `project_id` 있는 대화에서도 grant 휴먼이 @멘션에서 사라진다. 정정 — **BE `/api/v2/members`에 `project_id` 선택 분기를 추가**(project_id 없으면 org 스코프: grant 판정 불요 — 휴먼=org_members 전원, 에이전트=org의 team_members type=agent 전원)하고 **FE는 `/api/members` 그대로 유지**. `project_id` 있는 기존 분기는 무변경.
- 실패≠0건 — `r.ok` 검사 추가, 실패 시 `mentionLoadFailed` 상태로 드롭다운에 별도 실패 문구 표시.
- AC③ 카운트: apps/web 전체에서 "fetchWithAuth 응답을 `.ok` 검사 없이 바로 `json()`→데이터로 쓰는" 자리 **28곳**(파일 18개) 확인 — 5+ 문턱 넘어 lint 가드 후보로 유효. 이번 PR 스코프는 chat-input.tsx 1건만, 전수 리팩터는 별도 스토리 판단 필요.

## Test plan
- [x] BE `test_3687_members_org_scope_realdb.py` 신규 2 tests: team_members 행이 없는 org owner+에이전트가 org 스코프에서 뜬다(양성대조) / project 스코프는 grant 모델 무회귀 — 라이브 뮤테이션(org-스코프 분기 무력화) → 404 RED 확인 후 복원 → GREEN
- [x] FE `chat-input.mention-org-scope.test.tsx` 신규 3 tests: org 스코프 멤버 ≥1건 / project 스코프 유지(회귀가드) / 422→실패 얼굴 — all pass, 라이브 뮤테이션(`r.ok` 검사 제거) → RED 확인 후 복원 → GREEN
- [x] 기존 `chat-input.*.test.ts(x)` 5개 파일(65 tests)·members 관련 BE 테스트 39건 전부 통과, 회귀 없음
- [x] `i18n-key-coverage`/`i18n-template-key-coverage`/`i18n.test.ts` 통과
- [x] eslint clean, py_compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)