### PR TITLE
[SID:3735] fix(FE): 잔존 3건 — 측정 계획 문구 걷기 + 카드 프리미티브 통일 2건

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -494,7 +494,6 @@
     "clusterUnclosedShowMore": "Show {n} more",
     "clusterUnclosedCapNotice": "Showing top {shown} · {total} total",
     "clusterUnclosedViewQueue": "View full queue",
-    "clusterUnclosedMeasurePlanMissing": "+{count} have no measure plan yet",
     "clusterUnclosedUnmeasurableGoal": "{count} declared unmeasurable",
     "clusterAuthFailureTitle": "Agent auth failures",
     "clusterAuthFailureSub": "Requests keep being rejected due to API key issues",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -494,7 +494,6 @@
     "clusterUnclosedShowMore": "{n}건 더보기",
     "clusterUnclosedCapNotice": "상위 {shown}건 표시 중 · 총 {total}건",
     "clusterUnclosedViewQueue": "전체 큐 보기",
-    "clusterUnclosedMeasurePlanMissing": "+{count}건은 측정 계획이 아직 없음",
     "clusterUnclosedUnmeasurableGoal": "{count}건은 측정 불가로 선언됨",
     "clusterAuthFailureTitle": "에이전트 인증 실패",
     "clusterAuthFailureSub": "API 키 문제로 요청이 반복 거부됨",

--- a/apps/web/scripts/handrolled-card-baseline.json
+++ b/apps/web/scripts/handrolled-card-baseline.json
@@ -12,7 +12,8 @@
     "26건 — 이 26건은 이 스토리와 무관한 기존 부채, 「더 늘지 않는다」 계약대로 여기서 통째로",
     "grandfather한다). now-face.tsx·loop-face.tsx·attention-cluster-board.tsx 3개 키는 같은",
     "PR1이 Card primitive로 이관해 여기서 뺐다(story #3736 ⑪의 「원인 3파일」). 263키 → 270키",
