### PR TITLE
[SID:3722] feat(BE): 도구 호출 감사 파이프라인 PR1 — agent_run_tool_calls 테이블+미들웨어+귀속+조회

### DIFF
--- a/backend/alembic/versions/0356_agent_run_tool_calls.py
+++ b/backend/alembic/versions/0356_agent_run_tool_calls.py
@@ -1,0 +1,62 @@
+"""story #3722(Trust·BE, 페드루 PO 確定 2026-09-09) — 에이전트 인증 API 요청 1건 =
+agent_run_tool_calls 1행. unhandled_error_events(0355)와 동형 관례(FK 없는 org_id/
+method/path·비밀값 미저장) — run_id만 예외로 FK를 건다(agent_runs.id ON DELETE CASCADE,
+그 run이 지워지면 그 run에 귀속된 호출 기록도 같이 지워지는 게 정직 — 「run이 없는데
+run의 도구 호출 기록만 남는」 모순 방지). agent_id/org_id는 FK 없음(unhandled_error_
+events 관례 그대로 — 조회용 요약 테이블, 강제 조인 이유 0).
+
+Revision ID: 0356
+Revises: 0355
+Create Date: 2026-09-09
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0356"
+down_revision = "0355"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_run_tool_calls",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "run_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("agent_runs.id", ondelete="CASCADE"), nullable=True,
+        ),
+        sa.Column("tool", sa.Text(), nullable=True),
+        sa.Column("method", sa.Text(), nullable=False),
+        sa.Column("path", sa.Text(), nullable=False),
+        sa.Column("status_code", sa.Integer(), nullable=False),
+        sa.Column("duration_ms", sa.Integer(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("input_summary", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("attribution_reason", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # run_id·created_at 복합 인덱스 — GET /agent-runs/{id}/tool-calls 커서 조회(run_id로
+    # 필터 후 created_at DESC 최신순)가 정본 읽기 경로.
+    op.create_index(
+        "ix_agent_run_tool_calls_run_id_created_at", "agent_run_tool_calls", ["run_id", "created_at"],
+    )
+    # org_id·created_at — 보존기간 정리 스윕(30일)이 org 무관 전역 스캔이라 이 인덱스는
+    # created_at 단독으로도 충분하지만, 향후 org별 감사 조회 대비 겸용으로 같이 둔다.
+    op.create_index("ix_agent_run_tool_calls_created_at", "agent_run_tool_calls", ["created_at"])
+    op.create_index("ix_agent_run_tool_calls_agent_id", "agent_run_tool_calls", ["agent_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_run_tool_calls_agent_id", table_name="agent_run_tool_calls")
+    op.drop_index("ix_agent_run_tool_calls_created_at", table_name="agent_run_tool_calls")
+    op.drop_index("ix_agent_run_tool_calls_run_id_created_at", table_name="agent_run_tool_calls")
+    op.drop_table("agent_run_tool_calls")

--- a/backend/alembic/versions/0357_agent_run_tool_calls.py
+++ b/backend/alembic/versions/0357_agent_run_tool_calls.py
@@ -7,11 +7,14 @@ events 관례 그대로 — 조회용 요약 테이블, 강제 조인 이유 0).
 
 ⚠️페드루 PO 지시(2026-09-09 07:28Z) — 미르코 #4079(3734, 0356_site_channel_post_
 drafts_soft_delete)와 revision 0356이 충돌해 #4079를 먼저 착지시키기로(선생님 급)
-0357·down_revision="0355"(임시)로 재번호했다. #4079 착지 뒤 develop 리베이스하며
-down_revision을 "0356"으로 한 번 더 고칠 것 — 지금은 과도기 상태.
+0357로 재번호했다. down_revision은 "0356"(#4079가 develop에 아직 안 착지한 지금은
+alembic sibling-collision 가드가 RED가 정상 — #4079 착지 뒤 rebase 한 번이면
+그린으로 정리된다). 페드루 PO 추가 지시(07:54Z) — #4079의 dual-head 대칭 가드가
+#4076이 0357(down 0355)로 열려 있는 한 #4079를 영원히 RED로 잡아 down을 다시
+"0356"으로 되돌림(과도기 down=0355는 폐기).
 
 Revision ID: 0357
-Revises: 0355
+Revises: 0356
 Create Date: 2026-09-09
 """
 from __future__ import annotations
@@ -22,7 +25,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 revision = "0357"
-down_revision = "0355"
+down_revision = "0356"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0357_agent_run_tool_calls.py
+++ b/backend/alembic/versions/0357_agent_run_tool_calls.py
@@ -5,7 +5,12 @@ method/path·비밀값 미저장) — run_id만 예외로 FK를 건다(agent_run
 run의 도구 호출 기록만 남는」 모순 방지). agent_id/org_id는 FK 없음(unhandled_error_
 events 관례 그대로 — 조회용 요약 테이블, 강제 조인 이유 0).
 
-Revision ID: 0356
+⚠️페드루 PO 지시(2026-09-09 07:28Z) — 미르코 #4079(3734, 0356_site_channel_post_
+drafts_soft_delete)와 revision 0356이 충돌해 #4079를 먼저 착지시키기로(선생님 급)
+0357·down_revision="0355"(임시)로 재번호했다. #4079 착지 뒤 develop 리베이스하며
+down_revision을 "0356"으로 한 번 더 고칠 것 — 지금은 과도기 상태.
+
+Revision ID: 0357
 Revises: 0355
 Create Date: 2026-09-09
 """
@@ -16,7 +21,7 @@ from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
-revision = "0356"
+revision = "0357"
 down_revision = "0355"
 branch_labels = None
 depends_on = None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -410,6 +410,13 @@ from app.services.au_metering import AUMeteringMiddleware  # noqa: E402
 
 app.add_middleware(AUMeteringMiddleware)
 
+# story #3722(Trust·BE) — 에이전트 인증 API 요청 1건 = agent_run_tool_calls 1행(서버
+# 관측 기록). AUMeteringMiddleware와 같은 SSOT(request.state.au_actor/au_org_id/
+# au_user_id)를 재사용 — 새 에이전트 판별 로직 0. fail-open(기록 실패가 요청에 영향 0).
+from app.services.tool_call_recording import ToolCallRecordingMiddleware  # noqa: E402
+
+app.add_middleware(ToolCallRecordingMiddleware)
+
 app.include_router(auth.router)
 app.include_router(health.router)
 app.include_router(activity_logs.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
 from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPersona
 from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
+from app.models.agent_run_tool_call import AgentRunToolCall
 from app.models.agent_session import AgentSession
 from app.models.auth_identity import AuthIdentity, AuthMigration, AuthMigrationEvent
 from app.models.auth_native_bootstrap import AuthNativeBootstrapCode

--- a/backend/app/models/agent_run_tool_call.py
+++ b/backend/app/models/agent_run_tool_call.py
@@ -1,0 +1,48 @@
+"""story #3722 — 에이전트 인증 API 요청 1건 = 이 테이블 1행. `unhandled_error_events`
+(0355)와 동형 관례: 비밀값(헤더·raw 쿼리스트링·body 원문)은 저장하지 않는다 —
+`input_summary`는 이미 마스킹·절단된 요약만(app/services/tool_call_masking.py).
+
+`run_id`만 예외로 FK(ON DELETE CASCADE) — 그 외 org_id/agent_id는 FK 없음(조회용 요약
+테이블, 강제 조인 이유 0 — 인증 직후 삭제 경합 등으로 참조 대상이 이미 사라졌어도 이
+기록 자체는 「그 요청이 있었다」는 사실을 안 잃는다)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AgentRunToolCall(Base):
+    __tablename__ = "agent_run_tool_calls"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    run_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agent_runs.id", ondelete="CASCADE"), nullable=True,
+    )
+    # PR2(MCP 이름표, X-Sprintable-Tool)가 채우기 전까지는 항상 null — REST 직접 호출은
+    # 이름표가 없어도 method/path만으로 기록이 선다(그 자체가 이 스토리의 요구사항).
+    tool: Mapped[str | None] = mapped_column(Text, nullable=True)
+    method: Mapped[str] = mapped_column(Text, nullable=False)
+    # 쿼리스트링 제외(unhandled_error_events 관례 그대로 — 토큰/코드류가 쿼리에 실릴 수
+    # 있다) — 라우트 템플릿이 있으면 그것(예 "/api/v2/stories/{id}"), 없으면 raw path.
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    status_code: Mapped[int] = mapped_column(Integer, nullable=False)
+    duration_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    input_summary: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 열거형 문자열(tool_call_attribution.py의 AttributionReason과 동형) — 귀속 성공
+    # 케이스도 값을 남겨(header/story_scope/single_running) 분포를 셀 수 있게 한다(페드루
+    # PO 지시 — ⓐ/ⓑ'/ⓑ/ⓒ 각 1건 라이브 재현이 AC).
+    attribution_reason: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False,
+    )

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -8,10 +8,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.agent_run_tool_call import AgentRunToolCall
 from app.models.project import Project
 from app.models.team import TeamMember
 from app.repositories.agent_run import AgentRunRepository
 from app.schemas.agent_run import AgentRunResponse, CreateAgentRun, UpdateAgentRun
+from app.schemas.agent_run_tool_call import AgentRunToolCallResponse
 from app.services.agent_run_lifecycle import AGENT_RUN_TIMEOUT_HOURS
 
 router = APIRouter(prefix="/api/v2/agent-runs", tags=["agent-runs", "Work"])
