### PR TITLE
[SID:3725][SID:3727] fix(BE): agent_runs 응답·시각 필드 additive — 3707류 4~6번째 인스턴스

### DIFF
--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -194,7 +194,11 @@ async def create_agent_run(
 
     # story #2161: "시작할 때 이미 끝날 시각을 갖고 태어나게" — deadline_at은 클라 미제공(항상
     # 서버 계산, A2ATask.deadline_at 선례와 동형·클라가 자기 기한을 임의 연장 못 하게).
-    run = await repo.create(
+    #
+    # story #3727 — started_at/finished_at은 미제공 시 각각 DB server_default(now())/NULL을
+    # 그대로 둔다(named-arg로 항상 넘기면 미제공=None이 그 기본값을 덮어써 버린다 — 「생략」과
+    # 「명시적 null」을 create 경로에서도 가른다, UpdateAgentRun의 exclude_unset과 동형 원칙).
+    create_fields: dict = dict(
         org_id=org_id,
         agent_id=body.agent_id,
         project_id=body.project_id,
@@ -211,6 +215,11 @@ async def create_agent_run(
         cost_usd=body.cost_usd,
         deadline_at=datetime.now(timezone.utc) + timedelta(hours=AGENT_RUN_TIMEOUT_HOURS),
     )
+    if body.started_at is not None:
+        create_fields["started_at"] = body.started_at
+    if body.finished_at is not None:
+        create_fields["finished_at"] = body.finished_at
+    run = await repo.create(**create_fields)
     name_map = await _agent_name_map(session, {run.agent_id})
     return AgentRunResponse.model_validate(run).model_copy(update={"agent_name": name_map.get(run.agent_id)})
 

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -31,6 +31,14 @@ class CreateAgentRun(BaseModel):
     cost_usd: float | None = None
     # duration_ms(2a5f21d3): DB GENERATED ALWAYS(started/finished_at 파생)라 클라 입력 불가 —
     # 명시 세팅 시 GeneratedAlwaysError. 입력 표면에서 제거(응답 AgentRunResponse엔 read-only 유지).
+    # story #3727 — MCP emit_event가 이미 보낼 준비가 돼 있었으나(sprintable_mcp/tools/
+    # agent_runs.py) 이 스키마에 둘 다 없어 조용히 버려지고 있었다(2161이 UpdateAgentRun.
+    # finished_at만 닫고 이쪽은 놓침 — 3707류 4·5번째 인스턴스). 라우터가 미제공 시 컬럼의
+    # DB server_default(started_at=now())/NULL(finished_at)을 그대로 두도록 명시 제공 시에만
+    # repo.create()에 넘긴다(생략과 명시 null을 가른다 — UpdateAgentRun의 exclude_unset과 동형
+    # 원칙을 create 경로에도 적용).
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
 
 
 class UpdateAgentRun(BaseModel):
@@ -43,6 +51,10 @@ class UpdateAgentRun(BaseModel):
     cost_usd: float | None = None
     # duration_ms: GENERATED ALWAYS라 입력 불가(2a5f21d3) — 제거.
     last_error_code: str | None = None
+    # story #3727 — MCP update_run_status가 이미 보낼 준비가 돼 있었으나(sprintable_mcp/
+    # tools/agent_runs.py UPDATE_RUN_STATUS_FORWARD_FIELDS) 이 스키마에 없어 조용히
+    # 버려지고 있었다(2161이 finished_at만 닫고 started_at은 놓침 — 3707류 6번째 인스턴스).
+    started_at: datetime | None = None
     # story #2161: MCP update_run_status는 이미 finished_at을 보낼 준비가 돼 있었으나(
     # sprintable_mcp/tools/agent_runs.py) 이 스키마에 필드가 없어 조용히 버려지고 있었다 —
     # 정상 종료조차 duration_ms(GENERATED, started/finished_at 파생)가 영구 NULL이던 근본.
@@ -62,6 +74,11 @@ class AgentRunResponse(BaseModel):
     # (agent_id 자체는 그대로 정본) — team_members에서 조인해 채우고, 못 찾으면(예: 멤버 삭제)
     # null(지어내지 않는다).
     agent_name: str | None = None
+    # story #3725 — 모델(agent_run.py)엔 컬럼이 실재하고 배포 라이프사이클/리퍼가 이미 직접
+    # 쓰는데, 이 응답 스키마엔 5필드가 아예 없어 실행 상세의 재시도·실패 처분 UI가 늘
+    # 폴백/미표시였다(3707류 — «있는데 응답에 안 실음»). additive(from_attributes=True라
+    # ORM 속성명 그대로 자동 매핑, 값이 없으면 null — 지어내지 않는다).
+    deployment_id: uuid.UUID | None = None
     story_id: uuid.UUID | None = None
     memo_id: uuid.UUID | None = None
     trigger: str
@@ -76,6 +93,13 @@ class AgentRunResponse(BaseModel):
     cost_usd: float | None = None
     duration_ms: int | None = None
     last_error_code: str | None = None
+    # story #3725 — 위 deployment_id 코멘트와 동형 갭.
+    failure_disposition: str | None = None
+    # retry_count/max_retries는 DB NOT NULL(default 0/3, llm_call_count와 동형) — 항상 값이
+    # 있다(null 아님).
+    retry_count: int
+    max_retries: int
+    next_retry_at: datetime | None = None
     llm_call_count: int
     run_metadata: dict[str, Any]
     started_at: datetime

--- a/backend/tests/test_3724_agent_run_mcp_be_fe_contract_guard.py
+++ b/backend/tests/test_3724_agent_run_mcp_be_fe_contract_guard.py
@@ -32,10 +32,15 @@ GENERATED라 어느 쪽 Input에도 없고 있어서도 안 된다). #4067(#3719
 (2026-09-09 05:27Z), #3726 그라운딩(같은 시각)이 가드② 잔여 13건 중 5건(llm_provider·
 llm_provider_key·computed_cost_cents·per_run_cap_cents·billing_notes)은 phantom이
 아니라 SaaS 오버레이 계층 필드임을 밝혀 PO 決로 별도 목록(`GUARD2_GRANDFATHER_SAAS_
-OVERLAY`, "줄어들지 않는" 영구 pin)으로 분리했다 — 나머지(가드① 3건 + 가드② 8건)만 후속
-스토리(#3725·#3730)가 닫히는 대로 실제로 줄어드는 `GUARD2_GRANDFATHER_PENDING`에 남는다.
+OVERLAY`, "줄어들지 않는" 영구 pin)으로 분리했다 — 나머지(가드① 3건 + 가드② 8건)가 후속
+스토리(#3725·#3730)가 닫히는 대로 실제로 줄어드는 `GUARD2_GRANDFATHER_PENDING`에 남았다.
 각 항목은 후속 스토리가 있고, 그 스토리가 닫히면 그 grandfather에서도 빠져야 한다
 (카운트-핀이 그 삭제를 강제한다 — 늘어나면 리뷰, 줄어들면 카운트도 같이 줄여야 커밋된다).
+#3730(#4074)·#3727+#3725(#4072, 둘 다 2026-09-09) 전부 착지해 GUARD1_GRANDFATHER·
+GUARD2_GRANDFATHER_PENDING 둘 다 0(빈 dict)이다 — 이 파일의 카운트-핀·자가진단 테스트가
+그 실측을 매 리베이스마다 강제해 잡아냈다(유나 판정 2026-09-09 05:41Z가 우려한 "핀만
+green이고 내용은 stale" 상태가 실제로 두 번 재현→수리됨, #4072 리베이스 도중 자가진단
+테스트 2건이 정확히 그 상태를 RED로 잡은 것으로 실측 확認).
 """
 from __future__ import annotations
 
@@ -53,12 +58,10 @@ from sprintable_mcp.tools.agent_runs import (
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _FE_AGENT_RUN_DETAIL = _REPO_ROOT / "apps/web/src/components/agents/agent-run-detail.tsx"
 
-# ── 가드① grandfather — story #3727(1pt·medium)이 셋 다 닫는다 ─────────────────────────
-GUARD1_GRANDFATHER: dict[tuple[str, str], str] = {
-    ("emit_event", "started_at"): "story #3727 — CreateAgentRun에 없어 생성 시 조용히 버려짐",
-    ("emit_event", "finished_at"): "story #3727 — CreateAgentRun에 없어 생성 시 조용히 버려짐",
-    ("update_run_status", "started_at"): "story #3727 — UpdateAgentRun에 없어 갱신 시 조용히 버려짐(finished_at은 #2161이 이미 고쳐 위반 아님)",
-}
+# ── 가드① grandfather — story #3727이 셋 다 닫았다(#4072, 2026-09-09) ──────────────────
+# CreateAgentRun에 started_at·finished_at, UpdateAgentRun에 started_at을 추가해 MCP가
+# 이미 보내던 값이 더는 Pydantic extra=ignore로 조용히 버려지지 않는다 — 0건.
+GUARD1_GRANDFATHER: dict[tuple[str, str], str] = {}
 
 
 def test_mcp_forward_fields_are_subset_of_be_schema_fields():
@@ -91,10 +94,9 @@ def test_mcp_forward_fields_are_subset_of_be_schema_fields():
 def test_guard1_grandfather_count_pinned():
     """항목 수가 조용히 늘면(새 silent-drop) 리뷰 없이 못 지나가게, 줄면(#3727 착지) 이
     상수도 같이 줄이라는 신호."""
-    assert len(GUARD1_GRANDFATHER) == 3, (
-        f"GUARD1_GRANDFATHER 항목 수가 3이 아니라 {len(GUARD1_GRANDFATHER)} — 늘었으면 새 "
-        "silent-drop이 또 생긴 것(원인 리뷰 필요), 줄었으면 story #3727이 그만큼 닫힌 것이니 "
-        "이 상수·주석도 같이 정리할 것."
+    assert len(GUARD1_GRANDFATHER) == 0, (
+        f"GUARD1_GRANDFATHER 항목 수가 0이 아니라 {len(GUARD1_GRANDFATHER)} — story #3727이 "
+        "닫아 0으로 줄었다(#4072). 늘었으면 새 silent-drop이 생긴 것(원인 리뷰 필요)."
     )
 
 
@@ -190,18 +192,12 @@ GUARD2_GRANDFATHER_SAAS_OVERLAY: dict[str, str] = {
     "billing_notes": "SaaS 계층(OSS-stub 관례) — 이 저장소 범위 밖, 손 안 댐",
 }
 
-# ⓑ 임시(후속 스토리가 닫으면 실제로 줄어드는 목록) — #3725(5, AgentRunResponse additive)가
-# 마저 닫는다. #3721(tool_call_history·tool_audit_trail)·#3730(session_id·continuity_debug·
-# memory_compaction_policy 은퇴 — #3726 決)은 이미 착지해 목록에서 빠졌다(카운트
-# 15→13→8→5로 줄어든 이력 그대로 — 그 자체가 이 가드의 "줄어드는" 계약이 실제로 지켜진다는
-# 증거).
-GUARD2_GRANDFATHER_PENDING: dict[str, str] = {
-    "deployment_id": "story #3725 — DB 컬럼 실재(agent_runs.deployment_id), 응답 스키마에만 없음",
-    "failure_disposition": "story #3725 — DB 컬럼 실재, 응답 스키마에만 없음",
-    "retry_count": "story #3725 — DB 컬럼 실재, 응답 스키마에만 없음",
-    "max_retries": "story #3725 — DB 컬럼 실재, 응답 스키마에만 없음",
-    "next_retry_at": "story #3725 — DB 컬럼 실재, 응답 스키마에만 없음",
-}
+# ⓑ 임시(후속 스토리가 닫으면 실제로 줄어드는 목록) — #3725도 닫아(#4072, 2026-09-09)
+# 이제 0이다. #3721(tool_call_history·tool_audit_trail)·#3730(session_id·continuity_debug·
+# memory_compaction_policy 은퇴 — #3726 決)·#3725(AgentRunResponse additive 5필드) 전부
+# 착지해 목록에서 빠졌다(카운트 15→13→8→5→0으로 줄어든 이력 그대로 — 그 자체가 이 가드의
+# "줄어드는" 계약이 실제로 지켜진다는 증거).
+GUARD2_GRANDFATHER_PENDING: dict[str, str] = {}
 
 
 def _extract_ts_interface_field_names(source: str, interface_name: str) -> list[str]:
@@ -255,10 +251,9 @@ def test_guard2_saas_overlay_grandfather_count_pinned():
 def test_guard2_pending_grandfather_count_pinned():
     """임시 목록은 후속 스토리(#3725)가 닫히는 대로 실제로 줄어들어야 한다 — 이미
     #3721(2개)·#3730(3개)이 착지해 15→13→8→5로 준 이력 그대로."""
-    assert len(GUARD2_GRANDFATHER_PENDING) == 5, (
-        f"GUARD2_GRANDFATHER_PENDING 항목 수가 5가 아니라 {len(GUARD2_GRANDFATHER_PENDING)} — "
-        "늘었으면 새 phantom 필드가 또 생긴 것(원인 리뷰 필요), 줄었으면 후속 스토리(#3725)가 "
-        "그만큼 닫힌 것이니 이 상수·주석도 같이 정리할 것."
+    assert len(GUARD2_GRANDFATHER_PENDING) == 0, (
+        f"GUARD2_GRANDFATHER_PENDING 항목 수가 0이 아니라 {len(GUARD2_GRANDFATHER_PENDING)} — "
+        "story #3725가 닫아 0으로 줄었다(#4072). 늘었으면 새 phantom 필드가 생긴 것(원인 리뷰 필요)."
     )
 
 

--- a/backend/tests/test_3725_agent_run_response_additive_fields_realdb.py
+++ b/backend/tests/test_3725_agent_run_response_additive_fields_realdb.py
@@ -1,0 +1,202 @@
+"""story #3725 — `AgentRunResponse`에 모델 실재 5필드(deployment_id·failure_disposition·
+retry_count·max_retries·next_retry_at)가 빠져 실행 상세의 재시도·실패 처분 UI가 늘 폴백이던
+것, 실 PG.
+
+이 5필드엔 공개 API 쓰기 경로가 없다(CreateAgentRun/UpdateAgentRun에 없음 — 리퍼·재시도
+스케줄러가 내부에서 직접 쓴다). 그래서 이 테스트는 DB 직접 fixture로 값을 심고 GET 응답에
+그대로 실리는지만 pin한다(쓰기 경로 자체는 이 스토리 범위 밖).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent A")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _set_retry_fields_directly(Session, run_id, deployment_id, next_retry_at):
+    """공개 쓰기 경로가 없는 필드(리퍼/재시도 스케줄러 내부 전용) — DB 직접 fixture."""
+    from sqlalchemy import text
+    async with Session() as s:
+        await s.execute(
+            text(
+                "UPDATE agent_runs SET deployment_id = :dep, failure_disposition = :fd, "
+                "retry_count = :rc, max_retries = :mr, next_retry_at = :nra WHERE id = :id"
+            ),
+            {
+                "dep": deployment_id, "fd": "retry_scheduled", "rc": 2, "mr": 3,
+                "nra": next_retry_at, "id": run_id,
+            },
+        )
+        await s.commit()
+
+
+@pytest.mark.anyio
+async def test_additive_fields_readable_after_direct_db_write():
+    """AC 핵심 — DB에 값이 실재하면(리퍼/재시도 스케줄러가 채운 것처럼) GET 응답에 그대로
+    실려야 한다. 스키마에서 5필드를 도로 빼면(mutation-kill) 이 테스트가 정확히 이 자리서
+    RED(값은 DB에 있는데 응답이 조용히 안 보여줌)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/agent-runs",
+                json={"agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"]), "status": "failed"},
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            run_id = create_resp.json()["id"]
+            deployment_id = uuid.uuid4()
+            next_retry_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+            await _set_retry_fields_directly(Session, run_id, deployment_id, next_retry_at)
+
+            get_resp = await client.get(f"/api/v2/agent-runs/{run_id}")
+            assert get_resp.status_code == 200, get_resp.text
+            body = get_resp.json()
+
+            assert body["deployment_id"] == str(deployment_id), f"deployment_id 안 실림(회귀): {body}"
+            assert body["failure_disposition"] == "retry_scheduled", f"failure_disposition 안 실림(회귀): {body}"
+            assert body["retry_count"] == 2, f"retry_count 안 실림(회귀): {body}"
+            assert body["max_retries"] == 3, f"max_retries 안 실림(회귀): {body}"
+            assert body["next_retry_at"] is not None, f"next_retry_at 안 실림(회귀): {body}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_additive_fields_default_when_unset_no_fiction():
+    """리퍼/재시도가 아직 안 건드린 run — nullable 셋(deployment_id·failure_disposition·
+    next_retry_at)은 null, NOT NULL 기본값 둘(retry_count=0·max_retries=3)은 그 기본값
+    그대로여야 한다(지어내지 않는다 — 응답 스키마가 값을 임의로 바꾸지 않음을 pin)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/agent-runs",
+                json={"agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"])},
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            body = create_resp.json()
+
+            assert body["deployment_id"] is None
+            assert body["failure_disposition"] is None
+            assert body["retry_count"] == 0
+            assert body["max_retries"] == 3
+            assert body["next_retry_at"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3727_agent_run_timestamps_passthrough_realdb.py
+++ b/backend/tests/test_3727_agent_run_timestamps_passthrough_realdb.py
@@ -1,0 +1,251 @@
+"""story #3727 — agent_runs 시각 3필드(emit_event의 started_at·finished_at, update_run_status의
+started_at)가 자연 경로에서 조용히 버려지던 것, 실 PG.
+
+3707·3719와 같은 클래스의 4·5·6번째 인스턴스 — 3724 가드①을 실제로 짜다 발견됐다. 2161은
+UpdateAgentRun.finished_at 한쪽만 닫았다(그 회귀는 별도 유지·이 파일에서도 무변 확認).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent A")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_create_with_started_at_and_finished_at_persists_and_readable():
+    """AC 핵심 — POST(emit_event 경로)가 보내는 started_at/finished_at이 DB에 실제로 닿고
+    GET 응답에 실리는지. 스키마에서 도로 빼면(mutation-kill) 이 테스트가 정확히 이 자리서
+    RED(POST 바디가 조용히 버려짐 → 서버 기본값/NULL로 대체)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            reported_started = datetime(2026, 9, 1, 3, 0, 0, tzinfo=timezone.utc)
+            reported_finished = datetime(2026, 9, 1, 3, 5, 0, tzinfo=timezone.utc)
+            resp = await client.post(
+                "/api/v2/agent-runs",
+                json={
+                    "agent_id": str(seeded["agent_id"]),
+                    "project_id": str(seeded["project_id"]),
+                    "status": "completed",
+                    "started_at": reported_started.isoformat(),
+                    "finished_at": reported_finished.isoformat(),
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["started_at"].startswith("2026-09-01T03:00:00"), f"started_at 안 실림(회귀): {body}"
+            assert body["finished_at"].startswith("2026-09-01T03:05:00"), f"finished_at 안 실림(회귀): {body}"
+            # duration_ms(GENERATED, started/finished_at 파생) — 값이 실제로 반영됐는지 회귀.
+            assert body["duration_ms"] == 300_000, f"duration_ms가 보고된 시각으로 계산 안 됨: {body}"
+
+            get_resp = await client.get(f"/api/v2/agent-runs/{body['id']}")
+            assert get_resp.status_code == 200, get_resp.text
+            assert get_resp.json()["started_at"].startswith("2026-09-01T03:00:00")
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_without_started_at_keeps_server_default_not_null():
+    """미제공 시 서버 기본값(now())을 명시 None으로 덮어쓰지 않아야 한다 — 「생략」과 「명시
+    null」을 create 경로에서도 가른다(UpdateAgentRun exclude_unset과 동형 원칙)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agent-runs",
+                json={"agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"])},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["started_at"] is not None, "started_at 미제공 시 서버 기본값이 안 채워짐(회귀)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_started_at_persists_and_readable():
+    """AC 핵심 — PATCH(update_run_status 경로)가 보내는 started_at이 DB에 닿고 GET 응답에
+    실리는지."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/agent-runs",
+                json={"agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"])},
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            run_id = create_resp.json()["id"]
+
+            corrected_started = datetime(2026, 9, 1, 2, 0, 0, tzinfo=timezone.utc)
+            patch_resp = await client.patch(
+                f"/api/v2/agent-runs/{run_id}",
+                json={"status": "running", "started_at": corrected_started.isoformat()},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            assert patch_resp.json()["started_at"].startswith("2026-09-01T02:00:00"), (
+                f"PATCH 응답에 started_at이 안 실림(회귀): {patch_resp.json()}"
+            )
+
+            get_resp = await client.get(f"/api/v2/agent-runs/{run_id}")
+            assert get_resp.status_code == 200, get_resp.text
+            assert get_resp.json()["started_at"].startswith("2026-09-01T02:00:00")
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_finished_at_no_regression_story_2161():
+    """story #2161 회귀 감시 — UpdateAgentRun.finished_at 경로는 이번 변경 전에도 이미
+    됐었다. started_at을 추가하며 그 경로를 안 깼는지."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/agent-runs",
+                json={"agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"])},
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            run_id = create_resp.json()["id"]
+
+            finished = datetime(2026, 9, 1, 4, 0, 0, tzinfo=timezone.utc)
+            patch_resp = await client.patch(
+                f"/api/v2/agent-runs/{run_id}",
+                json={"status": "completed", "finished_at": finished.isoformat()},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            assert patch_resp.json()["finished_at"].startswith("2026-09-01T04:00:00")
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_s36.py
+++ b/backend/tests/test_s36.py
@@ -34,6 +34,14 @@ def _mock_run(status: str = "running") -> MagicMock:
     r.cost_usd = None
     r.duration_ms = None
     r.last_error_code = None
+    # story #3725 — AgentRunResponse에 5필드 추가. MagicMock은 명시 안 하면 자동으로
+    # MagicMock을 만들어내(retry_count/max_retries는 int 필수라 ValidationError) agent_name과
+    # 동형으로 세팅.
+    r.deployment_id = None
+    r.failure_disposition = None
+    r.retry_count = 0
+    r.max_retries = 3
+    r.next_retry_at = None
     r.llm_call_count = 0
     r.run_metadata = {}
     r.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

두 스토리 모두 #3724 그라운딩(같은 세션)에서 나온 «스키마에 없어 조용히 버려짐» 클래스의 후속이라 같은 파일(`schemas/agent_run.py`·`routers/agent_runs.py`)을 건드려 한 PR로 묶는다(#3724 본문 명시 허용).

### #3725 — `AgentRunResponse`에 모델 실재 5필드 additive
`deployment_id`·`failure_disposition`·`retry_count`·`max_retries`·`next_retry_at`. 배포 라이프사이클/리퍼가 이미 이 컬럼들을 직접 쓰는데 응답 스키마에 없어 실행 상세의 재시도·실패 처분 UI(`canManuallyRetryRun`·재시도 배지·「다음 재시도」줄)가 늘 폴백/미표시였다. 순수 additive(`from_attributes=True`로 ORM 속성명 그대로 자동 매핑) — 라우터 변경 0. `retry_count`/`max_retries`는 DB NOT NULL(default 0/3)이라 `llm_call_count`와 동형으로 non-optional `int`로 타입.

### #3727 — `CreateAgentRun`에 `started_at`·`finished_at`, `UpdateAgentRun`에 `started_at`
MCP `emit_event`·`update_run_status`는 이미 이 필드들을 보낼 준비가 돼 있었으나(`EMIT_EVENT_FORWARD_FIELDS`·`UPDATE_RUN_STATUS_FORWARD_FIELDS`, #3724 실측) 스키마에 없어 Pydantic `extra=ignore`로 조용히 버려지고 있었다(#2161이 `UpdateAgentRun.finished_at` 한쪽만 닫고 나머지 셋은 놓침). 라우터 `create_agent_run`은 미제공 시 DB `server_default(now())`/NULL을 그대로 두도록 값이 있을 때만 `repo.create()`에 넘긴다(「생략」과 「명시 null」을 create 경로에서도 가른다 — `UpdateAgentRun`의 `exclude_unset`과 동형 원칙).

## Test plan
- [x] 둘 다 realdb(alembic-migrated pg@16 로컬 실측) write→read 왕복 + mutation-kill 확인(필드 제거 → RED → 복원 → GREEN)
- [x] #3707/#3719/#2161 회귀 무변
- [x] `test_s36.py`의 `_mock_run()` MagicMock fixture에 신규 5필드 명시(기존 습관과 동형 — 미명시 시 MagicMock이 자동 생성한 값이 `retry_count`/`max_retries`의 non-optional `int` 제약을 위반해 ValidationError)
- [x] agent_run 관련 백엔드 회귀 96개 green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CrDpiShJoThxE2JbUbRc4N

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrDpiShJoThxE2JbUbRc4N