### PR TITLE
[SID:3728] fix(i18n): 정방향 가드 사각 2건 + 미사용 키 정리 후보 목록(artifact)

### DIFF
--- a/apps/web/src/lib/i18n-template-key-coverage.test.ts
+++ b/apps/web/src/lib/i18n-template-key-coverage.test.ts
@@ -45,7 +45,10 @@ function hasKey(messages: unknown, dotted: string): boolean {
 // 새 템플릿 조합 키(`t(\`prefix_${var}\`)` 형태)를 만들면 이 표가 조용히 낡는다. 그 상태로는
 // 가드가 계속 초록인데 새 키만 화면에 그대로 뜬다 — 새 조합 키를 추가할 때 반드시 여기 항목을
 // 같이 추가할 것.
-const TEMPLATE_KEY_TABLE: Array<[string, string[], string]> = [
+// story #3728 — export되어 verify-no-unused-i18n-keys.ts(reverse-key 가드)가 재사용한다.
+// 이 표에 등록된 조합 키는 "사용됨"으로 간주(정적 스캔이 못 보는 동적 조합의 알려진
+// 유한 부분집합) — 복제 0, 소비처가 이 표 하나를 SSOT로 같이 본다.
+export const TEMPLATE_KEY_TABLE: Array<[string, string[], string]> = [
   ['proofCapsule.risk.', ['low', 'medium', 'high'], 'proof-capsule.tsx RISK_KEY 값 타입'],
   ['settings.mcpConnections.status.', ['active', 'error', 'pending_oauth', 'disconnected'], 'mcp-connection-settings.tsx McpConnectionSummary.status'],
   ['settings.mcpConnections.auth.', ['oauth', 'api_key', 'api_token'], 'mcp-connection-settings.tsx McpConnectionSummary.authStrategy'],
@@ -65,6 +68,12 @@ const TEMPLATE_KEY_TABLE: Array<[string, string[], string]> = [
   ['loops.status', ['Draft', 'Briefing', 'Generating', 'Deciding', 'Executing', 'Measuring', 'Closed', 'Abandoned'], 'loop-status-badge.tsx LoopStatus'],
   ['settings.notification_category_', ['story', 'task', 'sprint', 'system'], 'settings/page.tsx NOTIFICATION_CATEGORIES'],
   ['settings.event_', ['story', 'story_assigned', 'task', 'task_assigned', 'task_completed', 'sprint_closed', 'info', 'warning', 'system', 'standup_reminder', 'reward', 'invitation'], 'settings/page.tsx NOTIFICATION_CATEGORIES[].types'],
+  // story #3728(unused-key 역방향 가드 착수 중 발견) — recruiter-client.tsx WakeMethodBody의
+  // `t.rich(\`kitOrientingWakeBody_${method}\`, ...)`가 애초에 이 표에 등록된 적이 없던
+  // 진짜 사각(이 가드 자신의 미검출 갭). 'unknown'은 별도 분기(kitOrientingWakeBodyUnknown,
+  // 위 t('...') 정적 호출로 이미 잡힘)라 여기 값 목록에서 제외 — RuntimeWakeMethod(services/
+  // recruit.ts)의 나머지 5값. 5키 전부 ko/en에 이미 존재 확認(신규 추가 아님).
+  ['recruiter.kitOrientingWakeBody_', ['channel-plugin', 'channel-plugin-marketplace', 'connector-host', 'connector-sidecar', 'connector-sdk'], 'services/recruit.ts RuntimeWakeMethod(\'unknown\' 제외 — 별도 분기)'],
 ];
 
 describe('i18n 템플릿 리터럴 조합 키 커버리지 — 정적 가드 사각지대의 유한 부분집합 (#2228)', () => {

--- a/scripts/i18n-key-parser.js
+++ b/scripts/i18n-key-parser.js
@@ -117,9 +117,15 @@ const HOOK_BIND_RE = /const\s+(\w+)\s*=\s*(?:await\s+)?(?:useTranslations|getTra
  * 양성을 낸다. 룩비하인드에 `.`을 추가해 「바로 앞이 단어문자·`$`·`.` 중 어느 것도 아닐
  * 때만」 매치하도록 좁힌다 — 로컬 `t()` 직접 호출(정상 케이스)은 앞이 공백·`(`·`{` 등이라
  * 영향 없고, 멤버 접근(`xxx.t(...)`)만 제외된다.
+ *
+ * story #3728(미르코, unused-key 역방향 가드 착수 중 발견) — `t.rich('key', {...})`
+ * (next-intl의 리치텍스트 렌더 API, 21개 실사용처 실측)는 `varName\(`이 리터럴로 "t("를
+ * 요구해 "t.rich("엔 안 걸렸다. `(?:\.rich)?`를 `\(` 앞에 얹는다 — 룩비하인드는 `varName`
+ * 시작 위치 그대로라 `acc.t.rich(...)` 같은 멤버 접근은 여전히 배제된다(위 #3149 보호
+ * 그대로 유지, 시작 문자 앞이 `.`이면 애초에 매치 자체가 시작 안 함).
  */
 function extractKeyUsages(content, varName) {
-  const re = new RegExp(`(?<![\\w$.])${escapeRegExp(varName)}\\(\\s*['"]([\\w.]+)['"]`, 'g');
+  const re = new RegExp(`(?<![\\w$.])${escapeRegExp(varName)}(?:\\.rich)?\\(\\s*['"]([\\w.]+)['"]`, 'g');
   return [...content.matchAll(re)].map((m) => m[1]);
 }
 

--- a/scripts/i18n-key-parser.test.js
+++ b/scripts/i18n-key-parser.test.js
@@ -67,6 +67,23 @@ describe('extractKeyUsages — 멤버접근(`obj.t(...)`)은 로컬 t() 호출�
   });
 });
 
+// story #3728 — t.rich('key', {...})(next-intl 리치텍스트 렌더 API)는 위 varName\( 정규식이
+// 리터럴 "t(" 시작을 요구해 안 잡혔다(21개 실사용처 실측, unused-key 역방향 가드 착수 중 발견).
+describe('extractKeyUsages — t.rich(...)도 로컬 t()와 동형으로 잡힌다(story #3728)', () => {
+  it('t.rich(\'key\', {...})가 잡힌다(실사례: proof-capsule.tsx t.rich(\'gate.owner\', ...))', () => {
+    expect(extractKeyUsages("t.rich('gate.owner', { name });", 't')).toEqual(['gate.owner']);
+  });
+
+  it('멤버접근 acc.t.rich(...)는 여전히 안 잡힌다(#3149 보호가 .rich 확장 뒤에도 유지)', () => {
+    expect(extractKeyUsages("acc.t.rich('title', {});", 't')).toEqual([]);
+  });
+
+  it('한 파일에 t(...)와 t.rich(...)가 공존하면 둘 다 잡힌다', () => {
+    const content = "t('plain');\nt.rich('richOne', {});";
+    expect(extractKeyUsages(content, 't')).toEqual(['plain', 'richOne']);
+  });
+});
+
 describe('extractHookBindings — useTranslations/getTranslations 훅 바인딩 추출', () => {
   it('const 변수명 = useTranslations(ns) 패턴을 잡는다', () => {
     const map = extractHookBindings("const t = useTranslations('nav');");


### PR DESCRIPTION
## 요약(성격 전환 — PO 決 2026-09-09)

이 스토리는 원래 "미사용(역방향) i18n 키" CI 가드 신설이었다. 그라운딩 실측 결과, 정규식 파서(`extractKeyUsages`)로는 「역방향 완전성」을 원리상 보장할 수 없다는 것이 드러났다:

1. **pass1(정적)**: 정규식 미해석 **1267/5185(24.4%)** — `acc.t('key')` 콜백/스코프 객체 멤버접근(story #3149가 정방향에서 의도적으로 배제한 바로 그 패턴), 함수가 리터럴 키를 통째 반환하는 헬퍼 등, 정규식이 원리상 못 보는 패턴을 이 코드베이스가 광범위하게 씀.
2. **pass2(문자열 존재 검사, PO 지정 방법론)**: 정규식 미해석 후보 ∩ 리프 키 이름이 apps/web+packages+ee 어디에도 따옴표/백틱 문자열로 「존재조차」 안 함 → 592개.
3. **pass3(동적 조합 사이트 분리, PO 리뷰로 추가)**: pass2 초안이 `flow.ladderName_*` 등 **43개** 키를 「리터럴 문자열 부재」로 오판했다 — 실제로는 `t(\`ladderName_${level}\`)`류 템플릿 조합으로 살아있는데, 조합된 전체 문자열이 코드에 리터럴로 나타나지 않아 pass2가 원리상 못 잡는 클래스였다. apps/web+ee 전체에서 네임스페이스 훅 바인딩과 함께 조합 사이트를 전수 추출(58곳 자동+1곳 수동)해 12개 접두사 그룹·43키를 분리 → **592 → 549**.

549는 "수백" 구간이라 CI 가드로는 신호 대 잡음이 안 맞는다 — PO 決으로 **① 정방향 가드 개선(이 PR) ② 일회 정리 목록(artifact, 삭제 0건) ③ 컴파일러 기반 완전 해석 가드는 story #3732(backlog, 별건)**로 성격 전환.

## ① 정방향 가드 개선(이 PR의 코드 변경 전부)

1. `extractKeyUsages`(공유 파서, `scripts/i18n-key-parser.js`)가 `t.rich('key', {...})`(next-intl 리치텍스트 렌더 API)를 못 잡던 갭 — 21개 실사용처 실측 후 `(?:\.rich)?` 삽입으로 확장. #3149 멤버접근 오귀속 보호(`acc.t.rich(...)` 배제)는 lookbehind가 `varName` 시작 위치를 그대로 지켜 구조적으로 유지.
2. `TEMPLATE_KEY_TABLE`(story #2228, `i18n-template-key-coverage.test.ts`)에 `recruiter.kitOrientingWakeBody_` 프리픽스(RuntimeWakeMethod 5값) 신규 등재 — 이 가드 자신이 처음부터 못 보던 진짜 사각. 5키 전부 ko/en에 이미 존재 확認(신규 키 추가 아님). 양성대조: 가짜 값 주입 → RED 확認 後 원복.

## ② 미사용 키 정리 후보 목록 — Sprintable artifact(코드 아님)

[미사용 i18n 키 정리 후보 목록](entity:doc:80efc90e-e970-4112-934c-e6d4943d91f0) — pass3 분리 뒤 **549개**, 네임스페이스별 집계(34개 영향)+**pass3 조합-도달 43키(12개 접두사 그룹, file:line 포함)** 별도 절+**층화10+무작위10(20건, 시드 43) 재표본**(20/20 진짜 죽음, pass3 밖 클래스 0건). `agents`(70%, 워크플로우 에디터 계열 통째 은퇴 정황)·`usage`(79%)·`pricing`(68%) 등 고비율 네임스페이스는 "기능 자체가 은퇴됐는가"를 먼저 확認하도록 안내. **삭제는 이 PR·이 목록에서 0건** — 후속 배치 삭제 스토리 몫. pass3가 찾은 미등록 조합 사이트는 story #2228 후속 몫으로 남기고 이 PR에서 TEMPLATE_KEY_TABLE에 등재하지 않는다(PO 決).

## 테스트

`i18n-key-parser.test.js`에 `.rich()` 3건(정상 호출·멤버접근 배제·공존) 추가 — 16/16 GREEN. `i18n-key-coverage.test.ts`·`i18n-template-key-coverage.test.ts` 무회귀.

## 검증
- `vitest run` — parser 16/16, coverage 가드 2/2.
- `tsc --noEmit`/`eslint` clean.
- `next build --webpack` 성공.

## 게이트
카디르 QA(fail 방향 코드 판정·동적 조합/네임스페이스 오탐 0 표본) — **코드 3파일은 리뷰 완료(PO)**, artifact는 PO 리뷰 반영해 새 리비전 게시 완료. 유나 해당 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGJiE8cPVwnsEmCrE2zakd