### PR TITLE
[SID:3359] feat(BE): 레시피 channel→connector_key 매핑 리졸버

### DIFF
--- a/backend/app/routers/content_rules.py
+++ b/backend/app/routers/content_rules.py
@@ -99,6 +99,15 @@ class ContentRulesFields(BaseModel):
     brand_kit: dict | None = None
     generation_budget: GenerationBudgetRule | None = None
     utm_rules: UtmRules | None = None
+    # story #3359 CHANGES(카디르 발견, 페드루 PO 리뷰 2026-09-08) — 리졸버
+    # (channel_connector_map.py::resolve_connector_key_for_channel)의 org override
+    # 우선순위①이 이 필드가 없어 죽은 경로였다: extra="forbid"라 PUT body에
+    # channel_connector_map을 실으면 422로 거부돼, org가 blog/newsletter 같은
+    # 별칭을 «영원히» 등록할 방법이 없었다(리졸버는 읽기만 살아있고 쓰기 계약이
+    # 없었다). 편집 UI는 여전히 후속(#3359 AC 스코프 경계 그대로)이지만, 이 스키마
+    # 필드(기존 content-rules API로 쓸 수 있게 하는 것)는 리졸버가 실제로 살아
+    # 있으려면 필수라 여기 포함한다.
+    channel_connector_map: dict[str, str] | None = None
 
 
 class PutContentRulesRequest(BaseModel):

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1318,6 +1318,12 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
 
     draft_doc_ref: str | None = None
     draft_id: str | None = None
+    # story #3359 — 레시피 stage 게이트의 neutral_facts엔 게이트 생성 시점(recipe_gate_
+    # hooks.py::_build_approval_neutral_facts)에 이미 stage/channel이 박혀 있다. 이
+    # payload 자체엔 없어(preset.gate.verdict 계약 불변) 아래 gate_row 재조회에서만
+    # 채워진다 — publish 다음-행동 문구를 채널별 커넥터명으로 구체화하는 데 쓴다.
+    gate_stage: str | None = None
+    gate_channel: str | None = None
     # story #3487(0329) — payload에 gate_id가 있으면(이 함수의 유일한 발행부는 항상
     # 채운다) 그 행만 정확히 읽는다. story #3478(gate.scope_key) 이후 같은 work_item에
     # 목적지가 다른 external_publish 게이트가 둘 이상일 수 있어, 아래 (work_item_id,
@@ -1349,6 +1355,9 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
             # 모두에서 만들어지지 않는다) — 링크가 아니라 참조로만 싣는다(PO 2026-09-03
             # 13:33Z, 실행 권유 아님).
             draft_id = facts.get("draft_id")
+            gate_stage = facts.get("stage")
+            _channel_raw = facts.get("channel")
+            gate_channel = _channel_raw if isinstance(_channel_raw, str) and _channel_raw and _channel_raw != "미확認" else None
     if draft_doc_ref:
         lines.append(f"- 대상 산출물: {draft_doc_ref}")
     if draft_id:
@@ -1415,8 +1424,27 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
             "발행으로 자동 재오픈됩니다."
         )
     elif verdict == "approved":
+        # story #3359 — publish stage면 channel→connector_key를 리졸버로 구체화한다
+        # (예전엔 "발행 도구를 쓰세요"뿐이라 모든 채널이 정의에 박힌 connector_key
+        # 그대로 threads로 새는 클래스였다). publish가 아니거나 channel을 모르면
+        # 기존 제네릭 문구 그대로(회귀 0).
+        _connector_line: str | None = None
+        if gate_stage == "publish" and gate_channel:
+            from app.services.channel_connector_map import resolve_connector_key_for_channel
+
+            _connector_key = await resolve_connector_key_for_channel(db, org_id=org_id, channel=gate_channel)
+            if _connector_key:
+                _connector_line = (
+                    f"- 다음 행동: {_connector_key} 커넥터로 발행하세요(channel={gate_channel})."
+                )
+            else:
+                _connector_line = (
+                    f"- 다음 행동: channel={gate_channel}에 대한 커넥터 매핑이 없습니다 — "
+                    "조직 설정에 channel_connector_map을 등록하세요."
+                )
         lines.append(
-            "- 다음 행동: 이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 이 "
+            _connector_line
+            or "- 다음 행동: 이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 이 "
             "승인 게이트를 확인하는 발행 도구를 쓰세요)."
         )
 
