### PR TITLE
[SID:3702] fix(BE): 챗 bare #N 승격 — 같은 메시지 안 미연결 PR 언급도 모호 처리

### DIFF
--- a/backend/app/services/story_ref_promoter.py
+++ b/backend/app/services/story_ref_promoter.py
@@ -247,6 +247,10 @@ async def promote_bare_story_refs(
     같은 N이 org 전체(레포 무관) `pull_request_story_link.pr_number`에도 있으면
     모호(스토리 번호와 PR 번호가 우연히 겹침)로 보고 치환하지 않는다(PO rule② — 둘
     다 이 플랫폼 원장이라 "같은 프레임"으로 판정, 다른 소스를 비교하지 않는다).
+    story #3702(rule② 사각 정정) — 원장(PullRequestStoryLink)에 아직 안 링크된 PR도
+    이 메시지 «자신»이 ①(explicit — GitHub URL·owner/repo#N)로 그 번호를 PR로 이미
+    증언했으면 같은 모호함이다(실사고: "PR #4052(URL 포함)... #4052" — 뒤 #4052가
+    org 원장엔 없어도(링크 전) message-local 증거로 모호 처리한다).
 
     두 갈래 모두 resolve 실패(그 번호/PR의 대상이 없음·타 project 소속)면 **그 매치만**
     원문 그대로 남긴다(전체 all-or-nothing 아님 — 은퇴한 @handle 파서의 "매치 0건=조회도
@@ -338,9 +342,16 @@ async def promote_bare_story_refs(
         return result, promoted_ids
     protected = _protected_spans(result)
     candidates = [c for c in candidates if not _in_protected_span(c[0], protected)]
-    # PO rule② — 같은 N이 org(레포 무관) pr_number에도 있으면 모호. story_number와
-    # pr_number가 같은 플랫폼 원장(다른 소스가 아니다)이라 이 대조가 "같은 프레임"이다.
-    candidates = [c for c in candidates if c[2] not in org_pr_numbers]
+    # story #3702(rule② 사각 정정, 페드루 PO 確定 2026-09-08) — rule②(org_pr_numbers)는
+    # PullRequestStoryLink에 «이미 링크된» PR만 안다. 아직 스토리에 안 링크된 PR을
+    # 이 메시지 안에서 GitHub URL이나 owner/repo#N으로 먼저 명시했으면(①이 찾은 explicit,
+    # 원장 링크 존재 여부 무관 — story_id 해석 성공/실패와 무관하게 「이 메시지 안에서 N이
+    # PR 번호로 쓰였다」는 사실 자체는 확정) 그 번호가 뒤에서 맨 #N으로 다시 나와도 같은
+    # 모호함이다(실사고: "PR #4052(URL 포함) 머지됐는. #4052 관련..." — 뒤 #4052가 org_pr_
+    # numbers엔 없어도(링크 전) story #4052로 오승격됐다). org_pr_numbers(영속 원장)와
+    # message_pr_numbers(이 메시지 자체가 증언하는 PR 번호)를 합쳐 하나의 모호 집합으로 본다.
+    message_pr_numbers = frozenset(n for _, _, _, n in explicit)
+    candidates = [c for c in candidates if c[2] not in org_pr_numbers and c[2] not in message_pr_numbers]
     if not candidates:
         return result, promoted_ids
 

--- a/backend/tests/test_2629_bare_story_ref_promotion.py
+++ b/backend/tests/test_2629_bare_story_ref_promotion.py
@@ -800,6 +800,103 @@ async def test_promote_bare_number_ambiguous_with_org_pr_number_not_promoted():
         await engine.dispose()
 
 
+async def test_promote_message_local_unlinked_pr_url_makes_later_bare_number_ambiguous():
+    """story #3702(rule② 사각 정정, 페드루 PO 確定 2026-09-08) — 실사고 재현: 같은
+    메시지 안에서 GitHub PR URL로 N을 먼저 명시했는데(원장에 아직 안 링크됨 — 갓 연
+    PR) 뒤에서 별도로 맨 #N을 또 쓰면, org_pr_numbers(영속 원장)엔 그 N이 없어도
+    message-local 증거(explicit)로 모호 처리해 story 승격을 막아야 한다. 원장 링크가
+    없으니 URL 부분도 그대로 남는다(PO rule① "없으면 침묵")."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            wrong_story = await _seed_story(s, org.id, project.id, number=4052, title="무관한 스토리")
+            content = (
+                "PR #4052 (https://github.com/moonklabs/sprintable/pull/4052) 머지됐는. "
+                "#4052 관련 후속 확認 바라는"
+            )
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content  # 둘 다 손 안 댐 — URL은 원장 미링크(침묵), 뒤 #4052는 모호.
+            assert promoted_ids == set()
+            assert wrong_story.id not in promoted_ids
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_message_local_owner_repo_hash_makes_later_bare_number_ambiguous():
+    """story #3702 — owner/repo#N 형태(URL 아님)로도 같은 message-local 모호함이 걸린다."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            wrong_story = await _seed_story(s, org.id, project.id, number=46, title="무관한 스토리")
+            content = "moonklabs/sprintable#46 확인 필요. #46 후속도 같이"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content
+            assert promoted_ids == set()
+            assert wrong_story.id not in promoted_ids
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_message_local_linked_pr_url_still_resolves_and_later_bare_number_stays_ambiguous():
+    """story #3702 — URL이 원장에 «이미 링크된» PR을 가리키면 ①이 정상 승격하고
+    (기존 rule① 무회귀), 뒤의 맨 #N(같은 번호)은 여전히 모호(=이번엔 org_pr_numbers
+    로도 이미 걸림 — 이 테스트는 두 경로가 서로 안 부딪히는지 확認)."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            wrong_story = await _seed_story(s, org.id, project.id, number=46, title="무관한 스토리")
+            linked_story = await _seed_story(s, org.id, project.id, number=999, title="연결된 작업")
+            await _seed_pr_link(
+                s, org.id, linked_story.id, repo_full_name="moonklabs/sprintable", pr_number=46,
+            )
+            content = "https://github.com/moonklabs/sprintable/pull/46 머지됐는. #46 후속 확認"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            expected_token = build_reference_token("story", linked_story.id, "#46 연결된 작업")
+            assert result == f"{expected_token} 머지됐는. #46 후속 확認"
+            assert promoted_ids == {linked_story.id}
+            assert wrong_story.id not in promoted_ids
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_message_local_ambiguity_does_not_affect_unrelated_numbers():
+    """story #3702 음성대조 — message-local PR 번호와 무관한 다른 #N은 그대로 승격된다
+    (과잉 배제 방지, 무회귀)."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            unrelated_story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            content = "https://github.com/moonklabs/sprintable/pull/4052 참고. #24 도 확認"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            expected_token = build_reference_token("story", unrelated_story.id, "#24 보드 리팩터")
+            assert result == f"https://github.com/moonklabs/sprintable/pull/4052 참고. {expected_token} 도 확認"
+            assert promoted_ids == {unrelated_story.id}
+    finally:
+        await engine.dispose()
+
+
 async def test_promote_github_pr_url_resolves_to_linked_story():
     """PO rule① — GitHub PR URL은 owner/repo가 URL 자체에 명시돼 있어 원장 유일성
     문제 없이 바로 (repo_full_name, pr_number)를 뽑아 대조한다."""


### PR DESCRIPTION
## 요약
- story #3652(rule②)가 다룬 "story 번호↔PR 번호 표기 공간 충돌" 방어는 **영속 원장(PullRequestStoryLink)에 이미 링크된 PR만** 커버했다.
- 같은 메시지 안에서 아직 링크 안 된 PR을 GitHub URL이나 `owner/repo#N`으로 먼저 언급하고, 뒤에서 별도로 맨 `#N`을 쓰면 오승격되는 사각을 실측(오늘, 디디 메시지 반복 재현 — customer-zero)으로 확인·정정.

## 실사고
"PR #4052 (https://github.com/moonklabs/sprintable/pull/4052) 머지됐는. #4052 관련 후속..." — 앞 "PR #4052"는 `_PR_PREFIX_RE`로 이미 제외되지만, 뒤 "#4052"는 직전 토큰이 "PR"이 아니라 다른 산문이라 안 걸리고, `org_pr_numbers`(영속 원장)에도 4052가 아직 없어(링크 전) rule②도 안 걸려 무관 story #4052로 오승격.

## 처방(최소 델타)
①(`_find_explicit_repo_pr_candidates` — GitHub URL·owner/repo#N)이 찾은 PR 번호를 `message_pr_numbers`로 모아, ②(맨 #N)의 기존 `org_pr_numbers` 필터에 합집합으로 더한다. 원장 링크 존재/해석 성공 여부와 무관하게 "이 메시지 안에서 N이 PR 번호로 쓰였다"는 사실 자체가 모호함의 근거 — 기존 rule①/②(영속 원장 기반)는 무변, 신규 축(message-local 증거)만 additive.

## 테스트
- 신규 4건: ①URL 미링크+뒤 bare#N(양성) ②owner/repo#N 형태+뒤 bare#N(양성) ③URL 이미 링크된 케이스에서 두 경로 안 부딪힘(무회귀) ④무관 번호는 과잉배제 안 됨(음성대조)
- fix 되돌려 신규 2건 실패 확認 완료(사본↔사본 아님)
- 기존 `test_2629`(38건)+`test_2702`(2건) 전체 무회귀 — 총 44건 그린

## 반응형 확인
- BE 전용 변경, 화면 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb5TRLyLCXzgLwaiQoTtrx