### PR TITLE
[SID:3624] feat(FE): IA S3 — nav 항목 범위(project/org) 값+「프로젝트」 표식

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -90,6 +90,7 @@
     "settings": "Settings",
     "standup": "Standup",
     "retro": "Retro",
+    "scopeProject": "Project",
     "docs": "Docs",
     "artifacts": "Artifacts",
     "rewards": "Rewards",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -90,6 +90,7 @@
     "settings": "설정",
     "standup": "스탠드업",
     "retro": "회고",
+    "scopeProject": "프로젝트",
     "docs": "문서",
     "artifacts": "산출물",
     "rewards": "리워드",

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -162,7 +162,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     const groups = [...container.querySelectorAll('[data-slot="sidebar-group"]')];
     expect(groups.length).toBe(EXPECTED_GROUPS.length);
     groups.forEach((groupEl, i) => {
-      const itemLabels = [...groupEl.querySelectorAll('[data-slot="sidebar-menu-button"] span')].map((el) => el.textContent);
+      const itemLabels = [...groupEl.querySelectorAll('[data-slot="sidebar-menu-button"] span[data-nav-label]')].map((el) => el.textContent);
       expect(itemLabels).toEqual(EXPECTED_GROUPS[i]!.labels);
     });
   });
@@ -188,6 +188,49 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     expect(boardBtn?.textContent).toContain('B');
     const standupBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('스탠드업'));
     expect(standupBtn?.textContent).toContain('S');
