### PR TITLE
[SID:3716] fix(FE): raw-fetch 가드가 주석 속 백틱 fetch를 실 호출로 세던 것 복구

### DIFF
--- a/apps/web/scripts/verify-no-new-raw-fetch-api.test.ts
+++ b/apps/web/scripts/verify-no-new-raw-fetch-api.test.ts
@@ -86,6 +86,28 @@ describe('extractRawFetchApiCalls — 주석·문자열 안 fetch 오탐 봉쇄(
     );
     expect(hits).toEqual([]);
   });
+
+  // (d) 페드루 PO 지적(2026-09-09, 유나 PASS 뒤 fail-open 칸) — (a)~(c)는 전부 «오탐을
+  // 막는» 방향이다. 놓치는 방향(fail-open)은 문자열 리터럴 안의 `//`가 «진짜 주석
+  // 시작」으로 오인돼 그 뒤(같은 줄의 실 raw fetch)가 통째로 지워지는 경우 — 3716
+  // AC1 「문자열 리터럴 안」 낱말이 정확히 이 칸이다.
+  it('(d) 문자열 리터럴 안의 `//`(URL 등) 뒤에 와도 같은 줄의 실 raw fetch를 놓치지 않는다(fail-open 방지)', () => {
+    const hits = extractRawFetchApiCalls(
+      "const cdn = 'https://cdn.example.com//assets'; const r = await fetch('/api/real');",
+      'components/some-file.ts',
+    );
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.urlPrefix).toBe('/api/real');
+  });
+
+  it('(d-2) 백틱 템플릿 리터럴 안의 `//`(URL 등) 뒤에 와도 같은 줄의 실 raw fetch를 놓치지 않는다', () => {
+    const hits = extractRawFetchApiCalls(
+      'const base = `${origin}//x`; const r = await fetch(\'/api/real\');',
+      'components/some-file.ts',
+    );
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.urlPrefix).toBe('/api/real');
+  });
 });
 
 // story #2691 — 선언된 baseline 크기를 고정해 조용한 증감(리뷰 없는 추가/삭제)을 막는다

--- a/apps/web/scripts/verify-no-new-raw-fetch-api.test.ts
+++ b/apps/web/scripts/verify-no-new-raw-fetch-api.test.ts
@@ -44,6 +44,50 @@ describe('extractRawFetchApiCalls — 순수 판정 함수(AC4)', () => {
   });
 });
 
