### PR TITLE
[SID:3689] fix(FE): abandoned 배지 색 warning으로 분리 — 상태 카탈로그 한 자리

### DIFF
--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -13,6 +13,7 @@ import { canManuallyRetryRun, getRunErrorDisplay, getRunFailureDisposition, getT
 import { fetchWithAuth } from '@/lib/db/client';
 import { formatRelativeTime } from '@/lib/storage/format';
 import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
+import { agentRunStatusBadgeVariant, type AgentRunStatus } from '@/lib/agent-run-status';
 
 interface ToolCallEntry {
   type?: string;
@@ -90,10 +91,7 @@ interface RunDetail {
   model: string | null;
   llm_provider: 'managed' | 'byom' | null;
   llm_provider_key: string | null;
-  // story #3680 — 'abandoned'(agent_runs_status_check DB CHECK 7값 중 하나, alembic
-  // 0207) 추가. agent-runs-list.tsx AgentRun.status와 동형(그 파일과 동시 수정 —
-  // 목록에서 이 상태로 진입했을 때 상세도 낱말·배지가 있어야 한다).
-  status: 'queued' | 'held' | 'running' | 'hitl_pending' | 'completed' | 'failed' | 'abandoned';
+  status: AgentRunStatus;
   duration_ms: number | null;
   llm_call_count: number;
   input_tokens: number | null;
@@ -117,17 +115,6 @@ interface RunDetail {
   finished_at: string | null;
   created_at: string;
 }
-
-const STATUS_BADGE_VARIANT: Record<string, 'success' | 'destructive' | 'info' | 'outline' | 'secondary'> = {
-  completed: 'success',
-  hitl_pending: 'secondary',
-  failed: 'destructive',
-  running: 'info',
-  queued: 'outline',
-  held: 'secondary',
-  // story #3680 — failed와 동형 색(둘 다 "정상 종료가 아닌 종단" 사실).
-  abandoned: 'destructive',
-};
 
 function formatDuration(ms: number | null): string {
   if (ms == null) return '-';
@@ -313,7 +300,7 @@ export function AgentRunDetail({
         <SectionCard>
           <SectionCardHeader>
             <div className="flex flex-wrap items-center gap-3">
-              <Badge variant={STATUS_BADGE_VARIANT[run.status] ?? 'outline'}>
+              <Badge variant={agentRunStatusBadgeVariant(run.status)}>
                 {t(`status_${run.status}`)}
               </Badge>
               <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/agents/agent-run-status-wiring.test.tsx
+++ b/apps/web/src/components/agents/agent-run-status-wiring.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// story #3689(3680 후속) — agent-runs-list.tsx·agent-run-detail.tsx가 각자 status→
+// variant 맵을 들고 있던 것을 apps/web/src/lib/agent-run-status.ts 카탈로그 한 자리로
+// 합쳤다. 이 테스트는 "두 화면이 실제로 그 카탈로그를 읽는지"를 증명한다(뮤테이션
+// 대용) — 카탈로그 모듈을 몽키패치해 abandoned 변이를 실측값(warning)과 다른 값
+// (info)으로 바꾸면, list·detail 둘 다 그 새 값을 그대로 반영해야 한다. 반영이 안
+// 되면 어느 화면이 여전히 자기 맵을 하드코딩하고 있다는 뜻.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { TopBarProvider } from '@/components/nav/top-bar-context';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+// 실 카탈로그 대신 abandoned=info로 몽키패치(실측 warning과 다른 값 — 두 화면이
+// 이 값을 그대로 보이면 카탈로그를 실제로 참조한다는 뜻).
+vi.mock('@/lib/agent-run-status', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/agent-run-status')>('@/lib/agent-run-status');
+  return {
+    ...actual,
+    agentRunStatusBadgeVariant: (status: string) => (status === 'abandoned' ? 'info' : actual.agentRunStatusBadgeVariant(status)),
+  };
+});
+
+import { AgentRunsList } from './agent-runs-list';
+import { AgentRunDetail } from './agent-run-detail';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <TopBarProvider>{node}</TopBarProvider>
+    </NextIntlClientProvider>
+  );
+}
+
+const PROJECT_ID = 'proj-1';
+
+beforeEach(() => {
+  useDashboardContextMock.mockReturnValue({ projectId: PROJECT_ID });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const ABANDONED_RUN_ROW = {
+  id: 'run-abandoned-1', agent_id: 'agent-1', agent_name: '테스트 에이전트', deployment_id: null,
+  session_id: null, memo_id: null, story_id: null, trigger: 'manual', model: null,
+  llm_provider: null, llm_provider_key: null, status: 'abandoned', duration_ms: 1000,
+  llm_call_count: 1, input_tokens: null, output_tokens: null, cost_usd: null,
+  computed_cost_cents: 0, per_run_cap_cents: null, billing_notes: [],
+  result_summary: null, error_message: null, last_error_code: null,
+  retry_count: null, max_retries: null, next_retry_at: null, failure_disposition: null,
+  started_at: null, finished_at: null, created_at: '2026-09-08T00:00:00Z',
+};
+
+describe('agent-run-status 카탈로그 배선(story #3689) — list·detail 공유 확인', () => {
+  it('AgentRunsList가 카탈로그의 abandoned 변이를 그대로 배지 클래스에 반영한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, json: async () => ({ data: [ABANDONED_RUN_ROW], meta: null }),
+    })));
+    await act(async () => { root.render(wrap(<AgentRunsList />)); });
+    await flush();
+
+    const badge = [...container.querySelectorAll('span, div')].find((el) => el.textContent === koMessages.agentRuns.status_abandoned);
+    expect(badge).toBeDefined();
+    expect(badge?.className).toContain('bg-info-tint');
+    expect(badge?.className).not.toContain('bg-warning-tint');
+  });
+
+  it('AgentRunDetail이 카탈로그의 abandoned 변이를 그대로 배지 클래스에 반영한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, json: async () => ({ data: ABANDONED_RUN_ROW }),
+    })));
+    await act(async () => {
+      root.render(wrap(<AgentRunDetail runId="run-abandoned-1" locale="ko" onBack={() => {}} />));
+    });
+    await flush();
+
+    const badge = [...container.querySelectorAll('span, div')].find((el) => el.textContent === koMessages.agentRuns.status_abandoned);
+    expect(badge).toBeDefined();
+    expect(badge?.className).toContain('bg-info-tint');
+    expect(badge?.className).not.toContain('bg-warning-tint');
+  });
+});