@@ -2546,6 +2574,7 @@ async def apply_recipe_role_bindings(
     # story #3317 PR B — capability(publish:<channel> 등) 요구 stage의 커넥터 준비 상태를
     # 경고로만 알린다(apply 자체는 안 막음, PO 확定). capability 선언 없는 stage는 완전
     # no-op(무선언 정의 회귀 0).
+    from app.services.channel_connector_map import resolve_connector_key_for_channel
     from app.services.connector_registry import (
         find_org_connectors_by_kind, get_org_connector, missing_required_org_config,
     )
@@ -2556,7 +2585,21 @@ async def apply_recipe_role_bindings(
         if not capability:
             continue
         kind = capability["kind"]
-        connector_key = capability.get("connector_key")
+        # story #3359 — capability.connector_key는 정의 저자가 적은 채널 라벨(예:
+        # "threads"·"blog")이지 반드시 실 connector_key는 아니다. 리졸버(진리원천 하나,
+        # publish 다음-행동 문구와 동일 함수)로 해소한다 — 매핑 없으면 옛처럼 "그 커넥터가
+        # 없다"로 오인시키지 않고 "channel=X 매핑 없음"으로 명시(삼키지 않는다).
+        declared_channel = capability.get("connector_key")
+        connector_key = (
+            await resolve_connector_key_for_channel(db, org_id=org_id, channel=declared_channel)
+            if declared_channel else None
+        )
+        if declared_channel and not connector_key:
+            warnings.append(
+                f"stage={stage!r}: channel={declared_channel!r}에 대한 커넥터 매핑이 없습니다 — "
+                f"조직 설정에 channel_connector_map을 등록하세요."
+            )
+            continue
         if connector_key:
             row = await get_org_connector(db, org_id=org_id, connector_key=connector_key)
             if row is None:

--- a/backend/app/services/channel_connector_map.py
+++ b/backend/app/services/channel_connector_map.py
@@ -1,0 +1,57 @@
+"""story #3359(레시피·채널 확장, 페드루 PO 確定 2026-09-08) — 마케팅 파이프라인 정의의
+publish/measure capability가 connector_key="threads"로 고정돼 payload.channel(threads·
+blog·newsletter 등)이 승인 카드 표시용으로만 쓰이고 실제 커넥터 선택엔 안 쓰이던 갭.
+
+이 리졸버가 진리원천 하나 — 트리거 지점 둘(_render_gate_verdict_message의 publish
+다음-행동 문구·apply_recipe_role_bindings의 정적 경고) 전부 이 함수 하나를 거친다.
+
+기본 매핑(_DEFAULT_CHANNEL_CONNECTOR_MAP)은 sprintable-agent-plugins의 커넥터 정본
+descriptor(*.schema.ts의 connectorKey/channel 필드)를 실측 대조해서만 넣는다 — threads·
+instagram·site_git·stibee 네 커넥터 전부 declared channel이 자기 connectorKey와 1:1
+그대로(threads→threads·instagram→instagram·site_git→site_git·stibee→stibee)라 이
+항등 매핑(channel 라벨이 곧 connector_key인 경우, 기존 정의 전부가 이 형태로 써 왔다
+— apply_recipe_role_bindings의 capability.connector_key가 원래 실 connector_key값
+그 자체였다, 회귀 0 유지 필수)은 안전하게 기본값으로 박는다.
+
+story 본문이 예로 든 blog→site_git·newsletter→stibee 같은 **별칭**(channel 라벨 ≠
+connector_key)은 커넥터 레지스트리 어디에도 'blog'·'newsletter'라는 declared channel이
+없다 — 그 라벨은 recipe/조직이 붙이는 의미일 뿐 레지스트리가 보증하는 사실이 아니다.
+불확실한 별칭을 기본값으로 지어내면 발행이 조용히 틀린 커넥터로 샐 수 있어(PO 지적),
+항등이 아닌 별칭은 org override가 없는 한 항상 None(→ 호출부가 "매핑 없음" 에러로
+삼키지 않고 명시한다)."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.content_rules import get_org_content_rules
+
+# sprintable-agent-plugins/plugins/sprintable/connectors/{threads,instagram,site_git,
+# stibee}.schema.ts 실측(2026-09-08) — 네 커넥터 전부 `channel` 필드가 자신의
+# `connectorKey`와 문자 그대로 같다(항등 매핑). 'blog'/'newsletter' 같은 별칭은 그
+# 레지스트리 어디에도 declared되지 않아 여기 없다(org가 명시로 등록해야 한다 —
+# 지어내지 않는다).
+_DEFAULT_CHANNEL_CONNECTOR_MAP: dict[str, str] = {
+    "threads": "threads",
+    "instagram": "instagram",
+    "site_git": "site_git",
+    "stibee": "stibee",
+}
+
+
+async def resolve_connector_key_for_channel(
+    db: AsyncSession, *, org_id: uuid.UUID, channel: str,
+) -> str | None:
+    """channel(payload.channel, 예: threads·blog·newsletter·instagram)을 org가 발행에
+    실제로 쓸 connector_key로 해소한다. 우선순위: ①org_content_rules.rules.
+    channel_connector_map(org가 화면/API로 등록한 override) ②검증된 기본 매핑
+    ③없음(None) — 지어내지 않는다, 호출부가 "channel=X 매핑 없음"을 명시한다."""
+    row = await get_org_content_rules(db, org_id=org_id)
+    if row is not None:
+        org_map = (row.rules or {}).get("channel_connector_map")
+        if isinstance(org_map, dict):
+            override = org_map.get(channel)
+            if isinstance(override, str) and override:
+                return override
+    return _DEFAULT_CHANNEL_CONNECTOR_MAP.get(channel)

--- a/backend/tests/test_3359_channel_connector_map.py
+++ b/backend/tests/test_3359_channel_connector_map.py
@@ -1,0 +1,179 @@
+"""story #3359(레시피·채널 확장, 페드루 PO 確定 2026-09-08) — channel→connector_key
+리졸버(resolve_connector_key_for_channel)와 두 트리거 지점(events.py:_render_gate_
+verdict_message의 publish 다음-행동 문구·apply_recipe_role_bindings의 정적 경고) 실증.
+
+세 축:
+① 리졸버 자체(mock db) — org override→기본→None 3분기.
+② 다음-행동 문구(mock db, test_3387과 동형 fixture) — publish+channel 있으면 커넥터명
+   구체화·매핑 없으면 에러 문구·publish 아니거나 channel 없으면 회귀 0(test_3387이
+   이미 gate_type=qa로 고정한 회귀 축과 겹치지 않게 gate_type=external_publish 아닌
+   레시피 stage 축만 다룬다).
+③ apply_recipe_role_bindings 경고(realdb, test_3317b와 동형 fixture) — 정적 하드코딩이
+   아니라 리졸버 경유라는 증거(org override가 경고 내용을 바꾼다) + 별칭 미매핑 시
+   기존 "등록 안 됨" 문구가 아니라 새 "channel=X 매핑 없음" 문구."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── ① 리졸버 자체 ──────────────────────────────────────────────────────────
+
+
+def _fake_rules_row(rules: dict | None):
+    row = MagicMock()
+    row.rules = rules
+    return row
+
+
+async def test_resolver_org_override_wins_over_default(monkeypatch):
+    """threads 기본값은 threads지만 org가 명시로 다른 커넥터를 지정했으면 그걸 우선한다."""
+    from app.services import channel_connector_map as mod
+
+    async def _fake_get(_db, *, org_id):
+        return _fake_rules_row({"channel_connector_map": {"threads": "custom_threads_v2"}})
+
+    monkeypatch.setattr(mod, "get_org_content_rules", _fake_get)
+    result = await mod.resolve_connector_key_for_channel(AsyncMock(), org_id=uuid.uuid4(), channel="threads")
+    assert result == "custom_threads_v2"
+
+
+async def test_resolver_falls_back_to_verified_default_when_no_override(monkeypatch):
+    """org_content_rules 행 자체가 없거나 channel_connector_map이 없으면 검증된 기본값
+    (항등 매핑)으로 떨어진다."""
+    from app.services import channel_connector_map as mod
+
+    async def _fake_get(_db, *, org_id):
+        return None
+
+    monkeypatch.setattr(mod, "get_org_content_rules", _fake_get)
+    assert await mod.resolve_connector_key_for_channel(AsyncMock(), org_id=uuid.uuid4(), channel="threads") == "threads"
+    assert await mod.resolve_connector_key_for_channel(AsyncMock(), org_id=uuid.uuid4(), channel="site_git") == "site_git"
+
+
+async def test_resolver_unknown_channel_without_override_is_none(monkeypatch):
+    """'blog'는 레지스트리 어디에도 declared channel이 아니다 — org override 없으면
+    지어내지 않고 None(호출부가 «매핑 없음»으로 명시)."""
+    from app.services import channel_connector_map as mod
+
+    async def _fake_get(_db, *, org_id):
+        return _fake_rules_row({"channel_connector_map": {}})
+
+    monkeypatch.setattr(mod, "get_org_content_rules", _fake_get)
+    result = await mod.resolve_connector_key_for_channel(AsyncMock(), org_id=uuid.uuid4(), channel="blog")
+    assert result is None
+
+
+async def test_resolver_org_override_resolves_unverified_alias(monkeypatch):
+    """org가 명시로 blog→site_git을 등록하면 그건 지어낸 게 아니라 org 자신의 선언이라
+    정상 해소된다 — None 경로가 «영구히 안 됨»이 아니라 «아직 org가 안 정했음»임을 보인다."""
+    from app.services import channel_connector_map as mod
+
+    async def _fake_get(_db, *, org_id):
+        return _fake_rules_row({"channel_connector_map": {"blog": "site_git"}})
+
+    monkeypatch.setattr(mod, "get_org_content_rules", _fake_get)
+    result = await mod.resolve_connector_key_for_channel(AsyncMock(), org_id=uuid.uuid4(), channel="blog")
+    assert result == "site_git"
+
+
+# ─── ② 다음-행동 문구(events.py::_render_gate_verdict_message) ──────────────
+
+
+class _FakeGateRow:
+    def __init__(self, neutral_facts: dict | None, *, id_=None):
+        self.neutral_facts = neutral_facts
+        self.id = id_ or uuid.uuid4()
+
+
+class _FakeResult:
+    def __init__(self, row):
+        self._row = row
+
+    def scalar_one_or_none(self):
+        return self._row
+
+
+def _fake_db(gate_row=None):
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_FakeResult(gate_row))
+    db.get = AsyncMock(return_value=gate_row)
+    return db
+
+
+def _payload(*, verdict: str = "approved") -> dict:
+    return {
+        "work_item_type": "story",
+        "work_item_id": str(uuid.uuid4()),
+        "gate_type": "recipe_stage_gate",
+        "verdict": verdict,
+        "resolution_note": None,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _stub_work_item_ref(monkeypatch):
+    from app.routers import events as events_module
+
+    async def _fake_ref(*_args, **_kwargs):
+        return "[제목](entity:story:11111111-1111-1111-1111-111111111111)"
+
+    monkeypatch.setattr(events_module, "_render_event_notification_work_item_ref", _fake_ref)
+
+
+async def _render(gate_row=None) -> str:
+    from app.routers.events import _render_gate_verdict_message
+
+    return await _render_gate_verdict_message(_fake_db(gate_row), org_id=uuid.uuid4(), payload=_payload())
+
+
+async def test_publish_stage_with_mapped_channel_names_the_connector(monkeypatch):
+    from app.services import channel_connector_map as mod
+
+    async def _fake_resolve(_db, *, org_id, channel):
+        assert channel == "threads"
+        return "threads"
+
+    monkeypatch.setattr(mod, "resolve_connector_key_for_channel", _fake_resolve)
+    text = await _render(_FakeGateRow({"stage": "publish", "channel": "threads"}))
+    assert "threads 커넥터로 발행하세요" in text
+    assert "channel=threads" in text
+    # 옛 제네릭 문구는 대체됐다 — 둘 다 있으면 안 헷갈리게 하나만.
+    assert "이 승인 게이트를 확인하는 발행 도구를 쓰세요" not in text
+
+
+async def test_publish_stage_with_unmapped_channel_states_missing_mapping_not_silent(monkeypatch):
+    from app.services import channel_connector_map as mod
+
+    async def _fake_resolve(_db, *, org_id, channel):
+        return None
+
+    monkeypatch.setattr(mod, "resolve_connector_key_for_channel", _fake_resolve)
+    text = await _render(_FakeGateRow({"stage": "publish", "channel": "blog"}))
+    assert "channel=blog" in text
+    assert "매핑이 없습니다" in text
+    assert "발행 도구를 쓰세요" not in text
+
+
+async def test_non_publish_stage_keeps_generic_text_regression():
+    """publish가 아닌 stage(예: approve)는 리졸버를 안 타고 옛 제네릭 문구 그대로."""
+    text = await _render(_FakeGateRow({"stage": "approve", "channel": "threads"}))
+    assert "이 정의의 다음 stage 이벤트를 발행하세요" in text
+    assert "커넥터로 발행하세요" not in text
+
+
+async def test_publish_stage_without_channel_keeps_generic_text_regression():
+    """stage=publish여도 channel을 모르면(neutral_facts에 없거나 미확認) 리졸버를 안 타고
+    옛 제네릭 문구 그대로 — 지어낼 channel이 없다."""
+    text = await _render(_FakeGateRow({"stage": "publish", "channel": "미확認"}))
+    assert "이 정의의 다음 stage 이벤트를 발행하세요" in text
+    assert "커넥터로 발행하세요" not in text

--- a/backend/tests/test_3359_content_rules_channel_connector_map_write.py
+++ b/backend/tests/test_3359_content_rules_channel_connector_map_write.py
@@ -1,0 +1,124 @@
+"""story #3359 CHANGES(카디르 발견, 페드루 PO 리뷰 2026-09-08) — 리졸버의 org override
+우선순위①이 쓰기 계약 부재로 죽은 경로였다: `ContentRulesFields`(extra="forbid")에
+`channel_connector_map` 필드가 없어 PUT body에 실으면 422로 거부됐다 — org가 blog/
+newsletter 같은 별칭을 영원히 등록 못 하는 상태(리졸버는 읽기만 살아있고 쓰기 통로가
+없었다). 세팅 헬퍼는 test_3471_org_content_rules_lint.py 재사용(중복 재발명 금지).
+
+이 파일은 기존 mocked 뮤테이션킬(test_3359_channel_connector_map.py::
+test_resolver_org_override_wins_over_default)의 짝 — 그건 get_org_content_rules를
+mock해 «리졸버 로직 자체»를 검증했고, 여긴 실 PUT→실 DB→리졸버 왕복으로 «쓰기 계약이
+실제로 뚫려 있는지»를 검증한다."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.test_3471_org_content_rules_lint import (
+    _client_for,
+    _seed_human,
+    _seed_org,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_put_channel_connector_map_no_longer_422():
+    """뮤테이션 킬 — channel_connector_map 필드가 ContentRulesFields에서 다시 빠지면
+    (또는 extra="forbid"가 이 필드를 여전히 모르면) 이 PUT이 422로 되돌아간다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={
+                    "rules": {"channel_connector_map": {"blog": "site_git", "newsletter": "stibee"}},
+                    "expected_version": 0,
+                },
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["rules"]["channel_connector_map"] == {"blog": "site_git", "newsletter": "stibee"}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_written_override_round_trips_through_real_resolver_no_mocking():
+    """실 PUT → 실 org_content_rules 행 → resolve_connector_key_for_channel(실 DB
+    조회, mock 0)까지 왕복 — 쓰기 계약과 리졸버가 실제로 이어져 있다는 증거(둘 중
+    하나만 고치고 다른 쪽을 안 잇는 클래스를 잡는다)."""
+    from app.main import app
+    from app.services.channel_connector_map import resolve_connector_key_for_channel
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"channel_connector_map": {"blog": "site_git"}}, "expected_version": 0},
+            )
+        assert r.status_code == 200, r.text
+
+        async with Session() as s:
+            resolved = await resolve_connector_key_for_channel(s, org_id=org_id, channel="blog")
+        assert resolved == "site_git"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_still_unknown_key_returns_422_regression():
+    """회귀 0 — channel_connector_map을 열어준 게 extra="forbid" 자체를 약화시키지
+    않았는지(정말 모르는 키는 여전히 거부)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.put(
+                f"/api/v2/organizations/{org_id}/content-rules",
+                json={"rules": {"totally_unknown_field": "x"}, "expected_version": 0},
+            )
+        assert r.status_code == 422, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3359_recipe_apply_resolver_realdb.py
+++ b/backend/tests/test_3359_recipe_apply_resolver_realdb.py
@@ -1,0 +1,154 @@
+"""story #3359 — apply_recipe_role_bindings의 정적 capability 경고가 하드코딩이 아니라
+resolve_connector_key_for_channel 리졸버를 실제로 거친다는 증거(realdb). test_3317b의
+세팅 헬퍼(_seed_org_project/_seed_agent/_seed_definition/_register_connector_from_
+fixture/_auth)를 재사용한다(중복 재발명 금지, 이 파일과 동형 관례)."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_3317b_recipe_capability_apply_check import (
+    _STIBEE_FIXTURE,
+    _THREADS_FIXTURE,
+    _auth,
+    _realdb_session,
+    _register_connector_from_fixture,
+    _seed_agent,
+    _seed_definition,
+    _seed_org_project,
+)
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [pytest.mark.destructive_schema, pytest.mark.anyio]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+async def test_org_override_changes_which_connector_the_warning_checks():
+    """뮤테이션 킬 — capability.connector_key="threads"인데 org가 channel_connector_map으로
+    threads→stibee를 override했으면, 경고는 threads가 아니라 stibee 등록 여부를 본다(리졸버를
+    실제로 거친다는 증거 — 하드코딩이면 이 override는 무시되고 여전히 threads를 본다)."""
+    from app.routers.events import ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings
+    from app.services.content_rules import put_org_content_rules
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="c3359a")
+            caller_id = await _seed_agent(s, org_id, project_id, name="caller")
+            agent_id = await _seed_agent(s, org_id, project_id, name="worker")
+            # threads는 등록(충족), stibee는 미등록 — override 전이면 threads라 경고 0.
+            await _register_connector_from_fixture(s, org_id, _THREADS_FIXTURE)
+            await put_org_content_rules(
+                s, org_id=org_id, rules={"channel_connector_map": {"threads": "stibee"}},
+                expected_version=0, updated_by_member_id=None,
+            )
+
+            definition = await _seed_definition(
+                s, org_id=org_id, key="org.c3359a.recipe_cap",
+                stage_metadata={
+                    "publish": {
+                        "role": "Agent", "action": "발행",
+                        "capability": {"kind": "publish", "connector_key": "threads"},
+                    },
+                },
+            )
+            resp = await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=None, role_mapping={"publish": str(agent_id)}),
+                db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+            assert len(resp.warnings) == 1
+            assert "stibee" in resp.warnings[0]
+            assert "connector_key='stibee'" in resp.warnings[0] or "stibee" in resp.warnings[0]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+async def test_unmapped_alias_states_missing_mapping_not_registered():
+    """capability.connector_key="blog"(레지스트리 어디에도 없는 별칭, org override도
+    없음) → 옛 "커넥터가 등록돼 있지 않습니다"가 아니라 "channel=blog에 대한 커넥터
+    매핑이 없습니다"로 원인이 다르게 명시된다(등록 문제와 매핑 문제를 안 섞는다)."""
+    from app.routers.events import ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="c3359b")
+            caller_id = await _seed_agent(s, org_id, project_id, name="caller")
+            agent_id = await _seed_agent(s, org_id, project_id, name="worker")
+
+            definition = await _seed_definition(
+                s, org_id=org_id, key="org.c3359b.recipe_cap",
+                stage_metadata={
+                    "publish": {
+                        "role": "Agent", "action": "발행",
+                        "capability": {"kind": "publish", "connector_key": "blog"},
+                    },
+                },
+            )
+            resp = await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=None, role_mapping={"publish": str(agent_id)}),
+                db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+            assert len(resp.warnings) == 1
+            assert "channel='blog'" in resp.warnings[0]
+            assert "매핑이 없습니다" in resp.warnings[0]
+            assert "등록돼 있지" not in resp.warnings[0]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+async def test_org_override_resolving_alias_to_registered_connector_yields_no_warning():
+    """org가 blog→site_git을 등록하고 site_git 커넥터가 실제로 이 org에 완전 등록돼
+    있으면 경고 0 — 별칭도 org override를 거치면 정상 통과한다는 증거."""
+    from app.routers.events import ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings
+    from app.services.connector_registry import set_org_connector_schema
+    from app.services.content_rules import put_org_content_rules
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="c3359c")
+            caller_id = await _seed_agent(s, org_id, project_id, name="caller")
+            agent_id = await _seed_agent(s, org_id, project_id, name="worker")
+
+            # site_git은 org_config 필드가 없어(자격증명은 조직 저장소 좌표라 실제로는
+            # source='org_config' 필드가 있지만 이 테스트는 등록 자체만 본다) fields=[]
+            # 로도 missing_required_org_config가 빈 목록을 낸다 — 경고 0 확인용 최소셋.
+            await set_org_connector_schema(
+                s, org_id=org_id, connector_key="site_git", version="1.0.0", channel="site_git",
+                fields=[], requires_env=[], kinds=["publish"], created_by=None,
+            )
+
+            await put_org_content_rules(
+                s, org_id=org_id, rules={"channel_connector_map": {"blog": "site_git"}},
+                expected_version=0, updated_by_member_id=None,
+            )
+
+            definition = await _seed_definition(
+                s, org_id=org_id, key="org.c3359c.recipe_cap",
+                stage_metadata={
+                    "publish": {
+                        "role": "Agent", "action": "발행",
+                        "capability": {"kind": "publish", "connector_key": "blog"},
+                    },
+                },
+            )
+            resp = await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=None, role_mapping={"publish": str(agent_id)}),
+                db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+            assert resp.warnings == []
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1532,6 +1532,16 @@
       "file": "tests/test_3663_wake_resting_schedule_unique_collision.py",
       "sec": 21.0,
       "source": "story-3663-wake-resting-schedule-unique-collision(PR #4037 CHANGES 처방 — 페드루 PO 追加 2026-09-08, 신규 destructive_schema 테스트 미등재로 Backend pytest+전용 guard FAIL. 로컬 raw pytest 3건 3.45s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 21s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3359_recipe_apply_resolver_realdb.py",
