### PR TITLE
[SID:3718] fix(FE): 스토리 태스크 총계를 목록 길이 대신 BE X-Total-Count로

### DIFF
--- a/apps/web/src/app/api/tasks/route.test.ts
+++ b/apps/web/src/app/api/tasks/route.test.ts
@@ -5,12 +5,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const h = vi.hoisted(() => ({
   getAuthContext: vi.fn(), createTaskRepository: vi.fn(),
   list: vi.fn(), create: vi.fn(), parseBody: vi.fn(),
+  // story #3718 — getStoryTaskCounts가 service.list(길이 세기) 대신 service.count
+  // (BE X-Total-Count)를 쓰도록 바뀌어 mock 표면도 같이 늘어난다.
+  count: vi.fn(),
 }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
 vi.mock('@/lib/storage/factory', () => ({ createTaskRepository: h.createTaskRepository }));
 vi.mock('@/services/task', async (importActual) => ({
   ...(await importActual<typeof import('@/services/task')>()),
-  TaskService: class { list = h.list; create = h.create; },
+  TaskService: class { list = h.list; create = h.create; count = h.count; },
 }));
 vi.mock('@sprintable/shared', async (importActual) => ({
   // 공유 모듈은 export 다수(VALID_STORY_TRANSITIONS 등 타 소비자 참조) — importActual로 전부 유지·parseBody만 오버라이드.
@@ -45,17 +48,18 @@ describe('/api/tasks (직접 서비스 TaskService)', () => {
     expect(body.meta).toBeTruthy();
   });
 
-  it('GET: single story_id adds totalCount/doneCount (getStoryTaskCounts)', async () => {
-    // main list + counts(all, done) = 3 호출
-    h.list
-      .mockResolvedValueOnce([task('1', 'todo'), task('2', 'done')])  // main page
-      .mockResolvedValueOnce([task('1'), task('2')])                  // all
-      .mockResolvedValueOnce([task('2', 'done')]);                    // done
+  it('GET: single story_id adds totalCount/doneCount from service.count(story #3718 — X-Total-Count, list().length 아님)', async () => {
+    h.list.mockResolvedValueOnce([task('1', 'todo'), task('2', 'done')]); // main page
+    h.count
+      .mockResolvedValueOnce(2)  // total
+      .mockResolvedValueOnce(1); // done
     const res = await GET(new Request('http://localhost/api/tasks?story_id=s1'));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.meta.totalCount).toBe(2);
     expect(body.meta.doneCount).toBe(1);
+    expect(h.count).toHaveBeenCalledWith({ story_id: 's1' });
+    expect(h.count).toHaveBeenCalledWith({ story_id: 's1', status: 'done' });
   });
 
   it('POST: 401 when unauthenticated', async () => {
@@ -168,5 +172,51 @@ describe('/api/tasks GET — cursor pagination hasMore/nextCursor 과대조회(s
     expect(body.data).toHaveLength(5);
     expect(body.meta.hasMore).toBe(false);
     expect(body.meta.nextCursor).toBeNull();
+  });
+});
+
+// story #3718(FE 완전성-정직, 3713/3717 후속) — getStoryTaskCounts가 service.list(...).length
+// 로 총계를 셌다. BE 기본 페이지 상한(미지정 시 1000)에 잘린 근사치라 태스크 1000건 초과
+// 스토리에선 「N개 중 M개」의 N 자체가 거짓이었다. service.count(BE X-Total-Count)로 교체.
+describe('/api/tasks GET — getStoryTaskCounts가 목록 길이가 아닌 service.count를 쓴다(story #3718)', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createTaskRepository.mockResolvedValue({});
+  });
+
+  it('(a) count가 1500(목록 길이 상한 1000을 초과하는 값)을 반환하면 totalCount=1500 그대로 나간다(list().length였다면 1000 이하로 잘렸을 값 — 되돌리면 RED)', async () => {
+    h.list.mockResolvedValueOnce(Array.from({ length: 20 }, (_, i) => task(String(i))));
+    h.count.mockResolvedValueOnce(1500).mockResolvedValueOnce(300);
+    const res = await GET(new Request('http://localhost/api/tasks?story_id=s1&limit=20'));
+    const body = await res.json();
+    expect(body.meta.totalCount).toBe(1500);
+    expect(body.meta.doneCount).toBe(300);
+  });
+
+  it('(c) count가 둘 다 null(BE 헤더 부재)이면 totalCount/doneCount는 현재 페이지 길이로 폴백한다(무회귀 — 화면이 깨지지 않게)', async () => {
+    h.list.mockResolvedValueOnce([task('1', 'todo'), task('2', 'done')]);
+    h.count.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    const res = await GET(new Request('http://localhost/api/tasks?story_id=s1'));
+    const body = await res.json();
+    expect(body.meta.totalCount).toBe(2);
+    expect(body.meta.doneCount).toBe(1);
+  });
+
+  it('(d) getStoryTaskCounts는 story_id 분기에서 service.list를 카운트 목적으로 부르지 않는다(main page 호출 1회만 — 목록 길이로 세는 경로 0)', async () => {
+    h.list.mockResolvedValueOnce([task('1')]);
+    h.count.mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+    await GET(new Request('http://localhost/api/tasks?story_id=s1'));
+    expect(h.list).toHaveBeenCalledTimes(1); // main page만 — counts용 list 호출 0
+    expect(h.count).toHaveBeenCalledTimes(2); // total·done
+  });
+
+  it('25건 이하(기존 표본 규모) 무회귀 — count 값 그대로 반영', async () => {
+    h.list.mockResolvedValueOnce(Array.from({ length: 20 }, (_, i) => task(String(i), i % 5 === 0 ? 'done' : 'todo')));
+    h.count.mockResolvedValueOnce(25).mockResolvedValueOnce(5);
+    const res = await GET(new Request('http://localhost/api/tasks?story_id=s1&limit=20'));
+    const body = await res.json();
+    expect(body.meta.totalCount).toBe(25);
+    expect(body.meta.doneCount).toBe(5);
   });
 });

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -14,15 +14,16 @@ async function getStoryTaskCounts(
   dbClient: DbClient | undefined,
 ) {
   if (!dbClient) {
-    const [allTasks, doneTasks] = await Promise.all([
-      service.list({ story_id: storyId }),
-      service.list({ story_id: storyId, status: 'done' }),
+    // story #3718(FE 완전성-정직, 3713/3717 후속) — list(...).length는 BE 기본 페이지
+    // 상한(미지정 시 1000)에 잘린 근사치였다(태스크 1000건 초과 스토리에서 「N개 중
+    // M개」의 N 자체가 거짓). count()가 BE X-Total-Count(필터 適用 後·limit 適用 前
+    // 진짜 총계)를 읽는다 — 헤더가 없으면 null(false/0으로 위장 안 함).
+    const [totalCount, doneCount] = await Promise.all([
+      service.count({ story_id: storyId }),
+      service.count({ story_id: storyId, status: 'done' }),
     ]);
 
-    return {
-      totalCount: allTasks.length,
-      doneCount: doneTasks.length,
-    };
+    return { totalCount, doneCount };
   }
 
   const [totalResult, doneResult] = await Promise.all([

--- a/apps/web/src/services/task.ts
+++ b/apps/web/src/services/task.ts
@@ -15,6 +15,12 @@ export class TaskService {
     return this.repository.list(filters);
   }
 
+  // story #3718 — 진짜 총계(BE X-Total-Count). list(...).length는 안 쓴다(getStoryTaskCounts
+  // 참고).
+  async count(filters: Omit<TaskListFilters, 'limit' | 'cursor'>) {
+    return this.repository.count(filters);
+  }
+
   async getById(id: string, scope?: RepositoryScopeContext) {
     return this.repository.getById(id, scope);
   }

--- a/packages/core-storage/src/interfaces/ITaskRepository.ts
+++ b/packages/core-storage/src/interfaces/ITaskRepository.ts
@@ -47,6 +47,13 @@ export interface TaskListFilters extends PaginationOptions {
 export interface ITaskRepository {
   create(input: CreateTaskInput): Promise<Task>;
   list(filters: TaskListFilters): Promise<Task[]>;
+  /** story #3718(FE 완전성-정직, 3713/3717 후속) — 필터 適用 後·limit 適用 前 진짜 총계
+   * (BE X-Total-Count, tasks.py 규약 — goals.py와 동형). `list(...).length`는 BE 기본
+   * 페이지 상한(미지정 시 1000)에 잘린 근사치라 총계로 못 쓴다(getStoryTaskCounts가
+   * 이 병을 앓았다). 헤더가 없거나 파싱 불가면 null — false/0으로 위장하지 않는다
+   * (story #3705와 동형 규율: "모르면 모른다고 표시"). cursor/limit은 count 의미상
+   * 무관하므로 필터에서 제외. */
+  count(filters: Omit<TaskListFilters, 'limit' | 'cursor'>): Promise<number | null>;
   getById(id: string, scope?: RepositoryScopeContext): Promise<Task>;
   update(id: string, input: UpdateTaskInput): Promise<Task>;
   delete(id: string, orgId: string): Promise<void>;

--- a/packages/storage-api/src/ApiTaskRepository.test.ts
+++ b/packages/storage-api/src/ApiTaskRepository.test.ts
@@ -87,3 +87,73 @@ describe('ApiTaskRepository.list — TaskListFilters 키 완전성(story #3713, 
     expect(Object.keys(TEST_VALUE_AND_EXPECTED_PARAM).sort()).toEqual(Object.keys(TASK_LIST_FILTER_KEYS).sort());
   });
 });
+
+// story #3718(FE 완전성-정직, 3713/3717 후속) — getStoryTaskCounts(tasks/route.ts)가
+// list(...).length로 총계를 셌다. BE tasks.py는 필터 適用 後·limit 適用 前 COUNT를
+// X-Total-Count 헤더로 이미 준다(goals.py와 동형 규약) — list().length는 BE 기본
+// 페이지 상한(미지정 시 1000)에 잘린 근사치라 총계로 못 쓴다. count()가 그 헤더를 읽는다.
+function stubFetchWithHeaders(totalCount: string | null) {
+  const headers = new Headers();
+  if (totalCount !== null) headers.set('x-total-count', totalCount);
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    headers,
+    json: async () => ({ data: [] }),
+  })) as unknown as ReturnType<typeof vi.fn>;
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('ApiTaskRepository.count — X-Total-Count 헤더에서 진짜 총계를 읽는다(story #3718)', () => {
+  it('(a) 헤더 total=1500 → count()가 1500을 반환한다(목록 길이 1000 상한과 무관 — 되돌리면 RED)', async () => {
+    stubFetchWithHeaders('1500');
+    const repo = new ApiTaskRepository('token');
+    const n = await repo.count({ story_id: 's1' });
+    expect(n).toBe(1500);
+  });
+
+  it('(b) status=done 필터로 부르면 done count가 헤더값 그대로 온다(목록 길이 아님)', async () => {
+    const fetchMock = stubFetchWithHeaders('42');
+    const repo = new ApiTaskRepository('token');
+    const n = await repo.count({ story_id: 's1', status: 'done' });
+    expect(n).toBe(42);
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).toContain('status=done');
+    expect(requestedUrl).toContain('limit=1');
+  });
+
+  it('(c) 헤더가 없으면 null(0/false로 위장하지 않는다 — story #3705 규율 동형)', async () => {
+    stubFetchWithHeaders(null);
+    const repo = new ApiTaskRepository('token');
+    const n = await repo.count({ story_id: 's1' });
+    expect(n).toBeNull();
+  });
+
+  it('(c-2) 헤더값이 숫자로 파싱 불가하면 null', async () => {
+    stubFetchWithHeaders('not-a-number');
+    const repo = new ApiTaskRepository('token');
+    const n = await repo.count({ story_id: 's1' });
+    expect(n).toBeNull();
+  });
+
+  it('count()는 요청에 limit=1을 실어 행 자체는 최소화한다(집계 목적, 목록 표시 아님)', async () => {
+    const fetchMock = stubFetchWithHeaders('3');
+    const repo = new ApiTaskRepository('token');
+    await repo.count({ story_id: 's1' });
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).toContain('limit=1');
+    expect(requestedUrl).not.toContain('cursor=');
+  });
+});
+
+// (e) 기존 fastapiCall 호출부(list/create/getById/update/delete) 무회귀 — fastapiCallRaw
+// 공유 추출 뒤에도 body 반환 동작이 그대로인지 값으로 고정.
+describe('ApiTaskRepository — fastapiCallRaw 공유 추출 뒤 기존 fastapiCall 호출부 무회귀(story #3718 (e))', () => {
+  it('list()는 여전히 body(JSON) 그대로만 반환한다(헤더 래핑 없음 — stub과 동형)', async () => {
+    stubFetch();
+    const repo = new ApiTaskRepository('token');
+    const result = await repo.list({ story_id: 's1' });
+    expect(result).toEqual({ data: [] });
+  });
+});

--- a/packages/storage-api/src/ApiTaskRepository.ts
+++ b/packages/storage-api/src/ApiTaskRepository.ts
@@ -1,5 +1,5 @@
 import type { ITaskRepository, Task, CreateTaskInput, UpdateTaskInput, TaskListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
-import { fastapiCall } from './utils';
+import { fastapiCall, fastapiCallWithMeta } from './utils';
 
 // story #3713(라이브 결함, 유나 배포 56 실측 02:40Z) — list() query 조립이 TaskListFilters의
 // cursor·limit(+project_id·status_ne)을 안 실어 BE 커서가 전진하지 않았다(같은 5행·같은
@@ -47,6 +47,29 @@ export class ApiTaskRepository implements ITaskRepository {
         cursor: filters.cursor,
       },
     });
+  }
+
+  // story #3718(FE 완전성-정직, 3713/3717 후속) — getStoryTaskCounts(tasks/route.ts)가
+  // list().length로 총계를 셌다 — BE 기본 페이지 상한(미지정 시 1000)에 잘린 근사치를
+  // 「N개 중 M개」의 N으로 써 왔다(태스크 1000건 초과 스토리에서만 드러나는 병, 낮은
+  // 우선순위지만 실 결함). BE tasks.py는 필터 適用 後·limit 適用 前 COUNT를 X-Total-Count
+  // 헤더로 이미 준다(goals.py와 동형 규약) — limit=1로 행 자체는 최소화하고 헤더만 읽는다.
+  async count(filters: Omit<TaskListFilters, 'limit' | 'cursor'>): Promise<number | null> {
+    const { headers } = await fastapiCallWithMeta<Task[]>('GET', '/api/v2/tasks', this.accessToken, {
+      query: {
+        story_id: filters.story_id,
+        project_id: filters.project_id,
+        assignee_id: filters.assignee_id,
+        status: filters.status,
+        status_ne: filters.status_ne,
+        ids: filters.ids?.join(','),
+        limit: 1,
+      },
+    });
+    const raw = headers.get('x-total-count');
+    if (raw == null) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
   }
 
   async getById(id: string, _scope?: RepositoryScopeContext): Promise<Task> {

--- a/packages/storage-api/src/index.ts
+++ b/packages/storage-api/src/index.ts
@@ -1,4 +1,4 @@
-export { fastapiCall, mapApiError } from './utils';
+export { fastapiCall, fastapiCallWithMeta, mapApiError } from './utils';
 export type { ApiCallError } from './utils';
 
 // FastAPI(/api/v2/*) 직타 레포지토리. 과거 `Supabase*Repository` 명명은 실동작(FastAPI HTTP)

--- a/packages/storage-api/src/utils.ts
+++ b/packages/storage-api/src/utils.ts
@@ -31,16 +31,18 @@ function getBaseUrl(): string {
   );
 }
 
