### PR TITLE
[SID:3691] fix: fetch-ok-check baseline stale로 develop 전체 RED (merge-order race)

### DIFF
--- a/apps/web/scripts/fetch-response-without-ok-check-baseline.json
+++ b/apps/web/scripts/fetch-response-without-ok-check-baseline.json
@@ -17,7 +17,6 @@
     "app/(authenticated)/settings/page.tsx::const res = await fetchWithAuth(`/api/team-members?project_id=${currentProjectId}&type=human`).catch(() => null);",
     "components/agents/access-matrix-tab.tsx::const g = await fetchWithAuth(`/api/agents/access-matrix`).catch(() => null);",
     "components/chat/add-participant-modal.tsx::fetchWithAuth(`/api/members?is_active=true&project_id=${projectId}`)",
-    "components/chat/chat-input.tsx::fetchWithAuth(`/api/members?is_active=true${projectId ? `&project_id=${projectId}` : ''}`)",
     "components/chat/file-viewer.tsx::const convertRes = await fetchWithAuth(`/api/attachments/convert?asset_id=${encodeURIComponent(assetId)}`, {",
     "components/chat/file-viewer.tsx::const signRes = await fetchWithAuth(",
     "components/chat/new-conversation-modal.tsx::fetchWithAuth('/api/team-members?type=agent')",


### PR DESCRIPTION
## 요약
- develop HEAD(48a6c6c6, PR#4035)의 `fetch-response-without-ok-check-baseline.json`이 #4034(chat-input.tsx `.ok` 추가로 이미 고침)를 반영 못 한 stale 스냅샷으로 착지 — 가드의 「baseline에 있으나 이번 스캔에서 안 걸리면 FAIL」 규칙에 걸려 develop 전 PR CI가 RED(merge-order race 클래스, 카디르 진단).
- 가드 자신의 `--write-baseline` 경로로 origin/develop HEAD 기준 재생성(손편집 아님).

## 실제 diff
- 제거: `components/chat/chat-input.tsx::fetchWithAuth(...members?is_active=true...)` 1건(고쳐진 자리)
- 추가: 0건(다른 drift 없음 — 재생성 자체가 답)

## 검증(fresh worktree, origin/develop 기준)
- `pnpm run verify:no-fetch-response-without-ok-check` → 27건, stale 0, GREEN
- `--selftest` → 4/4 PASS
- `vitest run scripts/verify-no-fetch-response-without-ok-check.test.ts` → 8/8 PASS

[SID:3691]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KVcT2ehcPQFL3nBxbZMsGy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVcT2ehcPQFL3nBxbZMsGy