+// story #3716(카디르 재현, #4062 오탐 1회) — 가드가 주석을 안 벗겨 «주석 속 백틱
+// fetch(`/api/…`)»도 실 호출로 셌다(디디의 설명 주석 fetch(`/api/team-members`)가
+// CI를 빨갛게 만든 실사고). stripComments()(scripts/i18n-key-parser.js, story #3156
+// 통합·#3023 정규식 리터럴 백틱 픽스 포함)를 그대로 재사용해 닫는다.
+describe('extractRawFetchApiCalls — 주석·문자열 안 fetch 오탐 봉쇄(story #3716)', () => {
+  // (a) 이 케이스는 수정 前엔 RED였다(양성대조) — stripComments 적용 前 코드로 되돌려
+  // 재실행하면 이 테스트가 실패하는 것을 실측 확認했다(PR 본문에 grep 근거 남김).
+  it('(a) 줄 주석 안의 fetch(`/api/…`)는 안 잡는다 — #4062 실사고 재현', () => {
+    const hits = extractRawFetchApiCalls(
+      '// story #4062 — /api/team-members·/api/glance/attention 응답을 합친다: fetch(`/api/team-members`)·fetch(`/api/glance/attention`)',
+      'components/glance/load-glance-data.ts',
+    );
+    expect(hits).toEqual([]);
+  });
+
+  it('(a-2) 블록 주석 안의 fetch(`/api/…`)도 안 잡는다', () => {
+    const hits = extractRawFetchApiCalls(
+      '/* 예전엔 fetch(`/api/legacy`)로 불렀으나 지금은 fetchWithAuth로 교체됨 */',
+      'components/some-file.ts',
+    );
+    expect(hits).toEqual([]);
+  });
+
+  it('(b) 같은 파일에 주석과 실 코드가 같이 있으면 실 코드만 잡는다', () => {
+    const hits = extractRawFetchApiCalls(
+      "// fetch(`/api/decoy`) — 이건 주석, 세면 안 됨\nconst res = await fetch('/api/team-members');",
+      'components/glance/load-glance-data.ts',
+    );
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.urlPrefix).toBe('/api/team-members');
+  });
+
+  // (c) story #3023 — 정규식 리터럴 안의 백틱을 문자열 델리미터로 오인하면, 그 뒤 파일
+  // 전체가 "닫히지 않은 문자열 안"으로 착각돼 진짜 `//` 주석·그 안의 fetch(`/api/…`)를
+  // 놓친다(stripComments의 REGEX_LITERAL_CONTEXT_CHARS 분기가 정확히 이걸 닫는다).
+  it('(c) 정규식 리터럴 속 백틱(#3023 동형) 뒤에 와도 주석 안 fetch를 여전히 걸러낸다', () => {
+    const hits = extractRawFetchApiCalls(
+      'const INLINE_CODE_SPAN_RE = /`[^`\\n]*`/g;\n// fetch(`/api/decoy`)',
+      'lib/some-parser.ts',
+    );
+    expect(hits).toEqual([]);
+  });
+});
+
 // story #2691 — 선언된 baseline 크기를 고정해 조용한 증감(리뷰 없는 추가/삭제)을 막는다
 // (verify-no-i18n-phrase-collision.ts의 GRANDFATHER_BASELINE_COUNT_TEST와 동일 관례).
 describe('GRANDFATHER_BASELINE_COUNT_TEST — 41번째부터는 review 없이 조용히 못 늘어난다(관례 재사용)', () => {

--- a/apps/web/scripts/verify-no-new-raw-fetch-api.ts
+++ b/apps/web/scripts/verify-no-new-raw-fetch-api.ts
@@ -24,6 +24,13 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+// story #3716(카디르 재현, #4062 오탐 1회) — 이 가드는 주석을 안 벗겨 «주석 속 백틱
+// fetch(`/api/…`)»도 실 호출로 셌다. i18n-key-coverage.test.ts가 이미 쓰는 공유
+// stripComments()(scripts/i18n-key-parser.js, story #3156 통합·#3023 정규식 리터럴
+// 백틱 픽스 포함)를 그대로 재사용한다 — 복제 0. plain CJS·repo-root scripts/(apps/web
+// 워크스페이스 밖) — moduleResolution:bundler+allowJs라 tsx/vitest 양쪽에서 그대로
+// 해석된다(i18n-key-coverage.test.ts 선례와 동일 패턴).
+import { stripComments } from '../../../scripts/i18n-key-parser.js';
 
 const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
 const EXT_RE = /\.(tsx?|ts)$/;
@@ -60,7 +67,10 @@ function stablePrefix(url: string): string {
 export function extractRawFetchApiCalls(content: string, file: string): RawFetchHit[] {
   if (EXEMPT_FILES.has(file)) return [];
   const hits: RawFetchHit[] = [];
-  for (const m of content.matchAll(RAW_FETCH_RE)) {
+  // story #3716 — 주석·문자열 리터럴 안의 fetch(`/api/…`)는 실 호출이 아니다(#4062에서
+  // 디디의 설명 주석이 정확히 이 자리에 걸려 CI가 빨개졌다). 정규식 스캔 前에 벗긴다.
+  const stripped = stripComments(content) as string;
+  for (const m of stripped.matchAll(RAW_FETCH_RE)) {
     const url = m[2] ?? '';
     if (!url.startsWith('/api/')) continue;
     // fetchWithAuth(...)/rateLimitedFetch(...) 호출은 `fetch(`로 시작하지 않으므로 이

--- a/apps/web/src/lib/pagination-envelope-consumers.test.ts
+++ b/apps/web/src/lib/pagination-envelope-consumers.test.ts
@@ -21,25 +21,14 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+// story #3716(재발 차단, verify-no-new-raw-fetch-api.ts #4062 오탐 후속) — 이 파일이
+// 자체 stripComments()를 독립 구현으로 들고 있던 것 자체가 그 오탐 클래스였다(파서
+// 복제 2곳이 서로 다른 결함을 갖는 #3149/#3156과 동형). i18n-key-coverage.test.ts·
+// verify-no-new-raw-fetch-api.ts와 같은 공유 구현(story #3023 정규식 리터럴 백틱
+// 픽스 포함)으로 통일한다 — 복제 0.
+import { stripComments } from '../../../../scripts/i18n-key-parser.js';
 
 const SRC_ROOT = path.resolve(__dirname, '..');
-
-function stripComments(text: string): string {
-  let out = text.replace(/\/\*[\s\S]*?\*\//g, '');
-  out = out
-    .split('\n')
-    .map((line) => {
-      const idx = line.indexOf('//');
-      if (idx === -1) return line;
-      const before = line.slice(0, idx);
-      const quotes = (before.match(/"/g) || []).length
-        + (before.match(/'/g) || []).length
-        + (before.match(/`/g) || []).length;
-      return quotes % 2 === 0 ? before : line;
-    })
-    .join('\n');
-  return out;
-}
 
 function collectSourceFiles(dir: string): string[] {
   const out: string[] = [];


### PR DESCRIPTION
## 요약
카디르 재현(#4062에서 디디의 설명 주석 `fetch(\`/api/team-members\`)`가 CI를 빨갛게 만든 실사고) — `verify-no-new-raw-fetch-api.ts`의 `extractRawFetchApiCalls`가 주석을 안 벗기고 정규식을 원문 그대로에 돌려 **주석 속 백틱 fetch(`/api/…`)도 실 호출로 셌다**. 이 가드는 「구조」가 아니라 「문자열」을 세고 있었다.

## 처방
`pagination-envelope-consumers.test.ts`가 자체 구현으로 들고 있던 `stripComments()`를 걷어내고, 이미 존재하는 공유 구현(`scripts/i18n-key-parser.js` — story #3156이 `i18n-key-coverage.test.ts`·`check-i18n-keys.js` 두 소비처를 통합할 때 만든 것, story #3023 정규식 리터럴 백틱 픽스 포함)을 raw-fetch 가드도 같이 가져다 쓴다. 세 소비처(raw-fetch 가드·pagination 가드·i18n 가드)가 이제 **같은 파서 하나** — 복제 0.

## 테스트
selftest 4건 추가:
- (a)(a-2) 줄/블록 주석 속 fetch → 0건
- (b) 주석+실코드 혼재 시 실코드만 → 1건
- (c) #3023 동형(정규식 리터럴 속 백틱) 뒤에도 주석 무시 유지 → 0건

## Mutation-kill
comment-strip 호출을 제거하고 재실행 → **4건 전부 RED**(포함 (a) 자신)을 실측 확인 後 원복.

## Grandfather·count-pin 무변
수정 前後 둘 다 고유 호출 **158건**·grandfather **158건** 그대로 — 주석 오탐이 158건 안에 섞여 있지 않았다(목록 수정 불요).

## 검증
- `vitest run scripts/verify-no-new-raw-fetch-api.test.ts src/lib/pagination-envelope-consumers.test.ts src/lib/i18n-key-coverage.test.ts` — 16/16 GREEN.
- `tsc --noEmit` clean, `eslint` 0 warning.
- `tsx scripts/verify-no-new-raw-fetch-api.ts` 재실행 — 158/158 그대로, 신규 0건.
- `next build --webpack` 성공.

## 적기만(스코프 밖·미수정)
다른 「문자열 세기」 가드들에 같은 갭이 있는지 얕은 grep으로 훑었으나(정규식 `.test()` 오탐이 다수 섞여) 신뢰할 만한 목록이 못 됐다 — 이 세션에서 검증 못 함, 별도 triage 필요. 후보(미검증, grep 원시 결과): `verify-no-new-md-breakpoint.ts`·`verify-no-i18n-phrase-collision.ts`·`verify-no-new-raw-button.ts`·`verify-no-new-tint-color-text.ts`·`verify-no-alpha-focus-ring.ts`·`verify-no-muted-foreground-alpha.ts`·`verify-no-subtle-alpha-bg.ts`·`verify-no-hardcoded-aria-label.ts`·`verify-no-date-tolocalestring.ts`·`verify-no-raw-error-message.ts`·`verify-no-request-url-as-base.ts`·`verify-no-duplicate-i18n-keys.ts`·`verify-no-hanja-in-i18n.ts`·`verify-no-handrolled-card.ts`·`verify-no-handrolled-modal.ts`·`verify-no-fetch-response-without-ok-check.ts`·`verify-no-direct-backend-v2-call.ts`.

## 게이트
카디르 QA(가드 fail 방향 코드 판정) 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGJiE8cPVwnsEmCrE2zakd