### PR TITLE
[SID:3719] fix(BE+MCP): agent_runs.last_error_code 자연 경로 배선 — 3707 반대편 갭

### DIFF
--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -205,6 +205,7 @@ async def create_agent_run(
         status=body.status,
         result_summary=body.result_summary,
         error_message=body.error_message,
+        last_error_code=body.last_error_code,
         input_tokens=body.input_tokens,
         output_tokens=body.output_tokens,
         cost_usd=body.cost_usd,

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -23,6 +23,9 @@ class CreateAgentRun(BaseModel):
     # emit_event/update_run_status가 실어 보내도 Pydantic이 조용히 버렸다(extra=ignore 기본값)
     # — dev 전 프로젝트에 「failed + error_message」 실행이 0건이던 근본.
     error_message: str | None = None
+    # story #3719 — UpdateAgentRun엔 last_error_code가 있는데 CreateAgentRun엔 없어 생성
+    # 시점(emit_event 경로)엔 처음부터 채울 수 없었다(3707과 동형 갭, 반대편 스키마).
+    last_error_code: str | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
     cost_usd: float | None = None

--- a/backend/sprintable_mcp/tools/agent_runs.py
+++ b/backend/sprintable_mcp/tools/agent_runs.py
@@ -21,6 +21,8 @@ class EmitEventInput(SprintableInput):
     result_summary: str | None = None
     status: RunStatus | None = None
     error_message: str | None = None
+    # story #3719 — CreateAgentRun에 last_error_code가 생겨 이제 생성 시점부터 실을 수 있다.
+    last_error_code: str | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
     started_at: str | None = None
@@ -31,6 +33,8 @@ class UpdateRunStatusInput(SprintableInput):
     run_id: str
     status: RunStatus
     error_message: str | None = None
+    # story #3719 — BE UpdateAgentRun엔 이미 있던 필드인데 이 도구가 안 실어 보내던 것을 배선.
+    last_error_code: str | None = None
     result_summary: str | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
@@ -54,7 +58,8 @@ async def emit_event(args: EmitEventInput) -> list[TextContent]:
             "project_id": client.require_project_id(),  # E-MCP-OPT ff6cb90d: try 안에서 호출(가이드 에러 캡처).
         }
         for field in ("model", "story_id", "memo_id", "result_summary", "status",
-                      "error_message", "input_tokens", "output_tokens", "started_at", "finished_at"):
+                      "error_message", "last_error_code", "input_tokens", "output_tokens",
+                      "started_at", "finished_at"):
             val = getattr(args, field)
             if val is not None:
                 body[field] = val
@@ -66,8 +71,8 @@ async def emit_event(args: EmitEventInput) -> list[TextContent]:
 async def update_run_status(args: UpdateRunStatusInput) -> list[TextContent]:
     """에이전트 런 상태 업데이트."""
     body: dict = {"status": args.status}
-    for field in ("error_message", "result_summary", "input_tokens", "output_tokens",
-                  "cost_usd", "started_at", "finished_at"):
+    for field in ("error_message", "last_error_code", "result_summary", "input_tokens",
+                  "output_tokens", "cost_usd", "started_at", "finished_at"):
         val = getattr(args, field)
         if val is not None:
             body[field] = val

