### PR TITLE
[skip ci] chore: retain GHCR image versions

### DIFF
--- a/.github/workflows/container-retention.yml
+++ b/.github/workflows/container-retention.yml
@@ -1,0 +1,31 @@
+name: Container Retention
+
+on:
+  workflow_run:
+    workflows: ["Docker Publish"]
+    types: [completed]
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: container-retention-sprintable
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retain the 25 newest image-version records
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: sprintable
+          package-type: container
+          min-versions-to-keep: 25
+          token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,8 +37,10 @@ jobs:
           images: |
             ghcr.io/moonklabs/sprintable
           tags: |
+            # Keep a stable tag for the default branch. Historical commit tags
+            # are intentionally not published because retention keeps a small
+            # rolling set of image records.
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-,format=short
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 


### PR DESCRIPTION
## 목적
GHCR 컨테이너 이미지 버전이 무제한 누적되는 것을 방지합니다.

## 변경
- Docker Publish가 성공한 뒤 최신 25개 image-version record만 유지
- 매일 03:23 UTC에 동일 정책으로 재점검
- GITHUB_TOKEN에 packages: write 권한을 명시

25개 레코드는 현재 multi-arch 구조에서 약 최근 5개 빌드를 보존합니다.