### PR TITLE
[SID:3709] fix(FE): 스토리 상세 패널 태스크 «조회 중»을 «없음»으로 오단정하지 않음

### DIFF
--- a/apps/web/src/components/epics/epic-swimlane-board.test.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.test.tsx
@@ -155,6 +155,9 @@ type FetchStub = {
   // QA changes 10R HIGH③(카디르+codex, 2026-08-22) — StoryDetailPanel 배선 검증용(tasks
   // 실 fetch·delete 성공 시 카드 제거). story_id별 태스크 목록.
   tasksByStoryId?: Record<string, Array<Record<string, unknown>>>;
+  // story #3709(FE 완전성-정직) — 이 story_id의 /api/tasks 응답을 즉시 안 주고 붙잡아 둔다
+  // (조회 中 상태를 직접 재는 테스트용). 해소는 resolvePendingTasksFetch(storyId, rows)로.
+  deferTasksFor?: string[];
   deleteStorySpy?: (id: string) => void;
   // story #3299 — kanban-board.test.tsx #3287 AC4와 동형(domain-labels 응답 스텁).
   domainLabels?: Array<{ domain: string; canonical_slug: string; label_ko: string | null; label_en: string | null }>;
@@ -167,6 +170,17 @@ type FetchStub = {
 // 지연)」을 CI 로그만으로 갈라준다(페드루 의심 — 순수 지연이면 레인 테스트도 가끔 튀어야
 // 하는데 항상 bulk 2건만이라 결정론적 환경 차 가능성).
 let callLog: string[] = [];
+
+// story #3709(FE 완전성-정직) — deferTasksFor에 걸린 story_id의 /api/tasks 응답을
+// 붙잡아 둘 resolver 저장소. 조회 中 상태(tasksLoading)를 직접 재려면 fetch를
+// stubFetch의 tasksByStoryId(즉시 resolve)와 별개로 지연시킬 수 있어야 한다.
+let pendingTasksResolvers: Record<string, (v: { ok: boolean; json: () => Promise<unknown> }) => void> = {};
+function resolvePendingTasksFetch(storyId: string, rows: Array<Record<string, unknown>>) {
+  const resolve = pendingTasksResolvers[storyId];
+  if (!resolve) throw new Error(`no pending /api/tasks fetch for story_id=${storyId}`);
+  resolve({ ok: true, json: async () => ({ data: rows, meta: { hasMore: false, nextCursor: null } }) });
+  delete pendingTasksResolvers[storyId];
+}
 
 // story #2959(PO 배포 실픽셀, 2026-08-23) — 기본축이 trust로 반전되면서(kanban-board.tsx
 // #3378 도입분에 이어 이 뷰도) trust_stage 없는 고정 fixture가 어느 컬럼에도 안 걸려
@@ -184,10 +198,11 @@ function withDefaultTrustStage(list: Array<Record<string, unknown>>): Array<Reco
   return list.map((s) => ('trust_stage' in s ? s : { ...s, trust_stage: deriveDefaultTrustStage(String(s['status'])) }));
 }
 
-function stubFetch({ stories = [], epics = [], members = [], bulkPatchSpy, singlePatchSpy, singlePatchOk = true, bulkPatchOk = true, storiesGetSpy, storyPages, epicPages, singlePatchResponseData, bulkPatchResponseData, storiesFetchFails = false, storiesAlwaysHasMore = false, tasksByStoryId = {}, deleteStorySpy, domainLabels }: FetchStub) {
+function stubFetch({ stories = [], epics = [], members = [], bulkPatchSpy, singlePatchSpy, singlePatchOk = true, bulkPatchOk = true, storiesGetSpy, storyPages, epicPages, singlePatchResponseData, bulkPatchResponseData, storiesFetchFails = false, storiesAlwaysHasMore = false, tasksByStoryId = {}, deferTasksFor = [], deleteStorySpy, domainLabels }: FetchStub) {
   stories = withDefaultTrustStage(stories);
   storyPages = storyPages?.map((page) => ({ ...page, stories: withDefaultTrustStage(page.stories) }));
   callLog = [];
+  pendingTasksResolvers = {};
   vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
     callLog.push(`${init?.method ?? 'GET'} ${url}`);
     if (typeof url === 'string' && url.includes('/domain-labels')) {
@@ -211,6 +226,11 @@ function stubFetch({ stories = [], epics = [], members = [], bulkPatchSpy, singl
     }
     if (typeof url === 'string' && url.startsWith('/api/tasks?')) {
       const storyId = new URL(url, 'http://localhost').searchParams.get('story_id') ?? '';
+      if (deferTasksFor.includes(storyId)) {
+        return new Promise<{ ok: boolean; json: () => Promise<unknown> }>((resolve) => {
+          pendingTasksResolvers[storyId] = resolve;
+        });
+      }
       return { ok: true, json: async () => ({ data: tasksByStoryId[storyId] ?? [], meta: { hasMore: false, nextCursor: null } }) };
     }
     if (typeof url === 'string' && url.startsWith('/api/stories?')) {
@@ -845,6 +865,27 @@ describe('EpicSwimlaneBoard — StoryDetailPanel 배선(story #2931, QA changes 
     await waitForCondition(() => deletedId === 's1', 'DELETE 호출 발화');
     await waitForCondition(() => !(container.textContent?.includes('삭제될카드') ?? false), '삭제 후 카드 실종(onDeleteSuccess 배선)');
     expect(container.textContent).not.toContain('삭제될카드');
+  });
+
+  // story #3709(FE 완전성-정직, 3704 후속) — 응답 前(조회 中)엔 tasks=[]·totalCount=null인데
+  // 로딩 신호가 없으면 StoryDetailPanel이 이걸 "정말 0개"로 오단정했다(kanban-board.tsx와
+  // 동형 갭 — 형제 호출부).
+  it('응답 前(조회 中)엔 "태스크가 없습니다" 대신 "불러오는 중"이 뜬다', async () => {
+    await mount({
+      epics: [{ id: 'e1', title: '에픽', status: 'active', position: 1 }],
+      stories: [{ id: 's1', title: '로딩카드', status: 'backlog', priority: 'medium', epic_id: 'e1' }],
+      deferTasksFor: ['s1'],
+    });
+    const card = container.querySelector('[title="로딩카드"]') as HTMLElement;
+    await act(async () => { card.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForCondition(() => container.textContent?.includes('로딩카드') ?? false, '패널 오픈');
+
+    expect(container.textContent).not.toContain(koMessages.board.noTasks);
+    expect(container.textContent).toContain(koMessages.board.loading);
+
+    await act(async () => { resolvePendingTasksFetch('s1', []); }); // 응답 도착 — 진짜 0건.
+    await waitForCondition(() => (container.textContent?.includes(koMessages.board.noTasks) ?? false), '응답 後 정당한 빈 상태');
+    expect(container.textContent).not.toContain(koMessages.board.loading);
   });
 });
 

--- a/apps/web/src/components/epics/epic-swimlane-board.test.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.test.tsx
@@ -158,6 +158,10 @@ type FetchStub = {
   // story #3709(FE 완전성-정직) — 이 story_id의 /api/tasks 응답을 즉시 안 주고 붙잡아 둔다
   // (조회 中 상태를 직접 재는 테스트용). 해소는 resolvePendingTasksFetch(storyId, rows)로.
   deferTasksFor?: string[];
+  // story #3709 후속(카디르 재-QA, PR#4060) — 응답 객체(res.ok)는 즉시 오되 res.json()
+  // 파싱만 붙잡아 둔다 — "파싱 사이에 다른 스토리로 전환" 레이스 재현용. 해소는
+  // resolvePendingTasksJson(storyId, rows)로.
+  deferTasksJsonFor?: string[];
   deleteStorySpy?: (id: string) => void;
   // story #3299 — kanban-board.test.tsx #3287 AC4와 동형(domain-labels 응답 스텁).
   domainLabels?: Array<{ domain: string; canonical_slug: string; label_ko: string | null; label_en: string | null }>;
@@ -182,6 +186,15 @@ function resolvePendingTasksFetch(storyId: string, rows: Array<Record<string, un
   delete pendingTasksResolvers[storyId];
 }
 
+// story #3709 후속 — deferTasksJsonFor 짝(json() 파싱 지연 전용).
+let pendingTasksJsonResolvers: Record<string, (v: unknown) => void> = {};
+function resolvePendingTasksJson(storyId: string, rows: Array<Record<string, unknown>>) {
+  const resolve = pendingTasksJsonResolvers[storyId];
+  if (!resolve) throw new Error(`no pending /api/tasks json() for story_id=${storyId}`);
+  resolve({ data: rows, meta: { hasMore: false, nextCursor: null } });
+  delete pendingTasksJsonResolvers[storyId];
+}
+
 // story #2959(PO 배포 실픽셀, 2026-08-23) — 기본축이 trust로 반전되면서(kanban-board.tsx
 // #3378 도입분에 이어 이 뷰도) trust_stage 없는 고정 fixture가 어느 컬럼에도 안 걸려
 // 카드가 조용히 사라졌다(storyColumnId: axisMode==='trust'면 status!=='done'일 때
@@ -198,11 +211,12 @@ function withDefaultTrustStage(list: Array<Record<string, unknown>>): Array<Reco
   return list.map((s) => ('trust_stage' in s ? s : { ...s, trust_stage: deriveDefaultTrustStage(String(s['status'])) }));
 }
 
-function stubFetch({ stories = [], epics = [], members = [], bulkPatchSpy, singlePatchSpy, singlePatchOk = true, bulkPatchOk = true, storiesGetSpy, storyPages, epicPages, singlePatchResponseData, bulkPatchResponseData, storiesFetchFails = false, storiesAlwaysHasMore = false, tasksByStoryId = {}, deferTasksFor = [], deleteStorySpy, domainLabels }: FetchStub) {
+function stubFetch({ stories = [], epics = [], members = [], bulkPatchSpy, singlePatchSpy, singlePatchOk = true, bulkPatchOk = true, storiesGetSpy, storyPages, epicPages, singlePatchResponseData, bulkPatchResponseData, storiesFetchFails = false, storiesAlwaysHasMore = false, tasksByStoryId = {}, deferTasksFor = [], deferTasksJsonFor = [], deleteStorySpy, domainLabels }: FetchStub) {
   stories = withDefaultTrustStage(stories);
   storyPages = storyPages?.map((page) => ({ ...page, stories: withDefaultTrustStage(page.stories) }));
   callLog = [];
   pendingTasksResolvers = {};
+  pendingTasksJsonResolvers = {};
   vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
     callLog.push(`${init?.method ?? 'GET'} ${url}`);
     if (typeof url === 'string' && url.includes('/domain-labels')) {
@@ -230,6 +244,12 @@ function stubFetch({ stories = [], epics = [], members = [], bulkPatchSpy, singl
         return new Promise<{ ok: boolean; json: () => Promise<unknown> }>((resolve) => {
           pendingTasksResolvers[storyId] = resolve;
         });
+      }
+      if (deferTasksJsonFor.includes(storyId)) {
+        return {
+          ok: true,
+          json: () => new Promise<unknown>((resolve) => { pendingTasksJsonResolvers[storyId] = resolve; }),
+        };
       }
       return { ok: true, json: async () => ({ data: tasksByStoryId[storyId] ?? [], meta: { hasMore: false, nextCursor: null } }) };
     }
@@ -886,6 +906,34 @@ describe('EpicSwimlaneBoard — StoryDetailPanel 배선(story #2931, QA changes 
     await act(async () => { resolvePendingTasksFetch('s1', []); }); // 응답 도착 — 진짜 0건.
     await waitForCondition(() => (container.textContent?.includes(koMessages.board.noTasks) ?? false), '응답 後 정당한 빈 상태');
     expect(container.textContent).not.toContain(koMessages.board.loading);
+  });
+
+  // story #3709 후속(카디르 재-QA, PR#4060 2026-09-09) — 위 cancelled 대조가 fetch 직후일
+  // 뿐, res.json() 자체가 비동기라 그 파싱 사이에 다른 스토리로 전환될 수 있다
+  // (kanban-board.tsx #3704 후속과 동형 갭) — 재대조 없으면 늦게 파싱된 A 응답이 B의
+  // tasksLoading을 false로 내려 «조회 中»을 «없음»으로 오단정한다.
+  it('json() 파싱 사이 다른 스토리로 전환하면 늦게 파싱된 응답이 새 스토리 상태를 안 덮는다', async () => {
+    await mount({
+      epics: [{ id: 'e1', title: '에픽', status: 'active', position: 1 }],
+      stories: [
+        { id: 's1', title: 'A카드', status: 'backlog', priority: 'medium', epic_id: 'e1' },
+        { id: 's2', title: 'B카드', status: 'backlog', priority: 'medium', epic_id: 'e1' },
+      ],
+      deferTasksJsonFor: ['s1'],
+      tasksByStoryId: { s2: [{ id: 't2', title: 'B태스크', status: 'todo' }] },
+    });
+    const cardA = container.querySelector('[title="A카드"]') as HTMLElement;
+    await act(async () => { cardA.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForCondition(() => container.textContent?.includes('A카드') ?? false, 'A 패널 오픈'); // fetch 레벨 응답은 옴 — json() 파싱만 대기 中.
+
+    const cardB = container.querySelector('[title="B카드"]') as HTMLElement;
+    await act(async () => { cardB.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForCondition(() => container.textContent?.includes('B태스크') ?? false, 'B 정착');
+
+    await act(async () => { resolvePendingTasksJson('s1', [{ id: 't1', title: 'A태스크', status: 'todo' }]); });
+    expect(container.textContent).toContain('B태스크'); // 여전히 B 값 그대로.
+    expect(container.textContent).not.toContain('A태스크'); // 늦게 파싱된 A가 섞이면 안 됨.
+    expect(container.textContent).not.toContain(koMessages.board.loading); // B가 다시 로딩으로 안 내려가야 함.
   });
 });
 

--- a/apps/web/src/components/epics/epic-swimlane-board.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.tsx
@@ -307,6 +307,12 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
         if (cancelled) return;
         if (res.ok) {
           const json = await res.json();
+          // story #3709 후속(카디르 재-QA, PR#4060, 2026-09-09) — 위 대조는 fetch 직후일
+          // 뿐, res.json() 자체가 비동기라 그 파싱 사이에 다른 스토리로 전환될 수 있다
+          // (kanban-board.tsx #3704 후속과 동형 갭) — 파싱 뒤 재대조 없으면 늦게 온 옛
+          // 응답이 새 스토리의 tasksLoading을 false로 내려 «조회 中»을 «없음»으로
+          // 오단정한다.
+          if (cancelled) return;
           setStoryTasks(json.data ?? []);
           const tasksMeta = parseCursorMeta(json.meta, 'EpicSwimlaneBoard tasks');
           setStoryTasksNextCursor(tasksMeta.nextCursor);

--- a/apps/web/src/components/epics/epic-swimlane-board.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.tsx
@@ -276,6 +276,9 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
   // story #3703(FE 완전성-정직) — /api/tasks의 meta.totalCount(story_id 지정 시 BE 항상
   // 반환). 기존에도 fetch는 하고 있었지만 nextCursor만 뽑고 이 값은 버렸다.
   const [storyTasksTotalCount, setStoryTasksTotalCount] = useState<number | null>(null);
+  // story #3709(FE 완전성-정직, 3704 후속) — 조회 中(응답 前)엔 tasks=[]·totalCount=null이라
+  // StoryDetailPanel이 "정말 0개"와 구별을 못 했다(kanban-board.tsx와 동형 갭).
+  const [storyTasksLoading, setStoryTasksLoading] = useState(false);
   const [loadingMoreStoryTasks, setLoadingMoreStoryTasks] = useState(false);
   const { toasts, addToast, dismissToast } = useToast();
 
@@ -290,12 +293,14 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
       setStoryTasks([]);
       setStoryTasksNextCursor(null);
       setStoryTasksTotalCount(null);
+      setStoryTasksLoading(false);
       return;
     }
     let cancelled = false;
     setStoryTasks([]);
     setStoryTasksNextCursor(null);
     setStoryTasksTotalCount(null);
+    setStoryTasksLoading(true);
     (async () => {
       try {
         const res = await fetchWithAuth(`/api/tasks?story_id=${selectedStoryId}&limit=20`);
@@ -307,8 +312,9 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
           setStoryTasksNextCursor(tasksMeta.nextCursor);
           setStoryTasksTotalCount(typeof tasksMeta.totalCount === 'number' ? tasksMeta.totalCount : null);
         }
+        setStoryTasksLoading(false);
       } catch {
-        if (!cancelled) { setStoryTasks([]); setStoryTasksNextCursor(null); setStoryTasksTotalCount(null); }
+        if (!cancelled) { setStoryTasks([]); setStoryTasksNextCursor(null); setStoryTasksTotalCount(null); setStoryTasksLoading(false); }
       }
     })();
     return () => { cancelled = true; };
@@ -662,6 +668,7 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
                 story={selectedStory}
                 tasks={storyTasks}
                 tasksTotalCount={storyTasksTotalCount}
+                tasksLoading={storyTasksLoading}
                 getStatusLabel={domainLabels.statusLabel}
                 getEntityTypeLabel={domainLabels.entityTypeLabel}
                 nextTasksCursor={storyTasksNextCursor}

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -863,6 +863,31 @@ describe('KanbanBoard — handleStoryClick storyTasks 리셋·취소 가드(stor
     expect(dialog().textContent).not.toContain('A2'); // A page2가 B 목록에 섞이면 안 됨.
     expect(dialog().textContent).not.toContain('Tasks (5)'); // A의 총계(5)가 B 총계(1)를 덮으면 안 됨.
   });
+
+  // story #3709(FE 완전성-정직, 3704 후속) — 응답 前(조회 中)엔 tasks=[]·totalCount=null인데
+  // 로딩 신호가 없으면 StoryDetailPanel이 이걸 "정말 0개"로 오단정했다.
+  it('응답 前(조회 中)엔 "태스크가 없습니다" 대신 "불러오는 중"이 뜬다', async () => {
+    const aResponse = deferredTaskResponse();
+    stubFetchWithTasks(
+      [{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium' }],
+      { s1: () => aResponse.promise },
+    );
+    await mount();
+    await clickStory('S1'); // 응답 아직 안 옴(deferred) — 지금이 "조회 中" 창.
+
+    const dialog = () => container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog().textContent).not.toContain(koMessages.board.noTasks);
+    expect(dialog().textContent).toContain(koMessages.board.loading);
+
+    await act(async () => { // 응답 도착 — 진짜 0건이면 이제야 정당하게 "없습니다".
+      aResponse.resolve(taskOk([], 0));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(dialog().textContent).toContain(koMessages.board.noTasks);
+    expect(dialog().textContent).not.toContain(koMessages.board.loading);
+  });
 });
 
 // story #2104 — BE stories.py:1056(human-only 영구삭제 403)를 FE가 미리 안 보고 에이전트

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -165,6 +165,9 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
   const [loadingMore, setLoadingMore] = useState(false);
   const [loadingMoreEpics, setLoadingMoreEpics] = useState(false);
   const [loadingMoreStoryTasks, setLoadingMoreStoryTasks] = useState(false);
+  // story #3709(FE 완전성-정직, 3704 후속) — 조회 中(응답 前)엔 tasks=[]·totalCount=null이라
+  // StoryDetailPanel이 "정말 0개"와 구별을 못 했다 — 이 플래그로 「불러오는 중」을 그린다.
+  const [storyTasksLoading, setStoryTasksLoading] = useState(false);
   // story #3704(유나 발견+카디르 비블로커, #4054 재리뷰 中) — handleStoryClick은 이벤트
   // 핸들러라 형제(epic-swimlane-board.tsx/flow-node-story-panel.tsx)처럼 effect cleanup의
   // `cancelled` 클로저를 못 쓴다(재실행을 트리거할 의존성 배열이 없다) — 대신 클릭마다
@@ -547,6 +550,9 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
     setStoryTasks([]);
     setStoryTasksNextCursor(null);
     setStoryTasksTotalCount(null);
+    // story #3709(FE 완전성-정직) — 조회 시작을 패널에 알린다(응답/실패/취소 어느 쪽이든
+    // 아래에서 이 요청 자신이 마지막에 false로 내린다).
+    setStoryTasksLoading(true);
 
     // story #3704 blocker② — 이 함수는 클릭마다 호출되는 이벤트 핸들러라 형제 두 곳처럼
     // effect cleanup의 `cancelled` 클로저를 못 쓴다. 요청 순번을 자기 클로저에 캡처해 두고,
@@ -581,11 +587,13 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
         setStoryTasksNextCursor(null);
         setStoryTasksTotalCount(null);
       }
+      setStoryTasksLoading(false);
     } catch {
       if (storyTasksRequestRef.current !== requestId) return;
       setStoryTasks([]);
       setStoryTasksNextCursor(null);
       setStoryTasksTotalCount(null);
+      setStoryTasksLoading(false);
     }
   }, [searchParams, router]);
 
@@ -1856,6 +1864,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           story={selectedStory}
           tasks={storyTasks}
           tasksTotalCount={storyTasksTotalCount}
+          tasksLoading={storyTasksLoading}
           memberMap={memberMap}
           members={members}
           getStatusLabel={domainLabels.statusLabel}

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -999,3 +999,40 @@ describe('StoryDetailPanel — tasksTotalCount(story #3703, 완전성-정직)', 
     expect(container.textContent).toContain('태스크가 없습니다');
   });
 });
+
+// story #3709(FE 완전성-정직, 3704 후속) — 조회 中(응답 前)엔 tasks=[]·tasksTotalCount=null
+// 상태가 tasksLoading 없이는 "정말 0개"와 구별이 안 갔다. flow-node-story-panel.tsx와
+// 같은 낱말(t('loading')="불러오는 중...")로 조회 중임을 그대로 드러낸다.
+describe('StoryDetailPanel — tasksLoading(story #3709, 완전성-정직)', () => {
+  function makeTask(id: string): Task {
+    return { id, title: `task-${id}`, status: 'todo' };
+  }
+
+  it('tasksLoading=true면 tasks=[]·tasksTotalCount=null이어도 "태스크가 없습니다" 대신 "불러오는 중"이 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory()} tasks={[]} tasksTotalCount={null} tasksLoading onClose={() => {}} />,
+      ));
+    });
+    expect(container.textContent).not.toContain(koMessages.board.noTasks);
+    expect(container.textContent).toContain(koMessages.board.loading);
+  });
+
+  it('tasksLoading=false(기본값, 미제공)면 기존 동작 그대로 — 회귀 0', async () => {
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} tasksTotalCount={0} onClose={() => {}} />)); // tasksLoading 미제공
+    });
+    expect(container.textContent).toContain(koMessages.board.noTasks);
+    expect(container.textContent).not.toContain(koMessages.board.loading);
+  });
+
+  it('tasksLoading=true는 실제 태스크가 이미 있어도(예: 낙관적 이전 값 잔존) 우선한다 — 조회 中 신호가 최우선', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory()} tasks={[makeTask('1')]} tasksTotalCount={1} tasksLoading onClose={() => {}} />,
+      ));
+    });
+    expect(container.textContent).toContain(koMessages.board.loading);
+    expect(container.textContent).not.toContain('task-1');
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -1035,4 +1035,28 @@ describe('StoryDetailPanel — tasksLoading(story #3709, 완전성-정직)', () 
     expect(container.textContent).toContain(koMessages.board.loading);
     expect(container.textContent).not.toContain('task-1');
   });
