### PR TITLE
[SID:3712] fix(FE): Comments 탭 라벨도 조회 中엔 개수를 안 보인다

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -236,6 +236,33 @@ describe('StoryDetailPanel — org-switch 잔여 레이스 stale-guard (story #2
   });
 });
 
+// story #3712(FE 완전성-정직, #3709/#4060 Tasks 탭과 같은 얼굴) — 조회 中(응답 前)엔
+// comments=[]인데 탭 라벨이 loadingComments를 안 봐서 "Comments (0)"을 그렸다 — 본문은
+// 이미 loadingComments를 먼저 검사해 「불러오는 중」을 보이는데 라벨만 뒤처져 같은 화면
+// 두 세계였다.
+describe('StoryDetailPanel — Comments 탭 라벨 loadingComments(story #3712, 완전성-정직)', () => {
+  it('조회 中엔 탭 라벨이 개수를 안 보인다 — 응답 뒤엔 다시 보인다', async () => {
+    let resolveComments: ((v: unknown) => void) | undefined;
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (typeof url === 'string' && url.includes('/comments?limit=20')) {
+        return new Promise((resolve) => { resolveComments = resolve; });
+      }
+      return Promise.resolve({ ok: false, json: async () => null });
+    }));
+
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} />));
+    });
+    const trigger = () => Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.startsWith('Comments'));
+    expect(trigger()?.textContent).toBe('Comments'); // "(0)" 없음 — 아직 조회 中이라 모른다.
+
+    await act(async () => {
+      resolveComments?.({ ok: true, json: async () => ({ data: [{ id: 'c1', content: 'hi', created_by: 'u', created_at: '2026-01-01' }] }) });
+    });
+    expect(trigger()?.textContent).toBe('Comments (1)'); // 응답 뒤엔 지금처럼 수 표시.
+  });
+});
+
 // story #2933 H1(P0-H) — 구 FE 재파생(gate 목록+localStatus 조합, #3336 MEDIUM 드리프트
 // 실사례로 이미 1회 버그난 그 로직)을 폐기하고 story.trust_stage(BE derive_trust_stage()
 // 판정값)를 그대로 소비한다는 회귀가드. gate fetch를 몰라도(PO 조건① — 판정은 BE 한 곳)

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -2175,7 +2175,11 @@ export function StoryDetailPanel({ story, tasks, tasksTotalCount = null, tasksLo
                     40px 아래 본문의 「불러오는 중...」과 같은 화면 두 세계가 재발한다
                     (탭 라벨=아는 척·본문=정직, 서로 다른 사실을 동시에 말하는 꼴). */}
                 <TabsTrigger value="tasks" className="flex-1">{tasksLoading ? 'Tasks' : `Tasks (${tasksTotalCount ?? tasks.length})`}</TabsTrigger>
-                <TabsTrigger value="comments" className="flex-1">Comments ({comments.length})</TabsTrigger>
+                {/* story #3712(FE 완전성-정직, #4060/#3709 Tasks 탭과 같은 얼굴) — 조회
+                    中엔 개수를 아예 말하지 않는다. loadingComments인데도 「Comments (0)」을
+                    그리면 40px 아래 본문의 「불러오는 중...」과 같은 화면 두 세계가 된다
+                    (본문은 이미 loadingComments를 먼저 검사한다 — 라벨만 빠져 있었다). */}
+                <TabsTrigger value="comments" className="flex-1">{loadingComments ? 'Comments' : `Comments (${comments.length})`}</TabsTrigger>
                 <TabsTrigger value="activity" className="flex-1">Activity</TabsTrigger>
               </TabsList>
 


### PR DESCRIPTION
## 요약
그라운딩(develop 9a827f5e4 실물 대조, 페드루 PO 재확인) — 스토리 본문의 「빈 상태도 조회 中에 0을 단정한다」는 작성 시점 오독이었다:
- 본문(`:2258`)은 이미 `loadingComments`를 먼저 검사한다.
- fetch effect(`:1165-1189`)도 post-fetch·post-parse 이중 `cancelled` 재대조가 이미 서 있다.
- `kanban-board`·`epic-swimlane` 둘 다 `key={selectedStory.id}`로 패널을 리마운트해 스토리 전환 시 옛 값이 새 패널로 새어들 구조적 경로 자체가 없다.

**남은 진짜 갭은 탭 라벨 하나** — `Comments ({comments.length})`가 `loadingComments`를 안 봐서 조회 中(같은 마운트 안 `comments`가 아직 초기값 `[]`)엔 "Comments (0)"을 그렸다. 40px 아래 본문의 「불러오는 중...」과 같은 화면 두 세계 — #3709(#4060) Tasks 탭에서 페드루가 지적한 것과 완전히 같은 얼굴.

## 처방
`loadingComments`면 "Comments"(개수 미표시), 아니면 "Comments (N)" — effect·본문은 손대지 않음(이미 정확했다).

## 회귀(mutation-kill)
1건 추가(조회 中 "(0)" 0 · 응답 뒤 정상 표시) — 가드 제거 시 RED 확인 後 원복.

## 검증
- `pnpm vitest run src/components/kanban/story-detail-panel.test.tsx` — 50/50 GREEN.
- `tsc --noEmit` clean, `eslint` 0 warning.
- `next build --webpack` 성공.

## 게이트
카디르 QA + 유나 design 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGJiE8cPVwnsEmCrE2zakd