--- a/backend/tests/test_3719_agent_run_last_error_code_create_passthrough_realdb.py
+++ b/backend/tests/test_3719_agent_run_last_error_code_create_passthrough_realdb.py
@@ -1,0 +1,198 @@
+"""story #3719 — `agent_runs.last_error_code` 생성 시점 계약 누락, 실 PG.
+
+3707과 반대편 갭: `UpdateAgentRun`엔 `last_error_code`가 이미 있어 PATCH(exclude_unset
+패스스루)는 원래도 됐지만, `CreateAgentRun`엔 필드 자체가 없어 POST(emit_event 경로)로는
+처음부터 채울 수 없었다. `CreateAgentRun`에 필드 추가 + 라우터가 named-arg로 repo에 명시
+전달하는 수정을 write→read 왕복으로 pin(#3707 realdb 테스트와 동형 골격 재사용).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent A")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _fetch_run_last_error_code_db(Session, run_id):
+    from sqlalchemy import text
+    async with Session() as s:
+        row = (await s.execute(
+            text("SELECT last_error_code FROM agent_runs WHERE id = :i"), {"i": run_id},
+        )).one()
+        return row[0]
+
+
+@pytest.mark.anyio
+async def test_create_with_last_error_code_persists_and_is_readable_write_then_read_roundtrip():
+    """핵심 — POST(status=failed+last_error_code) → DB에 실제로 닿는지 → GET 응답에 실리는지.
+    CreateAgentRun에서 last_error_code를 도로 빼면(mutation-kill) 이 테스트가 정확히 이 자리서
+    RED(POST 바디가 조용히 버려짐)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            code = "E_SMOKE_3719"
+            resp = await client.post(
+                "/api/v2/agent-runs",
+                json={
+                    "agent_id": str(seeded["agent_id"]),
+                    "project_id": str(seeded["project_id"]),
+                    "status": "failed",
+                    "error_message": "[스모크·3719] 의도된 실패 표본",
+                    "last_error_code": code,
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["last_error_code"] == code, f"POST 응답에 last_error_code가 안 실림(회귀): {body}"
+
+            run_id = body["id"]
+            db_value = await _fetch_run_last_error_code_db(Session, run_id)
+            assert db_value == code, f"DB엔 안 닿음(응답만 echo, 회귀): {db_value!r}"
+
+            get_resp = await client.get(f"/api/v2/agent-runs/{run_id}")
+            assert get_resp.status_code == 200, get_resp.text
+            assert get_resp.json()["last_error_code"] == code
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_last_error_code_persists_and_readable_no_regression():
+    """UpdateAgentRun은 원래도 있었으나(exclude_unset 패스스루) 이번 수정이 그 경로를 깨지
+    않았는지 회귀 감시."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/agent-runs",
+                json={"agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"])},
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            run_id = create_resp.json()["id"]
+
+            code = "E_SMOKE_3719_PATCH"
+            patch_resp = await client.patch(
+                f"/api/v2/agent-runs/{run_id}",
+                json={"status": "failed", "last_error_code": code},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            assert patch_resp.json()["last_error_code"] == code, "PATCH 응답에 last_error_code가 안 실림(회귀)"
+
+            db_value = await _fetch_run_last_error_code_db(Session, run_id)
+            assert db_value == code, f"DB엔 안 닿음(회귀): {db_value!r}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3719_mcp_agent_run_last_error_code_wiring.py
+++ b/backend/tests/test_3719_mcp_agent_run_last_error_code_wiring.py
@@ -1,0 +1,102 @@
+"""story #3719 — MCP `emit_event`/`update_run_status`가 `last_error_code`를 실제 HTTP
+payload에 실어 보내는지 pin(test_2389_mcp_update_field_wiring.py와 동형 패턴).
+
+BE `UpdateAgentRun`엔 이미 `last_error_code`가 있었는데 `update_run_status`(tools/agent_runs.py)가
+PATCH body 조립 시 순회하는 필드 목록에서 빠져 있어 «스키마엔 있는데 도구가 안 보내는» 갭이었다
+(3707의 반대편 — 3707은 스키마 자체가 없었다). `CreateAgentRun`엔 필드 자체가 없어 `emit_event`
+경로도 막혀 있었다.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+sys.path.insert(0, ".")
+
+pytestmark = pytest.mark.anyio
+
+
+class _RecordingCall:
+    """client.post/patch를 흉내내며 마지막 호출의 path/json을 기록한다."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    async def __call__(self, path: str, *, json: dict | None = None):
+        self.calls.append((path, json or {}))
+        return {"id": "irrelevant", **(json or {})}
+
+    @property
+    def last_json(self) -> dict:
+        return self.calls[-1][1]
+
+
+async def test_update_run_status_wires_last_error_code_into_patch_payload(monkeypatch):
+    from sprintable_mcp.tools import agent_runs
+
+    recorder = _RecordingCall()
+    monkeypatch.setattr(agent_runs.client, "patch", recorder)
+
+    args = agent_runs.UpdateRunStatusInput(run_id="r1", status="failed", last_error_code="E_TIMEOUT")
+    await agent_runs.update_run_status(args)
+
+    assert recorder.last_json.get("last_error_code") == "E_TIMEOUT", (
+        "last_error_code가 UpdateRunStatusInput엔 선언돼 있지만 update_run_status()의 PATCH "
+        "payload엔 실리지 않았다 — 스키마 선언과 handler 배선(body 조립 for-loop)이 따로 논다."
+    )
+
+
+async def test_update_run_status_omits_last_error_code_when_not_provided(monkeypatch):
+    """미지정이면 payload에 아예 안 실려야(None 명시 전송으로 백엔드 값을 지우는 사고 방지)."""
+    from sprintable_mcp.tools import agent_runs
+
+    recorder = _RecordingCall()
+    monkeypatch.setattr(agent_runs.client, "patch", recorder)
+
+    args = agent_runs.UpdateRunStatusInput(run_id="r1", status="completed")
+    await agent_runs.update_run_status(args)
+
+    assert "last_error_code" not in recorder.last_json
+
+
+async def test_emit_event_wires_last_error_code_into_post_payload(monkeypatch):
+    from sprintable_mcp.tools import agent_runs
+
+    recorder = _RecordingCall()
+    monkeypatch.setattr(agent_runs.client, "post", recorder)
+    monkeypatch.setattr(agent_runs.client, "require_project_id", lambda: "p1")
+
+    args = agent_runs.EmitEventInput(agent_id="a1", trigger="manual", status="failed", last_error_code="E_TIMEOUT")
+    await agent_runs.emit_event(args)
+
+    assert recorder.last_json.get("last_error_code") == "E_TIMEOUT", (
+        "last_error_code가 EmitEventInput엔 선언돼 있지만 emit_event()의 POST payload엔 안 실렸다."
+    )
+
+
+async def test_emit_event_omits_last_error_code_when_not_provided(monkeypatch):
+    from sprintable_mcp.tools import agent_runs
+
+    recorder = _RecordingCall()
+    monkeypatch.setattr(agent_runs.client, "post", recorder)
+    monkeypatch.setattr(agent_runs.client, "require_project_id", lambda: "p1")
+
+    args = agent_runs.EmitEventInput(agent_id="a1", trigger="manual")
+    await agent_runs.emit_event(args)
+
+    assert "last_error_code" not in recorder.last_json
+
+
+async def test_update_run_status_still_wires_error_message_no_regression(monkeypatch):
+    """story #3707 회귀 감시 — 같은 for-loop에 필드를 추가하며 기존 error_message 순서를 깨지
+    않았는지."""
+    from sprintable_mcp.tools import agent_runs
+
+    recorder = _RecordingCall()
+    monkeypatch.setattr(agent_runs.client, "patch", recorder)
+
+    args = agent_runs.UpdateRunStatusInput(run_id="r1", status="failed", error_message="boom")
+    await agent_runs.update_run_status(args)
+
+    assert recorder.last_json.get("error_message") == "boom"


### PR DESCRIPTION
## Summary

BE `UpdateAgentRun`엔 `last_error_code`가 이미 있었는데(PATCH는 exclude_unset 패스스루라 원래도 됨) MCP `update_run_status`(`sprintable_mcp/tools/agent_runs.py`)가 PATCH body 조립 for-loop에서 이 필드를 안 실어 보내고 있었다 — 「스키마엔 있는데 도구가 안 보내는」 #3707의 반대편 클래스. `CreateAgentRun`엔 필드 자체가 없어 `emit_event`(생성 경로)로는 처음부터 채울 수 없었다.

- `CreateAgentRun`에 `last_error_code` 추가 + `create_agent_run` 라우터가 named-arg로 repo에 명시 전달(#4056 #3707 패턴과 동형).
- MCP `EmitEventInput`·`UpdateRunStatusInput` 둘 다 `last_error_code` 필드 추가 + 두 handler의 body 조립 for-loop에 실제로 실음.

## Test plan
- [x] BE realdb(`test_3719_agent_run_last_error_code_create_passthrough_realdb.py`) — alembic-migrated pg@16 로컬 실측: POST/PATCH가 DB에 실제로 닿는지 + GET 응답에 실리는지 write→read 왕복
- [x] MCP 단위(`test_3719_mcp_agent_run_last_error_code_wiring.py`) — `update_run_status`/`emit_event` 둘 다 payload에 `last_error_code`를 싣는지, 미지정 시 안 실리는지
- [x] mutation-kill — 스키마 필드/MCP for-loop 각각 제거 후 해당 테스트가 정확히 그 자리서 RED 확인, 복원 후 GREEN 재확인
- [x] #3707 회귀 무변 — `error_message`가 같은 for-loop에서 안 깨짐(`test_3707_..._realdb.py` + 신규 회귀 테스트 둘 다 green)
- [x] 관련 agent_run 백엔드 회귀 스위트 54개 green(1개는 배경-DB-connect 관련 기존 로컬 환경 결함으로 develop HEAD에서도 동일 실패 — 내 변경과 무관, baseline 대조로 확인)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CrDpiShJoThxE2JbUbRc4N

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrDpiShJoThxE2JbUbRc4N