--- a/apps/web/src/components/agents/agent-runs-list.tsx
+++ b/apps/web/src/components/agents/agent-runs-list.tsx
@@ -22,6 +22,11 @@ import {
 } from '@/services/agent-run-history';
 import { AgentRunDetail } from './agent-run-detail';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import {
+  AGENT_RUN_STATUS_ORDER,
+  agentRunStatusBadgeVariant,
+  type AgentRunStatus,
+} from '@/lib/agent-run-status';
 
 import { fetchWithAuth } from '@/lib/db/client';
 import { formatRelativeTime } from '@/lib/storage/format';
@@ -39,10 +44,7 @@ interface AgentRun {
   model: string | null;
   llm_provider: 'managed' | 'byom' | null;
   llm_provider_key: string | null;
-  // story #3680 — 'abandoned'(agent_runs_status_check DB CHECK 7값 중 하나, alembic
-  // 0207) 추가. 이 목록에서 그 값을 status 필터로 고를 길·배지·낱말이 지금껏 없어(그
-  // 자체가 별개 사각) AC2(abandoned run 표본 도달)가 이 파일 안 수정 없이는 못 닫힌다.
-  status: 'queued' | 'held' | 'running' | 'hitl_pending' | 'completed' | 'failed' | 'abandoned';
+  status: AgentRunStatus;
   duration_ms: number | null;
   llm_call_count: number;
   input_tokens: number | null;
@@ -63,19 +65,7 @@ interface AgentRun {
   created_at: string;
 }
 
-const STATUS_FILTERS = [ALL_RUN_STATUS_FILTER, 'completed', 'hitl_pending', 'failed', 'running', 'queued', 'held', 'abandoned'] as const;
-
-const STATUS_BADGE_VARIANT: Record<string, 'success' | 'destructive' | 'info' | 'outline' | 'secondary'> = {
-  completed: 'success',
-  hitl_pending: 'secondary',
-  failed: 'destructive',
-  running: 'info',
-  queued: 'outline',
-  held: 'secondary',
-  // story #3680 — failed와 동형 색(둘 다 "정상 종료가 아닌 종단" 사실). 별개 배지 색을
-  // 새로 발명하지 않는다.
-  abandoned: 'destructive',
-};
+const STATUS_FILTERS = [ALL_RUN_STATUS_FILTER, ...AGENT_RUN_STATUS_ORDER] as const;
 
 function formatDuration(ms: number | null): string {
   if (ms == null) return '-';
@@ -293,7 +283,7 @@ export function AgentRunsList() {
                         <h3 className="text-sm font-semibold text-foreground">
                           {run.agent_name ?? t('unknownAgent')}
                         </h3>
-                        <Badge variant={STATUS_BADGE_VARIANT[run.status] ?? 'outline'}>
+                        <Badge variant={agentRunStatusBadgeVariant(run.status)}>
                           {t(`status_${run.status}`)}
                         </Badge>
                         {run.model && <Badge variant="chip">{run.model}</Badge>}

--- a/apps/web/src/lib/agent-run-status.test.ts
+++ b/apps/web/src/lib/agent-run-status.test.ts
@@ -22,4 +22,15 @@ describe('agent-run-status 카탈로그', () => {
   it('모르는 status 문자열은 outline으로 폴백한다', () => {
     expect(agentRunStatusBadgeVariant('never-seen-status')).toBe('outline');
   });
+
+  // CHANGES(카디르 QA 실결함, PO 페드루 처방 2026-09-08) — plain object 인덱싱 뒤
+  // `??`만으로는 own-property가 아닌 Object.prototype 체인 키에서 값이 샌다
+  // (constructor·toString·__proto__는 전부 undefined가 아니라서 `??`가 안 걸린다).
+  // Object.hasOwn 가드로 이 셋 모두 outline이어야 한다.
+  it.each(['constructor', 'toString', 'hasOwnProperty', '__proto__', 'valueOf'])(
+    'Object.prototype 체인 키 "%s"는 outline으로 폴백한다(카디르 재현)',
+    (protoKey) => {
+      expect(agentRunStatusBadgeVariant(protoKey)).toBe('outline');
+    },
+  );
 });

--- a/apps/web/src/lib/agent-run-status.test.ts
+++ b/apps/web/src/lib/agent-run-status.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_RUN_STATUS_BADGE_VARIANT, AGENT_RUN_STATUS_ORDER, agentRunStatusBadgeVariant } from './agent-run-status';
+
+// story #3689(3680 후속, 유나 確定) — abandoned(「미완」)은 failed(「실패」)와 다른
+// 사실이라 다른 색이어야 한다. 폴백(모르는 상태=outline)과도 겹치면 안 된다.
+describe('agent-run-status 카탈로그', () => {
+  it('abandoned 변이는 failed와 다르다(warning≠destructive)', () => {
+    expect(AGENT_RUN_STATUS_BADGE_VARIANT.abandoned).toBe('warning');
+    expect(AGENT_RUN_STATUS_BADGE_VARIANT.abandoned).not.toBe(AGENT_RUN_STATUS_BADGE_VARIANT.failed);
+  });
+
+  it('abandoned 변이는 폴백(outline)과도 다르다', () => {
+    expect(AGENT_RUN_STATUS_BADGE_VARIANT.abandoned).not.toBe('outline');
+  });
+
+  it('agentRunStatusBadgeVariant가 카탈로그 값을 그대로 되돌린다(전 상태)', () => {
+    for (const status of AGENT_RUN_STATUS_ORDER) {
+      expect(agentRunStatusBadgeVariant(status)).toBe(AGENT_RUN_STATUS_BADGE_VARIANT[status]);
+    }
+  });
+
+  it('모르는 status 문자열은 outline으로 폴백한다', () => {
+    expect(agentRunStatusBadgeVariant('never-seen-status')).toBe('outline');
+  });
+});

--- a/apps/web/src/lib/agent-run-status.ts
+++ b/apps/web/src/lib/agent-run-status.ts
@@ -32,6 +32,12 @@ export const AGENT_RUN_STATUS_BADGE_VARIANT: Record<AgentRunStatus, AgentRunStat
   abandoned: 'warning',
 };
 
+// story #3689 CHANGES(카디르 QA, PO 페드루 처방 2026-09-08) — plain object 인덱싱
+// 뒤 `??`만으로는 own-property가 아닌 status(constructor·toString·__proto__ 등
+// Object.prototype 체인)에서 값이 새어나온다(`??`는 null/undefined만 폴백,
+// 프로토타입 상속값은 undefined가 아니다) — "모르는 status는 outline" 계약을
+// Object.hasOwn으로 먼저 지킨 뒤에만 조회한다.
 export function agentRunStatusBadgeVariant(status: string): AgentRunStatusBadgeVariant {
-  return (AGENT_RUN_STATUS_BADGE_VARIANT as Record<string, AgentRunStatusBadgeVariant>)[status] ?? 'outline';
+  if (!Object.hasOwn(AGENT_RUN_STATUS_BADGE_VARIANT, status)) return 'outline';
+  return (AGENT_RUN_STATUS_BADGE_VARIANT as Record<string, AgentRunStatusBadgeVariant>)[status];
 }

--- a/apps/web/src/lib/agent-run-status.ts
+++ b/apps/web/src/lib/agent-run-status.ts
@@ -1,0 +1,37 @@
+// story #3689(3680 후속, 유나 確定) — agent-runs-list.tsx·agent-run-detail.tsx가
+// 각자 status→{i18n 키, 배지 variant} 맵을 들고 있었다(3680에서 둘 다 손댐) —
+// 같은 사실은 한 자리에서만 말한다. 순서는 목록 필터 드롭다운 노출 순서.
+//
+// ⛔ warning(미완)과 destructive(실패)는 tint 밝기가 거의 같다(라 1.04·다 1.08 —
+// 색맹 조건에선 붙는다) — 구별을 색상이 하고 있으므로 배지에 낱말(「미완」·「실패」)
+// 이 항상 함께 서는 것이 전제다. 아이콘만 남기거나 글자를 지우는 변형 금지.
+export const AGENT_RUN_STATUS_ORDER = [
+  'completed',
+  'hitl_pending',
+  'failed',
+  'running',
+  'queued',
+  'held',
+  'abandoned',
+] as const;
+
+export type AgentRunStatus = (typeof AGENT_RUN_STATUS_ORDER)[number];
+
+export type AgentRunStatusBadgeVariant = 'success' | 'destructive' | 'info' | 'outline' | 'secondary' | 'warning';
+
+export const AGENT_RUN_STATUS_BADGE_VARIANT: Record<AgentRunStatus, AgentRunStatusBadgeVariant> = {
+  completed: 'success',
+  hitl_pending: 'secondary',
+  failed: 'destructive',
+  running: 'info',
+  queued: 'outline',
+  held: 'secondary',
+  // story #3689(유나 確定 2026-09-08) — «끝맺지 못함(미완)»과 «끝난 잘못됨(실패)»은
+  // 다른 사실이라 다른 색. secondary는 「사람 확인 대기·보류」와 얼굴이 겹치고,
+  // outline은 「모르는 상태」 폴백과 겹쳐 둘 다 기각(유나 근거).
+  abandoned: 'warning',
+};
+
+export function agentRunStatusBadgeVariant(status: string): AgentRunStatusBadgeVariant {
+  return (AGENT_RUN_STATUS_BADGE_VARIANT as Record<string, AgentRunStatusBadgeVariant>)[status] ?? 'outline';
+}


### PR DESCRIPTION
## 배경(3680 후속, 유나 確定 2026-09-08)

3680(#4032)에서 abandoned 상태가 목록 필터·배지·i18n에 추가됐지만 변이는 `destructive`로 「실패」와 같은 색이었다. 유나: «끝난 잘못됨(실패)»과 «끝맺지 못함(미완)»은 다른 사실이니 다른 색이 맞다. 또한 `agent-runs-list.tsx`·`agent-run-detail.tsx` 두 파일이 status→variant 맵을 각자 들고 있었다(같은 사실=같은 자리 위반).

## 처방

- `apps/web/src/lib/agent-run-status.ts` 신설: status→{순서, badge variant} 카탈로그 한 곳. `agentRunStatusBadgeVariant()`로 조회(모르는 status는 outline 폴백).
- `agent-runs-list.tsx`·`agent-run-detail.tsx` — 각자의 `STATUS_BADGE_VARIANT` 맵 제거, 카탈로그를 import해서 사용. `AgentRun.status` 타입도 카탈로그의 `AgentRunStatus`로 통일(리터럴 유니온 중복 제거).
- abandoned 변이 = `warning`(유나 確定 근거): secondary는 「사람 확인 대기·보류·미완」 셋이 겹치고, outline은 「모르는 상태」 폴백과 겹쳐 둘 다 기각.
- 카탈로그 주석에 명시: warning-tint·destructive-tint는 밝기가 거의 같아(라이트 1.04·다크 1.08) 구별을 색상이 하고 있음 — 배지에 낱말(「미완」·「실패」)이 항상 함께 서는 것이 전제, 아이콘만 남기거나 글자를 지우는 변형 금지.

## 테스트

- `agent-run-status.test.ts`(신설, 4건) — abandoned≠failed 변이, abandoned≠폴백(outline), 카탈로그 룩업 왕복, 모르는 status 폴백.
- `agent-run-status-wiring.test.tsx`(신설, 2건, 뮤테이션 대용) — `@/lib/agent-run-status`를 몽키패치해 abandoned 변이를 warning→info로 바꾼 뒤, list·detail 둘 다 새 값을 그대로 반영하는지 확인(반영 안 되면 어느 화면이 여전히 자기 맵을 하드코딩 중이라는 뜻).
- 기존 `agent-runs-list.test.tsx`·`agent-run-detail.test.tsx` 회귀 무결.
- `grep -rn STATUS_BADGE_VARIANT apps/web/src` — 카탈로그 파일 자체(정의+테스트) 외 중복 0.
- tsc --noEmit·eslint 클린. `pnpm vitest run src/components/agents src/lib/agent-run-status.test.ts` — 11 files, 42 tests 그린.

## 잔여

유나 실픽셀(다음 회차) — 「미완」 배지 대비·「실패」 옆에서 구분(dev-app).