+
+  // story #3709 후속(페드루 PO 지적, 유나 PASS 뒤 한 줄 더, 2026-09-09) — 탭 라벨
+  // 「Tasks (0)」이 조회 中에도 개수를 말해, 40px 아래 본문의 「불러오는 중...」과
+  // 같은 화면 두 세계였다(탭=아는 척, 본문=정직).
+  it('조회 中엔 탭 라벨이 개수를 안 보인다 — 응답 뒤엔 다시 보인다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory()} tasks={[]} tasksTotalCount={null} tasksLoading onClose={() => {}} />,
+      ));
+    });
+    const tasksTab = () => [...container.querySelectorAll('button')].find((b) => b.textContent?.startsWith('Tasks'));
+    expect(tasksTab()?.textContent).toBe('Tasks'); // "(0)" 없음 — 조회 中이라 아직 모른다.
+
+    await act(async () => { root.unmount(); });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory()} tasks={[makeTask('1')]} tasksTotalCount={1} onClose={() => {}} />,
+      ));
+    });
+    expect(tasksTab()?.textContent).toBe('Tasks (1)'); // 응답 뒤엔 지금처럼 수 표시.
+  });
 });

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -88,6 +88,11 @@ interface StoryDetailPanelProps {
    * 진짜 총계를 말해야 「Tasks (20)」이 "총 20개"로 오독되지 않는다. 호출부가 안 넘기면
    * (null/undefined) tasks.length로 자연 폴백 — 하위호환. */
   tasksTotalCount?: number | null;
+  /** story #3709(FE 완전성-정직, 3704 후속) — 조회 중(응답 前)엔 tasks=[]·tasksTotalCount=null이
+   * «정말 0개»(빈 상태)와 구별이 안 갔다 — 호출부가 이 값을 true로 넘기는 동안은 빈 상태
+   * 대신 「불러오는 중」을 그린다. 기본 false — 안 넘기는 호출부는 회귀 0(항상 «조회 끝난
+   * 것»으로 취급, 기존 동작 그대로). */
+  tasksLoading?: boolean;
   nextTasksCursor?: string | null;
   loadingMoreTasks?: boolean;
   onLoadMoreTasks?: () => void;
@@ -348,7 +353,7 @@ export function DescriptionViewer({
   );
 }
 
-export function StoryDetailPanel({ story, tasks, tasksTotalCount = null, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [], storyMap = {}, epicMap = {}, sprintMap = {}, onNavigate, projectId, overlayPosition, getStatusLabel, getEntityTypeLabel }: StoryDetailPanelProps) {
+export function StoryDetailPanel({ story, tasks, tasksTotalCount = null, tasksLoading = false, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [], storyMap = {}, epicMap = {}, sprintMap = {}, onNavigate, projectId, overlayPosition, getStatusLabel, getEntityTypeLabel }: StoryDetailPanelProps) {
   const t = useTranslations('board');
   const locale = useLocale();
   const displayTimezone = resolveDisplayTimezone().tz;
@@ -2177,7 +2182,12 @@ export function StoryDetailPanel({ story, tasks, tasksTotalCount = null, nextTas
                     시나리오(#4049/#4052 클래스)에서 이 PR이 막으려던 바로 그 오단정이
                     재발했다 — «정말 0개»와 «로드분만 0이고 더 있음»을 tasksTotalCount로
                     가른다. */}
-                {tasks.length === 0 && (tasksTotalCount == null || tasksTotalCount === 0) ? (
+                {tasksLoading ? (
+                  // story #3709(FE 완전성-정직) — 조회 중엔 flow-node-story-panel.tsx와 같은
+                  // 낱말(t('loading')="불러오는 중...")로 «아직 모름»을 그대로 드러낸다 —
+                  // 이 분기가 없으면 아래 tasks.length===0 분기가 «없음»으로 오단정한다.
+                  <p className="text-sm text-muted-foreground">{t('loading')}</p>
+                ) : tasks.length === 0 && (tasksTotalCount == null || tasksTotalCount === 0) ? (
                   <p className="text-sm text-muted-foreground">{t('noTasks')}</p>
                 ) : (
                   <>

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -2170,7 +2170,11 @@ export function StoryDetailPanel({ story, tasks, tasksTotalCount = null, tasksLo
             {/* Tabs for Tasks, Comments, Activity */}
             <Tabs defaultValue="tasks" className="w-full">
               <TabsList className="w-full">
-                <TabsTrigger value="tasks" className="flex-1">Tasks ({tasksTotalCount ?? tasks.length})</TabsTrigger>
+                {/* story #3709 후속(페드루 PO 지적, 유나 PASS 뒤 한 줄 더) — 조회 中엔
+                    개수를 아예 말하지 않는다. tasksLoading인데도 「Tasks (0)」을 그리면
+                    40px 아래 본문의 「불러오는 중...」과 같은 화면 두 세계가 재발한다
+                    (탭 라벨=아는 척·본문=정직, 서로 다른 사실을 동시에 말하는 꼴). */}
+                <TabsTrigger value="tasks" className="flex-1">{tasksLoading ? 'Tasks' : `Tasks (${tasksTotalCount ?? tasks.length})`}</TabsTrigger>
                 <TabsTrigger value="comments" className="flex-1">Comments ({comments.length})</TabsTrigger>
                 <TabsTrigger value="activity" className="flex-1">Activity</TabsTrigger>
               </TabsList>
@@ -2184,8 +2188,10 @@ export function StoryDetailPanel({ story, tasks, tasksTotalCount = null, tasksLo
                     가른다. */}
                 {tasksLoading ? (
                   // story #3709(FE 완전성-정직) — 조회 중엔 flow-node-story-panel.tsx와 같은
-                  // 낱말(t('loading')="불러오는 중...")로 «아직 모름»을 그대로 드러낸다 —
-                  // 이 분기가 없으면 아래 tasks.length===0 분기가 «없음»으로 오단정한다.
+                  // 계열(둘 다 t('loading')="불러오는 중..." 사용 — 실제 문자열 키는
+                  // flow-node의 flow.nodesLoading과 다르지만 같은 뜻을 같은 낱말로 말한다)로
+                  // «아직 모름»을 그대로 드러낸다 — 이 분기가 없으면 아래 tasks.length===0
+                  // 분기가 «없음»으로 오단정한다.
                   <p className="text-sm text-muted-foreground">{t('loading')}</p>
                 ) : tasks.length === 0 && (tasksTotalCount == null || tasksTotalCount === 0) ? (
                   <p className="text-sm text-muted-foreground">{t('noTasks')}</p>


### PR DESCRIPTION
## 요약
`StoryDetailPanel` Tasks 탭은 `tasks.length===0 && (tasksTotalCount==null||0)`이면 「태스크가 없습니다」를 그렸다 — 조회 中(응답 前·tasks=[]·totalCount=null)에도 같은 모양이라 «아직 모름»을 «없음»으로 단정했다(#3703/#4054 "모르면 모른다고 표시" 원칙의 남은 갈래).

- `flow-node-story-panel.tsx`만 `kind==='loading'`으로 패널 자체를 안 그려 이미 닫혀 있었다.
- `kanban-board.tsx`(handleStoryClick)·`epic-swimlane-board.tsx`(effect) 두 호출부는 로딩 신호를 패널에 안 넘겼다.

## 처방
- `StoryDetailPanel`에 `tasksLoading?: boolean`(기본 `false` — 미배선 호출부 회귀 0) 추가. `true`면 빈 상태 대신 flow-node와 같은 낱말(`t('loading')`="불러오는 중...").
- `kanban-board.tsx`: `handleStoryClick` 진입 시 true, 응답(res.ok/!ok/catch, 요청 순번 일치 시)에서 false — 기존 취소 가드(#3704)에 자연히 올라탐.
- `epic-swimlane-board.tsx`: effect 진입 시 true, `cancelled` 아닌 응답에서 false.

## 회귀(mutation-kill) — 4건
| 대상 | 방식 |
|---|---|
| story-detail-panel.tsx | 분기 자체를 지움 → RED |
| kanban-board.tsx | `tasksLoading` prop 배선 제거 → RED |
| epic-swimlane-board.tsx | `tasksLoading` prop 배선 제거 → RED (신규 `deferTasksFor` 테스트 헬퍼로 응답 지연 재현) |

## 검증
- `pnpm vitest run` — story-detail-panel.test.tsx(48) + kanban-board.test.tsx(54) + epic-swimlane-board.test.tsx(34) 전부 GREEN(136).
- `tsc --noEmit` clean, `eslint` 0 warning.
- `next build --webpack` 성공.

## 게이트
카디르 QA + 유나 design(호출부 3 × 「로딩 중」 열 빈 칸 0) 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGJiE8cPVwnsEmCrE2zakd