### PR TITLE
[SID:3717] fix(FE): tasks 라우트 limit+1 과대조회 누락 복구 — 「더 보기」가 이제는 안 그려짐

### DIFF
--- a/apps/web/src/app/api/tasks/route.test.ts
+++ b/apps/web/src/app/api/tasks/route.test.ts
@@ -113,3 +113,49 @@ describe('/api/tasks GET — ids 배치 lookup 분기(#2262 PR②, task 자신�
     expect(calledWith.ids).toHaveLength(200);
   });
 });
+
+// story #3717(PO 배포 57 API 축 실측 03:50Z, #3713 후속) — #3713이 리포지토리 경계
+// 전달(cursor/limit)을 고치자 그 뒤에 숨어 있던 두 번째 결함이 드러났다: 이 라우트가
+// buildCursorPageMeta의 「limit+1 과대조회」 계약(items.length > limit으로 hasMore
+// 판정, lib/pagination.ts)을 안 지켜 리포지토리에 정확히 요청 limit만 전달했다 —
+// BE가 정확히 그만큼만 주니 어떤 limit에서도 hasMore가 영영 false였다(형제
+// stories/route.ts:114는 +1이 이미 있음). #4061의 픽스 테스트는 「경계 전달」(리포지토리가
+// 받은 query)만 쟀고 「응답 hasMore가 실제로 선다」(결과)는 안 쟀다 — 이번엔 결과를 잰다.
+describe('/api/tasks GET — cursor pagination hasMore/nextCursor 과대조회(story #3717)', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createTaskRepository.mockResolvedValue({});
+  });
+
+  it('요청 limit=5인데 리포지토리엔 limit+1(6)이 전달된다(이 PR의 본질 — 지우면 RED)', async () => {
+    h.list.mockResolvedValue([]);
+    await GET(new Request('http://localhost/api/tasks?story_id=s1&limit=5'));
+    const calledWith = h.list.mock.calls[0]![0] as { limit?: number };
+    expect(calledWith.limit).toBe(6);
+  });
+
+  it('리포지토리가 요청보다 1건 더(6행) 주면 hasMore=true·nextCursor=5번째 행의 created_at(양성대조)', async () => {
+    h.list
+      .mockResolvedValueOnce([task('1'), task('2'), task('3'), task('4'), task('5'), task('6')]) // main page(6=limit+1)
+      .mockResolvedValueOnce([]) // counts: all
+      .mockResolvedValueOnce([]); // counts: done
+    const res = await GET(new Request('http://localhost/api/tasks?story_id=s1&limit=5'));
+    const body = await res.json();
+    expect(body.data).toHaveLength(5);
+    expect(body.meta.hasMore).toBe(true);
+    expect(body.meta.nextCursor).toBe(task('5').created_at);
+  });
+
+  it('리포지토리가 정확히 요청분(5행)만 주면 hasMore=false(마지막 페이지, 무회귀)', async () => {
+    h.list
+      .mockResolvedValueOnce([task('1'), task('2'), task('3'), task('4'), task('5')])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    const res = await GET(new Request('http://localhost/api/tasks?story_id=s1&limit=5'));
+    const body = await res.json();
+    expect(body.data).toHaveLength(5);
+    expect(body.meta.hasMore).toBe(false);
+    expect(body.meta.nextCursor).toBeNull();
+  });
+});

--- a/apps/web/src/app/api/tasks/route.test.ts
+++ b/apps/web/src/app/api/tasks/route.test.ts
@@ -135,11 +135,24 @@ describe('/api/tasks GET — cursor pagination hasMore/nextCursor 과대조회(s
     expect(calledWith.limit).toBe(6);
   });
 