-    "(신규 26건 grandfather - 3건 이관 제거 - 중복/재구성에 따른 소폭 차이)."
+    "(신규 26건 grandfather - 3건 이관 제거 - 중복/재구성에 따른 소폭 차이).",
+    "story #3743 그라운딩 前 잔존(2026-09-09, 페드루 PO 지적·배포 60 실픽셀) — org-briefing-shell.tsx(FaceSkeletonPanel)·workforce-face.tsx 2건이 loop-face.tsx와 같은 카드인데 Card primitive 이관에서 빠져 있었다(#3736 ⑪ 「원인 3파일」 당시 이 둘은 안 걸렸던 것으로 보임) — 이번에 마저 이관, 여기서 뺀다. 270키 → 268키."
   ],
   "keys": [
     "app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx::mx-2 mt-1.5 space-y-1.5 rounded-lg border border-border bg-card p-2",
@@ -234,9 +235,7 @@
     "components/meetings/audio-recorder.tsx::rounded-lg border bg-background p-4",
     "components/nav/context-switcher-chip.tsx::h-11 min-h-0 min-w-0 max-w-[190px] shrink-0 justify-start gap-2 overflow-hidden rounded-xl border border-border bg-card px-2 py-1.5 text-left font-normal hover:bg-muted disabled:opacity-60 lg:hidden",
     "components/nav/notification-bell.tsx::absolute right-0 top-full z-50 mt-1 hidden w-80 overflow-hidden rounded-lg border bg-background shadow-[var(--elev-overlay)] lg:flex lg:flex-col",
-    "components/org-briefing/org-briefing-shell.tsx::rounded-2xl border border-border bg-card p-4",
     "components/org-briefing/org-briefing-shell.tsx::rounded-xl border border-border bg-muted/40 px-4 py-3 text-sm text-foreground",
-    "components/org-briefing/workforce-face.tsx::rounded-2xl border border-border bg-card p-4 transition-shadow hover:shadow-[var(--elev-card)]",
     "components/organization/event-definer-form.tsx::flex items-center gap-1 rounded-xl border border-border bg-background pl-3",
     "components/organization/event-definer-form.tsx::flex items-center gap-2 rounded-lg border border-border bg-background px-2.5 py-1.5",
     "components/organization/event-definer-form.tsx::mt-3 rounded-xl border border-dashed border-border bg-muted/40 p-3",

--- a/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
@@ -255,7 +255,10 @@ describe('AttentionClusterBoard', () => {
       expect(queueLink!.textContent).toBe(koMessages.orgBriefing.clusterUnclosedViewQueue);
     });
 
-    it('measurePlanMissingGoalCount는 N에 안 더해지고 보조 텍스트로만 노출된다', async () => {
+    // story #3735(B갈래, 유나 사전) — 「+N건은 측정 계획이 아직 없음」은 사용자 화면 밖(운영
+    // 화면 몫)이라 걷었다(옛 MeasurePlanMissingNote). N엔 여전히 안 더해지고(prop 계약
+    // 무변), 렌더 자체가 사라졌는지가 이 테스트의 새 단언 — 되돌리면(주석 처리 되돌리면) RED.
+    it('measurePlanMissingGoalCount는 N에 안 더해지고, 보조 텍스트 자체가 이제 없다', async () => {
       await act(async () => {
         root.render(wrap(
           <AttentionClusterBoard falsified={[]} silentStall={EMPTY_SILENT_STALL} loop={[loopItem({})]} loopTotalCount={1} measurePlanMissingGoalCount={40} unmeasurableGoalCount={0} />,
@@ -263,7 +266,8 @@ describe('AttentionClusterBoard', () => {
       });
       const countBadge = container.querySelector('.rounded-full.bg-card');
       expect(countBadge?.textContent).toBe('1'); // 40이 합산 안 됨
-      expect(container.textContent).toContain('40');
+      expect(container.textContent).not.toContain('40');
+      expect(container.textContent).not.toContain('측정 계획이 아직 없음');
     });
 
     // story #2843/#2844 — unmeasurableGoalCount도 measurePlanMissingGoalCount와 동형(N 비합산·보조텍스트).
@@ -363,5 +367,20 @@ describe('AttentionClusterBoard', () => {
       // memberId가 없으면 재발급 링크 자체를 안 만든다(어디로 갈지 지어낼 수 없음).
       expect(container.querySelectorAll('a')).toHaveLength(0);
     });
+  });
+});
+
+// story #3735(B갈래, 유나 사전, 페드루 PO 지적 2026-09-09 배포 60 실픽셀) — 「측정 계획이
+// 아직 없음」 잔존 확인(clusterUnclosedMeasurePlanMissing 키 삭제 검증). 되돌리면(ko/en.json에
+// 키를 다시 넣으면) RED — 낱말 grep 0건이 이 기능의 계약이다.
+describe('story #3735 B갈래 — 「측정 계획이 아직 없음」 낱말 grep 0건', () => {
+  it('ko.json/en.json에 clusterUnclosedMeasurePlanMissing 키가 없다', async () => {
+    const enMessages = (await import('../../../messages/en.json')).default;
+    expect(Object.keys(koMessages.orgBriefing)).not.toContain('clusterUnclosedMeasurePlanMissing');
+    expect(Object.keys(enMessages.orgBriefing)).not.toContain('clusterUnclosedMeasurePlanMissing');
+  });
+
+  it('ko.json 어디에도 「측정 계획이 아직 없음」 문자열이 없다', () => {
+    expect(JSON.stringify(koMessages)).not.toContain('측정 계획이 아직 없음');
   });
 });

--- a/apps/web/src/components/org-briefing/attention-cluster-board.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.tsx
@@ -336,19 +336,9 @@ function SilentStallShell({
   );
 }
 
-// story #2830(§2 PO 보완 지시) — N 비포함·집계만 유지되는 3번째 카테고리(측정계획 없는 active
-// goal). 개별 목록·클릭 링크 없음(AC상 요건 없음), 카드 하단 옅은 보조 텍스트 한 줄로만 존재를
-// 알린다. 유나 스티어④ — "옅게"가 AA 밑으로 못 내려간다: text-muted-foreground(3.x대, AA 미달
-// 가능성)가 아니라 text-foreground 소형(11px)으로 대비는 지키되 크기/톤으로 옅음을 표현한다.
-function MeasurePlanMissingNote({ count }: { count: number }) {
-  const t = useTranslations('orgBriefing');
-  if (count <= 0) return null;
-  return (
-    <p className="border-t border-border bg-muted/30 px-4 py-2 text-[11px] text-foreground">
-      {t('clusterUnclosedMeasurePlanMissing', { count })}
-    </p>
-  );
-}
+// story #3735(B갈래, 유나 사전) — 「+N건은 측정 계획이 아직 없음」은 사용자 화면 밖(운영
+// 화면 몫)이라 걷는다. MeasurePlanMissingNote(옛 #2830)를 여기서 제거 — measurePlanMissing
+// GoalCount prop 자체(파생 계층)는 무변(이 스토리 범위 밖).
 
 // story #2843/#2844 — 명시 "측정 불가" 선언 goal 수. measure_plan_missing과 동형(N 비포함·
 // 집계만·개별 목록 없음) — 위조 채널 감시용(§4, unmeasurable 남발로 루프 N을 인위적으로
@@ -396,7 +386,9 @@ export function AttentionClusterBoard({
   silentStall,
   loop,
   loopTotalCount,
-  measurePlanMissingGoalCount,
+  // story #3735(B갈래) — 렌더 소비처 제거 후 미사용(파생 계층·prop 계약은 무변, 이 스토리
+  // 범위 밖). eslint no-unused-vars 관례대로 `_` 접두.
+  measurePlanMissingGoalCount: _measurePlanMissingGoalCount,
   unmeasurableGoalCount,
   authFailure = [],
   memberNames = {},
@@ -469,7 +461,6 @@ export function AttentionClusterBoard({
           {/* no-silent-cap(유나 스티어②) — 다 펼쳤어도 items[]가 top-20 cap이면 실제 총량과
               다를 수 있다는 것을 정직하게 알린다. */}
           {loopExpanded ? <LoopCapNotice shown={loop.length} total={loopTotalCount} /> : null}
-          <MeasurePlanMissingNote count={measurePlanMissingGoalCount} />
           <UnmeasurableGoalNote count={unmeasurableGoalCount} />
         </ClusterShell>
       ) : null}

--- a/apps/web/src/components/org-briefing/org-briefing-shell.tsx
+++ b/apps/web/src/components/org-briefing/org-briefing-shell.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { Card } from '@/components/ui/card';
 import { NowFace } from './now-face';
 import { LoopFace } from './loop-face';
 import { WorkforceFace } from './workforce-face';
@@ -17,8 +18,11 @@ import { WorkforceFace } from './workforce-face';
 // 3면 순차 fade-in stagger(lagom — clutter 추가 아닌 절제된 진입 리듬).
 
 function FaceSkeletonPanel({ title, subject }: { title: string; subject: string }) {
+  // 페드루 PO 지적(2026-09-09, 배포 60 실픽셀·유나군 정정) — loop-face.tsx/workforce-
+  // face.tsx와 같은 카드인데 옛 rounded-2xl 손코딩이 남아 있었다(projectId 미확定 상태라
+  // 평소엔 안 그려질 뿐 코드엔 있었다) — Card 프리미티브로 통일.
   return (
-    <div className="rounded-2xl border border-border bg-card p-4">
+    <Card className="p-4">
       <div className="mb-3 flex items-baseline gap-2.5">
         <h2 className="text-sm font-semibold text-foreground">{title}</h2>
         <span className="text-[11px] text-muted-foreground">{subject}</span>
@@ -33,7 +37,7 @@ function FaceSkeletonPanel({ title, subject }: { title: string; subject: string 
           <div className="h-2 w-20 animate-pulse rounded-full bg-muted" />
         </div>
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/apps/web/src/components/org-briefing/workforce-face.tsx
+++ b/apps/web/src/components/org-briefing/workforce-face.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Users, Bot } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
 import {
   buildWorkforceFace, parseActiveEpics, parseEpicStories, parseTeamMembers,
   type WorkforceFaceItem, type WorkforceFaceTranslator,
@@ -99,7 +100,10 @@ export function WorkforceFace({ projectId }: { projectId: string }) {
 
   return (
     // story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card.
-    <div className="rounded-2xl border border-border bg-card p-4 transition-shadow hover:shadow-[var(--elev-card)]">
+    // 페드루 PO 지적(2026-09-09, 배포 60 실픽셀) — loop-face.tsx와 같은 카드인데 옛
+    // rounded-2xl 손코딩이 남아 있어 다른 코너값(loop-face는 Card 프리미티브의 4px)이
+    // 섞여 보였다 — Card 프리미티브로 통일.
+    <Card className="p-4 transition-shadow hover:shadow-[var(--elev-card)]">
       <div className="mb-3 flex items-baseline gap-2.5">
         <span className="size-1.5 shrink-0 rounded-full bg-success" aria-hidden="true" />
         <h2 className="text-sm font-semibold text-foreground">{t('workforceTitle')}</h2>
@@ -121,6 +125,6 @@ export function WorkforceFace({ projectId }: { projectId: string }) {
       ) : (
         data.items.map((item) => <WorkforceRow key={item.id} item={item} memberNames={data.memberNames} t={t} />)
       )}
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
페드루 PO 지적(2026-09-09, 배포 60 실픽셀·유나군 정정) — #3735(A/B/C) 착지 뒤에도 남아 있던 잔존 3건. **이 PR 착지가 #3735 done 조건**(카드 8296725e에 묶음).

## 잔존 3건

1. **「+N건은 측정 계획이 아직 없음」** — 유나 사전 B갈래(사용자 화면에서 걷는다) 목록에 있었으나 실제 렌더 소비처(`MeasurePlanMissingNote`, `attention-cluster-board.tsx`)가 안 지워져 있었다. 컴포넌트+호출부+i18n 키(ko/en `clusterUnclosedMeasurePlanMissing`) 제거. N 비합산 계약(prop 자체·파생 계층)은 무변 — 이 스토리 범위 밖.
2. **`workforce-face.tsx`** — 「워크포스」 카드가 `loop-face.tsx`와 같은 자리인데 옛 `rounded-2xl border border-border bg-card` 손코딩이 남아 다른 코너값(loop-face는 Card 프리미티브의 4px)이 섞여 보였다. Card 프리미티브로 통일.
3. **`org-briefing-shell.tsx`(FaceSkeletonPanel)** — 같은 클래스 잔존(`projectId` 미확定 상태라 평소엔 안 그려질 뿐 코드엔 있었다) — 동형 처방.

`handrolled-card-baseline.json`에서 두 파일의 키 2건 제거(270→268, 가드의 "줄어들기만" 계약). 결과 = 조직 브리핑 5장 카드 전부 4px로 정합.

## Test plan
- [x] `attention-cluster-board.test.tsx`에 신규 "낱말 grep 0건" 테스트 2개(orgBriefing 키 목록 검사 + ko.json 전체 문자열 검사) — 되돌리면(ko.json에 키 재삽입) 직접 확인 RED.
- [x] 기존 `measurePlanMissingGoalCount는 N에...` 테스트를 "보조 텍스트 자체가 없다" 단언으로 갱신.
- [x] `verify-no-handrolled-card.ts` — workforce-face.tsx를 옛 rounded-2xl로 되돌려(baseline은 이미 줄어든 상태) exit 1(FAIL) 직접 확인 後 복원.
- [x] FE 전체 743파일/7309테스트 green · tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)