-export async function fastapiCall<T>(
+interface FastapiCallOptions {
+  body?: unknown;
+  query?: Record<string, string | number | boolean | null | undefined>;
+  orgId?: string;
+}
+
+async function fastapiCallRaw<T>(
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT',
   path: string,
   accessToken: string,
-  options?: {
-    body?: unknown;
-    query?: Record<string, string | number | boolean | null | undefined>;
-    orgId?: string;
-  },
-): Promise<T> {
+  options?: FastapiCallOptions,
+): Promise<{ data: T; headers: Headers }> {
   const url = new URL(path, getBaseUrl());
   if (options?.query) {
     for (const [k, v] of Object.entries(options.query)) {
@@ -65,6 +67,29 @@ export async function fastapiCall<T>(
     throw mapApiError(res.status, errBody);
   }
 
-  if (res.status === 204) return undefined as T;
-  return res.json() as Promise<T>;
+  const data = res.status === 204 ? (undefined as T) : (await res.json() as T);
+  return { data, headers: res.headers };
+}
+
+export async function fastapiCall<T>(
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT',
+  path: string,
+  accessToken: string,
+  options?: FastapiCallOptions,
+): Promise<T> {
+  const { data } = await fastapiCallRaw<T>(method, path, accessToken, options);
+  return data;
+}
+
+/** story #3718 — fastapiCall과 완전히 같은 요청·같은 에러 처리를 타되, 응답 헤더까지
+ * 호출부에 넘긴다(fastapiCall은 body만 반환해 X-Total-Count 같은 헤더가 소비처에
+ * 안 갔다 — ApiTaskRepository.count()가 이걸로 진짜 총계를 읽는다). 중복 구현 대신
+ * fastapiCallRaw를 공유해 fastapiCall의 기존 동작(호출부 무회귀)은 그대로 유지한다. */
+export async function fastapiCallWithMeta<T>(
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT',
+  path: string,
+  accessToken: string,
+  options?: FastapiCallOptions,
+): Promise<{ data: T; headers: Headers }> {
+  return fastapiCallRaw<T>(method, path, accessToken, options);
 }


### PR DESCRIPTION
## 요약(3713·3717 후속)
`getStoryTaskCounts`(tasks/route.ts)가 `service.list({story_id})`의 **목록 길이**로 totalCount/doneCount를 셌다. BE `list_tasks`는 limit 미지정 시 최대 1000행까지만 준다(`repositories/task.py:67`) — 태스크 1000건을 초과하는 스토리에선 「N개 중 M개 표시 중」의 **N 자체가 잘린 근사치**였다. BE `tasks.py`는 필터 適用 後·limit 適用 前 진짜 COUNT를 `X-Total-Count` 헤더로 이미 준다(`goals.py`와 동형 규약) — FE가 「세는 방법」을 잘못 고른 것.

## 그라운딩(PO 決)
"Story 리포지토리 선례"를 실측했더니 `packages/storage-api`의 `fastapiCall`은 JSON body만 반환하고 응답 헤더를 호출부에 안 넘겼다. 유일한 X-Total-Count 소비 선례는 `stories/route.ts:64-69`의 raw-proxy 조기분기뿐인데, 이건 리포지토리/서비스 계층을 완전히 우회하는 별도 경로 — **정식 경로와 우회 경로가 계약을 따로 가지는 클래스**(3713·3717과 동형)를 재생산하는 안이라 기각.

## 처방(B 축소판·additive, 기존 호출부 시그니처 무변)
- `utils.ts`: `fastapiCall` 내부를 `fastapiCallRaw`로 추출(요청·에러 처리 공유), 헤더까지 반환하는 `fastapiCallWithMeta` 신설 — `fastapiCall` 자신의 동작(body만 반환)은 무변.
- `ITaskRepository`: `count(filters)` 추가(limit/cursor 제외 — 집계 의미상 무관). 헤더 없음/파싱 불가 → `null`(false/0으로 위장 안 함, story #3705 규율 동형).
- `ApiTaskRepository.count()`: `limit=1`로 행 자체는 최소화하고 X-Total-Count만 읽는다.
- `TaskService.count()` → `getStoryTaskCounts`가 list 2회(길이 세기) 대신 count 2회(전체·done)로 교체. null이면 현재 페이지 길이로 폴백(무회귀 안전망).

## 테스트
`ApiTaskRepository.count` 5건 — (a) total=1500 그대로 반영 (b) done이 헤더값 (c)/(c-2) 헤더 없음/파싱불가→null (limit=1 확인 별도 1건) + 기존 `fastapiCall` 호출부 무회귀 1건.
`route.test.ts` 5건 — (a) 1500 반영 (c) null 폴백 (d) list가 카운트 목적으로 안 불림(grep 단언) + 25건 이하 무회귀. 기존 totalCount/doneCount 테스트도 count mock 기반으로 갱신.

## Mutation-kill
① `route.ts`를 `list().length`로 되돌려 5건 RED 확認 後 원복.
② `ApiTaskRepository.count`의 null-safety를 제거해 (c)(c-2) 2건 RED 확認 後 원복.

## 검증
- 다른 `ITaskRepository` 구현체 없음(grep 확인) — 인터페이스 확장이 안전한 이유.
- `tsc --noEmit` 3곳(`core-storage`·`storage-api`·`apps/web`) clean.
- `vitest run` — storage-api 42/42·tasks route 16/16.
- `next build --webpack` 성공.

## 적기만(스코프 밖·목록만, 손 안 댐)
`stories/route.ts:64-69` raw-proxy 분기를 이번 count() 경로로 이관하는 것은 별건 후보. 라이브 AC(태스크 > 1000건 표본)는 비용이 과해 테스트로 닫음 — PO 決(low 우선순위 근거와 동일).

## 게이트
카디르 QA·유나 design(문구 무변) 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGJiE8cPVwnsEmCrE2zakd