-  it('리포지토리가 요청보다 1건 더(6행) 주면 hasMore=true·nextCursor=5번째 행의 created_at(양성대조)', async () => {
-    h.list
-      .mockResolvedValueOnce([task('1'), task('2'), task('3'), task('4'), task('5'), task('6')]) // main page(6=limit+1)
-      .mockResolvedValueOnce([]) // counts: all
-      .mockResolvedValueOnce([]); // counts: done
+  // 카디르 재-QA(2026-09-09 04:17, codex mutation-kill 실측) — h.list가 호출 인자와
+  // 무관하게 고정 배열을 반환하면 이 테스트는 buildCursorPageMeta의 산술(6>5)만
+  // 재검증하는 동어반복이라, +1을 지워 리포지토리에 limit=5가 가도(mock이 여전히
+  // 6행을 주므로) GREEN인 채 남는다(경계 테스트만 RED로 잡혔다). limit-aware mock으로
+  // «리포지토리가 실제로 받은 limit」에 따라 반환량이 갈리게 해 결과 단언 자체가
+  // +1 전달에 의존하게 만든다.
+  function limitAwarePool(pool: ReturnType<typeof task>[]) {
+    return (args: { limit?: number; status?: string }) => {
+      let rows = pool;
+      if (args.status) rows = rows.filter((t) => t.status === args.status);
+      if (typeof args.limit === 'number') rows = rows.slice(0, args.limit);
+      return Promise.resolve(rows);
+    };
+  }
+
+  it('리포지토리가 요청보다 1건 더(6행) 주면 hasMore=true·nextCursor=5번째 행의 created_at(양성대조, limit-aware — +1 제거 시 RED 실측)', async () => {
+    const pool = [task('1'), task('2'), task('3'), task('4'), task('5'), task('6')];
+    h.list.mockImplementation(limitAwarePool(pool));
     const res = await GET(new Request('http://localhost/api/tasks?story_id=s1&limit=5'));
     const body = await res.json();
     expect(body.data).toHaveLength(5);
@@ -148,10 +161,8 @@ describe('/api/tasks GET — cursor pagination hasMore/nextCursor 과대조회(s
   });
 
   it('리포지토리가 정확히 요청분(5행)만 주면 hasMore=false(마지막 페이지, 무회귀)', async () => {
-    h.list
-      .mockResolvedValueOnce([task('1'), task('2'), task('3'), task('4'), task('5')])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
+    const pool = [task('1'), task('2'), task('3'), task('4'), task('5')];
+    h.list.mockImplementation(limitAwarePool(pool));
     const res = await GET(new Request('http://localhost/api/tasks?story_id=s1&limit=5'));
     const body = await res.json();
     expect(body.data).toHaveLength(5);

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -105,7 +105,11 @@ export async function GET(request: Request) {
       assignee_id: assigneeId,
       status,
       status_ne: statusNe,
-      limit: pageInput.limit,
+      // story #3717(PO 배포 57 API 축 실측 03:50Z) — #3713이 리포지토리 경계 전달을
+      // 고치자(cursor/limit이 이제 실제로 BE에 감) 그 뒤에 숨어 있던 두 번째 결함이
+      // 드러났다: BE가 정확히 limit개만 주니 buildCursorPageMeta의 `items.length > limit`
+      // 계약(과대조회 필요)이 영영 false였다 — 형제 stories/route.ts:114와 동형으로 +1.
+      limit: pageInput.limit + 1, // RC3: 오버페치 → buildCursorPageMeta hasMore 판단
       cursor: pageInput.cursor,
     });
     const { page, meta } = buildCursorPageMeta(tasks, pageInput.limit, 'created_at');


### PR DESCRIPTION
## 요약(PO 배포 57 API 축 실측 03:50Z)
`#3713`이 리포지토리 경계 전달(cursor/limit)을 고치자 그 뒤에 숨어 있던 **두 번째 결함**이 드러났다: `tasks/route.ts`가 `buildCursorPageMeta`의 「limit+1 과대조회」계약(`items.length > limit`으로 hasMore 판정)을 안 지켜 리포지토리에 정확히 요청 limit만 전달했다 — BE가 정확히 그만큼만 주니 **어떤 limit에서도 hasMore가 영영 false**였다. 형제 `stories/route.ts:114`·`goals/route.ts:80`은 이미 +1이 있고 tasks만 빠져 있었다.

배포 56(#3713 前)엔 리포지토리가 limit을 BE에 안 실어 BE가 최대 1000행을 주고 라우트가 잘라 hasMore가 **우연히** 서 있었다(커서만 안 넘어감) — #3713이 전달을 고치며 그 우연한 은폐가 걷혀 두 번째 결함이 드러난 것.

`#4061`의 픽스 테스트는 「경계 전달」(리포지토리가 받은 query)만 쟀고 「응답 hasMore가 실제로 선다」(결과)는 안 쟀다 — 이번엔 결과를 잰다.

## 처방
`limit: pageInput.limit + 1`(stories 동형·같은 주석 낱말).

## 회귀(mutation-kill) — 3건
| 테스트 | 내용 |
|---|---|
| ①전달 limit=요청+1 | 이 PR의 본질 — **+1 제거 시 RED 확인 後 원복** |
| ②6행 반환 | hasMore=true·nextCursor=5번째 행 created_at |
| ③5행(정확히 요청분) | hasMore=false(무회귀) |

## 검증
- `vitest run src/app/api/tasks/route.test.ts` — 12/12 GREEN.
- `tsc --noEmit` clean, `eslint` 0 warning.
- `next build --webpack` 성공.

## 적기만(스코프 밖·목록만, 손 안 댐)
커서 라우트 4곳 「+1 과대조회」 유무:
| 라우트 | +1 | 비고 |
|---|---|---|
| docs | 해당 없음 | BE가 `has_more`/`next_cursor`를 직접 계산해 그대로 신뢰(#2540) — 클라이언트 재추론 자체가 없는 구조 |
| goals | 있음(:80) | |
| stories | 있음(:114) | |
| tasks | 이번에 추가 | |

다른 갭 0. 근본 후보(별건): `buildCursorPageMeta`가 BE 진짜 커서 meta를 소비하는 쪽(docs 패턴)으로 옮기면 라우트마다 +1을 기억할 필요가 없다.

## 게이트
1. dev-app `/api/tasks?story_id=3711&limit=5` → hasMore true·nextCursor 확인(PO API 축 실측).
2. 유나 라이브(배포 58) — 표본 3711 「더 보기」 클릭 → 「25개 중 25개」·버튼 소멸, kanban·epic-swimlane 둘 다.
3. 카디르 QA(형제 stories와 동형 대조).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGJiE8cPVwnsEmCrE2zakd