### PR TITLE
[SID:3729] fix(infra): Dockerfile builder에 루트 scripts/ COPY — 배포 58 build-frontend 실패 복구

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -30,6 +30,12 @@ COPY --from=deps /app/packages ./packages
 COPY apps/web/ apps/web/
 # ee overlay (SaaS 빌드 시 주입, OSS에서는 빈 디렉토리 허용)
 COPY ee/ ee/
+# story #3729(배포 58 실사고, 2026-09-09) — 레포 루트 공유 스크립트(scripts/i18n-key-parser.js,
+# story #3156). apps/web 안 3파일(verify-no-new-raw-fetch-api.ts·i18n-key-coverage.test.ts·
+# pagination-envelope-consumers.test.ts)이 `../../../scripts/...`로 이 밖을 import하는데
+# builder 컨텍스트엔 없어 `pnpm build`의 타입체크가 Cannot find module로 죽었다(CI는 전체
+# 체크아웃이라 이 축을 안 잰다 — Docker 컨텍스트 전용 결함).
+COPY scripts/ scripts/
 WORKDIR /app/apps/web
 ENV NEXT_TELEMETRY_DISABLED=1
 # rewrites()가 빌드 시점에 routes-manifest.json으로 베이크인되므로 ARG로 주입 필요


### PR DESCRIPTION
## 요약(PO 배포 58 Cloud Build 진단 05:23Z)
`build-frontend`(`apps/web/Dockerfile`·`pnpm build`) 실패: `Cannot find module '../../../scripts/i18n-key-parser.js'`. `#4064`(story #3716)가 공유 파서를 레포 루트 `scripts/i18n-key-parser.js`로 옮겼는데, `apps/web/Dockerfile` builder 스테이지 COPY는 `package.json`·`packages/`·`apps/web/`·`ee/`뿐이라 **루트 `scripts/`가 빌드 컨텍스트에 없었다**. CI(Lint/Type Check/Test/Build 잡)는 전체 체크아웃이라 이 축을 안 잰다 — **Docker 컨텍스트 전용 결함**. 서빙 영향 0(배포 57 리비전 그대로).

## 처방
builder 스테이지에 `COPY scripts/ scripts/` 한 줄. `.dockerignore`에 scripts 제외 항목 없음 확認.

## 검증
Docker 데몬이 이 샌드박스에서 가동 불가(Docker Desktop 실행 시도 실패) — **못 돌리는 것 자체를 정직하게 적는다**. 대신 Dockerfile builder 스테이지의 COPY 집합(package.json·node_modules·packages/·apps/web/·ee/·scripts/)을 그대로 재현한 격리 디렉토리로 대리검증:
1. `scripts/` 뺀 채로 `tsc --noEmit` → Cloud Build 로그와 **글자 그대로 같은 TS2307 에러 3건** 동시 재현(`verify-no-new-raw-fetch-api.ts`·`i18n-key-coverage.test.ts`·`pagination-envelope-consumers.test.ts` — 「첫 오류에서 멈춰 하나만 보였다」는 PO 진단과 일치).
2. `scripts/` 추가 후 재실행 → **exit 0**.

진짜 `docker build`는 배포 58 재dispatch가 실측(PO 몫).

같은 경로를 import하는 3파일 전부 확認됨 — 셋 다 격리 재현에서 동시에 깨지고 동시에 풀렸다.

실 worktree: `tsc --noEmit` clean · `vitest run` 3파일 18/18 GREEN.

## 적기만(별건 스토리, PO가 오픈)
- 가드 「apps/web 안 파일의 `../../..` 밖 import 대상 경로 ⊆ Dockerfile COPY 집합」(같은 클래스 재발 차단).
- 공유 파서를 `packages/`로 이관하는 근본안 판단.

## 게이트
카디르 QA(Dockerfile diff·경로 실재) 최우선 큐 · 유나 해당 없음 · 배포 58 재dispatch로 최종 실측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGJiE8cPVwnsEmCrE2zakd