+  });
+
+  // story #9c5e82dc(IA·S3, 유나 § 確定 2026-09-08) — 「프로젝트」 표식은 scope:'project'
+  // 9항목에만 붙고, org 13·애매 2(inbox·settings)엔 안 붙는다(무표식=org를 뜻하지 않는다 —
+  // 이 테스트는 그 둘을 각각 대표 표본으로 확認한다).
+  it('scope:project 항목(보드)엔 「프로젝트」 표식이 붙는다', async () => {
+    await mount();
+    const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
+    expect(boardBtn?.textContent).toContain('프로젝트');
+  });
+
+  it('org 항목(구성원)엔 「프로젝트」 표식이 안 붙는다', async () => {
+    await mount();
+    const membersBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('구성원'));
+    expect(membersBtn?.textContent).not.toContain('프로젝트');
+  });
+
+  it('애매 항목(알림·설정)엔 「프로젝트」 표식이 안 붙는다', async () => {
+    await mount();
+    const inboxBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('알림'));
+    expect(inboxBtn?.textContent).not.toContain('프로젝트');
+    const settingsBtn = [...container.querySelectorAll('a')].find((a) => a.textContent === '설정');
+    expect(settingsBtn?.textContent).not.toContain('프로젝트');
+  });
+
+  it('순서는 라벨→표식→kbd다(보드: "보드" 다음 "프로젝트" 다음 "B")', async () => {
+    await mount();
+    const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
+    const text = boardBtn?.textContent ?? '';
+    const labelIdx = text.indexOf('보드');
+    const scopeIdx = text.indexOf('프로젝트');
+    const kbdIdx = text.lastIndexOf('B');
+    expect(labelIdx).toBeGreaterThanOrEqual(0);
+    expect(scopeIdx).toBeGreaterThan(labelIdx);
+    expect(kbdIdx).toBeGreaterThan(scopeIdx);
+  });
+
+  it('표식은 칩/배지 모양(테두리·배경)을 안 쓴다(유나 § — 성질이지 행위가 아니다)', async () => {
+    await mount();
+    const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
+    const scopeEl = [...(boardBtn?.querySelectorAll('span') ?? [])].find((s) => s.textContent === '프로젝트');
+    expect(scopeEl).toBeDefined();
+    expect(scopeEl?.className).not.toMatch(/border|bg-/);
   });
 
   it('현재 경로와 일치하는 정적 항목이 active로 표시된다(isActive 판정 보존)', async () => {

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -46,9 +46,26 @@ interface AppSidebarProps {
 
 function KbdHint({ children }: { children: React.ReactNode }) {
   return (
-    <kbd className="ml-auto hidden rounded border border-sidebar-border/60 bg-sidebar-accent/40 px-1.5 py-0 font-mono text-[10px] font-medium text-sidebar-foreground/60 group-data-[active=true]/menu-button:text-sidebar-foreground/80 sm:inline-flex">
+    <kbd className="hidden rounded border border-sidebar-border/60 bg-sidebar-accent/40 px-1.5 py-0 font-mono text-[10px] font-medium text-sidebar-foreground/60 group-data-[active=true]/menu-button:text-sidebar-foreground/80 sm:inline-flex">
       {children}
     </kbd>
+  );
+}
+
+// story #9c5e82dc(IA·S3, 유나 § 確定 2026-09-08) — 「이 항목은 프로젝트 것」이라는 «성질»
+// 표식. 칩/배지 모양(테두리·배경) 금지 — 칩은 "누를 수 있는 것"으로 읽히는데 이건 행위가
+// 아니라 성질이다. 라틴 약어("PJ")·아이콘 단독+sr-only 둘 다 기각(유나 § 그대로 — 약어는
+// 배워야 하는 어휘, sr-only는 시각 사용자에게 아무 말도 안 함). kbd(#KbdHint)와 같은
+// 자리·비슷한 크기(10px)지만 mono가 아니라 본문 폰트(한글이라). 순서는 라벨→표식→kbd
+// (성질이 이름에 붙고 행위가 끝에 간다).
+//
+// ⛔️무표식 = 조직 범위가 아니다(유나 § 명시) — org 13항목 + 애매 2항목(inbox·settings)
+// 둘 다 무표식이다. 이 표식은 "project임을 말한다"만 하지 "무표식=org"를 말하지 않는다.
+function ScopeMark({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-[10px] font-medium text-sidebar-foreground/60 group-data-[active=true]/menu-button:text-sidebar-foreground/80">
+      {children}
+    </span>
   );
 }
 
@@ -259,8 +276,13 @@ export function AppSidebar({
                         tooltip={label}
                       >
                         <Icon />
-                        <span>{label}</span>
-                        {item.kbdHint ? <KbdHint>{item.kbdHint}</KbdHint> : null}
+                        <span data-nav-label>{label}</span>
+                        {item.scope === 'project' || item.kbdHint ? (
+                          <span className="ml-auto flex shrink-0 items-center gap-1.5">
+                            {item.scope === 'project' ? <ScopeMark>{t('scopeProject')}</ScopeMark> : null}
+                            {item.kbdHint ? <KbdHint>{item.kbdHint}</KbdHint> : null}
+                          </span>
+                        ) : null}
                         {item.badgeKey && badgeCount > 0 ? (
                           <SidebarMenuBadge>
                             {badgeCount > badgeCap ? `${badgeCap}+` : badgeCount}

--- a/apps/web/src/lib/nav-config-scope.test.ts
+++ b/apps/web/src/lib/nav-config-scope.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { NAV_GROUPS } from './nav-config';
+
+// story #9c5e82dc(IA·S3, PO 確定 2026-09-08) — 새 자: 「프로젝트 전환 시 내용이 바뀌는
+// 항목」 대 「화면이 그렇다고 말하는 항목」 8:0→8:8(3600 문서 원안)이었으나, activity가
+// kind:'static'인데도 project_id로 실제 필터되는 것을 코드로 확認해 9:9로 정정됐다
+// (doc의 「실측」은 구현 前 추정 — 라이브 코드가 정본).
+const PROJECT_SCOPED_IDS = ['board', 'goals', 'loops', 'standup', 'retro', 'docs', 'artifacts', 'storage', 'activity'];
+// 애매(표식 없음) — scope 필드를 아예 안 쓴다. inbox=순수 개인 알림(project/org 필터 0),
+// settings=계정 설정인데 팀원 탭 하나만 project라 섞인 화면.
+const AMBIGUOUS_IDS = ['inbox', 'settings'];
+
+function allItems() {
+  return NAV_GROUPS.flatMap((g) => g.items);
+}
+
+describe('NAV_GROUPS scope — story #9c5e82dc(IA·S3 AC1)', () => {
+  it('항목 24개 전부가 scope 분류 대상이다(회귀 시 이 수부터 어긋난다)', () => {
+    expect(allItems()).toHaveLength(24);
+  });
+
+  it('project 스코프 9항목이 정확히 이 집합이다(8→9, activity 포함)', () => {
+    const projectIds = allItems().filter((i) => i.scope === 'project').map((i) => i.id).sort();
+    expect(projectIds).toEqual([...PROJECT_SCOPED_IDS].sort());
+  });
+
+  it('org 스코프 13항목 — project·애매를 뺀 나머지 전부', () => {
+    const orgIds = allItems().filter((i) => i.scope === 'org').map((i) => i.id).sort();
+    const expected = allItems()
+      .map((i) => i.id)
+      .filter((id) => !PROJECT_SCOPED_IDS.includes(id) && !AMBIGUOUS_IDS.includes(id))
+      .sort();
+    expect(orgIds).toEqual(expected);
+    expect(orgIds).toHaveLength(13);
+  });
+
+  it('애매 2항목(inbox·settings)은 scope 필드 자체가 없다(undefined — org로 기본값 안 깖)', () => {
+    for (const id of AMBIGUOUS_IDS) {
+      const item = allItems().find((i) => i.id === id);
+      expect(item?.scope, `${id}.scope`).toBeUndefined();
+    }
+  });
+
+  it('kind:"resource" 항목(8개)은 전부 project 스코프다(라우트 자체가 /{ws}/{proj}/... 파생)', () => {
+    const resourceItems = allItems().filter((i) => i.kind === 'resource');
+    expect(resourceItems).toHaveLength(8);
+    for (const item of resourceItems) {
+      expect(item.scope, `${item.id}.scope`).toBe('project');
+    }
+  });
+
+  // 양성대조 — project 집합이 실제로 하나라도 빠지면(또는 늘면) 이 테스트가 잡는다는 것을
+  // 스스로 증명(회귀가드가 아무 의미 없이 항상 그린이지 않다는 확認).
+  it('양성대조 — 픽스처에서 project 항목 하나를 빼면 위 자가 실제로 어긋남을 잡는다', () => {
+    const mutatedProjectIds = PROJECT_SCOPED_IDS.filter((id) => id !== 'activity');
+    const realProjectIds = allItems().filter((i) => i.scope === 'project').map((i) => i.id).sort();
+    expect(realProjectIds).not.toEqual([...mutatedProjectIds].sort());
+  });
+});

--- a/apps/web/src/lib/nav-config-scope.test.ts
+++ b/apps/web/src/lib/nav-config-scope.test.ts
@@ -5,10 +5,21 @@ import { NAV_GROUPS } from './nav-config';
 // 항목」 대 「화면이 그렇다고 말하는 항목」 8:0→8:8(3600 문서 원안)이었으나, activity가
 // kind:'static'인데도 project_id로 실제 필터되는 것을 코드로 확認해 9:9로 정정됐다
 // (doc의 「실측」은 구현 前 추정 — 라이브 코드가 정본).
+//
+// 카디르 QA 재감사(2026-09-08, codex) — 고정 숫자 테스트(9/13/2)만으로는 "분류 자체가
+// 틀렸다"를 못 잡는다는 게 실제로 드러났다: org-briefing·org-workforce가 원래 org로
+// 분류됐었으나 화면 «일부» 패널만 project(나머지는 org)인 혼합 화면이었다. PO 원칙 —
+// 표식은 "화면 전체에 대한 약속"이라 혼합/부수적 project_id 사용은 project로도 org로도
+// 정직할 수 없어 애매(무표식)로 간다. 이 재감사로 애매가 2→4로 늘었다(9/11/4).
 const PROJECT_SCOPED_IDS = ['board', 'goals', 'loops', 'standup', 'retro', 'docs', 'artifacts', 'storage', 'activity'];
-// 애매(표식 없음) — scope 필드를 아예 안 쓴다. inbox=순수 개인 알림(project/org 필터 0),
-// settings=계정 설정인데 팀원 탭 하나만 project라 섞인 화면.
-const AMBIGUOUS_IDS = ['inbox', 'settings'];
+// 애매(표식 없음) — scope 필드를 아예 안 쓴다.
+// - inbox: 순수 개인 알림(project/org 필터 0)
+// - settings: 계정 설정인데 팀원 탭 하나만 project라 섞인 화면
+// - org-briefing: 「지금」(org 전체) + 「실험실」·「워크포스」(project_id로 실 데이터, 없으면
+//   스켈레톤) 패널이 한 화면에 섞임(loop-face.tsx·workforce-face.tsx)
+// - org-workforce: agents-page-tabs.tsx 4탭 중 stats·recruit는 project 걸리고
+//   manage(기본)·access는 project 무관 — 탭에 따라 갈리는 혼합 화면
+const AMBIGUOUS_IDS = ['inbox', 'settings', 'org-briefing', 'org-workforce'];
 
 function allItems() {
   return NAV_GROUPS.flatMap((g) => g.items);
@@ -24,17 +35,17 @@ describe('NAV_GROUPS scope — story #9c5e82dc(IA·S3 AC1)', () => {
     expect(projectIds).toEqual([...PROJECT_SCOPED_IDS].sort());
   });
 
-  it('org 스코프 13항목 — project·애매를 뺀 나머지 전부', () => {
+  it('org 스코프 11항목 — project·애매를 뺀 나머지 전부(카디르 QA 재감사로 13→11)', () => {
     const orgIds = allItems().filter((i) => i.scope === 'org').map((i) => i.id).sort();
     const expected = allItems()
       .map((i) => i.id)
       .filter((id) => !PROJECT_SCOPED_IDS.includes(id) && !AMBIGUOUS_IDS.includes(id))
       .sort();
     expect(orgIds).toEqual(expected);
-    expect(orgIds).toHaveLength(13);
+    expect(orgIds).toHaveLength(11);
   });
 
-  it('애매 2항목(inbox·settings)은 scope 필드 자체가 없다(undefined — org로 기본값 안 깖)', () => {
+  it('애매 4항목(inbox·settings·org-briefing·org-workforce)은 scope 필드 자체가 없다(undefined — org로 기본값 안 깖)', () => {
     for (const id of AMBIGUOUS_IDS) {
       const item = allItems().find((i) => i.id === id);
       expect(item?.scope, `${id}.scope`).toBeUndefined();
@@ -49,11 +60,28 @@ describe('NAV_GROUPS scope — story #9c5e82dc(IA·S3 AC1)', () => {
     }
   });
 
+  // 혼합/부수적 project_id 사용은 project가 아니라 애매로 간다는 원칙의 회귀가드 —
+  // org-trust는 project_id를 쓰지만(이름 보완용, 부수적) 실질 콘텐츠(trust-scores)는
+  // org 전체라 org 유지다. 이 테스트가 org-briefing·org-workforce와 같은 취급으로
+  // 잘못 끌려가면(애매로 오분류되면) 잡는다.
+  it('org-trust는 project_id를 부수적으로만 쓰므로(이름 보완) 애매가 아니라 org다', () => {
+    const item = allItems().find((i) => i.id === 'org-trust');
+    expect(item?.scope).toBe('org');
+  });
+
   // 양성대조 — project 집합이 실제로 하나라도 빠지면(또는 늘면) 이 테스트가 잡는다는 것을
   // 스스로 증명(회귀가드가 아무 의미 없이 항상 그린이지 않다는 확認).
   it('양성대조 — 픽스처에서 project 항목 하나를 빼면 위 자가 실제로 어긋남을 잡는다', () => {
     const mutatedProjectIds = PROJECT_SCOPED_IDS.filter((id) => id !== 'activity');
     const realProjectIds = allItems().filter((i) => i.scope === 'project').map((i) => i.id).sort();
     expect(realProjectIds).not.toEqual([...mutatedProjectIds].sort());
+  });
+
+  // 양성대조 — 애매 집합이 실제로 하나 빠지면(예 org-workforce가 다시 org로 잘못 돌아가면)
+  // 이 테스트가 잡는다.
+  it('양성대조 — 픽스처에서 애매 항목 하나를 빼면 위 자가 실제로 어긋남을 잡는다', () => {
+    const mutatedAmbiguousIds = AMBIGUOUS_IDS.filter((id) => id !== 'org-workforce');
+    const realAmbiguousIds = allItems().filter((i) => i.scope === undefined).map((i) => i.id).sort();
+    expect(realAmbiguousIds).not.toEqual([...mutatedAmbiguousIds].sort());
   });
 });

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -97,7 +97,14 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     id: 'now',
     labelKey: 'zoneNow',
     items: [
-      { id: 'org-briefing', labelKey: 'orgBriefing', icon: Newspaper, kind: 'static', path: '/org-briefing', scope: 'org' },
+      // story #9c5e82dc(IA·S3, 카디르 QA 지적 반영·PO 정정 2026-09-08) — 애매(scope 필드
+      // 없음)로 재분류. 옛 판정(org)이 틀렸다 — org-briefing-shell.tsx의 「지금」(Now) 패널은
+      // org 전체 요청 집계지만, 같은 화면의 「실험실」(LoopFace)·「워크포스」(WorkforceFace)
+      // 패널은 projectId 없으면 스켈레톤만 그리고 있으면 project_id로 실 데이터를 건다
+      // (loop-face.tsx:26 `/api/hypotheses?project_id=`·workforce-face.tsx:30 `/api/stories?
+      // ...&project_id=`) — 화면 «일부»만 project라 표식이 "화면 전체에 대한 약속"을 못
+      // 지킨다(PO 원칙: 혼합 화면은 project로도 org로도 정직할 수 없어 무표식).
+      { id: 'org-briefing', labelKey: 'orgBriefing', icon: Newspaper, kind: 'static', path: '/org-briefing' },
       // story #9c5e82dc(IA·S3, PO 確定) — inbox는 scope 필드를 안 쓴다(애매). 메인 조회
       // (/api/notifications)가 project_id·org_id 둘 다 안 걸어 순수 사용자 개인 알림이다 —
       // project도 org도 아닌 계정 축이라 AC2 "화면은 모르는 것을 단정하지 않는다"로 무표식.
@@ -141,24 +148,34 @@ export const NAV_GROUPS: NavGroupConfig[] = [
       // 그대로 — 상태·발행 URL 열을 가진 목록이 문서 하나로 오독되는 것을 막기 위함.
       // 「관리」 구역의 org-connectors로도 옮기지 않는다 — 연결은 owner의 설정 행위,
       // 운영은 마케터의 일상 행위라는 가름(§5-2)이 그대로 적용된다.
+      // 근거: content/page.tsx 주석이 직접 "project 슬러그 불필요"라 명시(org_id 단일 스코프,
+      // site-posts drafts backend가 organizations/{org_id}/... 경로), project 필터 0건.
       { id: 'content', labelKey: 'content', icon: FileText, kind: 'static', path: '/content', scope: 'org' },
       // story #3402(Phase1·마케팅운영, PO 결정 2026-09-03 23:17Z) — 채널 포스트(Threads)
       // 관리 화면. NavItemConfig에 중첩 하위메뉴 구조가 없어(app-sidebar.tsx는 group.items를
       // 평평하게 순회) "블로그 포스트 아래" 배치는 이 배열에서 content 바로 뒤에 두는 것으로
       // 표현한다 — content(호스팅 블로그, org 스코프)와 같은 이유로 kind:'static'·top-level
       // 경로(channel_post_drafts도 org 스코프, project 무관).
+      // 근거: content/channel-posts/page.tsx에 project 관련 키워드 grep 0건(channel_post_
+      // drafts도 content와 동형 org 단일 스코프).
       { id: 'channel-posts', labelKey: 'channelPosts', icon: Share2, kind: 'static', path: '/content/channel-posts', scope: 'org' },
       // story #3376(페드루 PO 確定 2026-09-03) — 소셜 채널 OAuth 연결(조직이 소유한 외부
       // 계정·토큰). 예전 organization 구역에서 이관 — 「연결」 행위 자체는 마케터가 채널을
       // 붙이는 일상 실물이라 도메인 축(마케팅)으로 옮긴다(path 불변). story #ee78b047
       // (IA·S2, 2026-09-08, PO 確定) — 라벨은 「채널 연결」(옛 「채널」이 이웃 「채널
       // 포스트」의 접두어였다 — 이름이 스스로 갈라야 한다는 S2 AC1).
+      // 근거: organization/channels/page.tsx에 project 관련 키워드 grep 0건 — 채널 OAuth
+      // 연결은 org가 소유(project 무관).
       { id: 'org-channels', labelKey: 'orgChannels', icon: Share2, kind: 'static', path: '/organization/channels', scope: 'org' },
       // story #3472(페드루 PO 確定 2026-09-05) — 콘텐츠 규칙(금칙어·UTM 필수·톤·택소노미·
       // 채널 우선순위·브랜드 킷). 예전 organization 구역에서 이관 — path 불변.
+      // 근거: organization/content-rules/page.tsx에 project 관련 키워드 grep 0건 — 규칙 세트가
+      // org 단일 스코프(금칙어·톤·택소노미 등 조직 공통 정책).
       { id: 'org-content-rules', labelKey: 'orgContentRules', icon: ListChecks, kind: 'static', path: '/organization/content-rules', scope: 'org' },
       // story #3503(성과 보드 화면) — 발행된 글의 D+1/D+7 성과 표. 예전 organization
       // 구역에서 이관 — path 불변.
+      // 근거: organization/insights-board/page.tsx에 project 관련 키워드 grep 0건 — 발행 글
+      // 성과가 org 전체 집계(project로 안 거름).
       { id: 'org-insights-board', labelKey: 'orgInsightsBoard', icon: TrendingUp, kind: 'static', path: '/organization/insights-board', scope: 'org' },
     ],
   },
@@ -175,6 +192,11 @@ export const NAV_GROUPS: NavGroupConfig[] = [
       // organization 흡수(시안 매핑표) — 신뢰 축의 실물이 이제 여기 있다(이전엔 organization
       // 그룹 소속). path 불변, 그룹 소속만 이동. 라벨도 zoneTrust와 겹치던 "신뢰"→"신뢰 센터"로
       // 정정(같은 구역 안에서 구역명과 항목명이 동어반복하지 않게, 시안 신뢰 센터 표기 그대로).
+      // 근거(#9c5e82dc 카디르 QA 재감사 2026-09-08) — trust/page.tsx가 project_id를 쓰긴
+      // 하나(line 39) 실질 콘텐츠(rosterRows·groupedRoster, /api/trust-scores/org-summary)는
+      // project 무관이고, project_id는 team-members 조회로 표시 이름을 채우는 데만 쓰인다
+      // (mergeMemberLookup 이름 보완 — 부수적) — 목록 자체는 project 전환에 안 바뀌므로 org
+      // 유지(org-briefing·org-workforce와 달리 "일부 패널이 project"가 아니라 "이름표만").
       { id: 'org-trust', labelKey: 'orgTrust', icon: Award, kind: 'static', path: '/organization/trust', scope: 'org' },
     ],
   },
@@ -186,6 +208,7 @@ export const NAV_GROUPS: NavGroupConfig[] = [
       { id: 'artifacts', labelKey: 'artifacts', icon: GalleryVerticalEnd, kind: 'resource', path: 'artifacts', scope: 'project' },
       { id: 'storage', labelKey: 'storage', icon: HardDrive, kind: 'resource', path: 'storage', scope: 'project' },
       // organization 흡수(시안 매핑표) — memory는 지식 축의 실물. path 불변, 그룹 소속만 이동.
+      // 근거: memory/page.tsx에 project 관련 키워드 grep 0건 — 조직 공유 기억(org 단일 스코프).
       { id: 'org-memory', labelKey: 'orgMemory', icon: Brain, kind: 'static', path: '/organization/memory', scope: 'org' },
     ],
   },
@@ -202,11 +225,23 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     id: 'organization',
     labelKey: 'zoneOrganization',
     items: [
+      // 근거: OrgMembersSection의 project_ids는 초대할 때 «대상 프로젝트를 고르는» 액션
+      // 파라미터일 뿐(org-members-section.tsx:144), 멤버 목록 자체를 현재 project로 거르지
+      // 않는다 — 화면 콘텐츠가 project 전환에 안 바뀌므로 org.
       { id: 'org-members', labelKey: 'orgMembers', icon: Users2, kind: 'static', path: '/organization/members', scope: 'org' },
-      { id: 'org-workforce', labelKey: 'workforce', icon: Bot, kind: 'static', path: '/organization/workforce', scope: 'org' },
+      // story #9c5e82dc(IA·S3, 카디르 QA 지적 반영·PO 정정 2026-09-08) — 애매로 재분류.
+      // agents-page-tabs.tsx 4탭 중 기본(manage)·access는 project 무관(access는 오히려 «전
+      // project를 한 매트릭스로» 보여줌)인데, stats 탭(agent-performance-panel.tsx:97-99
+      // team-members/velocity-history/leaderboard 전부 `project_id=`)과 recruit 탭은
+      // project 걸림 — 탭에 따라 갈리는 혼합 화면이라 무표식.
+      { id: 'org-workforce', labelKey: 'workforce', icon: Bot, kind: 'static', path: '/organization/workforce' },
+      // 근거: role-member.tsx류 권한 목록이 org_id 스코프(팀 전체 권한 매트릭스), project
+      // 필터 없음.
       { id: 'org-roles', labelKey: 'orgRoles', icon: Shield, kind: 'static', path: '/organization/roles', scope: 'org' },
+      // 근거: 조직 이벤트 정의(org 레벨 웹훅/트리거 카탈로그), project 필터 없음.
       { id: 'org-events', labelKey: 'orgEvents', icon: Zap, kind: 'static', path: '/organization/events', scope: 'org' },
-      // story 4180f67f — 마케팅자동화 발행 커넥터(threads/stibee/instagram 등) org_config 설정 화면.
+      // story 4180f67f — 마케팅자동화 발행 커넥터(threads/stibee/instagram 등) org_config 설정
+      // 화면. 근거: connectors/page.tsx에 project 관련 키워드 grep 0건, org_config 단일 스코프.
       { id: 'org-connectors', labelKey: 'orgConnectors', icon: Plug, kind: 'static', path: '/organization/connectors', scope: 'org' },
     ],
   },

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -37,6 +37,14 @@ import {
 //                (앞 슬래시 없음 — 슬래시 유무로 kind를 오인하지 않게 값 자체로 구분).
 export type NavItemKind = 'static' | 'resource';
 
+// story #9c5e82dc(IA·S3, PO 確定 2026-09-08) — 「프로젝트를 바꿨을 때 내용이 실제로
+// 바뀌는가」로 잰 값(추정이 아니라 각 화면의 실 데이터 페칭 코드를 읽어 확認 — activity가
+// kind:'static'인데도 project_id로 실제 필터되는 것을 이렇게 잡아 8→9로 정정했다).
+// undefined(필드 자체를 안 씀) = 애매(inbox·settings — 화면 개념이 project/org 어느 한쪽으로
+// 안 떨어짐, AC2 "화면은 모르는 것을 단정하지 않는다") — 사이드바가 이 값을 몰라야 «표식을
+// 안 붙인다»는 사실 자체가 코드로 드러난다(기본값으로 org를 깔고 안 보여주는 게 아니다).
+export type NavItemScope = 'project' | 'org';
+
 export interface NavItemConfig {
   id: string;
   labelKey: string;
@@ -46,6 +54,7 @@ export interface NavItemConfig {
   kbdHint?: string;
   // 배지 소스 — 현재 카운트 자체는 컴포넌트 상태(폴링·SSE)라 여기 값이 아니라 렌더 쪽이 채운다.
   badgeKey?: 'inbox' | 'chats';
+  scope?: NavItemScope;
 }
 
 export interface NavGroupConfig {
@@ -88,7 +97,10 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     id: 'now',
     labelKey: 'zoneNow',
     items: [
-      { id: 'org-briefing', labelKey: 'orgBriefing', icon: Newspaper, kind: 'static', path: '/org-briefing' },
+      { id: 'org-briefing', labelKey: 'orgBriefing', icon: Newspaper, kind: 'static', path: '/org-briefing', scope: 'org' },
+      // story #9c5e82dc(IA·S3, PO 確定) — inbox는 scope 필드를 안 쓴다(애매). 메인 조회
+      // (/api/notifications)가 project_id·org_id 둘 다 안 걸어 순수 사용자 개인 알림이다 —
+      // project도 org도 아닌 계정 축이라 AC2 "화면은 모르는 것을 단정하지 않는다"로 무표식.
       { id: 'inbox', labelKey: 'inbox', icon: Inbox, kind: 'static', path: '/inbox', badgeKey: 'inbox' },
       // story #3179(S3c) — 'dashboard'(대시보드, /dashboard) 항목 제거. attention(S3a)·
       // pulse(S3b)가 chat으로 이전되며 /dashboard는 폐합(redirect-only 스텁)됐다 — 같은
@@ -105,11 +117,11 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     id: 'dev',
     labelKey: 'zoneDev',
     items: [
-      { id: 'board', labelKey: 'board', icon: Workflow, kind: 'resource', path: 'flow', kbdHint: 'B' },
-      { id: 'goals', labelKey: 'goals', icon: Layers, kind: 'resource', path: 'goals' },
-      { id: 'loops', labelKey: 'loops', icon: FlaskConical, kind: 'resource', path: 'loops' },
-      { id: 'standup', labelKey: 'standup', icon: Users, kind: 'resource', path: 'standup', kbdHint: 'S' },
-      { id: 'retro', labelKey: 'retro', icon: Gauge, kind: 'resource', path: 'retro', kbdHint: 'R' },
+      { id: 'board', labelKey: 'board', icon: Workflow, kind: 'resource', path: 'flow', kbdHint: 'B', scope: 'project' },
+      { id: 'goals', labelKey: 'goals', icon: Layers, kind: 'resource', path: 'goals', scope: 'project' },
+      { id: 'loops', labelKey: 'loops', icon: FlaskConical, kind: 'resource', path: 'loops', scope: 'project' },
+      { id: 'standup', labelKey: 'standup', icon: Users, kind: 'resource', path: 'standup', kbdHint: 'S', scope: 'project' },
+      { id: 'retro', labelKey: 'retro', icon: Gauge, kind: 'resource', path: 'retro', kbdHint: 'R', scope: 'project' },
     ],
   },
   {
@@ -129,47 +141,52 @@ export const NAV_GROUPS: NavGroupConfig[] = [
       // 그대로 — 상태·발행 URL 열을 가진 목록이 문서 하나로 오독되는 것을 막기 위함.
       // 「관리」 구역의 org-connectors로도 옮기지 않는다 — 연결은 owner의 설정 행위,
       // 운영은 마케터의 일상 행위라는 가름(§5-2)이 그대로 적용된다.
-      { id: 'content', labelKey: 'content', icon: FileText, kind: 'static', path: '/content' },
+      { id: 'content', labelKey: 'content', icon: FileText, kind: 'static', path: '/content', scope: 'org' },
       // story #3402(Phase1·마케팅운영, PO 결정 2026-09-03 23:17Z) — 채널 포스트(Threads)
       // 관리 화면. NavItemConfig에 중첩 하위메뉴 구조가 없어(app-sidebar.tsx는 group.items를
       // 평평하게 순회) "블로그 포스트 아래" 배치는 이 배열에서 content 바로 뒤에 두는 것으로
       // 표현한다 — content(호스팅 블로그, org 스코프)와 같은 이유로 kind:'static'·top-level
       // 경로(channel_post_drafts도 org 스코프, project 무관).
-      { id: 'channel-posts', labelKey: 'channelPosts', icon: Share2, kind: 'static', path: '/content/channel-posts' },
+      { id: 'channel-posts', labelKey: 'channelPosts', icon: Share2, kind: 'static', path: '/content/channel-posts', scope: 'org' },
       // story #3376(페드루 PO 確定 2026-09-03) — 소셜 채널 OAuth 연결(조직이 소유한 외부
       // 계정·토큰). 예전 organization 구역에서 이관 — 「연결」 행위 자체는 마케터가 채널을
       // 붙이는 일상 실물이라 도메인 축(마케팅)으로 옮긴다(path 불변). story #ee78b047
       // (IA·S2, 2026-09-08, PO 確定) — 라벨은 「채널 연결」(옛 「채널」이 이웃 「채널
       // 포스트」의 접두어였다 — 이름이 스스로 갈라야 한다는 S2 AC1).
-      { id: 'org-channels', labelKey: 'orgChannels', icon: Share2, kind: 'static', path: '/organization/channels' },
+      { id: 'org-channels', labelKey: 'orgChannels', icon: Share2, kind: 'static', path: '/organization/channels', scope: 'org' },
       // story #3472(페드루 PO 確定 2026-09-05) — 콘텐츠 규칙(금칙어·UTM 필수·톤·택소노미·
       // 채널 우선순위·브랜드 킷). 예전 organization 구역에서 이관 — path 불변.
-      { id: 'org-content-rules', labelKey: 'orgContentRules', icon: ListChecks, kind: 'static', path: '/organization/content-rules' },
+      { id: 'org-content-rules', labelKey: 'orgContentRules', icon: ListChecks, kind: 'static', path: '/organization/content-rules', scope: 'org' },
       // story #3503(성과 보드 화면) — 발행된 글의 D+1/D+7 성과 표. 예전 organization
       // 구역에서 이관 — path 불변.
-      { id: 'org-insights-board', labelKey: 'orgInsightsBoard', icon: TrendingUp, kind: 'static', path: '/organization/insights-board' },
+      { id: 'org-insights-board', labelKey: 'orgInsightsBoard', icon: TrendingUp, kind: 'static', path: '/organization/insights-board', scope: 'org' },
     ],
   },
   {
     id: 'trust',
     labelKey: 'zoneTrust',
     items: [
-      { id: 'activity', labelKey: 'activity', icon: ClipboardList, kind: 'static', path: '/activity' },
+      // story #9c5e82dc(IA·S3, PO 確定) — kind:'static'(고정 경로)라 겉보기엔 org스러웠지만
+      // 실제 데이터 페칭(activity-log-view.tsx)이 useDashboardContext().projectId로
+      // `/api/activity-logs?project_id=...`를 건다 — project 전환 시 내용이 실제로 바뀐다.
+      // 3600 문서의 "실측 8"은 구현 前 추정이었고(kind:'resource' 8항목만 셈), 이 화면은
+      // kind가 'static'이라 그 신호에서 빠졌다 — 실 코드가 정본이라 project로 정정(8→9).
+      { id: 'activity', labelKey: 'activity', icon: ClipboardList, kind: 'static', path: '/activity', scope: 'project' },
       // organization 흡수(시안 매핑표) — 신뢰 축의 실물이 이제 여기 있다(이전엔 organization
       // 그룹 소속). path 불변, 그룹 소속만 이동. 라벨도 zoneTrust와 겹치던 "신뢰"→"신뢰 센터"로
       // 정정(같은 구역 안에서 구역명과 항목명이 동어반복하지 않게, 시안 신뢰 센터 표기 그대로).
-      { id: 'org-trust', labelKey: 'orgTrust', icon: Award, kind: 'static', path: '/organization/trust' },
+      { id: 'org-trust', labelKey: 'orgTrust', icon: Award, kind: 'static', path: '/organization/trust', scope: 'org' },
     ],
   },
   {
     id: 'knowledge',
     labelKey: 'zoneKnowledge',
     items: [
-      { id: 'docs', labelKey: 'docs', icon: BookOpen, kind: 'resource', path: 'docs' },
-      { id: 'artifacts', labelKey: 'artifacts', icon: GalleryVerticalEnd, kind: 'resource', path: 'artifacts' },
-      { id: 'storage', labelKey: 'storage', icon: HardDrive, kind: 'resource', path: 'storage' },
+      { id: 'docs', labelKey: 'docs', icon: BookOpen, kind: 'resource', path: 'docs', scope: 'project' },
+      { id: 'artifacts', labelKey: 'artifacts', icon: GalleryVerticalEnd, kind: 'resource', path: 'artifacts', scope: 'project' },
+      { id: 'storage', labelKey: 'storage', icon: HardDrive, kind: 'resource', path: 'storage', scope: 'project' },
       // organization 흡수(시안 매핑표) — memory는 지식 축의 실물. path 불변, 그룹 소속만 이동.
-      { id: 'org-memory', labelKey: 'orgMemory', icon: Brain, kind: 'static', path: '/organization/memory' },
+      { id: 'org-memory', labelKey: 'orgMemory', icon: Brain, kind: 'static', path: '/organization/memory', scope: 'org' },
     ],
   },
   {
@@ -185,17 +202,20 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     id: 'organization',
     labelKey: 'zoneOrganization',
     items: [
-      { id: 'org-members', labelKey: 'orgMembers', icon: Users2, kind: 'static', path: '/organization/members' },
-      { id: 'org-workforce', labelKey: 'workforce', icon: Bot, kind: 'static', path: '/organization/workforce' },
-      { id: 'org-roles', labelKey: 'orgRoles', icon: Shield, kind: 'static', path: '/organization/roles' },
-      { id: 'org-events', labelKey: 'orgEvents', icon: Zap, kind: 'static', path: '/organization/events' },
+      { id: 'org-members', labelKey: 'orgMembers', icon: Users2, kind: 'static', path: '/organization/members', scope: 'org' },
+      { id: 'org-workforce', labelKey: 'workforce', icon: Bot, kind: 'static', path: '/organization/workforce', scope: 'org' },
+      { id: 'org-roles', labelKey: 'orgRoles', icon: Shield, kind: 'static', path: '/organization/roles', scope: 'org' },
+      { id: 'org-events', labelKey: 'orgEvents', icon: Zap, kind: 'static', path: '/organization/events', scope: 'org' },
       // story 4180f67f — 마케팅자동화 발행 커넥터(threads/stibee/instagram 등) org_config 설정 화면.
-      { id: 'org-connectors', labelKey: 'orgConnectors', icon: Plug, kind: 'static', path: '/organization/connectors' },
+      { id: 'org-connectors', labelKey: 'orgConnectors', icon: Plug, kind: 'static', path: '/organization/connectors', scope: 'org' },
     ],
   },
   {
     id: 'settings',
     items: [
+      // story #9c5e82dc(IA·S3, PO 確定) — scope 필드를 안 쓴다(애매). 화면 전체 개념은
+      // 계정 설정인데, 팀원 관리 탭 하나만 project_id를 쓴다(섞인 화면) — AC2 "화면은
+      // 모르는 것을 단정하지 않는다"로 org/project 어느 쪽 표식도 안 붙인다.
       { id: 'settings', labelKey: 'settings', icon: Settings, kind: 'static', path: '/settings' },
     ],
   },


### PR DESCRIPTION
## 배경

3600 문서 §2-④·부록 E·S3. 24항목 중 8이 프로젝트 것인데 구역이 한 마디도 안 함 — 축을 바꿔도(S1) 안 풀리는 독립 건.

## 처방

**데이터(PO 確定)** — 각 항목의 실 데이터 페칭 코드를 읽어 분류(추정 아님):
- project(9): board·goals·loops·standup·retro·docs·artifacts·storage + **activity**(kind:'static'이라 3600 문서 「실측 8」엔 없었으나, `/api/activity-logs?project_id=...`로 실제 필터되는 것을 확認 — 8→9 정정, 라이브 코드가 정본).
- org(13): 나머지 org_id 스코프 확認 항목 전부.
- 애매(scope 필드 자체를 안 씀, 2): inbox(순수 계정 알림)·settings(팀원 탭만 project, 화면 전체는 계정) — AC2 "화면은 모르는 것을 단정하지 않는다"를 필드 부재로 표현.

**표식(유나 § 確定)**:
- ko 「프로젝트」 / en "Project" — 축약 없음. 폭 실측(200/256px, 9행 전부 74~102px 여유) 결과 「PJ」·아이콘 단독 둘 다 안 들어가서가 아니라 **셋 다 들어가서** 기각(「읽히는가」로 고름 — 라틴 약어는 배워야 하는 어휘, sr-only는 시각 사용자에게 안 말함).
- 칩/배지 모양(테두리·배경) 금지 — 성질이지 행위가 아니다.
- 순서: 라벨 → 프로젝트 → kbd.
- ⛔ 무표식(org 13 + 애매 2)을 "org 범위"로 읽는 문구는 코드 어디에도 없음.

## AC 대조

1. 24항목 전부 scope 분류(9 project·13 org·2 무) — 실 코드 근거 ✅
2. 화면이 값을 말함(project만 표식) · 애매 2항목 무표식 ✅
3. 표식이 칩 없는 bare span(kbd와 같은 크기) — 폭 침범 최소화. en 폭 실측·두 테마 잘림 0은 배포 뒤 유나 라이브 몫(본인 명시)
4. [디자인] 유나 § 確定 그대로 배선 ✅

## 테스트

- `nav-config-scope.test.ts`(신규) — 9/13/2 분류 고정 + kind:'resource' 8항목 전부 scope:'project' 구조적 불변식 + 양성대조.
- `app-sidebar.test.tsx` — 표식 렌더 5건 신규(project 있음·org 없음·애매 없음·순서·모양=칩 아님).
- nav·i18n 계열 132건 재검증 그린. 전체 `pnpm vitest run` — 714 files·6941 tests 무회귀.
- `tsc --noEmit`·`eslint` 클린. `pnpm build` 성공.

## 잔여(유나 본인 명시)

- 배포 뒤: 9행 두 테마 잘림 0·표식 대비 ≥4.5 실측(현재 kbd 대비 4.72~4.77은 하한에 마진이 얇아 재측정 예정)·en 폭 200px 실측.
- 별건 후보(스토리에 기록): `showContextChip`이 project 9 밖(inbox·chats·more·rewards·에이전트 화면)에서도 쓰여, 상단 칩과 이 표식이 같은 사실을 다르게 말할 여지 — S3 착지 뒤 대조.