### PR TITLE
[SID:3704] fix(FE): kanban-board handleStoryClick — storyTasks 리셋+요청 순번 취소 가드

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -685,6 +685,106 @@ describe('KanbanBoard — 상세 패널 story 전환 시 로컬 state 리셋(#35
   });
 });
 
+// story #3704(유나 발견+카디르 비블로커, #4054 재리뷰 中) — handleStoryClick이 진입 시
+// storyTasks 자신을 안 비우고, A→B 연타에서 늦게 온 A 응답이 B의 tasks/nextCursor/totalCount를
+// 덮을 수 있었다(형제 epic-swimlane-board.tsx엔 cancelled 가드가 있는데 kanban-board만 없었다).
+function deferredTaskResponse() {
+  let resolve!: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
+  const promise = new Promise<{ ok: boolean; json: () => Promise<unknown> }>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+function taskOk(rows: Array<{ id: string; title: string; status: string }>, totalCount: number) {
+  return { ok: true, json: async () => ({ data: rows, meta: { nextCursor: null, totalCount } }) };
+}
+
+function stubFetchWithTasks(
+  stories: Array<Record<string, unknown> & { status: string }>,
+  taskHandlers: Record<string, () => Promise<{ ok: boolean; json: () => Promise<unknown> }>>,
+) {
+  const withTrustStage = stories.map((s) => ('trust_stage' in s ? s : { ...s, trust_stage: deriveDefaultTrustStage(s.status) }));
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url === 'string' && url.startsWith('/api/stories?')) {
+      const status = new URL(url, 'http://localhost').searchParams.get('status');
+      const matched = withTrustStage.filter((s) => s.status === status);
+      return { ok: true, json: async () => ({ data: matched, meta: { total: matched.length, nextCursor: null } }) };
+    }
+    if (typeof url === 'string' && url.startsWith('/api/members')) {
+      return { ok: true, json: async () => ({ data: [] }) };
+    }
+    if (typeof url === 'string' && url.startsWith('/api/tasks?story_id=')) {
+      const storyId = new URL(url, 'http://localhost').searchParams.get('story_id')!;
+      const handler = taskHandlers[storyId];
+      if (handler) return handler();
+      return taskOk([], 0);
+    }
+    return { ok: false, json: async () => null };
+  }));
+}
+
+describe('KanbanBoard — handleStoryClick storyTasks 리셋·취소 가드(story #3704)', () => {
+  async function clickStory(title: string) {
+    const card = container.querySelector(`[title="${title}"]`) as HTMLElement | null;
+    expect(card).not.toBeNull();
+    await act(async () => {
+      card!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('A 로드 後 B 클릭 응답 500 — B 패널에 A의 태스크가 한 건도 안 남는다(blocker①)', async () => {
+    stubFetchWithTasks(
+      [
+        { id: 's1', title: 'S1', status: 'backlog', priority: 'medium' },
+        { id: 's2', title: 'S2', status: 'backlog', priority: 'medium' },
+      ],
+      {
+        s1: () => Promise.resolve(taskOk([{ id: 't1', title: 'A태스크', status: 'todo' }], 1)),
+        s2: () => Promise.resolve({ ok: false, json: async () => null }),
+      },
+    );
+    await mount();
+    await clickStory('S1');
+    const dialog = () => container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog().textContent).toContain('A태스크');
+
+    await clickStory('S2');
+    expect(dialog().textContent).not.toContain('A태스크'); // 옛 스토리 태스크가 남으면 안 됨.
+    expect(dialog().textContent).toContain(koMessages.board.noTasks); // 정직한 빈 상태.
+  });
+
+  it('A 클릭→B 클릭, A 응답이 B보다 늦게 도착 — 패널은 끝까지 B 값이다(blocker②)', async () => {
+    const aResponse = deferredTaskResponse();
+    stubFetchWithTasks(
+      [
+        { id: 's1', title: 'S1', status: 'backlog', priority: 'medium' },
+        { id: 's2', title: 'S2', status: 'backlog', priority: 'medium' },
+      ],
+      {
+        s1: () => aResponse.promise,
+        s2: () => Promise.resolve(taskOk([{ id: 't2', title: 'B태스크', status: 'todo' }], 1)),
+      },
+    );
+    await mount();
+    await clickStory('S1'); // A 요청 발화 — 아직 응답 안 옴(deferred).
+    await clickStory('S2'); // B 요청 발화+즉시 응답 — 패널은 B 값으로 정착.
+
+    const dialog = () => container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog().textContent).toContain('B태스크');
+
+    await act(async () => { // 이제야 A의 늦은 응답이 도착 — 요청 순번이 안 맞아 버려져야 한다.
+      aResponse.resolve(taskOk([{ id: 't1', title: 'A태스크', status: 'todo' }], 1));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(dialog().textContent).toContain('B태스크'); // 여전히 B.
+    expect(dialog().textContent).not.toContain('A태스크'); // 늦게 온 A가 덮으면 안 됨.
+  });
+});
+
 // story #2104 — BE stories.py:1056(human-only 영구삭제 403)를 FE가 미리 안 보고 에이전트
 // 계정에도 삭제 트리거를 무조건 열었다(#2091/#2103과 같은 결함). 양방향 고정 — human까지
 // 잠그면 정당한 삭제가 봉쇄되는 더 큰 사고다(승격 위험목록의 잔여 미검증 칸 해소).

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -694,13 +694,13 @@ function deferredTaskResponse() {
   return { promise, resolve };
 }
 
-function taskOk(rows: Array<{ id: string; title: string; status: string }>, totalCount: number) {
-  return { ok: true, json: async () => ({ data: rows, meta: { nextCursor: null, totalCount } }) };
+function taskOk(rows: Array<{ id: string; title: string; status: string }>, totalCount: number, nextCursor: string | null = null) {
+  return { ok: true, json: async () => ({ data: rows, meta: { nextCursor, totalCount } }) };
 }
 
 function stubFetchWithTasks(
   stories: Array<Record<string, unknown> & { status: string }>,
-  taskHandlers: Record<string, () => Promise<{ ok: boolean; json: () => Promise<unknown> }>>,
+  taskHandlers: Record<string, (url: string) => Promise<{ ok: boolean; json: () => Promise<unknown> }>>,
 ) {
   const withTrustStage = stories.map((s) => ('trust_stage' in s ? s : { ...s, trust_stage: deriveDefaultTrustStage(s.status) }));
   vi.stubGlobal('fetch', vi.fn(async (url: string) => {
@@ -715,7 +715,7 @@ function stubFetchWithTasks(
     if (typeof url === 'string' && url.startsWith('/api/tasks?story_id=')) {
       const storyId = new URL(url, 'http://localhost').searchParams.get('story_id')!;
       const handler = taskHandlers[storyId];
-      if (handler) return handler();
+      if (handler) return handler(url);
       return taskOk([], 0);
     }
     return { ok: false, json: async () => null };
@@ -782,6 +782,86 @@ describe('KanbanBoard — handleStoryClick storyTasks 리셋·취소 가드(stor
     });
     expect(dialog().textContent).toContain('B태스크'); // 여전히 B.
     expect(dialog().textContent).not.toContain('A태스크'); // 늦게 온 A가 덮으면 안 됨.
+  });
+
+  // story #3704 후속(카디르 재-QA, PR#4055 2026-09-09) — 위 requestId 대조가 fetch 직후
+  // (res.json() 파싱 前)에만 있어, res.json() 자체가 비동기라 그 파싱 사이에 새 클릭이
+  // 순번을 올릴 수 있다 — 파싱 뒤(상태 반영 직전) 재대조가 없으면 옛 결과가 새 클릭보다
+  // 늦게 커밋된다.
+  it('res.json() 파싱 사이 새 클릭이 순번을 올리면 늦게 파싱된 A 결과를 커밋하지 않는다(blocker②-2)', async () => {
+    let resolveABody!: (v: unknown) => void;
+    const aBody = new Promise((res) => { resolveABody = res; });
+    stubFetchWithTasks(
+      [
+        { id: 's1', title: 'S1', status: 'backlog', priority: 'medium' },
+        { id: 's2', title: 'S2', status: 'backlog', priority: 'medium' },
+      ],
+      {
+        s1: () => Promise.resolve({ ok: true, json: () => aBody }), // fetch 레벨은 즉시 도착 — json() 파싱만 지연.
+        s2: () => Promise.resolve(taskOk([{ id: 't2', title: 'B태스크', status: 'todo' }], 1)),
+      },
+    );
+    await mount();
+    await clickStory('S1'); // A의 fetch 레벨 대조는 이미 통과 — 지금은 res.json() 파싱 대기 중.
+
+    await clickStory('S2'); // B로 이동 — requestId가 여기서 올라간다.
+    const dialog = () => container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog().textContent).toContain('B태스크');
+
+    await act(async () => { // A의 json() 파싱이 이제야 끝난다 — 파싱 뒤 재대조가 없으면 여기서 B를 덮는다.
+      resolveABody({ data: [{ id: 't1', title: 'A태스크', status: 'todo' }], meta: { nextCursor: null, totalCount: 1 } });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(dialog().textContent).toContain('B태스크');
+    expect(dialog().textContent).not.toContain('A태스크');
+  });
+
+  // story #3704 후속(유나 design CHANGES, PR#4055 2026-09-09) — onLoadMoreTasks(「더 보기」)는
+  // handleStoryClick과 별개 자리라 이 가드가 안 걸렸다. A에서 「더 보기」 pending 중
+  // onNavigate(패널 안 이동, 패널은 안 닫힘)로 B로 넘어가면 A의 page2 응답이 B 목록에
+  // append되고 totalCount까지 A 것으로 덮일 수 있었다.
+  it('A 「더 보기」 pending 중 B로 이동 — 늦게 온 A page2가 B 목록/총계를 덮지 않는다(blocker③)', async () => {
+    let resolveAPage2!: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const aPage2 = new Promise<{ ok: boolean; json: () => Promise<unknown> }>((res) => { resolveAPage2 = res; });
+    stubFetchWithTasks(
+      [
+        { id: 's1', title: 'S1', status: 'backlog', priority: 'medium' },
+        { id: 's2', title: 'S2', status: 'backlog', priority: 'medium' },
+      ],
+      {
+        s1: (url: string) => (url.includes('cursor=')
+          ? aPage2 // 「더 보기」(page2) — deferred.
+          : Promise.resolve(taskOk([{ id: 't1', title: 'A1', status: 'todo' }], 5, 'c1'))), // page1, nextCursor=c1.
+        s2: () => Promise.resolve(taskOk([{ id: 't2', title: 'B태스크', status: 'todo' }], 1)),
+      },
+    );
+    await mount();
+    await clickStory('S1');
+    const dialog = () => container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog().textContent).toContain('A1');
+
+    const loadMoreBtn = () => [...dialog().querySelectorAll('button')].find((b) => b.textContent === koMessages.board.loadMore) as HTMLElement | undefined;
+    expect(loadMoreBtn()).toBeDefined();
+    await act(async () => {
+      loadMoreBtn()!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    }); // page2 fetch 발화 — 아직 응답 안 옴(deferred).
+
+    await clickStory('S2'); // B로 이동 — requestId가 올라간다.
+    expect(dialog().textContent).toContain('B태스크');
+
+    await act(async () => { // 이제야 A의 page2가 도착 — B 패널을 덮으면 안 된다.
+      resolveAPage2(taskOk([{ id: 't1b', title: 'A2', status: 'todo' }], 5, null));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(dialog().textContent).toContain('B태스크');
+    expect(dialog().textContent).not.toContain('A2'); // A page2가 B 목록에 섞이면 안 됨.
+    expect(dialog().textContent).not.toContain('Tasks (5)'); // A의 총계(5)가 B 총계(1)를 덮으면 안 됨.
   });
 });
 

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -568,6 +568,11 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       if (storyTasksRequestRef.current !== requestId) return; // 그 사이 더 최신 클릭이 있었다 — 이 응답은 버린다.
       if (res.ok) {
         const json = await res.json();
+        // story #3704 후속(카디르 재-QA, PR#4055) — 위 대조는 fetch 직후일 뿐, res.json()
+        // 자체가 비동기라 그 파싱 사이에 더 최신 클릭이 순번을 올릴 수 있다 — 상태 반영
+        // «직전»(파싱 뒤)에 한 번 더 대조해야 그 창을 닫는다(안 닫으면 옛 결과가 새 클릭보다
+        // 늦게 커밋될 수 있다).
+        if (storyTasksRequestRef.current !== requestId) return;
         setStoryTasks(json.data ?? []);
         setStoryTasksNextCursor(json.meta?.nextCursor ?? null);
         setStoryTasksTotalCount(typeof json.meta?.totalCount === 'number' ? json.meta.totalCount : null);
@@ -1860,9 +1865,20 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           onLoadMoreTasks={async () => {
             if (!selectedStory || !storyTasksNextCursor) return;
             setLoadingMoreStoryTasks(true);
+            // story #3704 후속(유나 design CHANGES, PR#4055 재리뷰 2026-09-09) — 「더 보기」는
+            // handleStoryClick의 새 클릭이 아니라 «지금 열려있는 스토리 이어받기»라 순번을
+            // 올리지 않고 캡처만 한다. 패널이 onNavigate로 다른 스토리(B)로 넘어가면
+            // handleStoryClick이 순번을 올리므로, 이 응답이 늦게 와도 아래 대조에서 걸러진다
+            // (안 걸렀을 때: A page2가 B 패널에 append되고 totalCount까지 A 것으로 덮인다).
+            const requestId = storyTasksRequestRef.current;
             const res = await fetch(`/api/tasks?story_id=${selectedStory.id}&limit=20&cursor=${encodeURIComponent(storyTasksNextCursor)}`);
+            if (storyTasksRequestRef.current !== requestId) { setLoadingMoreStoryTasks(false); return; }
             if (res.ok) {
               const json = await res.json();
+              // story #3704 후속(카디르 재-QA, PR#4055) — res.json() 파싱 사이에도 다른
+              // 스토리로 이동할 수 있다(handleStoryClick이 순번을 올린다) — 상태 반영 직전에
+              // 한 번 더 대조.
+              if (storyTasksRequestRef.current !== requestId) { setLoadingMoreStoryTasks(false); return; }
               setStoryTasks((prev) => {
                 const existingIds = new Set(prev.map((t) => t.id));
                 return [...prev, ...(json.data ?? []).filter((t: Task) => !existingIds.has(t.id))];

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -165,6 +165,11 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
   const [loadingMore, setLoadingMore] = useState(false);
   const [loadingMoreEpics, setLoadingMoreEpics] = useState(false);
   const [loadingMoreStoryTasks, setLoadingMoreStoryTasks] = useState(false);
+  // story #3704(유나 발견+카디르 비블로커, #4054 재리뷰 中) — handleStoryClick은 이벤트
+  // 핸들러라 형제(epic-swimlane-board.tsx/flow-node-story-panel.tsx)처럼 effect cleanup의
+  // `cancelled` 클로저를 못 쓴다(재실행을 트리거할 의존성 배열이 없다) — 대신 클릭마다
+  // 증가시키는 요청 순번으로 "가장 최근 클릭의 응답만 반영"을 흉내낸다.
+  const storyTasksRequestRef = useRef(0);
 
   const selectedSprintId = searchParams.get('sprint_id') ?? '';
   const selectedEpicId = searchParams.get('epic_id') ?? '';
@@ -536,8 +541,18 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
 
   const handleStoryClick = useCallback(async (story: KanbanStory, { replace = false } = {}) => {
     setSelectedStory(story);
+    // story #3704 blocker① — storyTasks 자신도 세 값(tasks/nextCursor/totalCount)과 한 묶음으로
+    // 리셋한다. 전엔 이 줄이 빠져 있어, !res.ok(403/500 등)면 아래 if(res.ok) 블록을 통째로
+    // 건너뛰고 직전 스토리의 태스크 목록이 새 스토리 패널 밑에 그대로 남았다(catch만 비웠다).
+    setStoryTasks([]);
     setStoryTasksNextCursor(null);
     setStoryTasksTotalCount(null);
+
+    // story #3704 blocker② — 이 함수는 클릭마다 호출되는 이벤트 핸들러라 형제 두 곳처럼
+    // effect cleanup의 `cancelled` 클로저를 못 쓴다. 요청 순번을 자기 클로저에 캡처해 두고,
+    // 응답이 도착했을 때 "지금도 내가 최신 요청인지"를 대조 — A→B 연타에서 늦게 온 A의
+    // 응답이 B 패널의 tasks/nextCursor/totalCount를 덮는 것을 막는다.
+    const requestId = ++storyTasksRequestRef.current;
 
     // URL에 스토리 ID 반영
     const params = new URLSearchParams(searchParams);
@@ -550,13 +565,19 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
 
     try {
       const res = await fetchWithAuth(`/api/tasks?story_id=${story.id}&limit=20`);
+      if (storyTasksRequestRef.current !== requestId) return; // 그 사이 더 최신 클릭이 있었다 — 이 응답은 버린다.
       if (res.ok) {
         const json = await res.json();
         setStoryTasks(json.data ?? []);
         setStoryTasksNextCursor(json.meta?.nextCursor ?? null);
         setStoryTasksTotalCount(typeof json.meta?.totalCount === 'number' ? json.meta.totalCount : null);
+      } else {
+        setStoryTasks([]);
+        setStoryTasksNextCursor(null);
+        setStoryTasksTotalCount(null);
       }
     } catch {
+      if (storyTasksRequestRef.current !== requestId) return;
       setStoryTasks([]);
       setStoryTasksNextCursor(null);
       setStoryTasksTotalCount(null);


### PR DESCRIPTION
## 요약
- `kanban-board.tsx`의 `handleStoryClick`이 진입 시 `storyTasksNextCursor`/`storyTasksTotalCount`만 리셋하고 `storyTasks` 자신은 안 비워, 응답이 `!res.ok`(403/500 등)면 `if(res.ok)` 블록을 통째로 건너뛰어 **직전 스토리의 태스크가 새 스토리 패널 밑에 그대로 남았다**(blocker①).
- `cancelled` 가드가 없어 스토리 A→B 연타 시 **늦게 도착한 A의 응답이 B의 tasks/nextCursor/totalCount를 덮을 수 있었다**(blocker②). 형제 `epic-swimlane-board.tsx`·`flow-node-story-panel.tsx`엔 이미 같은 가드가 있음 — kanban-board만 빠져 있었다.
- 출처: 유나 발견(#4054 재리뷰 덤) + 카디르 비블로커 지적, 페드루 PO 그라운딩. story #3704.

## 처방
1. `handleStoryClick` 진입 시 `storyTasks`/`nextCursor`/`totalCount` 세 값을 한 묶음으로 리셋.
2. 이 함수는 클릭마다 호출되는 이벤트 핸들러라 형제들의 effect cleanup `cancelled` 클로저를 못 쓴다 — 클릭마다 증가하는 요청 순번(`useRef`)을 캡처해, 응답 도착 시 "지금도 최신 요청인지" 대조 후에만 반영. `!res.ok`도 catch와 동형으로 명시 리셋.

## 호출부 취소 의미론 대조표(AC3)
| 호출부 | 진입 리셋 3값 | `!ok` 처리 | 취소 가드 |
|---|---|---|---|
| kanban-board.tsx `handleStoryClick` | ✅(이번 PR) | ✅(이번 PR, else 명시) | ✅(이번 PR, requestId ref) |
| epic-swimlane-board.tsx (:288-315) | ✅ | ✅(entry reset이 커버) | ✅(cancelled 클로저) |
| flow-node-story-panel.tsx (:109-127) | ✅(key={storyId} 리마운트) | ✅(fetch 실패→null→빈 값) | ✅(cancelled 클로저) |

## 회귀 테스트
- (a) A 로드 後 B 클릭 응답 500 → B 패널에 A 태스크 0건, 정직 빈 상태.
- (b) A 클릭→B 클릭, A 응답이 B보다 늦게 도착 → 패널은 끝까지 B 값.
- 둘 다 mutation-kill 확인(처방 되돌리면 RED → 원복 후 51/51 GREEN).

## 검증
- `pnpm vitest run src/components/kanban/kanban-board.test.tsx` — 51/51 GREEN.
- `tsc --noEmit` clean, `eslint` 0 warning.
- `next build --webpack` 성공.

## 의존성 주의
이 브랜치는 `feat/3703-fe-completeness-honesty`(PR #4054) 위에서 분기했다 — `#4054`가 (`storyTasksTotalCount` 배선을 포함해) 아직 develop에 안 들어갔기 때문에, **이 PR은 #4054 머지 뒤에 리베이스/머지**한다. 그 전까지 diff엔 #4054 커밋이 함께 잡힌다(정상).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGJiE8cPVwnsEmCrE2zakd