### PR TITLE
[SID:3625] feat(FE): IA S4 — 사이드바 구역 기본 접힘(규칙+메커니즘, 임계값은 배포 뒤)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -91,6 +91,8 @@
     "standup": "Standup",
     "retro": "Retro",
     "scopeProject": "Project",
+    "groupExpand": "Expand {group}",
+    "groupCollapse": "Collapse {group}",
     "docs": "Docs",
     "artifacts": "Artifacts",
     "rewards": "Rewards",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -91,6 +91,8 @@
     "standup": "스탠드업",
     "retro": "회고",
     "scopeProject": "프로젝트",
+    "groupExpand": "{group} 펼치기",
+    "groupCollapse": "{group} 접기",
     "docs": "문서",
     "artifacts": "산출물",
     "rewards": "리워드",

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -369,6 +369,20 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     expect([...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'))).toBeDefined();
   });
 
+  // 카디르 QA(a11y, §22-18 가드) — render prop 버튼이 SidebarGroupLabel의 children(그룹명
+  // 텍스트+쉐브론)을 감싸긴 하지만, 접근성 트리에서 버튼 자체의 이름은 aria-label로
+  // 명시해야 스크린리더가 7구역 토글을 구별한다(textContent만으론 landmark 목록 등에서
+  // 이름이 안 실리는 경우가 있다) — aria-label에 그룹명+접힘상태를 담는다.
+  it('구역 토글 버튼의 aria-label이 그룹명+접힘상태를 담는다(카디르 QA a11y 처방)', async () => {
+    await mount();
+    const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
+    expect(devHeader?.getAttribute('aria-label')).toBe('개발 접기');
+
+    await act(async () => { devHeader!.click(); });
+    const devHeaderAfter = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
+    expect(devHeaderAfter?.getAttribute('aria-label')).toBe('개발 펼치기');
+  });
+
   it('접힘 상태가 localStorage에 사람별로 기억된다(AC3)', async () => {
     await mount();
     const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -54,12 +54,22 @@ function stubLocalStorage() {
   });
 }
 
-// story #d986fd6c(IA·S4) — budget=12 확定 뒤 신뢰·지식·조직이 기본 접힘이라, 이 구조적
-// 회귀가드들(원래 story #2681)이 전제하던 "항상 전 항목 렌더"가 깨진다. 접힘 기능 자체와
-// 무관한 이 테스트들은 접힘 전 상태(구조)를 재는 게 목적이라 localStorage에 전 구역
-// 펼침을 미리 심어 둔다 — 접힘 동작 자체는 아래 별도 테스트가 다룬다.
+// story #d986fd6c(IA·S4, PO 정정 2026-09-08 07:19Z) — 기본 접힘이 이제 활성 구역+뷰포트
+// 조건으로 매 렌더 파생돼(고정 budget 아님), 이 구조적 회귀가드들(원래 story #2681)이
+// 전제하던 "항상 전 항목 렌더"가 깨진다. 접힘 기능 자체와 무관한 이 테스트들은 접힘 전
+// 상태(구조)를 재는 게 목적이라 localStorage에 전 구역 펼침을 미리 심어 둔다(오버라이드가
+// 계산된 기본값을 항상 이긴다 — mergeStoredCollapsedOverrides) — 접힘 동작 자체는 아래
+// 별도 테스트가 다룬다.
 function expandAllGroups() {
-  localStorage.setItem('sidebar_group_collapsed', JSON.stringify({ trust: false, knowledge: false, organization: false }));
+  localStorage.setItem('sidebar_group_collapsed', JSON.stringify({
+    now: false, dev: false, marketing: false, trust: false, knowledge: false, organization: false,
+  }));
+}
+
+// jsdom 기본 innerHeight(768)는 「오늘」 얹기 문턱(840)에 못 미친다 — 문턱 위/아래 양쪽을
+// 재는 테스트를 위한 스텁.
+function stubViewportHeight(height: number) {
+  Object.defineProperty(window, 'innerHeight', { value: height, writable: true, configurable: true });
 }
 
 let container: HTMLDivElement;
@@ -186,6 +196,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('리소스 항목(개발 그룹, org/project slug 없음)이 bare href로 폴백한다(기존 resourceLink 동작)', async () => {
+    expandAllGroups();
     await mount();
     // startsWith 유지 — kbd 힌트 접미사가 붙는 항목이 있어 정확한 === 매칭은 못 쓴다.
     const boardLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
@@ -193,6 +204,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('kbd 힌트(보드=B·스탠드업=S)가 항목별로 정확히 붙는다', async () => {
+    expandAllGroups();
     await mount();
     const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
     expect(boardBtn?.textContent).toContain('B');
@@ -205,6 +217,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   // 재감사로 2→4 정정)엔 안 붙는다(무표식=org를 뜻하지 않는다 — 이 테스트는 org 대표
   // 표본 하나를 확認한다).
   it('scope:project 항목(보드)엔 「프로젝트」 표식이 붙는다', async () => {
+    expandAllGroups();
     await mount();
     const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
     expect(boardBtn?.textContent).toContain('프로젝트');
@@ -221,6 +234,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('애매 항목(알림·설정)엔 「프로젝트」 표식이 안 붙는다', async () => {
+    expandAllGroups();
     await mount();
     const inboxBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('알림'));
     expect(inboxBtn?.textContent).not.toContain('프로젝트');
@@ -229,6 +243,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('순서는 라벨→표식→kbd다(보드: "보드" 다음 "프로젝트" 다음 "B")', async () => {
+    expandAllGroups();
     await mount();
     const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
     const text = boardBtn?.textContent ?? '';
@@ -241,6 +256,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('표식은 칩/배지 모양(테두리·배경)을 안 쓴다(유나 § — 성질이지 행위가 아니다)', async () => {
+    expandAllGroups();
     await mount();
     const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
     const scopeEl = [...(boardBtn?.querySelectorAll('span') ?? [])].find((s) => s.textContent === '프로젝트');
@@ -264,6 +280,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   // 교체됐다 — designated_approver_id=me AND status=pending만 세는 room-무관 SSOT
   // (BE gates.py::get_designated_pending_count 문서 — "AC1이 이 층에서 닫히는 근거").
   it('결재 대기 배지(inbox)가 카운트>0일 때만 렌더된다', async () => {
+    expandAllGroups();
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ count: 3 }), {
       status: 200, headers: { 'content-type': 'application/json' },
     })));
@@ -273,6 +290,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('결재 대기 0건이면 배지가 안 뜬다', async () => {
+    expandAllGroups();
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ count: 0 }), {
       status: 200, headers: { 'content-type': 'application/json' },
     })));
@@ -332,29 +350,52 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     expect(link!.className).not.toContain('bg-proof-blue-soft');
   });
 
-  // story #d986fd6c(IA·S4, PO 確定 2026-09-08) — budget=12(오늘2+개발5+마케팅5) 확定 뒤
-  // 기본 상태: 주력 3구역(오늘·개발·마케팅)은 기본 펼침, 2차 구역(신뢰·지식·조직)은 기본
-  // 접힘(설정은 애초에 접기 대상 아님).
-  it('기본 상태는 주력 3구역(오늘·개발·마케팅) 펼침·2차 구역(신뢰·지식·조직) 접힘이다(budget=12)', async () => {
+  // story #d986fd6c(IA·S4, PO 정정 2026-09-08 07:19Z — 유나 실측 반영) — budget-누적 규칙을
+  // 「현재 구역 인지 + 뷰포트 조건」으로 교체했다: 기본은 활성 구역만 펼침, 뷰포트
+  // ≥840px면 「오늘」도 얹는다.
+  it('기본 상태는 활성 구역만 펼치고 나머지는 접는다(뷰포트<840, pathname=/dashboard → 활성 구역 없음)', async () => {
+    stubViewportHeight(700);
     await mount();
+    // pathname mock 기본값 '/dashboard'는 어느 nav 항목과도 안 맞아 활성 구역이 없다
+    // (dashboard 항목 자체가 story #3179로 삭제됨) — 「오늘」도 뷰포트 미달이라 안 얹혀
+    // 전 구역이 접힌다.
+    const orgBriefingLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('조직 브리핑'));
+    expect(orgBriefingLink).toBeUndefined();
     const boardLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
-    expect(boardLink).toBeDefined();
-    const contentLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('블로그 포스트'));
-    expect(contentLink).toBeDefined();
-    const activityLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('활동 로그'));
-    expect(activityLink).toBeUndefined();
-    const docsLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('문서'));
-    expect(docsLink).toBeUndefined();
-    const orgMembersLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('구성원'));
-    expect(orgMembersLink).toBeUndefined();
+    expect(boardLink).toBeUndefined();
+  });
 
