### PR TITLE
[SID:3663] fix: wake_resting_comment_schedules 유니크 충돌 — 쉬는 행 N≥2일 때 결정적 500

### DIFF
--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -97,20 +97,44 @@ async def wake_resting_comment_schedules(db: AsyncSession, *, connection_id: uui
     안 되는 반쪽 처방이 된다 — 연결이 non-active→active로 돌아오는 «모든» 경로
     (재연결 upsert·자격 교체·자동 갱신 성공, `channel_connection.py`의 세 자리)가
     공유하는 단일 깨우는 손이 이 함수다(호출부마다 각자 깨우는 로직을 새로 짜지
-    않는다). due_at=now()로 되돌려 다음 루프 틱이 즉시 다시 집는다."""
+    않는다).
+
+    story #3663(라이브 결함, 배포 51) — 한 publication에는 `_COLLECTION_OFFSETS`별
+    행이 여러 개 있고, 연결이 오래 쉬면 그 행들이 전부 connection_inactive가 된다.
+    예전엔 그 «전부»에 같은 `func.now()`(트랜잭션 타임스탬프 하나)를 줘서, 쉬는
+    행이 2개 이상인 publication에서 (publication_id, due_at) 유니크가 결정적으로
+    깨졌다(재연결 콜백 500). 지금은 행마다 마이크로초씩 벌려 서로 다른 due_at을
+    준다 — 이미 지난(due_at<=now) 행만 그렇게 "지금 이후"로 되돌리고, 아직 미래인
+    행은 원래 due_at을 그대로 둔다(앞당기지 않는다 — 그런 행이 지금 실제로 나오진
+    않지만 방어적으로 유지)."""
     from app.models.channel_publication import ChannelPublication
 
-    result = await db.execute(
-        update(CommentCollectionSchedule)
+    now = datetime.now(timezone.utc)
+    resting = (await db.execute(
+        select(CommentCollectionSchedule.id, CommentCollectionSchedule.due_at)
         .where(
             CommentCollectionSchedule.status == "connection_inactive",
             CommentCollectionSchedule.publication_id.in_(
                 select(ChannelPublication.id).where(ChannelPublication.connection_id == connection_id)
             ),
         )
-        .values(status="pending", due_at=func.now())
-    )
-    return result.rowcount
+        .order_by(CommentCollectionSchedule.publication_id, CommentCollectionSchedule.due_at)
+        .with_for_update()
+    )).all()
+
+    wake_offset = 0
+    for row_id, due_at in resting:
+        if due_at is not None and due_at > now:
+            new_due_at = due_at
+        else:
+            new_due_at = now + timedelta(microseconds=wake_offset)
+            wake_offset += 1
+        await db.execute(
+            update(CommentCollectionSchedule)
+            .where(CommentCollectionSchedule.id == row_id)
+            .values(status="pending", due_at=new_due_at)
+        )
+    return len(resting)
 
 
 def _text_sha256(text: str) -> str:

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -105,13 +105,23 @@ async def wake_resting_comment_schedules(db: AsyncSession, *, connection_id: uui
     행이 2개 이상인 publication에서 (publication_id, due_at) 유니크가 결정적으로
     깨졌다(재연결 콜백 500). 지금은 행마다 마이크로초씩 벌려 서로 다른 due_at을
     준다 — 이미 지난(due_at<=now) 행만 그렇게 "지금 이후"로 되돌리고, 아직 미래인
-    행은 원래 due_at을 그대로 둔다(앞당기지 않는다 — 그런 행이 지금 실제로 나오진
-    않지만 방어적으로 유지)."""
+    행은 원래 due_at을 그대로 둔다(앞당기지 않는다).
+
+    CHANGES(카디르 QA real PG 재현, PO 페드루 처방 2026-09-08) — 마이크로초
+    오프셋이 "새로 배정하는 값들끼리만" 겹치지 않게 했을 뿐, «보존하기로 정한»
+    미래 due_at과는 대조를 안 해 정확히 같은 마이크로초에서 재충돌할 수 있었다
+    (도달가능성은 낮지만 이 함수 자신의 유니크 계약을 반례로 깨는 결함). 이제
+    같은 publication의 보존 예정 due_at 집합을 먼저 걷고, 새 값 후보가 그 집합과
+    겹치면 다음 마이크로초로 건너뛴다(publication별로 독립 — 유니크 제약 자체가
+    publication_id 단위)."""
     from app.models.channel_publication import ChannelPublication
 
     now = datetime.now(timezone.utc)
     resting = (await db.execute(
-        select(CommentCollectionSchedule.id, CommentCollectionSchedule.due_at)
+        select(
+            CommentCollectionSchedule.id, CommentCollectionSchedule.publication_id,
+            CommentCollectionSchedule.due_at,
+        )
         .where(
             CommentCollectionSchedule.status == "connection_inactive",
             CommentCollectionSchedule.publication_id.in_(
@@ -122,13 +132,23 @@ async def wake_resting_comment_schedules(db: AsyncSession, *, connection_id: uui
         .with_for_update()
     )).all()
 
-    wake_offset = 0
-    for row_id, due_at in resting:
+    preserved_due_ats_by_pub: dict[uuid.UUID, set[datetime]] = {}
+    for _row_id, publication_id, due_at in resting:
+        if due_at is not None and due_at > now:
+            preserved_due_ats_by_pub.setdefault(publication_id, set()).add(due_at)
+
+    wake_offset_by_pub: dict[uuid.UUID, int] = {}
+    for row_id, publication_id, due_at in resting:
         if due_at is not None and due_at > now:
             new_due_at = due_at
         else:
-            new_due_at = now + timedelta(microseconds=wake_offset)
-            wake_offset += 1
+            preserved = preserved_due_ats_by_pub.get(publication_id, set())
+            offset = wake_offset_by_pub.get(publication_id, 0)
+            new_due_at = now + timedelta(microseconds=offset)
+            while new_due_at in preserved:
+                offset += 1
+                new_due_at = now + timedelta(microseconds=offset)
+            wake_offset_by_pub[publication_id] = offset + 1
         await db.execute(
             update(CommentCollectionSchedule)
             .where(CommentCollectionSchedule.id == row_id)

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -107,13 +107,14 @@ async def wake_resting_comment_schedules(db: AsyncSession, *, connection_id: uui
     준다 — 이미 지난(due_at<=now) 행만 그렇게 "지금 이후"로 되돌리고, 아직 미래인
     행은 원래 due_at을 그대로 둔다(앞당기지 않는다).
 
-    CHANGES(카디르 QA real PG 재현, PO 페드루 처방 2026-09-08) — 마이크로초
-    오프셋이 "새로 배정하는 값들끼리만" 겹치지 않게 했을 뿐, «보존하기로 정한»
-    미래 due_at과는 대조를 안 해 정확히 같은 마이크로초에서 재충돌할 수 있었다
-    (도달가능성은 낮지만 이 함수 자신의 유니크 계약을 반례로 깨는 결함). 이제
-    같은 publication의 보존 예정 due_at 집합을 먼저 걷고, 새 값 후보가 그 집합과
-    겹치면 다음 마이크로초로 건너뛴다(publication별로 독립 — 유니크 제약 자체가
-    publication_id 단위)."""
+    CHANGES(카디르 QA real PG 재현, PO 페드루 처방 2026-09-08, 2·3차) — 마이크로초
+    오프셋이 "새로 배정하는 값들끼리만"·"이번에 깨우는 배치의 보존 미래 행만"과는
+    안 겹치게 했지만, `uq_comment_collection_schedule_publication_due_at`는
+    **status 무관 테이블 전체**에 걸린 제약이다 — 같은 publication의 다른 상태
+    (pending·in_progress·captured 등) 행이 이미 쥔 due_at은 이 함수 시야 밖이라
+    새로 배정한 값이 그것과도 충돌할 수 있었다(부분집합 3형: 새-새·새-보존미래·
+    새-타상태). 근본 처방 — 새 due_at을 정할 때 회피집합을 그 publication의
+    «상태 무관 기존 due_at 전체»로 넓힌다."""
     from app.models.channel_publication import ChannelPublication
 
     now = datetime.now(timezone.utc)
@@ -131,21 +132,26 @@ async def wake_resting_comment_schedules(db: AsyncSession, *, connection_id: uui
         .order_by(CommentCollectionSchedule.publication_id, CommentCollectionSchedule.due_at)
         .with_for_update()
     )).all()
+    if not resting:
+        return 0
 
-    preserved_due_ats_by_pub: dict[uuid.UUID, set[datetime]] = {}
-    for _row_id, publication_id, due_at in resting:
-        if due_at is not None and due_at > now:
-            preserved_due_ats_by_pub.setdefault(publication_id, set()).add(due_at)
+    publication_ids = {publication_id for _row_id, publication_id, _due_at in resting}
+    occupied_by_pub: dict[uuid.UUID, set[datetime]] = {}
+    for publication_id, due_at in (await db.execute(
+        select(CommentCollectionSchedule.publication_id, CommentCollectionSchedule.due_at)
+        .where(CommentCollectionSchedule.publication_id.in_(publication_ids))
+    )).all():
+        occupied_by_pub.setdefault(publication_id, set()).add(due_at)
 
     wake_offset_by_pub: dict[uuid.UUID, int] = {}
     for row_id, publication_id, due_at in resting:
         if due_at is not None and due_at > now:
             new_due_at = due_at
         else:
-            preserved = preserved_due_ats_by_pub.get(publication_id, set())
+            occupied = occupied_by_pub.get(publication_id, set())
             offset = wake_offset_by_pub.get(publication_id, 0)
             new_due_at = now + timedelta(microseconds=offset)
-            while new_due_at in preserved:
+            while new_due_at in occupied:
                 offset += 1
                 new_due_at = now + timedelta(microseconds=offset)
             wake_offset_by_pub[publication_id] = offset + 1

--- a/backend/tests/test_3663_wake_resting_schedule_unique_collision.py
+++ b/backend/tests/test_3663_wake_resting_schedule_unique_collision.py
@@ -1,0 +1,236 @@
+"""story #3663(Phase2·마케팅운영·라이브 결함·dev 배포 51) — `wake_resting_comment_
+schedules`(story #3612의 「깨우는 손」)가 한 publication의 쉬는(connection_inactive)
+행 «전부»에 같은 `func.now()`를 줘서 (publication_id, due_at) 유니크를 결정적으로
+깼다(facebook_sandbox 「다시 연결」 콜백 500·error_id 08f867ac). `_COLLECTION_OFFSETS`
+(+1h·+1d·+7d)별로 행이 여러 개인 publication이 오래 쉬면 재현 100%.
+
+세팅 헬퍼는 test_3612_connection_notactive_precheck_norecord.py·
+test_3547_facebook_page_connection.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import sqlalchemy
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+from tests.test_3497_insight_snapshots import _seed_channel_connection, _seed_channel_publication
+from tests.test_3373_channel_connections_auth import _seed_human, _client_for, _setup_org_scoped_app
+from tests.test_3547_facebook_page_connection import _register_facebook_sandbox_app_credentials
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+    monkeypatch.setattr(config_module.settings, "channel_oauth_state_secret", "test-channel-oauth-state-secret")
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _seed_resting_row(session, *, org_id, publication_id, channel, external_id, due_at):
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    row = CommentCollectionSchedule(
+        id=uuid.uuid4(), org_id=org_id, publication_id=publication_id, channel=channel,
+        external_id=external_id, due_at=due_at, status="connection_inactive",
+        error_code="CHANNEL_CONNECTION_NOT_ACTIVE",
+    )
+    session.add(row)
+    await session.commit()
+    return row
+
+
+@pytest.mark.anyio
+async def test_ac1_wakes_n2_resting_rows_without_unique_violation():
+    """AC1 — 한 publication에 `_COLLECTION_OFFSETS` 3개 오프셋 행이 전부
+    connection_inactive로 seed됐을 때(라이브 재현), wake는 예외 0·3행 모두
+    pending·due_at 서로 다름을 낸다(예전엔 UniqueViolationError)."""
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.services.channel_post_comments import wake_resting_comment_schedules
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook_sandbox", status="expired")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook_sandbox", external_id="media-1",
+            )
+            anchor = datetime.now(timezone.utc) - timedelta(days=10)
+            for offset in (timedelta(hours=1), timedelta(days=1), timedelta(days=7)):
+                await _seed_resting_row(
+                    s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                    external_id="media-1", due_at=anchor + offset,
+                )
+
+            woken = await wake_resting_comment_schedules(s, connection_id=conn.id)
+            await s.commit()
+            assert woken == 3
+
+            rows = (await s.execute(
+                sqlalchemy.select(CommentCollectionSchedule).where(
+                    CommentCollectionSchedule.publication_id == pub.id,
+                ).order_by(CommentCollectionSchedule.due_at.asc())
+            )).scalars().all()
+            assert len(rows) == 3
+            assert all(r.status == "pending" for r in rows)
+            due_ats = [r.due_at for r in rows]
+            assert len(set(due_ats)) == 3, "due_at이 서로 달라야 유니크 충돌이 없다"
+            now = datetime.now(timezone.utc)
+            assert all(d <= now + timedelta(seconds=5) for d in due_ats), "지난 행은 지금 이후로 되돌아온다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac2_future_due_at_not_pulled_forward():
+    """AC2 — 아직 미래인 due_at을 가진 connection_inactive 행은 앞당기지 않는다
+    (원 due_at 유지). 이미 지난 행만 새 시각을 받는다."""
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    from app.services.channel_post_comments import wake_resting_comment_schedules
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook_sandbox", status="expired")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook_sandbox", external_id="media-1",
+            )
+            past_due_at = datetime.now(timezone.utc) - timedelta(hours=2)
+            future_due_at = datetime.now(timezone.utc) + timedelta(days=3)
+            past_row = await _seed_resting_row(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                external_id="media-1", due_at=past_due_at,
+            )
+            future_row = await _seed_resting_row(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                external_id="media-1", due_at=future_due_at,
+            )
+
+            woken = await wake_resting_comment_schedules(s, connection_id=conn.id)
+            await s.commit()
+            assert woken == 2
+
+            refreshed_past = await s.get(CommentCollectionSchedule, past_row.id)
+            refreshed_future = await s.get(CommentCollectionSchedule, future_row.id)
+            assert refreshed_past.status == "pending"
+            assert refreshed_past.due_at <= datetime.now(timezone.utc)
+            assert refreshed_future.status == "pending"
+            assert refreshed_future.due_at == future_due_at, "미래 due_at은 앞당기면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac3_reconnect_callback_with_and_without_target_connection_id_returns_200():
+    """AC3 — facebook_sandbox 재연결 콜백이 target_connection_id 有/無 두 경로
+    모두 200을 낸다(회귀 전엔 쉬는 행 N≥2인 publication에서 결정적 500).
+    facebook_sandbox_oauth.py는 실 HTTP 없이 인프로세스 결정적으로 답한다
+    (test_3547 상단 딱지와 동형 — 목 없이 진짜 authorize→callback 라우터를 태운다)."""
+    from app.main import app
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            # app_id 접미 ":pages-1" — facebook_sandbox_oauth.list_pages가 「Sandbox Page 1」
+            # 단일 후보만 돌려주는 갈래(2+개면 pending_selection이라 wake 경로를 안 탄다).
+            await _register_facebook_sandbox_app_credentials(
+                s, org_id=org_id, updated_by=owner_id, app_id="sandbox-app-id:pages-1",
+            )
+            # account_id를 list_pages의 고정 page_id와 맞춰야 upsert가 이 행을 그대로
+            # 갱신(재연결)한다 — 다른 account_id면 새 행이 생겨 wake 대상이 안 된다.
+            conn = ChannelConnection(
+                id=uuid.uuid4(), org_id=org_id, channel="facebook_sandbox", account_id="sandbox-page-1",
+                status="expired", credential_kind="oauth", refresh_mode="reissue_from_access_token",
+                encrypted_access_token=encrypt_channel_credential("plain-token"),
+            )
+            s.add(conn)
+            await s.commit()
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook_sandbox", external_id="media-1",
+            )
+            anchor = datetime.now(timezone.utc) - timedelta(days=10)
+            for offset in (timedelta(hours=1), timedelta(days=1), timedelta(days=7)):
+                await _seed_resting_row(
+                    s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                    external_id="media-1", due_at=anchor + offset,
+                )
+            connection_id = conn.id
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        # 경로 ① target_connection_id 有(재연결 의도) — 위에서 쉬게 seed한 연결을 지목.
+        async with _client_for(app) as client:
+            r_auth = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook_sandbox/authorize",
+                json={"target_connection_id": str(connection_id)},
+            )
+        assert r_auth.status_code == 200, r_auth.text
+        state = r_auth.json()["state"]
+        async with _client_for(app) as client:
+            r_cb = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook_sandbox/callback",
+                json={"code": "auth-code", "state": state},
+            )
+        assert r_cb.status_code == 200, r_cb.text
+
+        async with Session() as s:
+            rows = (await s.execute(
+                sqlalchemy.select(CommentCollectionSchedule).where(
+                    CommentCollectionSchedule.publication_id == pub.id,
+                )
+            )).scalars().all()
+            assert len(rows) == 3
+            assert all(r.status == "pending" for r in rows), "재연결 뒤 쉬던 행은 전부 pending으로 돌아온다"
+
+        # 경로 ② target_connection_id 無(신규/일반 authorize) — 같은 계정으로 다시
+        # upsert되며 같은 publication의 스케줄이 (이미 pending이라) 재차 무해해야 한다.
+        async with _client_for(app) as client:
+            r_auth2 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook_sandbox/authorize",
+            )
+        assert r_auth2.status_code == 200, r_auth2.text
+        state2 = r_auth2.json()["state"]
+        async with _client_for(app) as client:
+            r_cb2 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/facebook_sandbox/callback",
+                json={"code": "auth-code", "state": state2},
+            )
+        assert r_cb2.status_code == 200, r_cb2.text
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3663_wake_resting_schedule_unique_collision.py
+++ b/backend/tests/test_3663_wake_resting_schedule_unique_collision.py
@@ -69,6 +69,18 @@ async def _seed_resting_row(session, *, org_id, publication_id, channel, externa
     return row
 
 
+async def _seed_row_with_status(session, *, org_id, publication_id, channel, external_id, due_at, status):
+    from app.models.channel_post_comment import CommentCollectionSchedule
+
+    row = CommentCollectionSchedule(
+        id=uuid.uuid4(), org_id=org_id, publication_id=publication_id, channel=channel,
+        external_id=external_id, due_at=due_at, status=status,
+    )
+    session.add(row)
+    await session.commit()
+    return row
+
+
 @pytest.mark.anyio
 async def test_ac1_wakes_n2_resting_rows_without_unique_violation():
     """AC1 — 한 publication에 `_COLLECTION_OFFSETS` 3개 오프셋 행이 전부
@@ -170,6 +182,59 @@ async def test_new_offset_avoids_collision_with_preserved_future_due_at(monkeypa
             due_ats = [r.due_at for r in rows]
             assert len(set(due_ats)) == 3, "새로 배정된 값이 보존된 미래 값과 겹치면 안 된다"
             assert {row.id for row in (past_row_a, past_row_b, future_row)} == {r.id for r in rows}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_new_offset_avoids_collision_with_other_status_row_same_publication(monkeypatch):
+    """CHANGES(3차, 카디르 QA real PG 재현, PO 페드루 처방 2026-09-08) —
+    `uq_comment_collection_schedule_publication_due_at`는 status 무관 테이블
+    전체에 걸린다. 2차 처방(회피집합=이번 배치의 보존 미래 행)은 같은
+    publication의 «다른 상태»(pending 등) 행이 이미 쥔 due_at은 못 본다 — 그
+    행이 정확히 새로 배정될 첫 후보(now+0µs)를 쥐고 있으면 여전히 충돌한다."""
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    import app.services.channel_post_comments as channel_post_comments_module
+    from app.services.channel_post_comments import wake_resting_comment_schedules
+
+    fixed_now = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # noqa: ANN001
+            return fixed_now
+
+    monkeypatch.setattr(channel_post_comments_module, "datetime", _FixedDatetime)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook_sandbox", status="expired")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook_sandbox", external_id="media-1",
+            )
+            # 다른 상태(pending) 행이 정확히 새 배정 후보(now+0µs)를 이미 쥐고 있다
+            # — 이 publication의 다른 발행 오프셋 행(예: +7d)이 아직 안 쉬고 있는
+            # 정상적인 상황을 흉내(3663 시나리오의 흔한 실물 배열).
+            pending_row = await _seed_row_with_status(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                external_id="media-1", due_at=fixed_now, status="pending",
+            )
+            resting_row = await _seed_resting_row(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                external_id="media-1", due_at=fixed_now - timedelta(hours=1),
+            )
+
+            woken = await wake_resting_comment_schedules(s, connection_id=conn.id)
+            await s.commit()  # 옛(2·3차) 코드였다면 이 commit이 IntegrityError를 냈다.
+            assert woken == 1
+
+            refreshed_pending = await s.get(CommentCollectionSchedule, pending_row.id)
+            refreshed_resting = await s.get(CommentCollectionSchedule, resting_row.id)
+            assert refreshed_pending.due_at == fixed_now, "다른 상태 행의 기존 due_at은 건드리지 않는다"
+            assert refreshed_resting.status == "pending"
+            assert refreshed_resting.due_at != refreshed_pending.due_at, "새 값이 다른 상태 행의 due_at과 겹치면 안 된다"
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_3663_wake_resting_schedule_unique_collision.py
+++ b/backend/tests/test_3663_wake_resting_schedule_unique_collision.py
@@ -112,6 +112,69 @@ async def test_ac1_wakes_n2_resting_rows_without_unique_violation():
 
 
 @pytest.mark.anyio
+async def test_new_offset_avoids_collision_with_preserved_future_due_at(monkeypatch):
+    """CHANGES(카디르 QA real PG 재현, PO 페드루 처방 2026-09-08) — 마이크로초
+    오프셋이 "새로 배정하는 값들끼리만" 겹치지 않던 결함의 정확한 반례: 같은
+    publication에 과거 행 2개(now-2s·now-1s)와 보존될 미래 행 1개(now+1µs)가
+    있으면, 옛 코드는 두 번째 과거 행에 정확히 now+1µs를 줘 보존 행과 충돌했다
+    (real PG UniqueViolationError). now를 고정해 이 정확한 배열을 재현한다."""
+    from app.models.channel_post_comment import CommentCollectionSchedule
+    import app.services.channel_post_comments as channel_post_comments_module
+    from app.services.channel_post_comments import wake_resting_comment_schedules
+
+    fixed_now = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # noqa: ANN001 — datetime.now 시그니처 그대로.
+            return fixed_now
+
+    monkeypatch.setattr(channel_post_comments_module, "datetime", _FixedDatetime)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="facebook_sandbox", status="expired")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="facebook_sandbox", external_id="media-1",
+            )
+            past_row_a = await _seed_resting_row(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                external_id="media-1", due_at=fixed_now - timedelta(seconds=2),
+            )
+            past_row_b = await _seed_resting_row(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                external_id="media-1", due_at=fixed_now - timedelta(seconds=1),
+            )
+            preserved_future_due_at = fixed_now + timedelta(microseconds=1)
+            future_row = await _seed_resting_row(
+                s, org_id=org_id, publication_id=pub.id, channel="facebook_sandbox",
+                external_id="media-1", due_at=preserved_future_due_at,
+            )
+
+            woken = await wake_resting_comment_schedules(s, connection_id=conn.id)
+            await s.commit()  # 옛 코드였다면 이 commit이 IntegrityError를 냈다.
+            assert woken == 3
+
+            refreshed_future = await s.get(CommentCollectionSchedule, future_row.id)
+            assert refreshed_future.due_at == preserved_future_due_at, "보존 예정 미래 행은 앞당기지 않는다"
+
+            rows = (await s.execute(
+                sqlalchemy.select(CommentCollectionSchedule).where(
+                    CommentCollectionSchedule.publication_id == pub.id,
+                )
+            )).scalars().all()
+            assert len(rows) == 3
+            assert all(r.status == "pending" for r in rows)
+            due_ats = [r.due_at for r in rows]
+            assert len(set(due_ats)) == 3, "새로 배정된 값이 보존된 미래 값과 겹치면 안 된다"
+            assert {row.id for row in (past_row_a, past_row_b, future_row)} == {r.id for r in rows}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_ac2_future_due_at_not_pulled_forward():
     """AC2 — 아직 미래인 due_at을 가진 connection_inactive 행은 앞당기지 않는다
     (원 due_at 유지). 이미 지난 행만 새 시각을 받는다."""

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1527,6 +1527,11 @@
       "file": "tests/test_3679_hook_key_read_round_trip.py",
       "sec": 20.0,
       "source": "story-3679-hook-key-read-round-trip(PR 개설 前 선제 등재 — 로컬 raw pytest 3건 3.33s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 20s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3663_wake_resting_schedule_unique_collision.py",
+      "sec": 21.0,
+      "source": "story-3663-wake-resting-schedule-unique-collision(PR #4037 CHANGES 처방 — 페드루 PO 追加 2026-09-08, 신규 destructive_schema 테스트 미등재로 Backend pytest+전용 guard FAIL. 로컬 raw pytest 3건 3.45s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 21s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 원인(story #3663 본문 · PO Cloud Logging 실측 2026-09-08 01:21Z)

dev backend 2026-09-07T21:27:31Z · error_id `08f867ac-3bc1-4c61-9974-af30c120707a`

```
POST /api/v2/organizations/db474a4e-7427-4f25-a37e-697088913fad/channel-connections/facebook_sandbox/callback
asyncpg.exceptions.UniqueViolationError: duplicate key value violates unique constraint "uq_comment_collection_schedule_publication_due_at"
DETAIL: Key (publication_id, due_at)=(c547fa6d-6023-4591-9c88-b2ab25c445cf, 2026-09-07 21:27:31.661603+00) already exists.
```

실행 SQL: `UPDATE channel_post_comment_collection_schedule SET due_at=now(), status='pending' WHERE status='connection_inactive' AND publication_id IN (...)` = `wake_resting_comment_schedules`(story #3612의 「깨우는 손」).

한 publication에는 `_COLLECTION_OFFSETS`(+1h/+1d/+7d)별 스케줄 행이 여러 개이고, 연결이 오래 쉬면 그 행들이 전부 `connection_inactive`가 된다. 예전 코드는 그 «전부»에 같은 `func.now()`(트랜잭션 타임스탬프 하나)를 줘서, 쉬는 행이 2개 이상인 publication에서 `(publication_id, due_at)` 유니크가 결정적으로 깨졌다. 재연결 upsert·자격 교체·자동 갱신 성공 세 경로가 이 함수를 공유하므로 셋 다 같은 결함.

로컬 재현 4조합이 전부 200이었던 이유 = 쉬는 행을 publication당 1개만 seed했기 때문(실물은 2개 이상).

## 처방

`wake_resting_comment_schedules` — 대상 행을 개별 조회해 마이크로초씩 벌린 서로 다른 `due_at`을 부여한다. 이미 지난(`due_at<=now`) 행만 "지금 이후"로 되돌리고, 아직 미래인 행은 원 `due_at`을 유지(앞당기지 않음).

## 테스트

`backend/tests/test_3663_wake_resting_schedule_unique_collision.py` 신설(AC1~3):
- `test_ac1_wakes_n2_resting_rows_without_unique_violation` — 오프셋 3행 connection_inactive seed → wake → 예외 0·3행 pending·due_at 전부 다름. **수정 전 코드로 실행 시 위 UniqueViolationError 그대로 재현 확인(회귀 증명)**.
- `test_ac2_future_due_at_not_pulled_forward` — 미래 due_at 행은 앞당기지 않음, 지난 행만 갱신.
- `test_ac3_reconnect_callback_with_and_without_target_connection_id_returns_200` — facebook_sandbox 재연결 콜백 두 경로(target_connection_id 有/無) 모두 200.

기존 회귀 무결 확인: `test_3612_connection_notactive_precheck_norecord.py`(7건)·`test_3547_facebook_page_connection.py`(18건) 전체 재실행 그린.

로컬 실행(throwaway Postgres, `ALEMBIC_DATABASE_URL`/`PARITY_TEST_DATABASE_URL`):
```
28 passed
```

## 잔여

라이브 AC(PO 실측, dev 배포 뒤): PO Test Org FB Sandbox Page 1(641adabf) 「다시 연결」 → active·connect_error 0·쉬던 스케줄 pending 복귀. 해소되면 카디르 3640 ③ 양성대조·3567 런북 재개.