@@ -142,6 +144,43 @@ async def get_agent_run(
         raise HTTPException(status_code=404, detail="Agent run not found")
     name_map = await _agent_name_map(session, {run.agent_id})
     return AgentRunResponse.model_validate(run).model_copy(update={"agent_name": name_map.get(run.agent_id)})
+
+
+@router.get("/{id}/tool-calls", response_model=list[AgentRunToolCallResponse])
+async def list_agent_run_tool_calls(
+    id: uuid.UUID,
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentRunRepository = Depends(_get_repo),
+) -> list[AgentRunToolCallResponse]:
+    """story #3722(Trust·BE) — AgentRunResponse엔 안 싣는다(크기·조회 축 분리, PO 確定).
+    같은 인가축(get_agent_run과 동일 — org 검증 후 has_project_access, 없거나 타org·
+    무접근권은 404). 최신순(created_at DESC) — cursor는 이전 페이지 마지막 행의
+    created_at(ISO 8601), list_agent_runs의 커서 관례와 동형."""
+    from app.services.project_auth import has_project_access
+
+    run = await repo.get(id)
+    if run is None or run.org_id != org_id:
+        raise HTTPException(status_code=404, detail="Agent run not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), run.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Agent run not found")
+
+    cursor_dt: datetime | None = None
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid cursor (expected ISO 8601 datetime)")
+
+    q = select(AgentRunToolCall).where(AgentRunToolCall.run_id == id)
+    if cursor_dt is not None:
+        q = q.where(AgentRunToolCall.created_at < cursor_dt)
+    q = q.order_by(AgentRunToolCall.created_at.desc()).limit(limit)
+    rows = list((await session.execute(q)).scalars().all())
+    return [AgentRunToolCallResponse.model_validate(r) for r in rows]
 
 
 async def _agent_name_map(session: AsyncSession, agent_ids: set[uuid.UUID]) -> dict[uuid.UUID, str]:

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -2,8 +2,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from sqlalchemy import select
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Response
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -148,6 +148,7 @@ async def get_agent_run(
 
 @router.get("/{id}/tool-calls", response_model=list[AgentRunToolCallResponse])
 async def list_agent_run_tool_calls(
+    response: Response,
     id: uuid.UUID,
     limit: int = Query(default=50, ge=1, le=200),
     cursor: str | None = Query(default=None),
@@ -159,7 +160,11 @@ async def list_agent_run_tool_calls(
     """story #3722(Trust·BE) — AgentRunResponse엔 안 싣는다(크기·조회 축 분리, PO 確定).
     같은 인가축(get_agent_run과 동일 — org 검증 후 has_project_access, 없거나 타org·
     무접근권은 404). 최신순(created_at DESC) — cursor는 이전 페이지 마지막 행의
-    created_at(ISO 8601), list_agent_runs의 커서 관례와 동형."""
+    created_at(ISO 8601), list_agent_runs의 커서 관례와 동형.
+
+    X-Total-Count(페드루 PO 追加 2026-09-09) — run_id 기준 전체 건수(limit 適用 前,
+    cursor 페이지와 무관) — 3703/3706류(«한 페이지=전부」 오판) 재발 방지, goals.py
+    list_goals와 동형 관례."""
     from app.services.project_auth import has_project_access
 
     run = await repo.get(id)
@@ -174,6 +179,11 @@ async def list_agent_run_tool_calls(
             cursor_dt = datetime.fromisoformat(cursor)
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid cursor (expected ISO 8601 datetime)")
+
+    total = (await session.execute(
+        select(func.count()).select_from(AgentRunToolCall).where(AgentRunToolCall.run_id == id)
+    )).scalar_one()
+    response.headers["X-Total-Count"] = str(total)
 
     q = select(AgentRunToolCall).where(AgentRunToolCall.run_id == id)
     if cursor_dt is not None:

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1352,6 +1352,14 @@ async def publication_commands_tick(
         except Exception as exc:
             logger.exception("unhandled-error-events sweep tick error: %s", exc)
             counts["unhandled_error_events_swept"] = {"error": "unhandled"}
+        # story #3722(2026-09-09) — agent_run_tool_calls 30일 보존 정리. 위 축들과 같은
+        # 피기백 사상(새 Cloud Scheduler 잡 0) — 독립 try.
+        try:
+            from app.services.tool_call_recording import sweep_old_tool_calls
+            counts["agent_run_tool_calls_swept"] = await sweep_old_tool_calls(session)
+        except Exception as exc:
+            logger.exception("agent-run-tool-calls sweep tick error: %s", exc)
+            counts["agent_run_tool_calls_swept"] = {"error": "unhandled"}
         return _ok(counts)
     except Exception as exc:
         logger.exception("publication-commands cron error: %s", exc)

--- a/backend/app/schemas/agent_run_tool_call.py
+++ b/backend/app/schemas/agent_run_tool_call.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AgentRunToolCallResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    agent_id: uuid.UUID
+    run_id: uuid.UUID | None
+    tool: str | None
+    method: str
+    path: str
+    status_code: int
+    duration_ms: int
+    started_at: datetime
+    input_summary: dict[str, Any] | None
+    error: str | None
+    attribution_reason: str
+    created_at: datetime

--- a/backend/app/services/tool_call_attribution.py
+++ b/backend/app/services/tool_call_attribution.py
@@ -1,0 +1,114 @@
+"""story #3722(Trust·BE, 페드루 PO 確定 2026-09-09) — 에이전트 인증 요청 1건을 어느
+`agent_runs` 행에 귀속시킬지 추측 0으로 판정한다.
+
+체인(순서 그대로, 앞이 맞으면 뒤는 안 본다):
+  ⓐ header  — 요청에 `X-Sprintable-Run-Id`가 있고 그 run이 이 agent 것이면 그것.
+  ⓑ' story_scope — 요청이 story_id를 지니면(경로 템플릿 파라미터·쿼리·JSON body
+    최상위 — task→story 역조회는 안 한다) 이 agent의 **그 story**에 대한 running run이
+    정확히 1개일 때 그것.
+  ⓑ single_running — story_id가 없거나(또는 있어도 그 story엔 running run이 0개라
+    ⓑ'가 못 정했을 때) 이 agent 전체의 running run이 정확히 1개일 때 그것.
+  ⓒ 미귀속(run_id=None) — 그 외 전부. attribution_reason으로 세 갈래를 가른다:
+    - no_running_run: agent 전체 running run이 0개.
+    - ambiguous_multi_run: agent 전체 running run이 2개 이상(story_scope도 못 정한 뒤).
+    - ambiguous_multi_run_same_story: story_id는 있는데 **그 story**의 running run이
+      2개 이상 — 이건 agent-wide ⓑ로 안 내려간다(페드루 PO 판정: story 문맥이 있는데
+      거기서 이미 모호하면, 그 문맥을 버리고 agent 전체에서 다시 고르는 게 오히려 틀린
+      run을 정직해 보이게 만든다 — story 스코프가 있었다는 사실 자체를 reason에 남긴다).
+
+디디 판단(문서화 — 확認 필요, 명시 안 된 갈림길): story_id가 있는데 그 story의 running
+run이 **0개**인 경우는 ambiguous도 no_running_run도 아니라서 그대로 agent-wide ⓑ로
+내려간다(그 story 자체는 지금 안 도는 중일 뿐, agent 전체엔 다른 running run이 있을 수
+있다 — «이 story 얘기는 아니지만 이 agent 얘기는 맞다»는 뜻)."""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_run import AgentRun
+
+HEADER_NAME = "x-sprintable-run-id"
+
+
+@dataclass(frozen=True)
+class AttributionResult:
+    run_id: uuid.UUID | None
+    reason: str
+
+
+async def attribute_tool_call(
+    session: AsyncSession,
+    *,
+    agent_id: uuid.UUID,
+    header_run_id: str | None,
+    story_id: str | None,
+) -> AttributionResult:
+    # ⓐ header — 이 agent 소유가 아니면(다른 agent의 run_id를 사칭) 조용히 무시하고
+    # 체인을 계속 진행한다(401/403을 던지지 않는다 — 이 미들웨어는 기록 축이지 인가
+    # 축이 아니다, fail-open 원칙 그대로).
+    if header_run_id:
+        try:
+            header_uuid = uuid.UUID(header_run_id)
+        except ValueError:
+            header_uuid = None
+        if header_uuid is not None:
+            owned = (await session.execute(
+                select(AgentRun.id).where(AgentRun.id == header_uuid, AgentRun.agent_id == agent_id)
+            )).scalar_one_or_none()
+            if owned is not None:
+                return AttributionResult(run_id=owned, reason="header")
+
+    # ⓑ' story_scope
+    if story_id:
+        try:
+            story_uuid = uuid.UUID(story_id)
+        except ValueError:
+            story_uuid = None
+        if story_uuid is not None:
+            story_running = list((await session.execute(
+                select(AgentRun.id).where(
+                    AgentRun.agent_id == agent_id, AgentRun.story_id == story_uuid,
+                    AgentRun.status == "running",
+                )
+            )).scalars().all())
+            if len(story_running) == 1:
+                return AttributionResult(run_id=story_running[0], reason="story_scope")
+            if len(story_running) >= 2:
+                return AttributionResult(run_id=None, reason="ambiguous_multi_run_same_story")
+            # 0개 — story 문맥은 있으나 그 story엔 running run이 없다. agent-wide로 계속.
+
+    # ⓑ single_running(agent 전체)
+    agent_running = list((await session.execute(
+        select(AgentRun.id).where(AgentRun.agent_id == agent_id, AgentRun.status == "running")
+    )).scalars().all())
+    if len(agent_running) == 1:
+        return AttributionResult(run_id=agent_running[0], reason="single_running")
+    if len(agent_running) == 0:
+        return AttributionResult(run_id=None, reason="no_running_run")
+    return AttributionResult(run_id=None, reason="ambiguous_multi_run")
+
+
+def extract_story_id(
+    *, route_path: str | None, path_params: dict[str, str] | None,
+    query_params: dict[str, str] | None, body: dict[str, object] | None,
+) -> str | None:
+    """path 템플릿 파라미터 → 쿼리 → JSON body 최상위 순으로 story_id 후보를 찾는다
+    (첫 발견을 쓴다 — 여러 축에서 다른 값이 오는 모순 상황은 이 스토리 범위 밖, path
+    파라미터가 가장 신뢰도 높은 축이라 최우선). task→story 역조회는 하지 않는다(비용·
+    정확성 트레이드오프, 스토리 명시).
+
+    `/api/v2/stories/{id}`류(파라미터명이 `story_id`가 아니라 `id`)는 라우트 템플릿
+    문자열에 `/stories/`가 있을 때만 그 `id`를 story_id로 본다 — `id`라는 이름만으로는
+    어느 리소스인지 알 수 없다(예: `/api/v2/tasks/{id}`의 id는 task_id다)."""
+    if path_params and path_params.get("story_id"):
+        return str(path_params["story_id"])
+    if path_params and path_params.get("id") and route_path and "/stories/" in route_path:
+        return str(path_params["id"])
+    if query_params and query_params.get("story_id"):
+        return str(query_params["story_id"])
+    if body and isinstance(body.get("story_id"), str):
+        return body["story_id"]
+    return None

--- a/backend/app/services/tool_call_attribution.py
+++ b/backend/app/services/tool_call_attribution.py
@@ -8,7 +8,7 @@
     정확히 1개일 때 그것.
   ⓑ single_running — story_id가 없거나(또는 있어도 그 story엔 running run이 0개라
     ⓑ'가 못 정했을 때) 이 agent 전체의 running run이 정확히 1개일 때 그것.
-  ⓒ 미귀속(run_id=None) — 그 외 전부. attribution_reason으로 세 갈래를 가른다:
+  ⓒ 미귀속(run_id=None) — 그 외 전부. attribution_reason으로 갈래를 가른다:
     - no_running_run: agent 전체 running run이 0개.
     - ambiguous_multi_run: agent 전체 running run이 2개 이상(story_scope도 못 정한 뒤).
     - ambiguous_multi_run_same_story: story_id는 있는데 **그 story**의 running run이
@@ -16,10 +16,13 @@
       거기서 이미 모호하면, 그 문맥을 버리고 agent 전체에서 다시 고르는 게 오히려 틀린
       run을 정직해 보이게 만든다 — story 스코프가 있었다는 사실 자체를 reason에 남긴다).
 
-디디 판단(문서화 — 확認 필요, 명시 안 된 갈림길): story_id가 있는데 그 story의 running
+디디 판단(채택 — 페드루 PO 2026-09-09 06:22Z): story_id가 있는데 그 story의 running
 run이 **0개**인 경우는 ambiguous도 no_running_run도 아니라서 그대로 agent-wide ⓑ로
 내려간다(그 story 자체는 지금 안 도는 중일 뿐, agent 전체엔 다른 running run이 있을 수
-있다 — «이 story 얘기는 아니지만 이 agent 얘기는 맞다»는 뜻)."""
+있다 — «이 story 얘기는 아니지만 이 agent 얘기는 맞다»는 뜻). 단 이 낙하로 정해진 run은
+정의상 그 story의 것이 아니므로(그랬다면 위에서 이미 story_running에 걸렸을 것) reason을
+평범한 single_running과 갈라 **single_running_other_story**로 남긴다 — 「오귀속 의심」을
+나중에 셀 수 있는 유일한 단서(페드루 PO 追加)."""
 from __future__ import annotations
 
 import uuid
@@ -62,6 +65,7 @@ async def attribute_tool_call(
                 return AttributionResult(run_id=owned, reason="header")
 
     # ⓑ' story_scope
+    story_fallthrough = False
     if story_id:
         try:
             story_uuid = uuid.UUID(story_id)
@@ -78,14 +82,17 @@ async def attribute_tool_call(
                 return AttributionResult(run_id=story_running[0], reason="story_scope")
             if len(story_running) >= 2:
                 return AttributionResult(run_id=None, reason="ambiguous_multi_run_same_story")
-            # 0개 — story 문맥은 있으나 그 story엔 running run이 없다. agent-wide로 계속.
+            # 0개 — story 문맥은 있으나 그 story엔 running run이 없다. agent-wide로 계속
+            # (아래서 고르는 run은 정의상 이 story의 것이 아니다 — reason을 갈라 남긴다).
+            story_fallthrough = True
 
     # ⓑ single_running(agent 전체)
     agent_running = list((await session.execute(
         select(AgentRun.id).where(AgentRun.agent_id == agent_id, AgentRun.status == "running")
     )).scalars().all())
     if len(agent_running) == 1:
-        return AttributionResult(run_id=agent_running[0], reason="single_running")
+        reason = "single_running_other_story" if story_fallthrough else "single_running"
+        return AttributionResult(run_id=agent_running[0], reason=reason)
     if len(agent_running) == 0:
         return AttributionResult(run_id=None, reason="no_running_run")
     return AttributionResult(run_id=None, reason="ambiguous_multi_run")

--- a/backend/app/services/tool_call_masking.py
+++ b/backend/app/services/tool_call_masking.py
@@ -1,0 +1,59 @@
+"""story #3722(Trust·BE, 페드루 PO 確定 2026-09-09) — `agent_run_tool_calls.input_summary`에
+싣기 前에 요청 바디/쿼리를 마스킹·절단한다. #2836(agent_auth_failure.py) 규율 계승 —
+「원장·로그·이후 모든 신호 payload엔 raw 값이 절대 안 나간다」.
+
+규칙(스토리 確定 설계 그대로): 키 denylist(대소문자 무관 부분일치)면 값을 `[REDACTED]`로
+통째 대체 · 나머지 문자열 값은 120자에서 절단 · 최종 JSON 직렬화 결과가 2KB를 넘으면
+통째로 `{"_truncated": true}`로 대체(부분 잘린 JSON을 만들지 않는다 — 파싱 불가 JSON
+조각보다 "잘렸다"는 정직한 신호가 낫다)."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_DENYLIST_SUBSTRINGS = ("token", "key", "secret", "password", "authorization", "cookie")
+_VALUE_MAX_LEN = 120
+_SUMMARY_MAX_BYTES = 2048
+_REDACTED = "[REDACTED]"
+
+
+def _is_denylisted_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(sub in lowered for sub in _DENYLIST_SUBSTRINGS)
+
+
+def _mask_value(key: str, value: Any) -> Any:
+    if _is_denylisted_key(key):
+        return _REDACTED
+    if isinstance(value, str):
+        return value if len(value) <= _VALUE_MAX_LEN else value[:_VALUE_MAX_LEN] + "…"
+    if isinstance(value, dict):
+        return mask_mapping(value)
+    if isinstance(value, list):
+        # story #3722 — 리스트는 top-level 키 마스킹 규칙이 안 미친다(키가 없다). 원소가
+        # dict면 재귀 마스킹, 아니면(문자열/숫자 등) 그대로 — 리스트 자체를 통째로
+        # [REDACTED]하지 않는다(입력 형태를 과하게 지우면 디버깅 가치가 없어진다).
+        return [mask_mapping(v) if isinstance(v, dict) else v for v in value]
+    return value
+
+
+def mask_mapping(data: dict[str, Any]) -> dict[str, Any]:
+    """dict 하나를 얕게(재귀 포함) 마스킹 — 최상위·중첩 dict 키 전부 denylist 대조."""
+    return {k: _mask_value(k, v) for k, v in data.items()}
+
+
+def build_input_summary(*, query_params: dict[str, Any], body: dict[str, Any] | None) -> dict[str, Any] | None:
+    """쿼리+바디를 마스킹해 하나의 요약으로 합친다. 요청에 실을 게 아예 없으면(둘 다
+    빈 경우) None — 「빈 dict를 저장」과 「실을 게 없었다」를 가른다(지어내지 않는다)."""
+    summary: dict[str, Any] = {}
+    if query_params:
+        summary["query"] = mask_mapping(query_params)
+    if body:
+        summary["body"] = mask_mapping(body)
+    if not summary:
+        return None
+
+    serialized = json.dumps(summary, ensure_ascii=False, default=str)
+    if len(serialized.encode("utf-8")) > _SUMMARY_MAX_BYTES:
+        return {"_truncated": True}
+    return summary

--- a/backend/app/services/tool_call_masking.py
+++ b/backend/app/services/tool_call_masking.py
@@ -42,10 +42,21 @@ def mask_mapping(data: dict[str, Any]) -> dict[str, Any]:
     return {k: _mask_value(k, v) for k, v in data.items()}
 
 
-def build_input_summary(*, query_params: dict[str, Any], body: dict[str, Any] | None) -> dict[str, Any] | None:
-    """쿼리+바디를 마스킹해 하나의 요약으로 합친다. 요청에 실을 게 아예 없으면(둘 다
-    빈 경우) None — 「빈 dict를 저장」과 「실을 게 없었다」를 가른다(지어내지 않는다)."""
+def build_input_summary(
+    *,
+    path_params: dict[str, Any] | None = None,
+    query_params: dict[str, Any],
+    body: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """경로+쿼리+바디를 마스킹해 하나의 요약으로 합친다. 요청에 실을 게 아예 없으면(셋
+    다 빈 경우) None — 「빈 dict를 저장」과 「실을 게 없었다」를 가른다(지어내지 않는다).
+
+    path_params(페드루 PO 追加 2026-09-09) — route 템플릿(`/stories/{id}/...`)만으로는
+    «어느 스토리/태스크를 건드렸나»가 안 남는다. story_id 추출에 이미 읽는 값이라
+    비용 0 — denylist·절단 규칙 동일 적용(id류는 보통 denylist에 안 걸림)."""
     summary: dict[str, Any] = {}
+    if path_params:
+        summary["path"] = mask_mapping(path_params)
     if query_params:
         summary["query"] = mask_mapping(query_params)
     if body:

--- a/backend/app/services/tool_call_masking.py
+++ b/backend/app/services/tool_call_masking.py
@@ -15,6 +15,13 @@ _DENYLIST_SUBSTRINGS = ("token", "key", "secret", "password", "authorization", "
 _VALUE_MAX_LEN = 120
 _SUMMARY_MAX_BYTES = 2048
 _REDACTED = "[REDACTED]"
+# 카디르 QA②(2026-09-09) — list→list→dict처럼 리스트 원소 안에서 다시 리스트가
+# 나오면 옛 구현(리스트 원소가 dict인지만 봄)은 그 안쪽을 그대로 통과시켜 비밀값이
+# 평문으로 DB에 남았다. 임의 깊이 재귀로 고치되, 그 재귀 자체가 이 스토리가 방금
+# 고친 것과 같은 클래스(RecursionError, `_parse_json_body`)를 마스킹 함수 자신
+# 안에서 되풀이하지 않도록 깊이 상한을 둔다 — 넘으면 그 아래는 통째 truncated.
+_MAX_DEPTH = 20
+_TRUNCATED = "[truncated]"
 
 
 def _is_denylisted_key(key: str) -> bool:
@@ -22,24 +29,28 @@ def _is_denylisted_key(key: str) -> bool:
     return any(sub in lowered for sub in _DENYLIST_SUBSTRINGS)
 
 
-def _mask_value(key: str, value: Any) -> Any:
-    if _is_denylisted_key(key):
-        return _REDACTED
+def _mask_recursive(value: Any, depth: int) -> Any:
+    if depth > _MAX_DEPTH:
+        return _TRUNCATED
     if isinstance(value, str):
         return value if len(value) <= _VALUE_MAX_LEN else value[:_VALUE_MAX_LEN] + "…"
     if isinstance(value, dict):
-        return mask_mapping(value)
-    if isinstance(value, list):
-        # story #3722 — 리스트는 top-level 키 마스킹 규칙이 안 미친다(키가 없다). 원소가
-        # dict면 재귀 마스킹, 아니면(문자열/숫자 등) 그대로 — 리스트 자체를 통째로
-        # [REDACTED]하지 않는다(입력 형태를 과하게 지우면 디버깅 가치가 없어진다).
-        return [mask_mapping(v) if isinstance(v, dict) else v for v in value]
+        return {
+            k: (_REDACTED if _is_denylisted_key(k) else _mask_recursive(v, depth + 1))
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        # story #3722 — 리스트/튜플 원소는 키가 없다(denylist 판정 대상이 아니다).
+        # dict·list·tuple 어느 형태든 depth+1로 계속 내려간다(카디르 QA② 처방 —
+        # "지정 경로만"이 아니라 형태 클래스 전체를 잡는다).
+        return [_mask_recursive(v, depth + 1) for v in value]
     return value
 
 
 def mask_mapping(data: dict[str, Any]) -> dict[str, Any]:
-    """dict 하나를 얕게(재귀 포함) 마스킹 — 최상위·중첩 dict 키 전부 denylist 대조."""
-    return {k: _mask_value(k, v) for k, v in data.items()}
+    """dict 하나를 임의 깊이로 마스킹 — 최상위·중첩 dict 키 전부 denylist 대조,
+    list/tuple 안에 몇 겹이 있든 재귀한다(깊이 상한은 `_MAX_DEPTH` 참고)."""
+    return _mask_recursive(data, depth=0)
 
 
 def build_input_summary(

--- a/backend/app/services/tool_call_recording.py
+++ b/backend/app/services/tool_call_recording.py
@@ -136,7 +136,9 @@ class ToolCallRecordingMiddleware(BaseHTTPMiddleware):
             story_id = extract_story_id(
                 route_path=route_path, path_params=path_params, query_params=query_params, body=body,
             )
-            input_summary = build_input_summary(query_params=query_params or {}, body=body)
+            input_summary = build_input_summary(
+                path_params=path_params, query_params=query_params or {}, body=body,
+            )
             error = None if response.status_code < 400 else f"HTTP {response.status_code}"
 
             fire_and_forget(_record_tool_call_safe(

--- a/backend/app/services/tool_call_recording.py
+++ b/backend/app/services/tool_call_recording.py
@@ -40,6 +40,13 @@ _MAX_BODY_BYTES = 64 * 1024  # 마스킹 前 원시 바디를 파싱 시도할 �
 
 
 async def _parse_json_body(request: Request) -> dict | None:
+    """카디르 QA①(2026-09-09) — 깊이 중첩된 JSON 배열(64KB 이하도 가능, 예: depth
+    32000 ≈ 64000 bytes)은 CPython C 가속 스캐너를 써도 `json.loads()`가 Python
+    재귀 한계를 넘겨 `RecursionError`를 던진다 — `ValueError`/`UnicodeDecodeError`
+    밖의 클래스라 예전 except가 못 잡았고, 이 함수를 부르는 자리(call_next 前)가
+    미들웨어 자신의 try/except 밖이라 원 요청 500으로 그대로 새 나갔다("기록 실패는
+    원 요청을 안 막는다"는 이 스토리 자신의 규율 위반). 예외 종류를 가리지 않는다 —
+    파싱은 기록 축 부가 작업일 뿐, 어떤 형태로 실패해도 None 폴백이 유일하게 맞는 답."""
     try:
         raw = await request.body()
     except Exception:
@@ -48,7 +55,7 @@ async def _parse_json_body(request: Request) -> dict | None:
         return None
     try:
         parsed = json.loads(raw)
-    except (ValueError, UnicodeDecodeError):
+    except Exception:
         return None
     return parsed if isinstance(parsed, dict) else None
 
@@ -117,7 +124,17 @@ class ToolCallRecordingMiddleware(BaseHTTPMiddleware):
         if request.url.path in STREAMING_PATHS:
             return await call_next(request)
 
-        body = await _parse_json_body(request) if request.method in {"POST", "PUT", "PATCH"} else None
+        # 카디르 QA①(2026-09-09) — call_next() 前 전부(지금은 바디 파싱뿐)를 감싼다.
+        # _parse_json_body 자체가 이미 모든 예외를 삼키지만, 이 자리가 이 미들웨어
+        # 자신의 유일한 call_next-前 코드라 다시 한번 fail-open으로 못박는다 — 원 요청은
+        # 이 기록 축의 어떤 실패에도 절대 500으로 새면 안 된다.
+        body: dict | None = None
+        try:
+            if request.method in {"POST", "PUT", "PATCH"}:
+                body = await _parse_json_body(request)
+        except Exception:
+            logger.error("tool-call recording body parse failed path=%s method=%s",
+                         request.url.path, request.method, exc_info=True)
 
         response = await call_next(request)
 

--- a/backend/app/services/tool_call_recording.py
+++ b/backend/app/services/tool_call_recording.py
@@ -1,0 +1,154 @@
+"""story #3722(Trust·BE, 페드루 PO 確定 2026-09-09) — 에이전트 인증 API 요청 1건을
+`agent_run_tool_calls` 1행으로 기록하는 ASGI 미들웨어.
+
+`app/services/au_metering.py`(AUMeteringMiddleware)와 동형 사상 그대로 — `call_next()`
+먼저 기다린 뒤 `request.state.au_actor`(이미 `get_current_user()`가 심어 둔 SSOT, 새
+에이전트 판별 로직 0)를 읽어 에이전트 트래픽만 고르고, 실제 DB 왕복은 `fire_and_forget()`
+으로 응답 반환 밖으로 던진다 — 기록 실패가 원 요청에 영향을 주면 안 된다(fail-open은
+"기록"에만, 원 요청 흐름은 이 미들웨어가 죽어도 안 죽는다).
+
+MCP 도구 이름표(`X-Sprintable-Tool`)는 PR2 몫 — 지금은 항상 None으로 기록되고, method+
+path만으로도 "서버가 관측했다"는 사실 자체는 선다(그게 이 스토리의 핵심 — 에이전트 자기
+보고가 아니라 서버 관측)."""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+from app.models.agent_run_tool_call import AgentRunToolCall
+from app.services.au_metering import STREAMING_PATHS
+from app.services.pg_pubsub import fire_and_forget
+from app.services.tool_call_attribution import (
+    HEADER_NAME,
+    attribute_tool_call,
+    extract_story_id,
+)
+from app.services.tool_call_masking import build_input_summary
+
+logger = logging.getLogger(__name__)
+
+_MAX_BODY_BYTES = 64 * 1024  # 마스킹 前 원시 바디를 파싱 시도할 상한(폭주 방지·64KB)
+
+
+async def _parse_json_body(request: Request) -> dict | None:
+    try:
+        raw = await request.body()
+    except Exception:
+        return None
+    if not raw or len(raw) > _MAX_BODY_BYTES:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _route_path_template(request: Request) -> str:
+    route = request.scope.get("route")
+    path = getattr(route, "path", None)
+    return path if isinstance(path, str) else request.url.path
+
+
+async def _record_tool_call_safe(**kwargs) -> None:
+    """`fire_and_forget()`로 던져지는 실제 DB 왕복 — 이 코루틴 자신이 예외를 전부
+    삼켜야 한다(AUMeteringMiddleware의 `_record_au_usage_safe`와 동형 이유)."""
+    try:
+        from app.core.database import async_session_factory
+
+        async with async_session_factory() as session, session.begin():
+            await attribute_and_insert(session, **kwargs)
+    except Exception:
+        logger.error("tool-call recording failed agent_id=%s", kwargs.get("agent_id"), exc_info=True)
+
+
+async def attribute_and_insert(session, *, org_id, agent_id, header_run_id, story_id,
+                                tool, method, path, status_code, duration_ms, started_at,
+                                input_summary, error) -> None:
+    result = await attribute_tool_call(
+        session, agent_id=agent_id, header_run_id=header_run_id, story_id=story_id,
+    )
+    session.add(AgentRunToolCall(
+        id=uuid.uuid4(), org_id=org_id, agent_id=agent_id, run_id=result.run_id,
+        tool=tool, method=method, path=path, status_code=status_code, duration_ms=duration_ms,
+        started_at=started_at, input_summary=input_summary, error=error,
+        attribution_reason=result.reason,
+    ))
+
+
+_RETENTION_DAYS = 30
+
+
+async def sweep_old_tool_calls(session: AsyncSession, *, now: datetime | None = None) -> int:
+    """cron.py `/publication-commands` tick 피기백(새 Cloud Scheduler 잡 0 — #3672
+    sweep_old_unhandled_error_events와 동형 사상). 30일 지난 행을 지운다. `run_id`가
+    NULL인(미귀속) 행도 이 스윕 대상 — cascade는 run이 삭제될 때만 걸리고, run이 안
+    지워진 채 오래된 행은 이 스윕이 유일한 정리 경로다. 반환값=삭제 건수(tick 응답
+    카운트용)."""
+    now = now or datetime.now(UTC)
+    cutoff = now - timedelta(days=_RETENTION_DAYS)
+    result = await session.execute(
+        delete(AgentRunToolCall).where(AgentRunToolCall.created_at < cutoff)
+    )
+    await session.commit()
+    return result.rowcount or 0
+
+
+class ToolCallRecordingMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        started_perf = time.monotonic()
+        started_at = datetime.now(UTC)
+
+        # story #3722 — SSE 스트림은 body가 없고(GET) 응답도 무한 스트림이라 이 계측 대상이
+        # 아니다(AU 계측과 동일 denylist 재사용 — 두 축이 같은 예외를 따로 관리하면 드리프트
+        # 재발 클래스, feedback_shared_primitive_move_test_sweep 동형).
+        if request.url.path in STREAMING_PATHS:
+            return await call_next(request)
+
+        body = await _parse_json_body(request) if request.method in {"POST", "PUT", "PATCH"} else None
+
+        response = await call_next(request)
+
+        try:
+            if getattr(request.state, "au_actor", None) != "agent":
+                return response
+            org_id_raw = getattr(request.state, "au_org_id", None)
+            agent_id_raw = getattr(request.state, "au_user_id", None)
+            if not org_id_raw or not agent_id_raw:
+                return response
+
+            duration_ms = int((time.monotonic() - started_perf) * 1000)
+            route_path = _route_path_template(request)
+            path_params = dict(request.path_params) if request.path_params else None
+            query_params = dict(request.query_params) if request.query_params else None
+            story_id = extract_story_id(
+                route_path=route_path, path_params=path_params, query_params=query_params, body=body,
+            )
+            input_summary = build_input_summary(query_params=query_params or {}, body=body)
+            error = None if response.status_code < 400 else f"HTTP {response.status_code}"
+
+            fire_and_forget(_record_tool_call_safe(
+                org_id=uuid.UUID(str(org_id_raw)), agent_id=uuid.UUID(str(agent_id_raw)),
+                header_run_id=request.headers.get(HEADER_NAME), story_id=story_id,
+                tool=request.headers.get("x-sprintable-tool"), method=request.method,
+                path=route_path, status_code=response.status_code, duration_ms=duration_ms,
+                started_at=started_at, input_summary=input_summary, error=error,
+            ))
+        except Exception:
+            # story #3722 — 계측 "계획" 단계(요청 파싱·판별)의 예외도 원 응답을 절대
+            # 막으면 안 된다(AUMeteringMiddleware.dispatch()와 동형 try/except 배치).
+            logger.error("tool-call recording planning failed path=%s method=%s",
+                         request.url.path, request.method, exc_info=True)
+        return response

--- a/backend/tests/test_2697_project_scope_judge_count_lock.py
+++ b/backend/tests/test_2697_project_scope_judge_count_lock.py
@@ -52,6 +52,10 @@ _KNOWN_HITS = {
     # 동일 인가축(org 검증 후 has_project_access) — 존재/타org/무접근권 전부 404 비노출.
     # require_project_access로 아직 수렴 안 한 정당한 신규 잔존(형제 함수들과 동형 패턴).
     "app/routers/agent_runs.py::get_agent_run",
+    # story #3722(2026-09-09) — 신설 GET /agent-runs/{id}/tool-calls. 바로 위 get_agent_run
+    # 형제와 완전 동일 인가축(org 검증 후 has_project_access, 없거나 타org·무접근권 전부
+    # 404 비노출) — 같은 이유로 아직 require_project_access 미수렴, 정당한 신규 잔존.
+    "app/routers/agent_runs.py::list_agent_run_tool_calls",
     "app/routers/agent_runs.py::list_agent_runs",
     "app/routers/agent_runs.py::update_agent_run",
     "app/routers/analytics.py::_assert_project_access",
@@ -102,12 +106,13 @@ _KNOWN_HITS = {
     "app/services/project_auth.py::require_project_access",
     "app/services/workflow_parallel_approval.py::reassign_approver",
 }
-# raw 총량(고유 키 55개 + 아래 5개 함수의 내부 중복 5건 = 60) — len(_KNOWN_HITS)와 분리해 명시.
+# raw 총량(고유 키 56개 + 아래 5개 함수의 내부 중복 5건 = 61) — len(_KNOWN_HITS)와 분리해 명시.
 # story #1969(2026-08-30) — inbox_items 기능 완전 은퇴로 notifications.py::list_inbox/
 # list_incoming 자체가 삭제돼 그 2건의 raw 인라인 패턴도 함께 걷혀 61→59(story #2923이 더했던
 # 값이 정확히 되돌아감). story #4725d9c0(2026-09-08) — agent_runs.py::get_agent_run 신설로
-# +1(59→60, 위 _KNOWN_HITS 항목 참조).
-_RAW_INLINE_RAISE_BASELINE = 60
+# +1(59→60, 위 _KNOWN_HITS 항목 참조). story #3722(2026-09-09) — 형제 list_agent_run_tool_calls
+# 신설로 +1(60→61).
+_RAW_INLINE_RAISE_BASELINE = 61
 
 
 def _qualname_of(node: ast.AST, parents: dict[int, ast.AST]) -> str:

--- a/backend/tests/test_3722_tool_call_attribution_realdb.py
+++ b/backend/tests/test_3722_tool_call_attribution_realdb.py
@@ -160,9 +160,11 @@ async def test_ambiguous_multi_run_same_story_does_not_fall_back_to_agent_wide()
 
 
 @pytest.mark.anyio
-async def test_story_with_zero_running_falls_back_to_agent_wide_single_running():
-    """디디 판단(문서화) — story 문맥은 있는데 그 story엔 running run이 0개면 agent
-    전체로 넘어간다(그 story 얘기는 아니지만 이 agent 얘기는 맞다)."""
+async def test_story_with_zero_running_falls_back_to_agent_wide_single_running_other_story():
+    """디디 판단(채택 — 페드루 PO 06:22Z) — story 문맥은 있는데 그 story엔 running run이
+    0개면 agent 전체로 넘어간다(그 story 얘기는 아니지만 이 agent 얘기는 맞다). 단 이렇게
+    정해진 run은 정의상 그 story의 것이 아니므로 reason은 평범한 single_running이 아니라
+    single_running_other_story(오귀속 의심 단서, 페드루 PO 追加)."""
     from app.services.tool_call_attribution import attribute_tool_call
 
     engine, Session = await _session_factory()
@@ -176,7 +178,7 @@ async def test_story_with_zero_running_falls_back_to_agent_wide_single_running()
                 s, agent_id=ctx["agent_id"], header_run_id=None, story_id=str(uuid.uuid4()),
             )
             assert result.run_id == agent_wide_run.id
-            assert result.reason == "single_running"
+            assert result.reason == "single_running_other_story"
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_3722_tool_call_attribution_realdb.py
+++ b/backend/tests/test_3722_tool_call_attribution_realdb.py
@@ -1,0 +1,242 @@
+"""story #3722 — `attribute_tool_call()` 귀속 체인 전 갈래(ⓐ/ⓑ'/ⓑ/ⓒ×3) 실 PG."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_run(session, *, agent_id, org_id, project_id, status="running", story_id=None):
+    from app.models.agent_run import AgentRun
+    run = AgentRun(
+        id=uuid.uuid4(), org_id=org_id, agent_id=agent_id, project_id=project_id,
+        trigger="manual", status=status, story_id=story_id,
+    )
+    session.add(run)
+    await session.flush()
+    return run
+
+
+async def _seed_org_project_agent(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.flush()
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent A")
+    session.add(agent)
+    await session.flush()
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id}
+
+
+@pytest.mark.anyio
+async def test_header_wins_when_run_belongs_to_agent():
+    from app.services.tool_call_attribution import attribute_tool_call
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_org_project_agent(s)
+            run = await _make_run(s, **ctx)
+            other_run = await _make_run(s, **ctx)  # 여러 running run이 있어도 header가 이긴다.
+            await s.commit()
+
+            result = await attribute_tool_call(
+                s, agent_id=ctx["agent_id"], header_run_id=str(run.id), story_id=None,
+            )
+            assert result.run_id == run.id
+            assert result.reason == "header"
+            assert result.run_id != other_run.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_header_ignored_when_run_belongs_to_different_agent():
+    """다른 agent의 run_id를 사칭하면 조용히 무시하고 체인을 계속 진행한다(401 아님)."""
+    from app.services.tool_call_attribution import attribute_tool_call
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx_a = await _seed_org_project_agent(s)
+            ctx_b = await _seed_org_project_agent(s)
+            other_agent_run = await _make_run(s, **ctx_b)
+            await s.commit()
+
+            result = await attribute_tool_call(
+                s, agent_id=ctx_a["agent_id"], header_run_id=str(other_agent_run.id), story_id=None,
+            )
+            assert result.run_id is None
+            assert result.reason == "no_running_run"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_scope_wins_when_exactly_one_running_run_for_that_story():
+    from app.services.tool_call_attribution import attribute_tool_call
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_org_project_agent(s)
+            story_id = uuid.uuid4()
+            story_run = await _make_run(s, **ctx, story_id=story_id)
+            other_story_run = await _make_run(s, **ctx, story_id=uuid.uuid4())  # 다른 story — 무시돼야.
+            await s.commit()
+
+            result = await attribute_tool_call(
+                s, agent_id=ctx["agent_id"], header_run_id=None, story_id=str(story_id),
+            )
+            assert result.run_id == story_run.id
+            assert result.reason == "story_scope"
+            assert result.run_id != other_story_run.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ambiguous_multi_run_same_story_does_not_fall_back_to_agent_wide():
+    """페드루 PO 판정 — story 문맥이 있는데 그 안에서 이미 모호하면 agent 전체로 안
+    내려간다(설령 agent 전체엔 running run이 1개뿐이라도)."""
+    from app.services.tool_call_attribution import attribute_tool_call
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_org_project_agent(s)
+            story_id = uuid.uuid4()
+            await _make_run(s, **ctx, story_id=story_id)
+            await _make_run(s, **ctx, story_id=story_id)  # 같은 story에 running run 2개.
+            await s.commit()
+
+            result = await attribute_tool_call(
+                s, agent_id=ctx["agent_id"], header_run_id=None, story_id=str(story_id),
+            )
+            assert result.run_id is None
+            assert result.reason == "ambiguous_multi_run_same_story"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_with_zero_running_falls_back_to_agent_wide_single_running():
+    """디디 판단(문서화) — story 문맥은 있는데 그 story엔 running run이 0개면 agent
+    전체로 넘어간다(그 story 얘기는 아니지만 이 agent 얘기는 맞다)."""
+    from app.services.tool_call_attribution import attribute_tool_call
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_org_project_agent(s)
+            agent_wide_run = await _make_run(s, **ctx, story_id=None)  # story 없는 running run.
+            await s.commit()
+
+            result = await attribute_tool_call(
+                s, agent_id=ctx["agent_id"], header_run_id=None, story_id=str(uuid.uuid4()),
+            )
+            assert result.run_id == agent_wide_run.id
+            assert result.reason == "single_running"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_wide_single_running_when_no_story_id():
+    from app.services.tool_call_attribution import attribute_tool_call
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_org_project_agent(s)
+            run = await _make_run(s, **ctx)
+            await s.commit()
+
+            result = await attribute_tool_call(
+                s, agent_id=ctx["agent_id"], header_run_id=None, story_id=None,
+            )
+            assert result.run_id == run.id
+            assert result.reason == "single_running"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_running_run_is_unattributed():
+    from app.services.tool_call_attribution import attribute_tool_call
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_org_project_agent(s)
+            await _make_run(s, **ctx, status="completed")  # running 아님 — 카운트 안 됨.
+            await s.commit()
+
+            result = await attribute_tool_call(
+                s, agent_id=ctx["agent_id"], header_run_id=None, story_id=None,
+            )
+            assert result.run_id is None
+            assert result.reason == "no_running_run"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_wide_ambiguous_when_multiple_running_no_story():
+    from app.services.tool_call_attribution import attribute_tool_call
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_org_project_agent(s)
+            await _make_run(s, **ctx)
+            await _make_run(s, **ctx)
+            await s.commit()
+
+            result = await attribute_tool_call(
+                s, agent_id=ctx["agent_id"], header_run_id=None, story_id=None,
+            )
+            assert result.run_id is None
+            assert result.reason == "ambiguous_multi_run"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3722_tool_call_e2e_realdb.py
+++ b/backend/tests/test_3722_tool_call_e2e_realdb.py
@@ -1,0 +1,340 @@
+"""story #3722 — 전체 파이프라인 e2e(실 PG·실 agent API key 인증): 미들웨어→귀속→INSERT→
+GET 조회, cascade 삭제, 보존기간 스윕. 실 인증 경로(x-agent-api-key)로 태워 request.state.
+au_actor 등이 진짜 `get_current_user()`가 채운 값인지까지 함께 검증한다(get_current_user
+자체를 override하면 그 SSOT 세팅 라인이 안 돌아 미들웨어가 절대 못 본다 — dependency
+override로는 이 미들웨어를 정직하게 못 잰다, real-key 경로가 유일한 정답)."""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import UTC
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _drain_background_tasks() -> None:
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+    if pending:
+        await asyncio.gather(*pending)
+
+
+async def _seed_agent_with_key(session):
+    """test_2600_charlie_discovery_e2e_realdb.py `_seed_agent` 패턴 재사용."""
+    from app.core.security import hash_token
+    from app.models.api_key import ApiKey
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent A")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    raw_key = f"sk_live_{uuid.uuid4().hex}"
+    session.add(ApiKey(
+        id=uuid.uuid4(), team_member_id=agent.id, member_id=agent.id,
+        key_prefix=raw_key[:12], key_hash=hash_token(raw_key), scope=["read", "write"],
+    ))
+    await session.commit()
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id, "raw_key": raw_key}
+
+
+def _client_with_key(app, raw_key: str):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+        headers={"x-agent-api-key": raw_key},
+    )
+
+
+class _PatchedGlobalSessionFactory:
+    """test_2087_agent_api_key_usage_audit_trail_realdb.py 선례 확장 — `async_session_
+    factory`를 여러 모듈이 각자 `from app.core.database import async_session_factory`로
+    자기 네임스페이스에 따로 바인딩해 뒀다(app.core.database 원본만 패치하면 이 모듈들의
+    사본은 그대로 안 바뀐다 — `from X import Y`는 새 독립 바인딩). 이 요청 경로가 실제로
+    거치는 자리(get_current_user→_resolve_api_key가 쓰는 app.dependencies.auth·
+    AUMeteringMiddleware가 쓰는 app.services.au_metering) 전부를 같이 교체해야
+    "attached to a different loop" 없이 돈다."""
+
+    _MODULES = ("app.core.database", "app.dependencies.auth", "app.services.au_metering")
+
+    def __init__(self, session_factory):
+        self._session_factory = session_factory
+        self._orig: dict[str, object] = {}
+
+    async def __aenter__(self):
+        import importlib
+        for mod_name in self._MODULES:
+            mod = importlib.import_module(mod_name)
+            self._orig[mod_name] = mod.async_session_factory
+            mod.async_session_factory = self._session_factory
+        return self
+
+    async def __aexit__(self, *exc):
+        import importlib
+        for mod_name, orig in self._orig.items():
+            mod = importlib.import_module(mod_name)
+            mod.async_session_factory = orig
+
+
+def _wire_db(app, Session) -> None:
+    """get_db/get_read_db만 테스트 세션으로 갈아끼운다 — get_current_user는 절대 override
+    안 한다(진짜 인증 경로를 태워야 request.state.au_actor 등 SSOT가 실제로 채워진다,
+    모듈 docstring 참고). test_2600 관례(override_db_and_read) 그대로."""
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as sess:
+            try:
+                yield sess
+                await sess.commit()
+            except Exception:
+                await sess.rollback()
+                raise
+    override_db_and_read(app, _db)
+
+
+@pytest.mark.anyio
+async def test_real_agent_request_lands_a_row_attributed_to_single_running_run():
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.agent_run import AgentRun
+    from app.models.agent_run_tool_call import AgentRunToolCall
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_agent_with_key(s)
+            run = AgentRun(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"],
+                project_id=ctx["project_id"], trigger="manual", status="running",
+            )
+            s.add(run)
+            await s.commit()
+            run_id = run.id
+
+        app.dependency_overrides.clear()
+        _wire_db(app, Session)
+        client = _client_with_key(app, ctx["raw_key"])
+        async with _PatchedGlobalSessionFactory(Session):
+            async with client:
+                resp = await client.get(f"/api/v2/agent-runs?project_id={ctx['project_id']}")
+                await _drain_background_tasks()
+        assert resp.status_code == 200
+
+        async with Session() as s:
+            rows = list((await s.execute(
+                select(AgentRunToolCall).where(AgentRunToolCall.agent_id == ctx["agent_id"])
+            )).scalars().all())
+        assert len(rows) == 1, f"정확히 1행이 기록돼야(회귀): {rows}"
+        row = rows[0]
+        assert row.run_id == run_id, "단일 running run 상관(ⓑ)이 실제로 동작해야"
+        assert row.attribution_reason == "single_running"
+        assert row.method == "GET"
+        assert row.status_code == 200
+        assert row.org_id == ctx["org_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_tool_calls_endpoint_returns_rows_for_that_run_newest_first():
+    from datetime import datetime, timedelta
+
+    from app.main import app
+    from app.models.agent_run import AgentRun
+    from app.models.agent_run_tool_call import AgentRunToolCall
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_agent_with_key(s)
+            run = AgentRun(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"],
+                project_id=ctx["project_id"], trigger="manual", status="running",
+            )
+            s.add(run)
+            await s.commit()
+
+            now = datetime.now(UTC)
+            older = AgentRunToolCall(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"], run_id=run.id,
+                method="GET", path="/api/v2/older", status_code=200, duration_ms=5,
+                started_at=now - timedelta(minutes=5), attribution_reason="single_running",
+                created_at=now - timedelta(minutes=5),
+            )
+            newer = AgentRunToolCall(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"], run_id=run.id,
+                method="POST", path="/api/v2/newer", status_code=201, duration_ms=8,
+                started_at=now, attribution_reason="single_running", created_at=now,
+            )
+            s.add_all([older, newer])
+            await s.commit()
+            run_id = run.id
+
+        app.dependency_overrides.clear()
+        _wire_db(app, Session)
+        client = _client_with_key(app, ctx["raw_key"])
+        async with _PatchedGlobalSessionFactory(Session), client:
+            resp = await client.get(f"/api/v2/agent-runs/{run_id}/tool-calls")
+            await _drain_background_tasks()
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body) == 2
+        assert body[0]["path"] == "/api/v2/newer", "최신순(created_at DESC)이어야"
+        assert body[1]["path"] == "/api/v2/older"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_tool_calls_404_for_other_org_run():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_agent_with_key(s)
+            await s.commit()
+
+        app.dependency_overrides.clear()
+        _wire_db(app, Session)
+        client = _client_with_key(app, ctx["raw_key"])
+        async with _PatchedGlobalSessionFactory(Session), client:
+            resp = await client.get(f"/api/v2/agent-runs/{uuid.uuid4()}/tool-calls")
+            await _drain_background_tasks()
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_run_deletion_cascades_to_tool_calls():
+    from sqlalchemy import select
+
+    from app.models.agent_run import AgentRun
+    from app.models.agent_run_tool_call import AgentRunToolCall
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_agent_with_key(s)
+            run = AgentRun(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"],
+                project_id=ctx["project_id"], trigger="manual", status="running",
+            )
+            s.add(run)
+            await s.commit()
+            call = AgentRunToolCall(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"], run_id=run.id,
+                method="GET", path="/api/v2/x", status_code=200, duration_ms=1,
+                started_at=run.started_at, attribution_reason="single_running",
+            )
+            s.add(call)
+            await s.commit()
+            call_id = call.id
+            run_id = run.id
+
+            await s.delete(run)
+            await s.commit()
+
+            remaining = (await s.execute(
+                select(AgentRunToolCall).where(AgentRunToolCall.id == call_id)
+            )).scalar_one_or_none()
+            assert remaining is None, f"run(id={run_id}) 삭제가 cascade 안 됨(회귀)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_retention_sweep_deletes_only_rows_older_than_30_days():
+    from datetime import datetime, timedelta
+
+    from sqlalchemy import select
+
+    from app.models.agent_run_tool_call import AgentRunToolCall
+    from app.services.tool_call_recording import sweep_old_tool_calls
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_agent_with_key(s)
+            now = datetime.now(UTC)
+            old = AgentRunToolCall(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"], run_id=None,
+                method="GET", path="/api/v2/old", status_code=200, duration_ms=1,
+                started_at=now - timedelta(days=31), attribution_reason="no_running_run",
+                created_at=now - timedelta(days=31),
+            )
+            recent = AgentRunToolCall(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"], run_id=None,
+                method="GET", path="/api/v2/recent", status_code=200, duration_ms=1,
+                started_at=now - timedelta(days=1), attribution_reason="no_running_run",
+                created_at=now - timedelta(days=1),
+            )
+            s.add_all([old, recent])
+            await s.commit()
+
+            deleted_before = list((await s.execute(
+                select(AgentRunToolCall).where(AgentRunToolCall.agent_id == ctx["agent_id"])
+            )).scalars().all())
+            assert len(deleted_before) == 2
+
+            deleted = await sweep_old_tool_calls(s, now=now)
+            assert deleted >= 1  # 다른 테스트의 leftover 행도 30일 컷오프 대상이면 같이 잡힐 수 있다.
+
+            remaining = list((await s.execute(
+                select(AgentRunToolCall).where(AgentRunToolCall.agent_id == ctx["agent_id"])
+            )).scalars().all())
+            assert len(remaining) == 1
+            assert remaining[0].path == "/api/v2/recent"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3722_tool_call_e2e_realdb.py
+++ b/backend/tests/test_3722_tool_call_e2e_realdb.py
@@ -229,6 +229,53 @@ async def test_get_tool_calls_endpoint_returns_rows_for_that_run_newest_first():
         assert len(body) == 2
         assert body[0]["path"] == "/api/v2/newer", "최신순(created_at DESC)이어야"
         assert body[1]["path"] == "/api/v2/older"
+        assert resp.headers["X-Total-Count"] == "2"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_tool_calls_x_total_count_reflects_full_count_not_page_size():
+    """페드루 PO 追加(2026-09-09) — X-Total-Count는 limit 適用 前 run_id 기준 전체
+    건수(3703/3706류 «한 페이지=전부» 오판 재발 방지). 51행 표본에 limit=50 → 헤더 51."""
+    from datetime import datetime, timedelta
+
+    from app.main import app
+    from app.models.agent_run import AgentRun
+    from app.models.agent_run_tool_call import AgentRunToolCall
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _seed_agent_with_key(s)
+            run = AgentRun(
+                id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"],
+                project_id=ctx["project_id"], trigger="manual", status="running",
+            )
+            s.add(run)
+            await s.commit()
+
+            now = datetime.now(UTC)
+            for i in range(51):
+                s.add(AgentRunToolCall(
+                    id=uuid.uuid4(), org_id=ctx["org_id"], agent_id=ctx["agent_id"], run_id=run.id,
+                    method="GET", path=f"/api/v2/row-{i}", status_code=200, duration_ms=1,
+                    started_at=now - timedelta(seconds=i), attribution_reason="single_running",
+                    created_at=now - timedelta(seconds=i),
+                ))
+            await s.commit()
+            run_id = run.id
+
+        app.dependency_overrides.clear()
+        _wire_db(app, Session)
+        client = _client_with_key(app, ctx["raw_key"])
+        async with _PatchedGlobalSessionFactory(Session), client:
+            resp = await client.get(f"/api/v2/agent-runs/{run_id}/tool-calls?limit=50")
+            await _drain_background_tasks()
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()) == 50, "limit=50이 페이지를 자름"
+        assert resp.headers["X-Total-Count"] == "51", "헤더는 limit 適用 前 전체 건수"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3722_tool_call_extract_story_id.py
+++ b/backend/tests/test_3722_tool_call_extract_story_id.py
@@ -1,0 +1,71 @@
+"""story #3722 — `extract_story_id()` 축 우선순위(path 템플릿 파라미터 > 쿼리 > body
+최상위) · `/stories/{id}` 특례(파라미터명이 story_id가 아니라 id일 때 라우트 템플릿으로
+판별)."""
+from __future__ import annotations
+
+from app.services.tool_call_attribution import extract_story_id
+
+
+def test_path_param_story_id_wins_over_query_and_body():
+    result = extract_story_id(
+        route_path="/api/v2/goals/{story_id}/reference-candidates",
+        path_params={"story_id": "s1"},
+        query_params={"story_id": "s2"},
+        body={"story_id": "s3"},
+    )
+    assert result == "s1"
+
+
+def test_stories_route_id_param_treated_as_story_id():
+    result = extract_story_id(
+        route_path="/api/v2/stories/{id}",
+        path_params={"id": "s1"},
+        query_params=None,
+        body=None,
+    )
+    assert result == "s1"
+
+
+def test_tasks_route_id_param_not_treated_as_story_id():
+    """«id»라는 이름만으로는 어느 리소스인지 모른다 — /tasks/{id}의 id는 story_id가
+    아니다(회귀 표적: route_path 체크 없이 path_params["id"]를 그냥 쓰면 이 테스트가
+    실패한다)."""
+    result = extract_story_id(
+        route_path="/api/v2/tasks/{id}",
+        path_params={"id": "t1"},
+        query_params=None,
+        body=None,
+    )
+    assert result is None
+
+
+def test_query_param_used_when_no_path_param():
+    result = extract_story_id(
+        route_path="/api/v2/agent-runs",
+        path_params=None,
+        query_params={"story_id": "s1"},
+        body=None,
+    )
+    assert result == "s1"
+
+
+def test_body_top_level_used_as_last_resort():
+    result = extract_story_id(
+        route_path="/api/v2/stories/status",
+        path_params=None,
+        query_params=None,
+        body={"story_id": "s1"},
+    )
+    assert result == "s1"
+
+
+def test_returns_none_when_no_story_id_anywhere():
+    assert extract_story_id(route_path="/api/v2/notifications", path_params=None, query_params=None, body=None) is None
+
+
+def test_body_story_id_ignored_when_not_a_string():
+    """body["story_id"]가 문자열이 아니면(예: 리스트·숫자) 무시 — 지어내지 않는다."""
+    result = extract_story_id(
+        route_path="/api/v2/stories/bulk", path_params=None, query_params=None, body={"story_id": ["s1", "s2"]},
+    )
+    assert result is None

--- a/backend/tests/test_3722_tool_call_masking.py
+++ b/backend/tests/test_3722_tool_call_masking.py
@@ -61,9 +61,18 @@ def test_build_input_summary_combines_query_and_body():
     assert summary == {"query": {"status": "failed"}, "body": {"title": "t", "token": "[REDACTED]"}}
 
 
+def test_build_input_summary_includes_masked_path_params():
+    """story #3722 — 페드루 PO 追加(2026-09-09): route 템플릿만으로는 «어느 스토리/태스크를
+    건드렸나»가 안 남는다. path_params도 같은 마스킹 규칙으로 실린다."""
+    summary = build_input_summary(
+        path_params={"id": "story-123", "token": "leak"}, query_params={}, body=None,
+    )
+    assert summary == {"path": {"id": "story-123", "token": "[REDACTED]"}}
+
+
 def test_build_input_summary_returns_none_when_nothing_to_record():
     assert build_input_summary(query_params={}, body=None) is None
-    assert build_input_summary(query_params={}, body={}) is None
+    assert build_input_summary(path_params={}, query_params={}, body={}) is None
 
 
 def test_build_input_summary_truncates_whole_payload_over_2kb():

--- a/backend/tests/test_3722_tool_call_masking.py
+++ b/backend/tests/test_3722_tool_call_masking.py
@@ -1,0 +1,74 @@
+"""story #3722 — `tool_call_masking.py` denylist·절단·상한 규칙(스토리 確定 설계)."""
+from __future__ import annotations
+
+from app.services.tool_call_masking import (
+    _SUMMARY_MAX_BYTES,
+    _VALUE_MAX_LEN,
+    build_input_summary,
+    mask_mapping,
+)
+
+
+def test_denylisted_keys_redacted_case_insensitive():
+    masked = mask_mapping({
+        "token": "abc", "Authorization": "Bearer xyz", "api_key": "sk_live_x",
+        "password": "hunter2", "SECRET_VALUE": "s", "cookie": "c", "normal": "kept",
+    })
+    assert masked["token"] == "[REDACTED]"
+    assert masked["Authorization"] == "[REDACTED]"
+    assert masked["api_key"] == "[REDACTED]"
+    assert masked["password"] == "[REDACTED]"
+    assert masked["SECRET_VALUE"] == "[REDACTED]"
+    assert masked["cookie"] == "[REDACTED]"
+    assert masked["normal"] == "kept"
+
+
+def test_denylist_substring_match_catches_prefixed_suffixed_keys():
+    """부분일치 — "user_token"·"x_api_key" 같은 접두/접미 변형도 잡아야 한다(정확한 키
+    이름만 대조하면 놓치는 자리가 실무에 흔하다)."""
+    masked = mask_mapping({"user_token": "t", "x_api_key": "k", "session_secret": "s"})
+    assert masked["user_token"] == "[REDACTED]"
+    assert masked["x_api_key"] == "[REDACTED]"
+    assert masked["session_secret"] == "[REDACTED]"
+
+
+def test_nested_dict_masked_recursively():
+    masked = mask_mapping({"outer": {"token": "abc", "safe": "ok"}})
+    assert masked["outer"]["token"] == "[REDACTED]"
+    assert masked["outer"]["safe"] == "ok"
+
+
+def test_list_of_dicts_masked_per_element():
+    masked = mask_mapping({"items": [{"token": "a"}, {"safe": "b"}]})
+    assert masked["items"][0]["token"] == "[REDACTED]"
+    assert masked["items"][1]["safe"] == "b"
+
+
+def test_long_string_value_truncated_at_120_chars():
+    long_value = "x" * 500
+    masked = mask_mapping({"note": long_value})
+    assert len(masked["note"]) == _VALUE_MAX_LEN + 1  # +1 for the "…" marker
+    assert masked["note"].endswith("…")
+
+
+def test_short_string_value_not_truncated():
+    masked = mask_mapping({"note": "short"})
+    assert masked["note"] == "short"
+
+
+def test_build_input_summary_combines_query_and_body():
+    summary = build_input_summary(query_params={"status": "failed"}, body={"title": "t", "token": "x"})
+    assert summary == {"query": {"status": "failed"}, "body": {"title": "t", "token": "[REDACTED]"}}
+
+
+def test_build_input_summary_returns_none_when_nothing_to_record():
+    assert build_input_summary(query_params={}, body=None) is None
+    assert build_input_summary(query_params={}, body={}) is None
+
+
+def test_build_input_summary_truncates_whole_payload_over_2kb():
+    huge_body = {f"field_{i}": "y" * 100 for i in range(50)}
+    summary = build_input_summary(query_params={}, body=huge_body)
+    assert summary == {"_truncated": True}
+    import json
+    assert len(json.dumps(summary).encode("utf-8")) < _SUMMARY_MAX_BYTES

--- a/backend/tests/test_3722_tool_call_masking.py
+++ b/backend/tests/test_3722_tool_call_masking.py
@@ -44,6 +44,37 @@ def test_list_of_dicts_masked_per_element():
     assert masked["items"][1]["safe"] == "b"
 
 
+def test_list_in_dict_secret_masked():
+    """카디르 QA②(2026-09-09) 양성대조 1 — dict 안 list 안 dict."""
+    masked = mask_mapping({"items": [[{"password": "hunter2"}]]})
+    assert masked["items"][0][0]["password"] == "[REDACTED]"
+
+
+def test_list_in_list_in_dict_secret_masked():
+    """카디르 QA②(2026-09-09) 양성대조 2 — list 안 list 안 dict(옛 구현이 못 잡던
+    바로 그 모양: 리스트 원소가 dict인지만 봐서 이 자리를 그대로 통과시켰다)."""
+    masked = mask_mapping({"outer": [[{"secret": "leak-me"}]]})
+    assert masked["outer"][0][0]["secret"] == "[REDACTED]"
+    assert "leak-me" not in str(masked)
+
+
+def test_dict_in_list_in_dict_secret_masked():
+    """카디르 QA②(2026-09-09) 양성대조 3 — dict 안 list 안 dict(중첩 순서 반대)."""
+    masked = mask_mapping({"a": {"b": [{"api_key": "leak-me-too"}]}})
+    assert masked["a"]["b"][0]["api_key"] == "[REDACTED]"
+    assert "leak-me-too" not in str(masked)
+
+
+def test_masking_never_recursion_errors_on_pathological_depth():
+    """카디르 QA②(2026-09-09) — 마스킹 함수 자신이 RecursionError를 내면 이 스토리가
+    방금 고친 것과 같은 클래스가 재발한다. 깊이 상한 너머는 truncated로 끊긴다."""
+    nested = "leaf"
+    for _ in range(500):
+        nested = [nested]
+    masked = mask_mapping({"deep": nested})
+    assert masked  # RecursionError 없이 반환됨 자체가 이 테스트의 핵심 단언
+
+
 def test_long_string_value_truncated_at_120_chars():
     long_value = "x" * 500
     masked = mask_mapping({"note": long_value})

--- a/backend/tests/test_3722_tool_call_recording_middleware.py
+++ b/backend/tests/test_3722_tool_call_recording_middleware.py
@@ -194,6 +194,28 @@ async def test_recording_exception_never_breaks_the_response(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_deeply_nested_json_body_never_500s_the_original_request(monkeypatch):
+    """카디르 QA①(2026-09-09) — depth 32000(≈64000 bytes, 64KB 상한 아래)짜리 중첩
+    배열은 CPython C 가속 스캐너를 쓴 `json.loads()`도 RecursionError를 던진다(재현
+    확認). 이전 except는 ValueError/UnicodeDecodeError만 잡아 이 예외가 call_next
+    前 보호막 밖으로 새 원 요청 500이 됐다 — 이 스토리 자신의 "기록 실패는 원 요청을
+    안 막는다" 규율 위반. 지금은 200 그대로·기록은 input_summary 없이(body=None) 붙는다."""
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    nested_json = ("[" * 32000 + "]" * 32000).encode("utf-8")
+    assert len(nested_json) < 64 * 1024
+    async with client:
+        resp = await client.post(
+            "/api/v2/stories/s-1/status", content=nested_json,
+            headers={"content-type": "application/json"},
+        )
+        await _drain_background_tasks()
+    assert resp.status_code == 200
+    assert len(recorded) == 1
+    summary = recorded[0]["input_summary"]
+    assert not summary or "body" not in summary
+
+
+@pytest.mark.anyio
 async def test_story_id_extracted_from_path_param_and_passed_to_attribution(monkeypatch):
     client, recorded = _build_app(monkeypatch, au_actor="agent")
     async with client:

--- a/backend/tests/test_3722_tool_call_recording_middleware.py
+++ b/backend/tests/test_3722_tool_call_recording_middleware.py
@@ -202,6 +202,9 @@ async def test_story_id_extracted_from_path_param_and_passed_to_attribution(monk
     assert resp.status_code == 200
     assert len(recorded) == 1
     assert recorded[0]["story_id"] == "s-123"
+    assert recorded[0]["input_summary"]["path"] == {"id": "s-123"}, (
+        "story #3722 페드루 PO 追加 — path_params가 input_summary에 실려야"
+    )
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_3722_tool_call_recording_middleware.py
+++ b/backend/tests/test_3722_tool_call_recording_middleware.py
@@ -1,0 +1,218 @@
+"""story #3722 — ToolCallRecordingMiddleware 판정 로직 회귀(실 DB 불요, DB 왕복 자체는
+모킹). test_3173_au_metering_middleware.py와 동형 패턴 — fire_and_forget()으로 응답
+반환 밖에 던져지므로 httpx.AsyncClient+ASGITransport로 같은 이벤트루프를 유지하고
+`_drain_background_tasks()`로 실제로 끝나길 기다린 뒤에야 assert한다."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+
+from app.services.tool_call_recording import ToolCallRecordingMiddleware
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _drain_background_tasks() -> None:
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+    if pending:
+        await asyncio.gather(*pending)
+
+
+def _build_app(monkeypatch, *, au_actor: str | None, org_id: str | None = "11111111-1111-1111-1111-111111111111",
+               agent_id: str | None = "22222222-2222-2222-2222-222222222222"):
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _fake_auth(request: Request, call_next):
+        request.state.au_actor = au_actor
+        request.state.au_org_id = org_id
+        request.state.au_user_id = agent_id
+        return await call_next(request)
+
+    app.add_middleware(ToolCallRecordingMiddleware)
+
+    @app.get("/api/v2/widgets")
+    async def read_widgets():
+        return JSONResponse({"data": []})
+
+    @app.post("/api/v2/stories/{id}/status")
+    async def update_story_status(id: str):
+        return JSONResponse({"data": {"id": id}}, status_code=200)
+
+    @app.get("/api/v2/widgets/missing")
+    async def read_missing():
+        return JSONResponse({"error": "nope"}, status_code=404)
+
+    @app.get("/api/v2/events/stream")
+    async def stream():
+        return JSONResponse({"data": "would-be-sse"})
+
+    recorded = []
+
+    async def _fake_insert(session, **kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr("app.services.tool_call_recording.attribute_and_insert", AsyncMock(side_effect=_fake_insert))
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    return client, recorded
+
+
+@pytest.mark.anyio
+async def test_agent_request_is_recorded_with_method_path_status_duration(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.get("/api/v2/widgets")
+        await _drain_background_tasks()
+    assert resp.status_code == 200
+    assert len(recorded) == 1
+    call = recorded[0]
+    assert call["method"] == "GET"
+    assert call["path"] == "/api/v2/widgets"
+    assert call["status_code"] == 200
+    assert call["duration_ms"] >= 0
+    assert call["error"] is None
+
+
+@pytest.mark.anyio
+async def test_human_traffic_never_recorded(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor="human")
+    async with client:
+        resp = await client.get("/api/v2/widgets")
+        await _drain_background_tasks()
+    assert resp.status_code == 200
+    assert recorded == []
+
+
+@pytest.mark.anyio
+async def test_unauthenticated_traffic_never_recorded(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor=None)
+    async with client:
+        resp = await client.get("/api/v2/widgets")
+        await _drain_background_tasks()
+    assert resp.status_code == 200
+    assert recorded == []
+
+
+@pytest.mark.anyio
+async def test_streaming_path_never_recorded(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.get("/api/v2/events/stream")
+        await _drain_background_tasks()
+    assert resp.status_code == 200
+    assert recorded == []
+
+
+@pytest.mark.anyio
+async def test_failed_response_is_still_recorded_with_error_set():
+    """AC — "성공・실패 모두" 기록된다(AU 계측과 다른 지점: 그쪽은 실패를 아예 안 세지만
+    이 스토리는 실패야말로 Trust 신호의 핵심이라 반드시 남긴다)."""
+    from unittest import mock
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _fake_auth(request: Request, call_next):
+        request.state.au_actor = "agent"
+        request.state.au_org_id = "11111111-1111-1111-1111-111111111111"
+        request.state.au_user_id = "22222222-2222-2222-2222-222222222222"
+        return await call_next(request)
+
+    app.add_middleware(ToolCallRecordingMiddleware)
+
+    @app.get("/api/v2/widgets/missing")
+    async def read_missing():
+        return JSONResponse({"error": "nope"}, status_code=404)
+
+    recorded = []
+
+    async def _fake_insert(session, **kwargs):
+        recorded.append(kwargs)
+
+    with mock.patch("app.services.tool_call_recording.attribute_and_insert", AsyncMock(side_effect=_fake_insert)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/v2/widgets/missing")
+            await _drain_background_tasks()
+    assert resp.status_code == 404
+    assert len(recorded) == 1
+    assert recorded[0]["status_code"] == 404
+    assert recorded[0]["error"] == "HTTP 404"
+
+
+@pytest.mark.anyio
+async def test_recording_never_blocks_response_even_if_insert_hangs(monkeypatch):
+    """조건(AUMeteringMiddleware와 동형 규율) — dispatch()가 attribute_and_insert를
+    inline await하지 않는다. 절대 안 끝나는 코루틴으로 바꿔도 응답은 즉시 돌아와야 한다."""
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _fake_auth(request: Request, call_next):
+        request.state.au_actor = "agent"
+        request.state.au_org_id = "11111111-1111-1111-1111-111111111111"
+        request.state.au_user_id = "22222222-2222-2222-2222-222222222222"
+        return await call_next(request)
+
+    app.add_middleware(ToolCallRecordingMiddleware)
+
+    @app.get("/api/v2/widgets")
+    async def read_widgets():
+        return JSONResponse({"data": []})
+
+    hung = asyncio.Event()
+
+    async def _never_returns(session, **kwargs):
+        await hung.wait()
+
+    monkeypatch.setattr("app.services.tool_call_recording.attribute_and_insert", AsyncMock(side_effect=_never_returns))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await asyncio.wait_for(client.get("/api/v2/widgets"), timeout=2.0)
+    assert resp.status_code == 200
+    hung.set()
+    await _drain_background_tasks()
+
+
+@pytest.mark.anyio
+async def test_recording_exception_never_breaks_the_response(monkeypatch):
+    """`_record_tool_call_safe`가 예외를 삼키는지(=원 요청에 절대 안 새는지) 확認."""
+    client, _ = _build_app(monkeypatch, au_actor="agent")
+    monkeypatch.setattr(
+        "app.services.tool_call_recording.attribute_and_insert",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    async with client:
+        resp = await client.get("/api/v2/widgets")
+        await _drain_background_tasks()  # 예외를 삼키는지까지 확認(안 삼키면 여기서 raise)
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_story_id_extracted_from_path_param_and_passed_to_attribution(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.post("/api/v2/stories/s-123/status", json={"status": "done"})
+        await _drain_background_tasks()
+    assert resp.status_code == 200
+    assert len(recorded) == 1
+    assert recorded[0]["story_id"] == "s-123"
+
+
+@pytest.mark.anyio
+async def test_body_secrets_masked_before_recording(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.post(
+            "/api/v2/stories/s-1/status", json={"status": "done", "api_token": "sk_live_should_not_leak"},
+        )
+        await _drain_background_tasks()
+    assert resp.status_code == 200
+    summary = recorded[0]["input_summary"]
+    assert summary["body"]["api_token"] == "[REDACTED]"
+    assert "sk_live_should_not_leak" not in str(summary)


### PR DESCRIPTION
## Summary
- Trust 축 관측 파이프라인 PR1(BE만) — 에이전트 인증 API 요청 1건 = `agent_run_tool_calls` 1행으로 기록(3720 그라운딩=지금 BE 어디에도 도구 호출 기록 0, 3721이 은퇴시킨 FE Timeline/Tool Audit Trail 구획의 원 목표를 이제 채운다).
- 마이그레이션 0356: `agent_run_tool_calls`(run_id FK CASCADE nullable·org_id·agent_id·method·path·status_code·duration_ms·started_at·input_summary JSONB·error·attribution_reason).
- `ToolCallRecordingMiddleware`: `AUMeteringMiddleware`(#3173)와 동형 사상 — `call_next()` 먼저 기다린 뒤 `request.state.au_actor`(기존 SSOT, 새 에이전트 판별 로직 0)로 에이전트 트래픽만 골라 `fire_and_forget()`으로 DB 왕복을 응답 반환 밖에 던진다. **성공·실패 모두 기록**(AU 계측과 다른 지점 — 이 스토리는 실패야말로 Trust 신호의 핵심).
- 귀속 체인(페드루 PO 確定 2026-09-09): ⓐ `X-Sprintable-Run-Id` 헤더(이 agent 소유일 때만) → ⓑ' story 스코프 상관(신설·주 경로 — 요청의 story_id와 일치하는 이 agent의 running run이 정확히 1개) → ⓑ agent 전체 running run이 정확히 1개 → ⓒ 미귀속(`attribution_reason` = `no_running_run`/`ambiguous_multi_run`/`ambiguous_multi_run_same_story`).
- 마스킹(`tool_call_masking.py`): denylist 키(token/key/secret/password/authorization/cookie, 대소문자·부분일치)=`[REDACTED]` · 값 120자 절단 · 전체 payload 2KB 상한(부분 JSON 아닌 전체 truncate).
- `GET /agent-runs/{id}/tool-calls`: cursor(ISO datetime) 페이지네이션, 최신순.
- 보존 스윕: `cron.py`의 기존 `publication-commands` tick에 피기백(새 Cloud Scheduler 잡 0, #3672 동형 관례) — 30일.

## 디디 판단(문서화 — PO 확인 요망)
페드루 PO의 귀속 규칙 메시지에 명시적으로 안 다뤄진 갈림길 하나: story_id는 있는데 **그 story의 running run이 0개**인 경우(ambiguous도 no_running_run도 아님) → 그대로 agent-wide ⓑ로 낙하시켰습니다(그 story 얘기는 아니지만 그 agent 얘기는 맞다는 뜻). `tool_call_attribution.py` 모듈 docstring에 이유를 남겼습니다 — 의도와 다르면 알려주시길.

## Test plan
- [x] `test_3722_tool_call_masking.py` 9/9 — denylist redact(대소문자·부분일치)·120자 절단·2KB 전체 상한·query+body 결합.
- [x] `test_3722_tool_call_extract_story_id.py` 7/7 — path param 우선순위·`/stories/{id}` 특수케이스·`/tasks/{id}` 오탐 방지 음성대조.
- [x] `test_3722_tool_call_recording_middleware.py` 9/9(mock) — 에이전트만 기록·성공/실패 모두 기록·스트리밍 경로 제외·기록 예외/블로킹이 원 응답에 안 새는지.
- [x] `test_3722_tool_call_attribution_realdb.py` 8/8(실 PG) — ⓐ/ⓑ'/ⓑ/ⓒ 4갈래 전부, `ambiguous_multi_run_same_story`가 agent-wide로 낙하 안 하는지 포함.
- [x] `test_3722_tool_call_e2e_realdb.py` 5/5(실 PG+실 agent API key 인증 경로) — 미들웨어→귀속→INSERT→GET 조회·run 삭제 cascade·보존 스윕.
- [x] 뮤테이션킬: `ambiguous_multi_run_same_story` 조기 return 제거 → RED(`ambiguous_multi_run`으로 오분류) 확인 후 복원.
- [x] `test_2697_project_scope_judge_count_lock.py` 회귀 수정 — 신규 `list_agent_run_tool_calls`가 형제 `get_agent_run`과 동일 인가축 패턴(카운트 55→56 unique / 60→61 raw).
- [x] 전체 non-destructive 스위트(10,245 collected, 관련 셋 재확인) 무회귀.
- [x] ruff clean.

## 후속(PR2, 이 PR 범위 밖)
FE Timeline/Tool Audit Trail 재건 + MCP `X-Sprintable-Tool`/`X-Sprintable-Run-Id` 이름표 배선(`call_tool()` 단일 훅).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrDpiShJoThxE2JbUbRc4N