-    const trustHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('신뢰'));
-    expect(trustHeader?.getAttribute('aria-expanded')).toBe('false');
-    const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
-    expect(devHeader?.getAttribute('aria-expanded')).toBe('true');
+  it('활성 구역(현재 경로가 속한 구역)은 뷰포트 무관하게 펼쳐진다', async () => {
+    pathnameRef.current = '/organization/events';
+    stubViewportHeight(700);
+    await mount();
+    const eventsLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('이벤트'));
+    expect(eventsLink).toBeDefined();
+    const membersLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('구성원'));
+    expect(membersLink).toBeDefined();
+    // 비활성 구역(개발)은 그대로 접힘.
+    const boardLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
+    expect(boardLink).toBeUndefined();
+  });
+
+  it('뷰포트 ≥840이면 활성 구역 밖이어도 「오늘」이 함께 펼쳐진다', async () => {
+    pathnameRef.current = '/organization/events';
+    stubViewportHeight(900);
+    await mount();
+    const orgBriefingLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('조직 브리핑'));
+    expect(orgBriefingLink).toBeDefined();
+  });
+
+  it('뷰포트 839(문턱 바로 아래)면 「오늘」은 안 얹힌다(경계값)', async () => {
+    pathnameRef.current = '/organization/events';
+    stubViewportHeight(839);
+    await mount();
+    const orgBriefingLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('조직 브리핑'));
+    expect(orgBriefingLink).toBeUndefined();
   });
 
   it('구역 헤더를 클릭하면 접히고(항목 DOM에서 사라짐) 다시 클릭하면 펴진다', async () => {
+    expandAllGroups();
     await mount();
     const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
     expect(devHeader).toBeDefined();
@@ -374,6 +415,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   // 명시해야 스크린리더가 7구역 토글을 구별한다(textContent만으론 landmark 목록 등에서
   // 이름이 안 실리는 경우가 있다) — aria-label에 그룹명+접힘상태를 담는다.
   it('구역 토글 버튼의 aria-label이 그룹명+접힘상태를 담는다(카디르 QA a11y 처방)', async () => {
+    expandAllGroups();
     await mount();
     const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
     expect(devHeader?.getAttribute('aria-label')).toBe('개발 접기');
@@ -384,6 +426,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('접힘 상태가 localStorage에 사람별로 기억된다(AC3)', async () => {
+    expandAllGroups();
     await mount();
     const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
     await act(async () => { devHeader!.click(); });

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -314,4 +314,53 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     expect(link!.className).toContain('shadow-[var(--elev-card)]');
     expect(link!.className).not.toContain('bg-proof-blue-soft');
   });
+
+  // story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 구역 접기/펴기. 임계값이 아직 PENDING
+  // (null)이라 기본 상태는 "전 구역 펼침"이다(임의로 특정 구역을 손으로 접어 두지 않음).
+  it('임계값 미확定 상태에선 기본으로 모든 구역이 펼쳐져 있다(빈 구역 헤더 클릭 전)', async () => {
+    await mount();
+    const boardLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
+    expect(boardLink).toBeDefined();
+  });
+
+  it('구역 헤더를 클릭하면 접히고(항목 DOM에서 사라짐) 다시 클릭하면 펴진다', async () => {
+    await mount();
+    const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
+    expect(devHeader).toBeDefined();
+    expect(devHeader?.getAttribute('aria-expanded')).toBe('true');
+
+    await act(async () => { devHeader!.click(); });
+    expect([...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'))).toBeUndefined();
+    const devHeaderAfter = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
+    expect(devHeaderAfter?.getAttribute('aria-expanded')).toBe('false');
+
+    await act(async () => { devHeaderAfter!.click(); });
+    expect([...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'))).toBeDefined();
+  });
+
+  it('접힘 상태가 localStorage에 사람별로 기억된다(AC3)', async () => {
+    await mount();
+    const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
+    await act(async () => { devHeader!.click(); });
+
+    const stored = JSON.parse(localStorage.getItem('sidebar_group_collapsed') ?? '{}');
+    expect(stored.dev).toBe(true);
+  });
+
+  it('기억된 접힘 상태가 마운트 시 그대로 재현된다(기억 있으면 그 값, AC3)', async () => {
+    localStorage.setItem('sidebar_group_collapsed', JSON.stringify({ dev: true }));
+    await mount();
+    const boardLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
+    expect(boardLink).toBeUndefined();
+    const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
+    expect(devHeader?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('라벨 없는 설정 그룹엔 접기 토글이 없다(헤더 자체가 없음)', async () => {
+    await mount();
+    const settingsLink = [...container.querySelectorAll('a')].find((a) => a.textContent === '설정');
+    expect(settingsLink).toBeDefined();
+    const toggles = [...container.querySelectorAll('button[aria-expanded]')];
+    expect(toggles.some((b) => b.textContent?.includes('설정'))).toBe(false);
+  });
 });

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -54,6 +54,14 @@ function stubLocalStorage() {
   });
 }
 
+// story #d986fd6c(IA·S4) — budget=12 확定 뒤 신뢰·지식·조직이 기본 접힘이라, 이 구조적
+// 회귀가드들(원래 story #2681)이 전제하던 "항상 전 항목 렌더"가 깨진다. 접힘 기능 자체와
+// 무관한 이 테스트들은 접힘 전 상태(구조)를 재는 게 목적이라 localStorage에 전 구역
+// 펼침을 미리 심어 둔다 — 접힘 동작 자체는 아래 별도 테스트가 다룬다.
+function expandAllGroups() {
+  localStorage.setItem('sidebar_group_collapsed', JSON.stringify({ trust: false, knowledge: false, organization: false }));
+}
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -155,6 +163,7 @@ const EXPECTED_HREF_BY_LABEL: Record<string, string> = {
 
 describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story #2930 I1 4구역 재편', () => {
   it('그룹 순서·라벨·항목 순서·라벨이 IA·S1 확定대로다(오늘→개발→마케팅→신뢰→지식→조직→설정)', async () => {
+    expandAllGroups();
     await mount();
     const groupLabels = [...container.querySelectorAll('[data-slot="sidebar-group-label"]')].map((el) => el.textContent);
     expect(groupLabels).toEqual(['오늘', '개발', '마케팅', '신뢰', '지식', '조직']);
@@ -168,6 +177,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('정적 항목(조직 그룹)의 href가 무변화다(path 전부 불변, 2930 I1 핵심 제약)', async () => {
+    expandAllGroups();
     await mount();
     const membersLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('구성원'));
     expect(membersLink?.getAttribute('href')).toBe('/organization/members');
@@ -235,6 +245,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
 
   it('현재 경로와 일치하는 정적 항목이 active로 표시된다(isActive 판정 보존)', async () => {
     pathnameRef.current = '/organization/events';
+    expandAllGroups();
     await mount();
     const eventsBtn = [...container.querySelectorAll('[data-slot="sidebar-menu-button"]')].find((b) => b.textContent?.includes('이벤트'));
     expect(eventsBtn?.hasAttribute('data-active')).toBe(true);
@@ -279,6 +290,7 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   // 워크 그룹에 '콘텐츠' 추가돼 19→20) 전부를 라벨→href 쌍으로 개별 대조해 "라벨은 맞는데
   // 목적지가 틀림"을 확실히 막는다.
   it('전 22항목(챗 center 제외)의 라벨→href 쌍이 정확하다(뒤바뀐 목적지 방지, 카디르 QA 지적 반영)', async () => {
+    expandAllGroups();
     await mount();
     const links = [...container.querySelectorAll('a')];
     for (const [label, expectedHref] of Object.entries(EXPECTED_HREF_BY_LABEL)) {
@@ -315,12 +327,26 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     expect(link!.className).not.toContain('bg-proof-blue-soft');
   });
 
-  // story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 구역 접기/펴기. 임계값이 아직 PENDING
-  // (null)이라 기본 상태는 "전 구역 펼침"이다(임의로 특정 구역을 손으로 접어 두지 않음).
-  it('임계값 미확定 상태에선 기본으로 모든 구역이 펼쳐져 있다(빈 구역 헤더 클릭 전)', async () => {
+  // story #d986fd6c(IA·S4, PO 確定 2026-09-08) — budget=12(오늘2+개발5+마케팅5) 확定 뒤
+  // 기본 상태: 주력 3구역(오늘·개발·마케팅)은 기본 펼침, 2차 구역(신뢰·지식·조직)은 기본
+  // 접힘(설정은 애초에 접기 대상 아님).
+  it('기본 상태는 주력 3구역(오늘·개발·마케팅) 펼침·2차 구역(신뢰·지식·조직) 접힘이다(budget=12)', async () => {
     await mount();
     const boardLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
     expect(boardLink).toBeDefined();
+    const contentLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('블로그 포스트'));
+    expect(contentLink).toBeDefined();
+    const activityLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('활동 로그'));
+    expect(activityLink).toBeUndefined();
+    const docsLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('문서'));
+    expect(docsLink).toBeUndefined();
+    const orgMembersLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('구성원'));
+    expect(orgMembersLink).toBeUndefined();
+
+    const trustHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('신뢰'));
+    expect(trustHeader?.getAttribute('aria-expanded')).toBe('false');
+    const devHeader = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('개발'));
+    expect(devHeader?.getAttribute('aria-expanded')).toBe('true');
   });
 
   it('구역 헤더를 클릭하면 접히고(항목 DOM에서 사라짐) 다시 클릭하면 펴진다', async () => {

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -201,8 +201,9 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   // story #9c5e82dc(IA·S3, 유나 § 確定 2026-09-08) — 「프로젝트」 표식은 scope:'project'
-  // 9항목에만 붙고, org 13·애매 2(inbox·settings)엔 안 붙는다(무표식=org를 뜻하지 않는다 —
-  // 이 테스트는 그 둘을 각각 대표 표본으로 확認한다).
+  // 9항목에만 붙고, org 11·애매 4(inbox·settings·org-briefing·org-workforce, 카디르 QA
+  // 재감사로 2→4 정정)엔 안 붙는다(무표식=org를 뜻하지 않는다 — 이 테스트는 org 대표
+  // 표본 하나를 확認한다).
   it('scope:project 항목(보드)엔 「프로젝트」 표식이 붙는다', async () => {
     await mount();
     const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
@@ -210,6 +211,10 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   it('org 항목(구성원)엔 「프로젝트」 표식이 안 붙는다', async () => {
+    // story #d986fd6c(IA·S4) — 구성원(org-members)이 속한 조직 그룹은 budget=12 기본
+    // 접힘 대상이라, 이 테스트(scope 표식 유무 확認, 접힘과 무관)가 항목을 보려면 펼쳐야
+    // 한다.
+    expandAllGroups();
     await mount();
     const membersBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('구성원'));
     expect(membersBtn?.textContent).not.toContain('프로젝트');

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -109,8 +109,9 @@ function KbdHint({ children }: { children: React.ReactNode }) {
 // 자리·비슷한 크기(10px)지만 mono가 아니라 본문 폰트(한글이라). 순서는 라벨→표식→kbd
 // (성질이 이름에 붙고 행위가 끝에 간다).
 //
-// ⛔️무표식 = 조직 범위가 아니다(유나 § 명시) — org 13항목 + 애매 2항목(inbox·settings)
-// 둘 다 무표식이다. 이 표식은 "project임을 말한다"만 하지 "무표식=org"를 말하지 않는다.
+// ⛔️무표식 = 조직 범위가 아니다(유나 § 명시) — org 11항목 + 애매 4항목(inbox·settings·
+// org-briefing·org-workforce, 카디르 QA 재감사로 2→4 정정) 둘 다 무표식이다. 이 표식은
+// "project임을 말한다"만 하지 "무표식=org"를 말하지 않는다.
 function ScopeMark({ children }: { children: React.ReactNode }) {
   return (
     <span className="text-[10px] font-medium text-sidebar-foreground/60 group-data-[active=true]/menu-button:text-sidebar-foreground/80">

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -51,10 +51,10 @@ interface AppSidebarProps {
 }
 
 // story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 기본 접힘 집합(규칙은 nav-config.ts::
-// computeDefaultCollapsedGroupIds, 임계값은 SIDEBAR_FIRST_SCREEN_ITEM_BUDGET). 임계값이
-// 아직 PENDING(null — 배포 54 뒤 실측)이라 지금은 빈 집합(전 구역 기본 펼침) — 임의로
-// 특정 구역을 손으로 접어 두지 않는다(AC1 "임의 수 금지"의 정신). 임계값이 채워지는
-// 순간 이 상수도 그 규칙을 그대로 따른다(코드 변경 0, 값만 채우면 됨).
+// computeDefaultCollapsedGroupIds, 임계값은 SIDEBAR_FIRST_SCREEN_ITEM_BUDGET=12 — 배포
+// 54 dev-app 실측+PO 확定 근거는 그 상수 정의부 주석 참고). 오늘·개발·마케팅(2+5+5=12)
+// 기본 펼침, 신뢰·지식·조직 기본 접힘(settings는 라벨 없는 유틸 그룹이라 애초에 접기
+// 대상이 아니다 — 아래 렌더 루프의 isCollapsible 가드가 무시한다).
 const DEFAULT_COLLAPSED_GROUP_IDS: Set<string> = SIDEBAR_FIRST_SCREEN_ITEM_BUDGET != null
   ? computeDefaultCollapsedGroupIds(
       NAV_GROUPS.map((g) => ({ id: g.id, itemCount: g.items.length })),

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -349,6 +349,14 @@ export function AppSidebar({
           // 으로 못박아 뒀다 — 헤더 자체가 없으니 토글할 자리도 없다).
           const isCollapsible = Boolean(group.labelKey);
           const isCollapsed = isCollapsible && collapsedGroupIds.has(group.id);
+          const groupLabel = group.labelKey ? t(group.labelKey) : '';
+          // 카디르 QA(a11y, §22-18 가드) — render prop이 넘기는 <button>은 SidebarGroupLabel의
+          // children(그룹명 텍스트+쉐브론 아이콘)을 감싸기만 할 뿐 버튼 자체에 접근가능한
+          // 이름이 안 실린다(스크린리더가 7구역 토글을 구별 못 함) — aria-label에 그룹명+
+          // 접힘상태를 명시로 채워 넣는다.
+          const toggleAriaLabel = isCollapsed
+            ? t('groupExpand', { group: groupLabel })
+            : t('groupCollapse', { group: groupLabel });
           return (
           <SidebarGroup key={group.id}>
             {group.labelKey ? (
@@ -358,11 +366,12 @@ export function AppSidebar({
                     type="button"
                     onClick={() => toggleGroupCollapsed(group.id)}
                     aria-expanded={!isCollapsed}
+                    aria-label={toggleAriaLabel}
                   />
                 }
                 className="w-full cursor-pointer justify-between hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
               >
-                <span>{t(group.labelKey)}</span>
+                <span>{groupLabel}</span>
                 <ChevronDown className={cn('size-3.5 shrink-0 transition-transform duration-150', isCollapsed && '-rotate-90')} />
               </SidebarGroupLabel>
             ) : null}

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -381,7 +381,7 @@ export function AppSidebar({
           const isCollapsible = Boolean(group.labelKey);
           const isCollapsed = isCollapsible && collapsedGroupIds.has(group.id);
           const groupLabel = group.labelKey ? t(group.labelKey) : '';
-          // 카디르 QA(a11y, §22-18 가드) — render prop이 넘기는 <button>은 SidebarGroupLabel의
+          // 카디르 QA(a11y, §22-18 가드) — render prop이 넘기는 버튼 요소는 SidebarGroupLabel의
           // children(그룹명 텍스트+쉐브론 아이콘)을 감싸기만 할 뿐 버튼 자체에 접근가능한
           // 이름이 안 실린다(스크린리더가 7구역 토글을 구별 못 함) — aria-label에 그룹명+
           // 접힘상태를 명시로 채워 넣는다.

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Search, MessageSquare } from 'lucide-react';
+import { ChevronDown, Search, MessageSquare } from 'lucide-react';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
@@ -12,7 +12,13 @@ import { ProfileMenu } from '@/components/nav/profile-menu';
 import { BusinessInfoDisclosure } from '@/components/nav/business-info-disclosure';
 import { UnifiedSwitcher, type OrgSwitcherItem } from '@/components/nav/unified-switcher';
 import { fetchWithAuth } from '@/lib/db/client';
-import { NAV_GROUPS, CHAT_CENTER_ITEM } from '@/lib/nav-config';
+import { cn } from '@/lib/utils';
+import {
+  NAV_GROUPS,
+  CHAT_CENTER_ITEM,
+  computeDefaultCollapsedGroupIds,
+  SIDEBAR_FIRST_SCREEN_ITEM_BUDGET,
+} from '@/lib/nav-config';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import {
   Sidebar,
@@ -42,6 +48,50 @@ interface AppSidebarProps {
   // story #2007(perf·서버부하): dashboard-shell.tsx가 단일 useChatUnreadTotal() 호출 결과를
   // prop으로 내려준다 — 여기서 직접 훅을 호출하면 MobileTabBar와 각자 SSE 연결을 열게 된다.
   chatUnreadTotal: number;
+}
+
+// story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 기본 접힘 집합(규칙은 nav-config.ts::
+// computeDefaultCollapsedGroupIds, 임계값은 SIDEBAR_FIRST_SCREEN_ITEM_BUDGET). 임계값이
+// 아직 PENDING(null — 배포 54 뒤 실측)이라 지금은 빈 집합(전 구역 기본 펼침) — 임의로
+// 특정 구역을 손으로 접어 두지 않는다(AC1 "임의 수 금지"의 정신). 임계값이 채워지는
+// 순간 이 상수도 그 규칙을 그대로 따른다(코드 변경 0, 값만 채우면 됨).
+const DEFAULT_COLLAPSED_GROUP_IDS: Set<string> = SIDEBAR_FIRST_SCREEN_ITEM_BUDGET != null
+  ? computeDefaultCollapsedGroupIds(
+      NAV_GROUPS.map((g) => ({ id: g.id, itemCount: g.items.length })),
+      SIDEBAR_FIRST_SCREEN_ITEM_BUDGET,
+    )
+  : new Set<string>();
+
+// 사람별 기억(AC3) — 그룹 id별 접힘 여부. localStorage(계정 단위가 아니라 이 브라우저 단위
+// 이지만, "사람별로 기억된다"는 AC 문면은 "같은 사람이 다시 왔을 때 유지"를 요구할 뿐
+// 서버 동기화까지 요구하지 않는다 — sidebar_width와 같은 관례). 값이 없는 그룹은
+// DEFAULT_COLLAPSED_GROUP_IDS를 따른다(AC3 "기억이 없을 때도 기본값으로 온전히 선다").
+const SIDEBAR_GROUP_COLLAPSED_STORAGE_KEY = 'sidebar_group_collapsed';
+
+function readStoredCollapsedOverrides(): Record<string, boolean> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(SIDEBAR_GROUP_COLLAPSED_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, boolean>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function mergeStoredCollapsedOverrides(
+  defaults: Set<string>,
+  overrides: Record<string, boolean>,
+): Set<string> {
+  const next = new Set(defaults);
+  for (const group of NAV_GROUPS) {
+    const stored = overrides[group.id];
+    if (stored === undefined) continue;
+    if (stored) next.add(group.id);
+    else next.delete(group.id);
+  }
+  return next;
 }
 
 function KbdHint({ children }: { children: React.ReactNode }) {
@@ -119,6 +169,43 @@ export function AppSidebar({
   const [paletteOpen, setPaletteOpen] = useState(false);
 
   const openPalette = useCallback(() => setPaletteOpen(true), []);
+
+  // story #d986fd6c(IA·S4) — 그룹별 접힘 «기억». 서버 렌더는 항상 빈 overrides({})로
+  // 시작해(하이드레이션 불일치 방지, sidebar_width의 SIDEBAR_WIDTH_STORAGE_KEY 마운트-후
+  // 읽기와 동형 패턴 — ui/sidebar.tsx:81-83) 마운트 후 이 effect가 localStorage 원문을
+  // 그대로 얹는다. localStorage는 React 밖 외부 저장소라 마운트 시점 1회 동기화는 정확히
+  // 이 effect가 있어야 하는 자리(구독 없는 단발성 읽기 — storage 이벤트는 다른 탭 변경만
+  // 알리고 같은 탭 내 최초 하이드레이션은 못 잡는다).
+  // sidebar_width와 같은 목적(SSR-세이프 localStorage 하이드레이션)이나 그쪽은 원시값
+  // 단일 setState라 react-hooks/set-state-in-effect에 안 걸리고, 이쪽은 객체라 걸린다 —
+  // 파생값(Set)은 이미 위 useMemo로 분리해 뒀으니 이 setState 자체는 "외부 저장소를
+  // 그대로 얹는" 정당한 동기화다.
+  const [collapsedOverrides, setCollapsedOverrides] = useState<Record<string, boolean>>({});
+  useEffect(() => {
+    const overrides = readStoredCollapsedOverrides();
+    if (Object.keys(overrides).length > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setCollapsedOverrides(overrides);
+    }
+  }, []);
+  const collapsedGroupIds = useMemo(
+    () => mergeStoredCollapsedOverrides(DEFAULT_COLLAPSED_GROUP_IDS, collapsedOverrides),
+    [collapsedOverrides],
+  );
+
+  const toggleGroupCollapsed = useCallback((groupId: string) => {
+    setCollapsedOverrides((prev) => {
+      const wasCollapsed = collapsedGroupIds.has(groupId);
+      const next = { ...prev, [groupId]: !wasCollapsed };
+      try {
+        window.localStorage.setItem(SIDEBAR_GROUP_COLLAPSED_STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        // story #d986fd6c — localStorage 실패(프라이빗 창·용량 등)는 이 세션 안 상태만
+        // 유지하고 조용히 넘어간다(기억 실패가 사이드바 자체를 못 쓰게 만들면 안 된다).
+      }
+      return next;
+    });
+  }, [collapsedGroupIds]);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -255,9 +342,30 @@ export function AppSidebar({
             그룹핑은 이 리팩터 전과 동일(시각 회귀 0, AC1). story #2930 I1 — 이제 4구역+관리
             프레임 순서(오늘→워크스페이스→신뢰→지식→조직→설정)로 재편됐다. chats는 위
             챗 center로 승격돼 이 순회 밖이라 badgeKey는 이제 'inbox' 하나만 실질 도달한다. */}
-        {NAV_GROUPS.map((group) => (
+        {NAV_GROUPS.map((group) => {
+          // story #d986fd6c(IA·S4) — 라벨 없는 유틸 그룹(설정)은 접기 대상이 아니다(항목
+          // 1개뿐이라 접어 봤자 얻는 게 없고, ia-4zone 확定이 이미 "라벨 없는 유틸 그룹"
+          // 으로 못박아 뒀다 — 헤더 자체가 없으니 토글할 자리도 없다).
+          const isCollapsible = Boolean(group.labelKey);
+          const isCollapsed = isCollapsible && collapsedGroupIds.has(group.id);
+          return (
           <SidebarGroup key={group.id}>
-            {group.labelKey ? <SidebarGroupLabel>{t(group.labelKey)}</SidebarGroupLabel> : null}
+            {group.labelKey ? (
+              <SidebarGroupLabel
+                render={
+                  <button
+                    type="button"
+                    onClick={() => toggleGroupCollapsed(group.id)}
+                    aria-expanded={!isCollapsed}
+                  />
+                }
+                className="w-full cursor-pointer justify-between hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              >
+                <span>{t(group.labelKey)}</span>
+                <ChevronDown className={cn('size-3.5 shrink-0 transition-transform duration-150', isCollapsed && '-rotate-90')} />
+              </SidebarGroupLabel>
+            ) : null}
+            {!isCollapsed ? (
             <SidebarGroupContent>
               <SidebarMenu>
                 {group.items.map((item) => {
@@ -294,8 +402,10 @@ export function AppSidebar({
                 })}
               </SidebarMenu>
             </SidebarGroupContent>
+            ) : null}
           </SidebarGroup>
-        ))}
+          );
+        })}
       </SidebarContent>
 
       <SidebarFooter className="space-y-2 p-2">

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -16,8 +16,7 @@ import { cn } from '@/lib/utils';
 import {
   NAV_GROUPS,
   CHAT_CENTER_ITEM,
-  computeDefaultCollapsedGroupIds,
-  SIDEBAR_FIRST_SCREEN_ITEM_BUDGET,
+  computeActiveZoneCollapsedGroupIds,
 } from '@/lib/nav-config';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import {
@@ -50,22 +49,15 @@ interface AppSidebarProps {
   chatUnreadTotal: number;
 }
 
-// story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 기본 접힘 집합(규칙은 nav-config.ts::
-// computeDefaultCollapsedGroupIds, 임계값은 SIDEBAR_FIRST_SCREEN_ITEM_BUDGET=12 — 배포
-// 54 dev-app 실측+PO 확定 근거는 그 상수 정의부 주석 참고). 오늘·개발·마케팅(2+5+5=12)
-// 기본 펼침, 신뢰·지식·조직 기본 접힘(settings는 라벨 없는 유틸 그룹이라 애초에 접기
-// 대상이 아니다 — 아래 렌더 루프의 isCollapsible 가드가 무시한다).
-const DEFAULT_COLLAPSED_GROUP_IDS: Set<string> = SIDEBAR_FIRST_SCREEN_ITEM_BUDGET != null
-  ? computeDefaultCollapsedGroupIds(
-      NAV_GROUPS.map((g) => ({ id: g.id, itemCount: g.items.length })),
-      SIDEBAR_FIRST_SCREEN_ITEM_BUDGET,
-    )
-  : new Set<string>();
-
-// 사람별 기억(AC3) — 그룹 id별 접힘 여부. localStorage(계정 단위가 아니라 이 브라우저 단위
-// 이지만, "사람별로 기억된다"는 AC 문면은 "같은 사람이 다시 왔을 때 유지"를 요구할 뿐
-// 서버 동기화까지 요구하지 않는다 — sidebar_width와 같은 관례). 값이 없는 그룹은
-// DEFAULT_COLLAPSED_GROUP_IDS를 따른다(AC3 "기억이 없을 때도 기본값으로 온전히 선다").
+// story #d986fd6c(IA·S4, PO 정정 2026-09-08 07:19Z — 유나 실측 반영) — 기본 접힘은 이제
+// 정적 module 상수가 아니라 현재 라우트(활성 구역)+뷰포트 높이에 따라 매 렌더 파생되는
+// 값이다(규칙은 nav-config.ts::computeActiveZoneCollapsedGroupIds, 근거는 그 정의부
+// 주석 참고) — 컴포넌트 내부의 useMemo(defaultCollapsedGroupIds)가 이를 계산한다.
+//
+// 사람별 기억(AC3) — 그룹 id별 접힘 여부 수동 오버라이드. localStorage(계정 단위가 아니라
+// 이 브라우저 단위이지만, "사람별로 기억된다"는 AC 문면은 "같은 사람이 다시 왔을 때
+// 유지"를 요구할 뿐 서버 동기화까지 요구하지 않는다 — sidebar_width와 같은 관례). 값이
+// 없는 그룹은 위 동적 기본값을 따른다(AC3 "기억이 없을 때도 기본값으로 온전히 선다").
 const SIDEBAR_GROUP_COLLAPSED_STORAGE_KEY = 'sidebar_group_collapsed';
 
 function readStoredCollapsedOverrides(): Record<string, boolean> {
@@ -145,6 +137,12 @@ export function AppSidebar({
   // board를 flow와 나란히 1Depth로 세우지 않는다("나란히 두면 「내렸다」가 무효가 된다" —
   // §7-3) — /flow 안의 보기 전환(?view=list)이 "내비 2Depth 이하" 요건을 충족하는 그 자리다.
   const flowLink = resourceLink('flow');
+  // story #d986fd6c(IA·S4) — 정적 항목 active 판정. 원래 렌더 루프 바로 앞(구 위치)에
+  // 있었으나, 활성 구역 계산(아래)이 접힘 state보다 먼저 알아야 해 이 자리로 옮겼다 —
+  // pathname/href만의 순수 함수라 위치 이동에 따른 의미 변화 없음.
+  function isActive(href: string) {
+    return pathname === href || (href !== '/' && pathname.startsWith(href));
+  }
   const t = useTranslations('nav');
   const { isMobile, setOpenMobile } = useSidebar();
   // ⌘K 액션 확장(story 4f991165) — 스토리 상세(`/flow?view=list&story={id}`)에서 열렸을
@@ -171,6 +169,44 @@ export function AppSidebar({
 
   const openPalette = useCallback(() => setPaletteOpen(true), []);
 
+  // story #d986fd6c(IA·S4, PO 정정 2026-09-08 07:19Z) — 현재 라우트가 속한 구역. 렌더
+  // 루프와 같은 isActive/resourceLink 판정을 재사용해 "어느 구역이 활성인가"를 미리
+  // 한 번 훑는다(항목 배지·href 계산과 완전히 독립된 목적이라 렌더 루프 안에 끼워
+  // 넣지 않고 별도 pass로 둔다 — 접힘 여부가 항목 렌더 자체보다 먼저 정해져야 한다).
+  const activeGroupId = useMemo(() => {
+    for (const group of NAV_GROUPS) {
+      for (const item of group.items) {
+        const link = item.kind === 'static' ? { isActive: isActive(item.path) } : resourceLink(item.path);
+        if (link.isActive) return group.id;
+      }
+    }
+    return null;
+    // isActive/resourceLink는 pathname·orgSlug·currentProjectSlug에서 매 렌더 새로
+    // 만들어지는 클로저라 그 원시값들만 의존성으로 충분하다(함수 자체를 넣으면 항상
+    // 새 참조라 메모가 무의미해진다).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, orgSlug, currentProjectSlug]);
+
+  // story #d986fd6c(IA·S4, PO 정정 2026-09-08 07:19Z) — 「오늘」을 얹을지 가르는 뷰포트
+  // 높이. SSR엔 window가 없어 null로 시작(하이드레이션 불일치 방지, sidebar_width와
+  // 동형 패턴) — 마운트 후 실측하고 resize에도 재측정한다.
+  const [viewportHeight, setViewportHeight] = useState<number | null>(null);
+  useEffect(() => {
+    const measure = () => setViewportHeight(window.innerHeight);
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
+
+  const defaultCollapsedGroupIds = useMemo(
+    () => computeActiveZoneCollapsedGroupIds({
+      groups: NAV_GROUPS.map((g) => ({ id: g.id, itemCount: g.items.length })),
+      activeGroupId,
+      viewportHeight,
+    }),
+    [activeGroupId, viewportHeight],
+  );
+
   // story #d986fd6c(IA·S4) — 그룹별 접힘 «기억». 서버 렌더는 항상 빈 overrides({})로
   // 시작해(하이드레이션 불일치 방지, sidebar_width의 SIDEBAR_WIDTH_STORAGE_KEY 마운트-후
   // 읽기와 동형 패턴 — ui/sidebar.tsx:81-83) 마운트 후 이 effect가 localStorage 원문을
@@ -185,13 +221,12 @@ export function AppSidebar({
   useEffect(() => {
     const overrides = readStoredCollapsedOverrides();
     if (Object.keys(overrides).length > 0) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setCollapsedOverrides(overrides);
     }
   }, []);
   const collapsedGroupIds = useMemo(
-    () => mergeStoredCollapsedOverrides(DEFAULT_COLLAPSED_GROUP_IDS, collapsedOverrides),
-    [collapsedOverrides],
+    () => mergeStoredCollapsedOverrides(defaultCollapsedGroupIds, collapsedOverrides),
+    [defaultCollapsedGroupIds, collapsedOverrides],
   );
 
   const toggleGroupCollapsed = useCallback((groupId: string) => {
@@ -279,10 +314,6 @@ export function AppSidebar({
     ];
     return () => { for (const unsub of unsubs) unsub(); };
   }, [mux]);
-
-  function isActive(href: string) {
-    return pathname === href || (href !== '/' && pathname.startsWith(href));
-  }
 
   return (
     <Sidebar variant="inset" collapsible="offcanvas">

--- a/apps/web/src/lib/nav-config-collapse.test.ts
+++ b/apps/web/src/lib/nav-config-collapse.test.ts
@@ -44,14 +44,26 @@ describe('computeDefaultCollapsedGroupIds — story #d986fd6c(IA·S4 AC1 규칙)
     expect(computeDefaultCollapsedGroupIds([], 5)).toEqual(new Set());
   });
 
-  // 임계값 자체는 배포 54 뒤 실측 전까지 PENDING(null) — 이 테스트는 "아직 안 채워졌다"는
-  // 사실을 고정한다(누가 실측 없이 임의 수를 채워 넣으면 이 테스트가 지적한다).
-  it('SIDEBAR_FIRST_SCREEN_ITEM_BUDGET은 아직 null이다(배포 54 뒤 실측 전까지 — 임의 수 금지)', () => {
-    expect(SIDEBAR_FIRST_SCREEN_ITEM_BUDGET).toBeNull();
+  // budget=12 확定(PO, 배포 54 dev-app 실측 뒤 2026-09-08) — 근거는 nav-config.ts::
+  // SIDEBAR_FIRST_SCREEN_ITEM_BUDGET 정의부 주석. 뷰포트 픽셀(1440×800→11, 1440×900→12)
+  // 이 아니라 «구역 성격»(주력 3구역 오늘·개발·마케팅 항목 합=12) 기준으로 PO가 골랐다 —
+  // 이 테스트는 그 값이 임의로 흔들리면 잡는다.
+  it('SIDEBAR_FIRST_SCREEN_ITEM_BUDGET은 12다(주력 3구역 오늘2+개발5+마케팅5 합, PO 확定 근거는 정의부 참고)', () => {
+    expect(SIDEBAR_FIRST_SCREEN_ITEM_BUDGET).toBe(12);
   });
 
   it('실 NAV_GROUPS 항목 수 합은 24다(회귀 시 이 값부터 어긋난다)', () => {
     const total = NAV_GROUPS.reduce((sum, g) => sum + g.items.length, 0);
     expect(total).toBe(24);
+  });
+
+  // 실 NAV_GROUPS + 확定 budget으로 규칙을 돌리면 PO가 의도한 정확히 그 결과가 나온다는
+  // 통합 회귀가드 — 순수 함수 단위 테스트(위)와 실제 배선(app-sidebar.tsx)을 잇는다.
+  it('실 NAV_GROUPS·budget=12로 규칙을 돌리면 신뢰·지식·조직·설정이 접히고 오늘·개발·마케팅은 펼쳐진다', () => {
+    const collapsed = computeDefaultCollapsedGroupIds(
+      NAV_GROUPS.map((g) => ({ id: g.id, itemCount: g.items.length })),
+      SIDEBAR_FIRST_SCREEN_ITEM_BUDGET!,
+    );
+    expect(collapsed).toEqual(new Set(['trust', 'knowledge', 'organization', 'settings']));
   });
 });

--- a/apps/web/src/lib/nav-config-collapse.test.ts
+++ b/apps/web/src/lib/nav-config-collapse.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { computeDefaultCollapsedGroupIds, NAV_GROUPS, SIDEBAR_FIRST_SCREEN_ITEM_BUDGET, type GroupItemCount } from './nav-config';
+import {
+  computeActiveZoneCollapsedGroupIds,
+  NAV_GROUPS,
+  SIDEBAR_EXPAND_NOW_MIN_VIEWPORT_HEIGHT,
+  SIDEBAR_NOW_GROUP_ID,
+  type GroupItemCount,
+} from './nav-config';
 
-// story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 규칙(이 함수)과 임계값(SIDEBAR_FIRST_SCREEN_
-// ITEM_BUDGET)을 분리했다. 규칙: NAV_GROUPS 순서대로(위에서부터) 항목을 누적하다 예산을
-// 넘기는 첫 구역부터 그 구역과 그 뒤 전부를 기본 접힘으로 둔다.
-describe('computeDefaultCollapsedGroupIds — story #d986fd6c(IA·S4 AC1 규칙)', () => {
+// story #d986fd6c(IA·S4, PO 정정 2026-09-08 07:19Z) — budget-누적 규칙(순서 고정)을 유나의
+// 라이브 실측(필요 뷰포트=615.5+32×N)이 반증해 「현재 구역 인지 + 뷰포트 조건」으로
+// 교체했다. 기본 = 활성 구역만 펼침, 뷰포트 ≥840px면 「오늘」도 얹는다.
+describe('computeActiveZoneCollapsedGroupIds — story #d986fd6c(IA·S4 AC1 규칙, 유나 실측 반영)', () => {
   const groups: GroupItemCount[] = [
     { id: 'now', itemCount: 2 },
     { id: 'dev', itemCount: 5 },
@@ -15,55 +21,64 @@ describe('computeDefaultCollapsedGroupIds — story #d986fd6c(IA·S4 AC1 규칙)
     { id: 'settings', itemCount: 1 },
   ];
 
-  it('예산이 넉넉하면(전 항목 합 이상) 아무 구역도 안 접힌다', () => {
-    expect(computeDefaultCollapsedGroupIds(groups, 24)).toEqual(new Set());
+  it('활성 구역만 펼치고 나머지는 전부 접는다(뷰포트 미달·미측정)', () => {
+    const collapsed = computeActiveZoneCollapsedGroupIds({ groups, activeGroupId: 'dev', viewportHeight: 700 });
+    expect(collapsed).toEqual(new Set(['now', 'marketing', 'trust', 'knowledge', 'organization', 'settings']));
   });
 
-  it('예산이 0이면 전 구역이 접힌다(첫 구역부터 이미 초과)', () => {
-    expect(computeDefaultCollapsedGroupIds(groups, 0)).toEqual(new Set(['now', 'dev', 'marketing', 'trust', 'knowledge', 'organization', 'settings']));
+  it('뷰포트 미측정(null, 마운트 前)이면 활성 구역만 펼치고 「오늘」은 안 얹는다(SSR 안전 기본값)', () => {
+    const collapsed = computeActiveZoneCollapsedGroupIds({ groups, activeGroupId: 'marketing', viewportHeight: null });
+    expect(collapsed.has('now')).toBe(true);
+    expect(collapsed.has('marketing')).toBe(false);
   });
 
-  it('예산이 구역 경계에 정확히 걸치면 그 구역까지는 펼치고 다음부터 접는다(now 2 + dev 5 = 7)', () => {
-    const collapsed = computeDefaultCollapsedGroupIds(groups, 7);
-    expect(collapsed).toEqual(new Set(['marketing', 'trust', 'knowledge', 'organization', 'settings']));
+  it('뷰포트 ≥840이면 활성 구역+「오늘」 둘 다 펼친다', () => {
+    const collapsed = computeActiveZoneCollapsedGroupIds({ groups, activeGroupId: 'organization', viewportHeight: 840 });
+    expect(collapsed.has('organization')).toBe(false);
+    expect(collapsed.has('now')).toBe(false);
+    expect(collapsed).toEqual(new Set(['dev', 'marketing', 'trust', 'knowledge', 'settings']));
   });
 
-  it('예산이 구역 중간에서 끊기면(now 2 + dev 5 = 7, +marketing 5=12인데 예산 9) 그 구역부터 접는다(부분 렌더 없음 — 구역 단위)', () => {
-    const collapsed = computeDefaultCollapsedGroupIds(groups, 9);
-    expect(collapsed).toEqual(new Set(['marketing', 'trust', 'knowledge', 'organization', 'settings']));
+  it('뷰포트 839(문턱 바로 아래)면 「오늘」은 안 얹는다(경계값)', () => {
+    const collapsed = computeActiveZoneCollapsedGroupIds({ groups, activeGroupId: 'organization', viewportHeight: 839 });
+    expect(collapsed.has('now')).toBe(true);
   });
 
-  it('한 번 접기 시작하면 뒤 구역은 예산과 무관하게 전부 접힌다(순서 우선 — 임의 선택 없음)', () => {
-    // trust(2)만 보면 남는 예산에 들어갈 수 있어도, marketing에서 이미 넘겼으므로 접힘.
-    const collapsed = computeDefaultCollapsedGroupIds(groups, 8);
-    expect(collapsed.has('marketing')).toBe(true);
-    expect(collapsed.has('trust')).toBe(true);
+  it('활성 구역이 이미 「오늘」이면(오늘 화면 보는 중) 뷰포트 무관하게 한 번만 펼친다(집합이라 중복 없음)', () => {
+    const collapsed = computeActiveZoneCollapsedGroupIds({ groups, activeGroupId: 'now', viewportHeight: 700 });
+    expect(collapsed.has('now')).toBe(false);
+    expect(collapsed.size).toBe(6);
   });
 
-  it('빈 예산 배열도 죽지 않는다(경계값)', () => {
-    expect(computeDefaultCollapsedGroupIds([], 5)).toEqual(new Set());
+  it('활성 구역이 null이면(챗 center·설정처럼 그룹 밖 라우트) 뷰포트 미달 시 전 구역 접힘', () => {
+    const collapsed = computeActiveZoneCollapsedGroupIds({ groups, activeGroupId: null, viewportHeight: 700 });
+    expect(collapsed).toEqual(new Set(groups.map((g) => g.id)));
   });
 
-  // budget=12 확定(PO, 배포 54 dev-app 실측 뒤 2026-09-08) — 근거는 nav-config.ts::
-  // SIDEBAR_FIRST_SCREEN_ITEM_BUDGET 정의부 주석. 뷰포트 픽셀(1440×800→11, 1440×900→12)
-  // 이 아니라 «구역 성격»(주력 3구역 오늘·개발·마케팅 항목 합=12) 기준으로 PO가 골랐다 —
-  // 이 테스트는 그 값이 임의로 흔들리면 잡는다.
-  it('SIDEBAR_FIRST_SCREEN_ITEM_BUDGET은 12다(주력 3구역 오늘2+개발5+마케팅5 합, PO 확定 근거는 정의부 참고)', () => {
-    expect(SIDEBAR_FIRST_SCREEN_ITEM_BUDGET).toBe(12);
+  it('활성 구역이 null이어도 뷰포트 ≥840이면 「오늘」은 펼친다', () => {
+    const collapsed = computeActiveZoneCollapsedGroupIds({ groups, activeGroupId: null, viewportHeight: 900 });
+    expect(collapsed.has('now')).toBe(false);
+  });
+
+  it('빈 구역 배열도 죽지 않는다(경계값)', () => {
+    expect(computeActiveZoneCollapsedGroupIds({ groups: [], activeGroupId: 'dev', viewportHeight: 900 })).toEqual(new Set());
+  });
+
+  it('SIDEBAR_EXPAND_NOW_MIN_VIEWPORT_HEIGHT는 840이다(유나 실측 615.5+32×7=839.5 반올림, 임의 수 아님)', () => {
+    expect(SIDEBAR_EXPAND_NOW_MIN_VIEWPORT_HEIGHT).toBe(840);
+  });
+
+  it('SIDEBAR_NOW_GROUP_ID는 실 NAV_GROUPS의 첫 구역 id와 일치한다(회귀가드)', () => {
+    expect(SIDEBAR_NOW_GROUP_ID).toBe(NAV_GROUPS[0]!.id);
+  });
+
+  it('실 NAV_GROUPS 최대 구역 크기는 5다(활성 구역 단독 펼침이 840 문턱 없이도 항상 775.5px 이하로 들어간다는 전제 회귀가드)', () => {
+    const maxItems = Math.max(...NAV_GROUPS.map((g) => g.items.length));
+    expect(maxItems).toBe(5);
   });
 
   it('실 NAV_GROUPS 항목 수 합은 24다(회귀 시 이 값부터 어긋난다)', () => {
     const total = NAV_GROUPS.reduce((sum, g) => sum + g.items.length, 0);
     expect(total).toBe(24);
-  });
-
-  // 실 NAV_GROUPS + 확定 budget으로 규칙을 돌리면 PO가 의도한 정확히 그 결과가 나온다는
-  // 통합 회귀가드 — 순수 함수 단위 테스트(위)와 실제 배선(app-sidebar.tsx)을 잇는다.
-  it('실 NAV_GROUPS·budget=12로 규칙을 돌리면 신뢰·지식·조직·설정이 접히고 오늘·개발·마케팅은 펼쳐진다', () => {
-    const collapsed = computeDefaultCollapsedGroupIds(
-      NAV_GROUPS.map((g) => ({ id: g.id, itemCount: g.items.length })),
-      SIDEBAR_FIRST_SCREEN_ITEM_BUDGET!,
-    );
-    expect(collapsed).toEqual(new Set(['trust', 'knowledge', 'organization', 'settings']));
   });
 });

--- a/apps/web/src/lib/nav-config-collapse.test.ts
+++ b/apps/web/src/lib/nav-config-collapse.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { computeDefaultCollapsedGroupIds, NAV_GROUPS, SIDEBAR_FIRST_SCREEN_ITEM_BUDGET, type GroupItemCount } from './nav-config';
+
+// story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 규칙(이 함수)과 임계값(SIDEBAR_FIRST_SCREEN_
+// ITEM_BUDGET)을 분리했다. 규칙: NAV_GROUPS 순서대로(위에서부터) 항목을 누적하다 예산을
+// 넘기는 첫 구역부터 그 구역과 그 뒤 전부를 기본 접힘으로 둔다.
+describe('computeDefaultCollapsedGroupIds — story #d986fd6c(IA·S4 AC1 규칙)', () => {
+  const groups: GroupItemCount[] = [
+    { id: 'now', itemCount: 2 },
+    { id: 'dev', itemCount: 5 },
+    { id: 'marketing', itemCount: 5 },
+    { id: 'trust', itemCount: 2 },
+    { id: 'knowledge', itemCount: 4 },
+    { id: 'organization', itemCount: 5 },
+    { id: 'settings', itemCount: 1 },
+  ];
+
+  it('예산이 넉넉하면(전 항목 합 이상) 아무 구역도 안 접힌다', () => {
+    expect(computeDefaultCollapsedGroupIds(groups, 24)).toEqual(new Set());
+  });
+
+  it('예산이 0이면 전 구역이 접힌다(첫 구역부터 이미 초과)', () => {
+    expect(computeDefaultCollapsedGroupIds(groups, 0)).toEqual(new Set(['now', 'dev', 'marketing', 'trust', 'knowledge', 'organization', 'settings']));
+  });
+
+  it('예산이 구역 경계에 정확히 걸치면 그 구역까지는 펼치고 다음부터 접는다(now 2 + dev 5 = 7)', () => {
+    const collapsed = computeDefaultCollapsedGroupIds(groups, 7);
+    expect(collapsed).toEqual(new Set(['marketing', 'trust', 'knowledge', 'organization', 'settings']));
+  });
+
+  it('예산이 구역 중간에서 끊기면(now 2 + dev 5 = 7, +marketing 5=12인데 예산 9) 그 구역부터 접는다(부분 렌더 없음 — 구역 단위)', () => {
+    const collapsed = computeDefaultCollapsedGroupIds(groups, 9);
+    expect(collapsed).toEqual(new Set(['marketing', 'trust', 'knowledge', 'organization', 'settings']));
+  });
+
+  it('한 번 접기 시작하면 뒤 구역은 예산과 무관하게 전부 접힌다(순서 우선 — 임의 선택 없음)', () => {
+    // trust(2)만 보면 남는 예산에 들어갈 수 있어도, marketing에서 이미 넘겼으므로 접힘.
+    const collapsed = computeDefaultCollapsedGroupIds(groups, 8);
+    expect(collapsed.has('marketing')).toBe(true);
+    expect(collapsed.has('trust')).toBe(true);
+  });
+
+  it('빈 예산 배열도 죽지 않는다(경계값)', () => {
+    expect(computeDefaultCollapsedGroupIds([], 5)).toEqual(new Set());
+  });
+
+  // 임계값 자체는 배포 54 뒤 실측 전까지 PENDING(null) — 이 테스트는 "아직 안 채워졌다"는
+  // 사실을 고정한다(누가 실측 없이 임의 수를 채워 넣으면 이 테스트가 지적한다).
+  it('SIDEBAR_FIRST_SCREEN_ITEM_BUDGET은 아직 null이다(배포 54 뒤 실측 전까지 — 임의 수 금지)', () => {
+    expect(SIDEBAR_FIRST_SCREEN_ITEM_BUDGET).toBeNull();
+  });
+
+  it('실 NAV_GROUPS 항목 수 합은 24다(회귀 시 이 값부터 어긋난다)', () => {
+    const total = NAV_GROUPS.reduce((sum, g) => sum + g.items.length, 0);
+    expect(total).toBe(24);
+  });
+});

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -286,52 +286,48 @@ export const CHAT_CENTER_ITEM: NavItemConfig = {
   id: 'chats', labelKey: 'chats', icon: MessageSquare, kind: 'static', path: '/chats', badgeKey: 'chats',
 };
 
-// story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 구역 기본 접힘. 「규칙」과 「임계값」을
-// 분리한다: 규칙(이 함수)은 지금 배선하고, 임계값(SIDEBAR_FIRST_SCREEN_ITEM_BUDGET)만
-// 배포 54(S1/S2/3694 라이브) 뒤 실측으로 채운다 — AC1이 "지금 재면 옛 구조를 재는 것"
-// 이라 명시한 그대로, dev-app이 아직 옛 6구역이라 지금 재는 수치는 무의미하다(PO 확認).
+// story #d986fd6c(IA·S4, PO 정정 2026-09-08 07:19Z — budget=12 되돌림) — 첫 시도(budget
+// 누적, 순서 고정)는 페드루 PO의 07:01Z 판단이 "픽셀보다 구역 성격"으로 고른 추정치였는데,
+// 유나가 배포 54 라이브에서 실측한 관계식이 그 추정을 반증했다: 필요 뷰포트(px) =
+// 615.5 + 32×N(펼친 항목 수). 12항목엔 1000px가 필요해(900px엔 8·800px엔 5만 들어감)
+// AC1 "첫 화면 스크롤 없이"를 budget=12는 못 지킨다.
 //
-// 규칙 — NAV_GROUPS 순서대로(위에서부터, 'now'가 항상 먼저라 사실상 최우선) 항목을
-// 누적하다 예산을 넘기는 첫 구역부터 그 구역과 그 뒤 구역 전부를 기본 접힘으로 둔다.
-// "탐(순서상 앞선 구역)이 우선"이라는 단순한 원칙 — 임의로 특정 구역을 손으로 골라
-// 접지 않는다(AC1 "임의로 고른 수 금지"의 정신을 구역 선택에도 적용).
+// 유나 실측 규칙으로 교체 — «budget 누적(순서 고정)»이 아니라 «현재 구역 인지 + 뷰포트
+// 조건»: 기본은 현재 활성 구역만 펼침(≤5항목=775.5px, 이 앱 최대 구역 크기가 5라 항상
+// 안전). 뷰포트 ≥840px(615.5+32×7=839.5 반올림)면 「오늘」(2항목)도 같이 펼친다(자주
+// 쓰는 진입점이라 조건이 맞으면 얹는다). 나머지는 접힘. 720px 이하는 접혀도 다 못
+// 맞추는 뷰포트라 "접힘의 약속 밖"으로 명시한다 — 그 경우의 도달성은 이 표면(사이드바)이
+// 아니라 모바일 허브·커맨드 팔레트가 이미 보장한다(AC2, depth≤2 무관).
 export interface GroupItemCount {
   id: string;
   itemCount: number;
 }
 
-// story #d986fd6c(IA·S4, PO 確定 2026-09-08, 배포 54 dev-app CF 실측 뒤) — budget=12 =
-// 주력 3구역(오늘·개발·마케팅) 항목 합(2+5+5) · 2차 구역(신뢰·지식·조직·설정)만 기본
-// 접힘 · 뷰포트 픽셀이 아니라 «구역 성격» 기준으로 정했다.
-//
-// 정밀측정(getBoundingClientRect, footer 경계 기준 "완전히 보이는 항목"만 카운트, 200px·
-// 256px 사이드바 폭 둘 다 — 폭은 항목 수에 무관함을 확認·라벨 truncate라 줄바꿈 없음)으로
-// 뷰포트 높이에 따라 11(1440×800)~12(1440×900)가 나왔으나, PO가 픽셀 대신 원칙으로
-// 확定했다 — budget의 일은 "매일 쓰는 주력 3구역은 기본 펼침, 2차 구역은 기본 접힘"이고,
-// 11을 쓰면 마케팅(5)이 통째로 접혀 지금 목표의 핵심 도구(블로그 포스트·채널 연결·성과
-// 보드)가 기본 숨김이 되는 게 뒤집힌 결과라 기각. 800px에서 성과 보드 하나가 접힘선에
-// 걸리는 건 "구역을 통째 접기"보다 "구역은 펼친 채 마지막 항목만 살짝 스크롤"이 낫고,
-// 전문가 화면 대부분(≥900px)에선 12가 스크롤 없이 다 들어간다.
-export const SIDEBAR_FIRST_SCREEN_ITEM_BUDGET: number | null = 12;
+// 615.5 + 32×7 = 839.5, 반올림해 840. 「오늘」을 얹을지 가르는 뷰포트 문턱(유나 실측).
+export const SIDEBAR_EXPAND_NOW_MIN_VIEWPORT_HEIGHT = 840;
+export const SIDEBAR_NOW_GROUP_ID = 'now';
 
-export function computeDefaultCollapsedGroupIds(
-  groups: readonly GroupItemCount[],
-  budget: number,
-): Set<string> {
+export interface ActiveZoneCollapseInput {
+  groups: readonly GroupItemCount[];
+  // 현재 라우트가 속한 구역 id. 어느 구역에도 안 걸리면(예: 챗 center·설정처럼 라벨 없는
+  // 유틸 그룹) null — "활성 구역이라 펼친다"는 규칙이 적용될 대상이 없다는 뜻이다.
+  activeGroupId: string | null;
+  // 마운트 전(SSR)엔 window가 없어 null — 그 상태에선 "「오늘」도 얹는다" 조건을 아직
+  // 모르니 보수적으로 안 얹는다(마운트 후 실측되면 재계산·하이드레이션 불일치 없음,
+  // sidebar_width와 동형 패턴).
+  viewportHeight: number | null;
+}
+
+export function computeActiveZoneCollapsedGroupIds(input: ActiveZoneCollapseInput): Set<string> {
+  const { groups, activeGroupId, viewportHeight } = input;
+  const expanded = new Set<string>();
+  if (activeGroupId) expanded.add(activeGroupId);
+  if (viewportHeight != null && viewportHeight >= SIDEBAR_EXPAND_NOW_MIN_VIEWPORT_HEIGHT) {
+    expanded.add(SIDEBAR_NOW_GROUP_ID);
+  }
   const collapsed = new Set<string>();
-  let used = 0;
-  let overBudget = false;
   for (const group of groups) {
-    if (overBudget) {
-      collapsed.add(group.id);
-      continue;
-    }
-    if (used + group.itemCount > budget) {
-      overBudget = true;
-      collapsed.add(group.id);
-      continue;
-    }
-    used += group.itemCount;
+    if (!expanded.has(group.id)) collapsed.add(group.id);
   }
   return collapsed;
 }

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -300,11 +300,19 @@ export interface GroupItemCount {
   itemCount: number;
 }
 
-// ⚠️PENDING(페드루 PO 확認 예정, 배포 54 뒤) — dev-app이 새 7구역(S1~S3) 구조로 재배포된
-// 뒤, 실 뷰포트에서 "스크롤 없이 보이는 항목 수"를 재서 이 값을 채운다. 그 전까지는
-// 회귀가드가 이 상수를 직접 쓰지 않고(합성 예산으로 규칙 함수만 단위 테스트) — 이 값
-// 자체를 규칙의 정답으로 삼는 테스트는 배포 뒤 추가한다.
-export const SIDEBAR_FIRST_SCREEN_ITEM_BUDGET: number | null = null;
+// story #d986fd6c(IA·S4, PO 確定 2026-09-08, 배포 54 dev-app CF 실측 뒤) — budget=12 =
+// 주력 3구역(오늘·개발·마케팅) 항목 합(2+5+5) · 2차 구역(신뢰·지식·조직·설정)만 기본
+// 접힘 · 뷰포트 픽셀이 아니라 «구역 성격» 기준으로 정했다.
+//
+// 정밀측정(getBoundingClientRect, footer 경계 기준 "완전히 보이는 항목"만 카운트, 200px·
+// 256px 사이드바 폭 둘 다 — 폭은 항목 수에 무관함을 확認·라벨 truncate라 줄바꿈 없음)으로
+// 뷰포트 높이에 따라 11(1440×800)~12(1440×900)가 나왔으나, PO가 픽셀 대신 원칙으로
+// 확定했다 — budget의 일은 "매일 쓰는 주력 3구역은 기본 펼침, 2차 구역은 기본 접힘"이고,
+// 11을 쓰면 마케팅(5)이 통째로 접혀 지금 목표의 핵심 도구(블로그 포스트·채널 연결·성과
+// 보드)가 기본 숨김이 되는 게 뒤집힌 결과라 기각. 800px에서 성과 보드 하나가 접힘선에
+// 걸리는 건 "구역을 통째 접기"보다 "구역은 펼친 채 마지막 항목만 살짝 스크롤"이 낫고,
+// 전문가 화면 대부분(≥900px)에선 12가 스크롤 없이 다 들어간다.
+export const SIDEBAR_FIRST_SCREEN_ITEM_BUDGET: number | null = 12;
 
 export function computeDefaultCollapsedGroupIds(
   groups: readonly GroupItemCount[],

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -285,3 +285,45 @@ export const MOBILE_HUB_EXCLUDE_IDS = new Set(['board', 'inbox', 'chats']);
 export const CHAT_CENTER_ITEM: NavItemConfig = {
   id: 'chats', labelKey: 'chats', icon: MessageSquare, kind: 'static', path: '/chats', badgeKey: 'chats',
 };
+
+// story #d986fd6c(IA·S4, PO 確定 2026-09-08) — 구역 기본 접힘. 「규칙」과 「임계값」을
+// 분리한다: 규칙(이 함수)은 지금 배선하고, 임계값(SIDEBAR_FIRST_SCREEN_ITEM_BUDGET)만
+// 배포 54(S1/S2/3694 라이브) 뒤 실측으로 채운다 — AC1이 "지금 재면 옛 구조를 재는 것"
+// 이라 명시한 그대로, dev-app이 아직 옛 6구역이라 지금 재는 수치는 무의미하다(PO 확認).
+//
+// 규칙 — NAV_GROUPS 순서대로(위에서부터, 'now'가 항상 먼저라 사실상 최우선) 항목을
+// 누적하다 예산을 넘기는 첫 구역부터 그 구역과 그 뒤 구역 전부를 기본 접힘으로 둔다.
+// "탐(순서상 앞선 구역)이 우선"이라는 단순한 원칙 — 임의로 특정 구역을 손으로 골라
+// 접지 않는다(AC1 "임의로 고른 수 금지"의 정신을 구역 선택에도 적용).
+export interface GroupItemCount {
+  id: string;
+  itemCount: number;
+}
+
+// ⚠️PENDING(페드루 PO 확認 예정, 배포 54 뒤) — dev-app이 새 7구역(S1~S3) 구조로 재배포된
+// 뒤, 실 뷰포트에서 "스크롤 없이 보이는 항목 수"를 재서 이 값을 채운다. 그 전까지는
+// 회귀가드가 이 상수를 직접 쓰지 않고(합성 예산으로 규칙 함수만 단위 테스트) — 이 값
+// 자체를 규칙의 정답으로 삼는 테스트는 배포 뒤 추가한다.
+export const SIDEBAR_FIRST_SCREEN_ITEM_BUDGET: number | null = null;
+
+export function computeDefaultCollapsedGroupIds(
+  groups: readonly GroupItemCount[],
+  budget: number,
+): Set<string> {
+  const collapsed = new Set<string>();
+  let used = 0;
+  let overBudget = false;
+  for (const group of groups) {
+    if (overBudget) {
+      collapsed.add(group.id);
+      continue;
+    }
+    if (used + group.itemCount > budget) {
+      overBudget = true;
+      collapsed.add(group.id);
+      continue;
+    }
+    used += group.itemCount;
+  }
+  return collapsed;
+}


### PR DESCRIPTION
## 배경

3600 문서 §7-2·부록 E·S4. AC1이 "지금 재면 옛 구조를 재는 것"이라 명시 — dev-app이 아직 S1(#4040은 머지됐으나 미배포) 이전 6구역이라, 정확한 임계값 실측은 배포 54(S1/S2/3694 라이브) 뒤로 미루고 PO 確定으로 **규칙·메커니즘부터 먼저 착수**했다.

## 처방

- **규칙**(`computeDefaultCollapsedGroupIds`, 순수 함수): NAV_GROUPS 순서대로 항목을 누적하다 예산을 넘기는 첫 구역부터 그 구역과 뒤 구역 전부를 기본 접힘으로 둔다 — "임의로 고른 수 금지"를 구역 선택에도 적용(특정 구역을 손으로 안 고름).
- **임계값**(`SIDEBAR_FIRST_SCREEN_ITEM_BUDGET`, 현재 `null`): 배포 54 뒤 페드루 PO가 실측해서 채운다. 값이 채워지기 전까지는 규칙이 "전 구역 펼침"으로 동작(안전한 기본값 — 임의 추정 없음).
- **UI**: 구역 헤더 전체가 토글 버튼(`aria-expanded`). 라벨 없는 유틸 그룹(설정)은 토글 대상 제외. `localStorage`(`sidebar_group_collapsed`)에 그룹별 기억 — 기존 `sidebar_width`와 동형 SSR-세이프 하이드레이션 패턴.

## AC 대조

1. 접힘 기본값이 측정 규칙으로 정해짐(임의 수 0) — 규칙 자체는 지금 배선, 임계값만 배포 뒤 ✅(부분)
2. 접힌 구역 항목도 커맨드 팔레트·모바일 허브로 도달 가능 — 이 두 표면은 이 컴포넌트의 접힘 state를 안 읽는 별도 소스(NAV_GROUPS 직접 순회)라 구조적으로 무영향, 기존 가드 무회귀로 확認 ✅
3. 접힘 상태가 사람별로 기억되고 기억 없을 때도 기본값으로 선다 ✅
4. [디자인] 새 자 — 배포 뒤 실측 예정

## 테스트

- `nav-config-collapse.test.ts`(신규) — 규칙 함수 8건(예산 경계·전량 접힘·전량 펼침·구역 단위 접힘 등) + `SIDEBAR_FIRST_SCREEN_ITEM_BUDGET`이 아직 `null`임을 고정(임의로 채워 넣으면 이 테스트가 잡음).
- `app-sidebar.test.tsx` — 접기/펴기 클릭·localStorage 기억·마운트 시 기억 재현·설정 그룹 토글 제외 5건 신규.
- nav 계열 85건 재검증 그린. 전체 `pnpm vitest run` — 714 files·6943 tests 무회귀.
- `tsc --noEmit`·`eslint` 클린(react-hooks/set-state-in-effect 대응 — 파생값은 useMemo로 분리, 원시 외부값만 effect에서 setState, 근거 주석+disable 1건). `pnpm build` 성공.

## ⚠️ 머지 순서 조정 필요

`app-sidebar.tsx`가 S3(#4044, 아직 미머지)와 겹친다 — 이 브랜치는 develop을 #4044 머지 前 시점에서 분기했다(PO 지시). 머지 순서는 PO가 조정.

## 잔여

`SIDEBAR_FIRST_SCREEN_ITEM_BUDGET` 실측값은 배포 54 뒤 PO가 채운다(코드 변경 0, 값만).