### PR TITLE
[SID:3623] feat(FE): IA S2 — 한 구역 이웃 이름의 접두 관계를 가른다

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -110,7 +110,7 @@
     "goals": "Goals",
     "loops": "Lab",
     "storage": "Storage",
-    "content": "Content",
+    "content": "Blog posts",
     "channelPosts": "Channel Posts",
     "zoneNow": "Today",
     "zoneDev": "Dev",
@@ -126,7 +126,7 @@
     "orgMemory": "Memory",
     "orgEvents": "Events",
     "orgConnectors": "Connectors",
-    "orgChannels": "Channels",
+    "orgChannels": "Channel connections",
     "orgContentRules": "Content rules",
     "orgInsightsBoard": "Performance board",
     "switcherOrgSettingsAria": "Organization settings",
@@ -2132,7 +2132,7 @@
     "imageUnavailable": "Image unavailable in public view"
   },
   "channelConnect": {
-    "pageTitle": "Channels",
+    "pageTitle": "Channel connections",
     "pageDescription": "Connect social channel accounts and manage their status. App credentials and OAuth tokens are handled only here.",
     "channelStatusNotConnected": "Not connected",
     "channelStatusConfigIncomplete": "Setup incomplete",
@@ -2257,7 +2257,7 @@
     "measurementGa4DisconnectEffect": "Disconnecting stops future traffic collection. Values collected so far are kept."
   },
   "content": {
-    "title": "Content",
+    "title": "Blog posts",
     "description": "Manage drafts, approvals, and publishing for hosted blog posts.",
     "loadFailed": "Failed to load posts.",
     "emptyTitle": "No drafts yet",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -110,7 +110,7 @@
     "goals": "목표",
     "loops": "실험실",
     "storage": "스토리지",
-    "content": "콘텐츠",
+    "content": "블로그 포스트",
     "channelPosts": "채널 포스트",
     "zoneNow": "오늘",
     "zoneDev": "개발",
@@ -126,7 +126,7 @@
     "orgMemory": "기억",
     "orgEvents": "이벤트",
     "orgConnectors": "커넥터",
-    "orgChannels": "채널",
+    "orgChannels": "채널 연결",
     "orgContentRules": "콘텐츠 규칙",
     "orgInsightsBoard": "성과 보드",
     "switcherOrgSettingsAria": "Organization 설정",
@@ -2132,7 +2132,7 @@
     "imageUnavailable": "공개 보기에서 이미지를 표시할 수 없습니다"
   },
   "channelConnect": {
-    "pageTitle": "채널",
+    "pageTitle": "채널 연결",
     "pageDescription": "소셜 채널 계정을 연결하고 상태를 관리합니다. 자격(앱 id·secret)과 OAuth 토큰은 여기서만 다룹니다.",
     "channelStatusNotConnected": "미연결",
     "channelStatusConfigIncomplete": "설정 미완",
@@ -2257,7 +2257,7 @@
     "measurementGa4DisconnectEffect": "연결을 해제하면 앞으로의 유입 수집이 멈춥니다. 지금까지 모인 값은 남습니다."
   },
   "content": {
-    "title": "글 관리",
+    "title": "블로그 포스트",
     "description": "호스팅 블로그에 실릴 글의 초안·승인·발행을 관리합니다.",
     "loadFailed": "글 목록을 불러오지 못했습니다.",
     "emptyTitle": "아직 초안이 없습니다",

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -96,7 +96,7 @@ async function mount() {
 const EXPECTED_GROUPS: Array<{ labelKey: string | null; labels: string[] }> = [
   { labelKey: 'zoneNow', labels: ['조직 브리핑', '알림'] },
   { labelKey: 'zoneDev', labels: ['보드', '목표', '실험실', '스탠드업', '회고'] },
-  { labelKey: 'zoneMarketing', labels: ['콘텐츠', '채널 포스트', '채널', '콘텐츠 규칙', '성과 보드'] },
+  { labelKey: 'zoneMarketing', labels: ['블로그 포스트', '채널 포스트', '채널 연결', '콘텐츠 규칙', '성과 보드'] },
   { labelKey: 'zoneTrust', labels: ['활동 로그', '신뢰 센터'] },
   { labelKey: 'zoneKnowledge', labels: ['문서', '산출물', '스토리지', '기억'] },
   { labelKey: 'zoneOrganization', labels: ['구성원', '워크포스', '권한', '이벤트', '커넥터'] },
@@ -120,11 +120,12 @@ const EXPECTED_GROUPS: Array<{ labelKey: string | null; labels: string[] }> = [
 // 챗 제외 22→23항목. story #3503 — 조직 그룹에 '성과 보드'(/organization/insights-board)
 // 추가돼 챗 제외 23→24항목.
 //
-// ⚠️'채널 포스트'는 텍스트가 '채널'로 시작한다 — 아래 매칭 로직의 startsWith 폴백이
-// '채널'을 찾을 때 '채널 포스트' 링크를 먼저 집을 위험이 있었다(페드루 PO 실측,
-// PR#3768 CI red). exact-match-first로 고쳐 해소했다(kbd힌트 항목은 텍스트에 공백
-// 없이 붙어 startsWith가 여전히 필요 — '보드'+'B'='보드B', exact 매치가 없어 정상적으로
-// startsWith로 폴백한다).
+// story #ee78b047(IA·S2, 2026-09-08, PO 確定) — 예전엔 '채널 포스트'가 텍스트상 '채널'로
+// 시작해 아래 매칭 로직의 startsWith 폴백이 '채널'을 찾을 때 '채널 포스트' 링크를 먼저
+// 집을 위험이 있었다(페드루 PO 실측, PR#3768 CI red — exact-match-first로 그때 해소).
+// S2가 '채널'을 '채널 연결'로 개명해 그 접두 관계 자체가 이제 없다 — exact-match-first
+// 자체는 일반 규율로 그대로 둔다(kbd힌트 항목은 텍스트에 공백 없이 붙어 startsWith가
+// 여전히 필요 — '보드'+'B'='보드B', exact 매치가 없어 정상적으로 startsWith로 폴백한다).
 const EXPECTED_HREF_BY_LABEL: Record<string, string> = {
   '채널 포스트': '/content/channel-posts',
   '구성원': '/organization/members',
@@ -134,7 +135,7 @@ const EXPECTED_HREF_BY_LABEL: Record<string, string> = {
   '기억': '/organization/memory',
   '이벤트': '/organization/events',
   '커넥터': '/organization/connectors',
-  '채널': '/organization/channels',
+  '채널 연결': '/organization/channels',
   '콘텐츠 규칙': '/organization/content-rules',
   '성과 보드': '/organization/insights-board',
   '조직 브리핑': '/org-briefing',
@@ -144,7 +145,7 @@ const EXPECTED_HREF_BY_LABEL: Record<string, string> = {
   '실험실': '/loops',
   '스탠드업': '/standup',
   '회고': '/retro',
-  '콘텐츠': '/content',
+  '블로그 포스트': '/content',
   '활동 로그': '/activity',
   '문서': '/docs',
   '산출물': '/artifacts',
@@ -240,9 +241,10 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     for (const [label, expectedHref] of Object.entries(EXPECTED_HREF_BY_LABEL)) {
       // story #3402(페드루 PO 실측, PR#3768 CI red) — exact match를 먼저 찾고, 없을
       // 때만 startsWith로 폴백한다. kbd 힌트 항목은 텍스트에 공백 없이 붙어("보드"+"B"
-      // ="보드B") exact가 안 걸려 여전히 startsWith로 정상 폴백하지만, '채널 포스트'처럼
-      // 두 단어를 공백으로 이은 라벨이 다른 라벨('채널')의 접두어가 되는 경우는 exact
-      // 우선이라야 정확한 항목을 집는다(순서 의존 없이 결정적).
+      // ="보드B") exact가 안 걸려 여전히 startsWith로 정상 폴백한다. story #ee78b047
+      // (IA·S2) 이전엔 '채널 포스트'가 다른 라벨('채널')의 접두어라 exact 우선이 결정적
+      // 정확성의 유일한 버팀목이었다 — S2가 '채널'을 '채널 연결'로 개명해 그 접두 관계는
+      // 사라졌지만, exact-match-first 자체는 일반 규율로 유지한다.
       const link = links.find((a) => a.textContent === label) ?? links.find((a) => a.textContent?.startsWith(label));
       expect(link, `링크 "${label}"를 찾지 못함`).toBeDefined();
       expect(link!.getAttribute('href'), `"${label}"의 href`).toBe(expectedHref);

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -121,22 +121,26 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     labelKey: 'zoneMarketing',
     items: [
       // story #3368(Phase0·마케팅운영 S4, doc phase0-post-manager-screen-design §5-2) — 호스팅
-      // 블로그 「글 관리」. site-posts drafts는 org 스코프(프로젝트 무관, backend
-      // organizations/{org_id}/site-posts/drafts)라 org-connectors(/organization/connectors)와
-      // 동형으로 kind:'static'·top-level 경로다. 「지식」 문서 트리(parent_id 계층) 밑에 두지
-      // 않는 이유는 §5-2 그대로 — 상태·발행 URL 열을 가진 목록이 문서 하나로 오독되는 것을
-      // 막기 위함. 「관리」 구역의 org-connectors로도 옮기지 않는다 — 연결은 owner의 설정
-      // 행위, 운영은 마케터의 일상 행위라는 가름(§5-2)이 그대로 적용된다.
+      // 블로그 글 관리(story #ee78b047 IA·S2, 2026-09-08, PO 確定으로 라벨은 「블로그
+      // 포스트」 — 「콘텐츠 규칙」과 접두 관계이던 옛 「콘텐츠」에서 개명). site-posts
+      // drafts는 org 스코프(프로젝트 무관, backend organizations/{org_id}/site-posts/
+      // drafts)라 org-connectors(/organization/connectors)와 동형으로 kind:'static'·
+      // top-level 경로다. 「지식」 문서 트리(parent_id 계층) 밑에 두지 않는 이유는 §5-2
+      // 그대로 — 상태·발행 URL 열을 가진 목록이 문서 하나로 오독되는 것을 막기 위함.
+      // 「관리」 구역의 org-connectors로도 옮기지 않는다 — 연결은 owner의 설정 행위,
+      // 운영은 마케터의 일상 행위라는 가름(§5-2)이 그대로 적용된다.
       { id: 'content', labelKey: 'content', icon: FileText, kind: 'static', path: '/content' },
       // story #3402(Phase1·마케팅운영, PO 결정 2026-09-03 23:17Z) — 채널 포스트(Threads)
       // 관리 화면. NavItemConfig에 중첩 하위메뉴 구조가 없어(app-sidebar.tsx는 group.items를
-      // 평평하게 순회) "콘텐츠 아래" 배치는 이 배열에서 content 바로 뒤에 두는 것으로
+      // 평평하게 순회) "블로그 포스트 아래" 배치는 이 배열에서 content 바로 뒤에 두는 것으로
       // 표현한다 — content(호스팅 블로그, org 스코프)와 같은 이유로 kind:'static'·top-level
       // 경로(channel_post_drafts도 org 스코프, project 무관).
       { id: 'channel-posts', labelKey: 'channelPosts', icon: Share2, kind: 'static', path: '/content/channel-posts' },
       // story #3376(페드루 PO 確定 2026-09-03) — 소셜 채널 OAuth 연결(조직이 소유한 외부
       // 계정·토큰). 예전 organization 구역에서 이관 — 「연결」 행위 자체는 마케터가 채널을
-      // 붙이는 일상 실물이라 도메인 축(마케팅)으로 옮긴다(path 불변).
+      // 붙이는 일상 실물이라 도메인 축(마케팅)으로 옮긴다(path 불변). story #ee78b047
+      // (IA·S2, 2026-09-08, PO 確定) — 라벨은 「채널 연결」(옛 「채널」이 이웃 「채널
+      // 포스트」의 접두어였다 — 이름이 스스로 갈라야 한다는 S2 AC1).
       { id: 'org-channels', labelKey: 'orgChannels', icon: Share2, kind: 'static', path: '/organization/channels' },
       // story #3472(페드루 PO 確定 2026-09-05) — 콘텐츠 규칙(금칙어·UTM 필수·톤·택소노미·
       // 채널 우선순위·브랜드 킷). 예전 organization 구역에서 이관 — path 불변.


### PR DESCRIPTION
## 배경

S1(#4040)로 마케팅 구역이 생기며 「콘텐츠」↔「콘텐츠 규칙」, 「채널 포스트」↔「채널」이 한 구역 이웃이 됐다 — 예전엔 구역이 갈라줬는데 그 역할이 사라졌다. 접두 관계 라벨은 PR#3768에서 링크 매칭(startsWith 폴백)이 어긋나 CI가 빨개진 전례가 있다.

## PO 確定(유나 § 대조 완료)

- `nav.content` + `content.title`: 「콘텐츠」→「블로그 포스트」 / "Content"→"Blog posts"
- `nav.orgChannels` + `channelConnect.pageTitle`: 「채널」→「채널 연결」 / "Channels"→"Channel connections"

`channel-posts`·`org-content-rules`는 그대로 — 더 짧은 이웃 쪽만 갈라도 접두 관계 2→0이 충족된다.

겸사겸사: `content.title`(화면 자신의 `<h1>`)이 「글 관리」로 사이드바 라벨 「콘텐츠」와 애초에 서로 달랐던 mismatch도 이 판에서 같이 닫힌다(라벨=착지 이름 일치).

## AC 대조

1. 마케팅 구역 안 이웃한 라벨들이 더는 접두 관계가 아니다 — ✅
2. 라벨 소비처가 한 키를 참조(사본 0) — 이미 구조적으로 만족(app-sidebar.tsx·more/page.tsx가 `nav-config.ts` 배열을 `labelKey`로 동적 순회, command-palette.tsx는 이 4항목 자체를 안 실음 — grep 전수 확認). path 0·새 키 0(기존 4키 값만 편집).
3. ko·en 양쪽 갱신, 옛 값 잔존 0(grep 확認 — 남은 "채널"/"콘텐츠" 매치는 전부 무관 네임스페이스).
4. [디자인] 접두 관계 쌍 2→0 — 유나 § 확定 대조 완료.

## 테스트

- `app-sidebar.test.tsx`(EXPECTED_GROUPS·EXPECTED_HREF_BY_LABEL 갱신)·`more/page.test.tsx`·`verify-mobile-nav-depth`·`verify-nav-config-routes`·`verify-no-orphan-resource-routes`·i18n 계열 13파일 230건 재검증 그린.
- 전체 `pnpm vitest run` — 712 files·6924 tests 무회귀.
- `tsc --noEmit`·`eslint` 클린. `pnpm build` 성공.

## 잔여

라벨 7자 잘림 0은 배포 뒤 유나 라이브 픽셀 회차의 몫.