+      "sec": 6.0,
+      "source": "story-3359-channel-connector-resolver(2026-09-08, 로컬 raw pytest 3건 0.9s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 6s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3359_content_rules_channel_connector_map_write.py",
+      "sec": 18.0,
+      "source": "story-3359-channel-connector-resolver-write-contract(2026-09-08 CHANGES, 로컬 raw pytest 3건 2.9s(app.main import 1회 포함) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 18s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
- 마케팅 파이프라인 정의의 publish/measure capability가 connector_key로 고정 문자열을 박고, `payload.channel`은 승인 카드 표시용으로만 쓰이던 갭(#3359).
- `resolve_connector_key_for_channel()` 리졸버 신설(`org_content_rules.rules` 재사용, 마이그 0) — org override 우선 → 검증된 기본 항등 매핑(threads/instagram/site_git/stibee, 커넥터 정본 실측 대조) → None("매핑 없음" 명시, 지어내지 않음).
- 배선 2점(진리원천 하나): `_render_gate_verdict_message`의 publish 다음-행동 문구 + `apply_recipe_role_bindings`의 정적 경고.

## 스코프
- 저장+리졸버+배선까지. 편집 UI는 후속 스토리(스토리 AC에 명시).
- blog→site_git·newsletter→stibee 같은 별칭은 커넥터 레지스트리가 보증 안 해 기본값에 없음 — org가 명시 등록해야 해소(PO 지적 반영).

## 검증
- 신규 12건(리졸버 단위 4·문구 렌더 4·apply 경고 realdb 3, 전부 GREEN) + 기존 test_3317b(15)/test_3387(12) 전량 무회귀.
- 두 배선 지점 모두 픽스 제거 상태로 재현(RED) 확인 후 복원.

[SID:3359]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KVcT2ehcPQFL3nBxbZMsGy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVcT2ehcPQFL3nBxbZMsGy