### PR TITLE
[SID:3695] feat(BE): insights-board에 work_item_id 필터 — story별 성과 대조

### DIFF
--- a/backend/app/routers/insights_board.py
+++ b/backend/app/routers/insights_board.py
@@ -130,6 +130,8 @@ async def get_insights_board_endpoint(
     sort_dir: str = Query(default="desc"),
     cursor: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
+    # story #bf290f69 — story별 성과 대조(blog+social 발행물을 한 story로 좁혀 보기).
+    work_item_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
@@ -141,6 +143,7 @@ async def get_insights_board_endpoint(
         result = await list_insights_board(
             db, org_id=org_id, window=window, channel=channel, status=status,
             sort=sort, sort_dir=sort_dir, cursor=cursor, limit=limit,
+            work_item_id=work_item_id,
         )
     except InsightsBoardInvalidWindowError as exc:
         raise HTTPException(

--- a/backend/app/services/insights_board.py
+++ b/backend/app/services/insights_board.py
@@ -135,6 +135,7 @@ async def list_insights_board(
     db: AsyncSession, *, org_id: uuid.UUID, window: str = "30d", channel: str | None = None,
     status: str | None = None, sort: str = "published_at", sort_dir: str = "desc",
     cursor: str | None = None, limit: int = 50, now: datetime | None = None,
+    work_item_id: uuid.UUID | None = None,
 ) -> dict[str, Any]:
     if window not in _WINDOW_DAYS:
         raise InsightsBoardInvalidWindowError(window)
@@ -143,6 +144,13 @@ async def list_insights_board(
 
     rows_cte = _build_union(org_id=org_id, channel=channel, since=since)
     query = select(rows_cte)
+
+    # story #bf290f69(Phase2·BE, 페드루 PO 確定 2026-09-08) — story별 성과 대조. 기존
+    # channel/status와 동형 narrowing(AND)뿐, 새 인가 축이 아니다(work_item_id는
+    # rows_cte 양쪽 팔이 이미 셀렉트해 두고 있었다 — #3516 comments_count 조인용).
+    # 다른 파라미터와 그대로 조합 가능(window/channel/status/sort 전부 무변).
+    if work_item_id is not None:
+        query = query.where(rows_cte.c.work_item_id == work_item_id)
 
     if status is not None:
         query = query.where(exists(

--- a/backend/tests/test_3502_insights_board_endpoints.py
+++ b/backend/tests/test_3502_insights_board_endpoints.py
@@ -90,6 +90,44 @@ async def test_get_insights_board_endpoint_agent_200_with_rows():
 
 
 @pytest.mark.anyio
+async def test_get_insights_board_endpoint_work_item_id_query_param_narrows_result():
+    """story #bf290f69 — HTTP 왕복으로 work_item_id 쿼리 파라미터가 실제로
+    list_insights_board까지 배선돼 있는지(서비스 함수 직접 호출 테스트는
+    test_bf290f69_insights_board_work_item_filter.py가 이미 덮는다 — 여기는 라우터
+    배선 자체만)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_a = await _seed_story(s, org_id, project_id)
+            story_b = await _seed_story(s, org_id, project_id)
+            await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_a, slug="post-wia", title="WI-A",
+                published_at=datetime.now(timezone.utc) - timedelta(days=1),
+            )
+            await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_b, slug="post-wib", title="WI-B",
+                published_at=datetime.now(timezone.utc) - timedelta(days=1),
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(
+                f"/api/v2/organizations/{org_id}/insights-board?work_item_id={story_a}"
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body["rows"]) == 1
+        assert body["rows"][0]["title"] == "WI-A"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_get_insights_board_endpoint_invalid_window_422():
     from app.main import app
 

--- a/backend/tests/test_bf290f69_insights_board_work_item_filter.py
+++ b/backend/tests/test_bf290f69_insights_board_work_item_filter.py
@@ -1,0 +1,139 @@
+"""story #bf290f69(Phase2·BE, 페드루 PO 確定 2026-09-08) — story별 성과 대조. 재그라운딩
+(착수 前) 결과 #3502 insights-board가 이미 UNION+d1/d7 버킷+work_item_id 셀렉트까지
+하고 있어, 새 엔드포인트가 아니라 기존 `list_insights_board`에 `work_item_id` narrowing
+필터 하나만 얹는다(신규 개념 0). 세팅 헬퍼는 test_3502_insights_board.py 재사용(중복
+재발명 금지, 이 파일과 동형 관례).
+
+핵심 축: work_item_id는 channel/status와 동형 AND-narrowing일 뿐 새 인가 축이 아니다
+— org_id 스코프(_build_union 안)는 무변, work_item_id 필터는 그 위에 추가로 좁힐 뿐."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_3471_org_content_rules_lint import _seed_org, _seed_story, _session_factory
+from tests.test_3502_insights_board import _seed_channel_publication, _seed_gate, _seed_site_post
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_work_item_id_narrows_to_that_story_blog_and_social_only():
+    """뮤테이션 킬(페드루 지정) — work_item_id로 좁히면 그 story의 발행물(blog+social
+    둘 다)만 온다. WHERE를 빼면(뮤테이션) 다른 story의 발행물이 새 들어온다(RED)."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_a = await _seed_story(s, org_id, project_id)
+            story_b = await _seed_story(s, org_id, project_id)
+            now = datetime.now(timezone.utc)
+
+            sp_a = await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_a, slug="post-a", title="A",
+                published_at=now - timedelta(days=1),
+            )
+            gate_a = await _seed_gate(s, org_id=org_id, work_item_id=story_a)
+            cp_a = await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate_a.id, channel="threads", published_at=now - timedelta(days=1),
+            )
+
+            # story_b — 다른 story, 새면 안 되는 발행물.
+            await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_b, slug="post-b", title="B",
+                published_at=now - timedelta(days=1),
+            )
+            gate_b = await _seed_gate(s, org_id=org_id, work_item_id=story_b)
+            await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate_b.id, channel="threads", published_at=now - timedelta(days=1),
+            )
+
+            result = await list_insights_board(s, org_id=org_id, window="30d", work_item_id=story_a)
+
+        ids = {r["publication_id"] for r in result["rows"]}
+        assert ids == {sp_a.id, cp_a.id}, f"story_a의 blog+social만 와야 하는데: {ids}"
+        assert all(r["work_item_id"] == story_a for r in result["rows"])
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_work_item_id_param_keeps_org_wide_behavior_unchanged():
+    """회귀 0 — work_item_id를 안 주면(기존 호출부 전부) 여러 story의 발행물이 그대로
+    다 온다(param 신설 前 동작과 동일)."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_a = await _seed_story(s, org_id, project_id)
+            story_b = await _seed_story(s, org_id, project_id)
+            now = datetime.now(timezone.utc)
+
+            sp_a = await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_a, slug="post-a2", title="A2",
+                published_at=now - timedelta(days=1),
+            )
+            sp_b = await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_b, slug="post-b2", title="B2",
+                published_at=now - timedelta(days=1),
+            )
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+
+        ids = {r["publication_id"] for r in result["rows"]}
+        assert ids == {sp_a.id, sp_b.id}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_work_item_id_combines_with_channel_filter():
+    """work_item_id도 channel/status와 같은 AND-narrowing 축 — 같은 story 안에서도
+    channel로 더 좁힐 수 있다(신규 상호작용 버그 없음 확인)."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_a = await _seed_story(s, org_id, project_id)
+            now = datetime.now(timezone.utc)
+
+            sp = await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_a, slug="post-c", title="C",
+                published_at=now - timedelta(days=1),
+            )
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_a)
+            await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, channel="threads", published_at=now - timedelta(days=1),
+            )
+
+            result = await list_insights_board(
+                s, org_id=org_id, window="30d", work_item_id=story_a, channel="hosted_site",
+            )
+
+        assert [r["publication_id"] for r in result["rows"]] == [sp.id]
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1547,6 +1547,11 @@
       "file": "tests/test_3696_insight_channel_dispatch_registered_guard.py",
       "sec": 15.0,
       "source": "story-3696-instagram-sandbox-insight-dispatch-guard(2026-09-08, 로컬 raw pytest 2건 1.9s(app.core.database 등 import 포함) 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 15s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_bf290f69_insights_board_work_item_filter.py",
+      "sec": 14.5,
+      "source": "story-3695-insights-board-work-item-filter(2026-09-08, 카디르 qa:changes 지적 — 신규 destructive_schema 파일 미등재. 로컬 raw pytest 3건 실측 반영 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
- 목표(블로그→소셜→GA4 성과 비교)에서 착수 前 재그라운딩 결과, 새 엔드포인트가 아니라 기존 `insights-board`(#3502)에 story 단위 필터만 빠져 있음을 확인 — 중복 빌드 회피.
- `list_insights_board`에 `work_item_id` 파라미터 추가(channel/status와 동형 AND-narrowing). 기존 UNION(site_post+channel_publication)·d1/d7 스냅샷 버킷·null≠0 정규화는 전부 무변(이미 충족).

## 검증
- 신규 4건(story 단위 좁힘·파라미터 미지정 무회귀·channel과 조합·HTTP 라우터 배선) 전부 GREEN.
- 뮤테이션: WHERE 제거 시 타 story 발행물 누출 재현 확인 후 복원.
- 기존 test_3502 스위트(23건) 전량 무회귀.

[SID:3695]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KVcT2ehcPQFL3nBxbZMsGy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVcT2ehcPQFL3nBxbZMsGy