### PR TITLE
[SID:3734] fix(BE): 성과 보드 — 원 초안 보관 시 발행분도 기본 목록에서 제외(AC3)

### DIFF
--- a/backend/app/routers/insights_board.py
+++ b/backend/app/routers/insights_board.py
@@ -132,6 +132,12 @@ async def get_insights_board_endpoint(
     limit: int = Query(default=50, ge=1, le=200),
     # story #bf290f69 — story별 성과 대조(blog+social 발행물을 한 story로 좁혀 보기).
     work_item_id: uuid.UUID | None = Query(default=None),
+    include_deleted: bool = Query(
+        default=False,
+        description="story #3734 AC3 후속(PO 라이브 판정 2026-09-09) — true면 원 초안이 "
+        "보관된(deleted_at not null) 발행분도 포함한다. 목록 두 곳(site-posts·"
+        "channel-posts drafts)과 같은 파라미터명·같은 뜻 — 기본은 제외.",
+    ),
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
@@ -143,7 +149,7 @@ async def get_insights_board_endpoint(
         result = await list_insights_board(
             db, org_id=org_id, window=window, channel=channel, status=status,
             sort=sort, sort_dir=sort_dir, cursor=cursor, limit=limit,
-            work_item_id=work_item_id,
+            work_item_id=work_item_id, include_deleted=include_deleted,
         )
     except InsightsBoardInvalidWindowError as exc:
         raise HTTPException(

--- a/backend/app/services/insights_board.py
+++ b/backend/app/services/insights_board.py
@@ -35,12 +35,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.pagination import decode_cursor, decode_metric_cursor, encode_cursor, encode_metric_cursor
+from app.models.channel_post_draft import ChannelPostDraft
 from app.models.channel_publication import ChannelPublication
 from app.models.channel_post_version import ChannelPostVersion
 from app.models.gate import Gate
 from app.models.insight_snapshot import InsightSnapshot
 from app.models.pm import Story
 from app.models.site_post import SitePost
+from app.models.site_post_draft import SitePostDraft
 from app.services.insight_snapshots import (
     NORMALIZED_KEYS,
     assemble_channel_post_asset_evidence,
@@ -71,7 +73,13 @@ def _blog_external_url_expr(base_url: str | None):
     return literal(base_url) + literal("/") + SitePost.lang + literal("/blog/") + SitePost.slug
 
 
-def _build_union(*, org_id: uuid.UUID, channel: str | None, since: datetime):
+def _build_union(*, org_id: uuid.UUID, channel: str | None, since: datetime, include_deleted: bool = False):
+    """story #3734 AC3 후속(PO 라이브 판정 2026-09-09 10:16Z) — 보관(soft-delete)은
+    초안(`SitePostDraft`/`ChannelPostDraft`)의 `deleted_at`만 찍고 발행 기록
+    (`SitePost`/`ChannelPublication`)은 무변(설계대로, #3291 승인 불변화와 정합) —
+    그래서 이 보드가 그 사실을 몰랐다. 두 목록 화면과 같은 낱말 「보관됨 보기」를
+    그대로 재사용(`include_deleted`, 목록 두 곳과 동일 파라미터명) — `True`면
+    보관된 발행분도 포함(집계·감사용), 기본은 제외."""
     site_post_arm = select(
         SitePost.id.label("publication_id"),
         literal("site_post").label("kind"),
@@ -87,9 +95,24 @@ def _build_union(*, org_id: uuid.UUID, channel: str | None, since: datetime):
         # story #3656 — site_post는 소재/훅 개념 자체가 없어 항상 null(channel_post_
         # draft_id와 동일 이유).
         cast(literal(None), PG_UUID(as_uuid=True)).label("version_id"),
+    ).select_from(SitePost)
+    # story #3734 AC3 후속 — SitePost에 draft로의 FK가 없다(site_posts.py 서비스와 동형
+    # 관례). (org_id, work_item_id, slug)가 site_post_drafts의 unique 제약과 정확히
+    # 일치해 그 키로 원 초안을 되찾는다(lang은 그 제약 밖이라 join 키에 안 씀).
+    site_post_arm = site_post_arm.outerjoin(
+        SitePostDraft,
+        (SitePostDraft.org_id == SitePost.org_id)
+        & (SitePostDraft.work_item_id == SitePost.source_story_id)
+        & (SitePostDraft.slug == SitePost.slug),
     ).where(
         SitePost.org_id == org_id, SitePost.unpublished_at.is_(None), SitePost.published_at >= since,
     )
+    if not include_deleted:
+        # 매칭되는 초안이 없으면(SitePostDraft.id IS NULL) 보관 여부를 판정할 수 없으니
+        # 배제하지 않는다("모른다≠보관됨") — 있는데 deleted_at이 찍힌 경우만 뺀다.
+        site_post_arm = site_post_arm.where(
+            (SitePostDraft.id.is_(None)) | (SitePostDraft.deleted_at.is_(None))
+        )
     if channel is not None and channel != "hosted_site":
         site_post_arm = site_post_arm.where(literal(False))  # 이 팔 자체를 비운다(채널 불일치).
 
@@ -117,11 +140,19 @@ def _build_union(*, org_id: uuid.UUID, channel: str | None, since: datetime):
         .join(Gate, Gate.id == ChannelPublication.gate_id)
         .join(Story, Story.id == Gate.work_item_id)
         .outerjoin(ChannelPostVersion, ChannelPostVersion.id == ChannelPublication.version_id)
+        # story #3734 AC3 후속 — ChannelPostVersion.draft_id는 이미 조인돼 있다(위,
+        # channel_post_draft_id 라벨의 출처) — 그 draft_id로 ChannelPostDraft까지
+        # 한 단계 더 조인해 deleted_at을 본다.
+        .outerjoin(ChannelPostDraft, ChannelPostDraft.id == ChannelPostVersion.draft_id)
         .where(
             ChannelPublication.org_id == org_id, ChannelPublication.status == "published",
             ChannelPublication.published_at.is_not(None), ChannelPublication.published_at >= since,
         )
     )
+    if not include_deleted:
+        channel_pub_arm = channel_pub_arm.where(
+            (ChannelPostDraft.id.is_(None)) | (ChannelPostDraft.deleted_at.is_(None))
+        )
     if channel is not None:
         if channel == "hosted_site":
             channel_pub_arm = channel_pub_arm.where(literal(False))
@@ -135,14 +166,14 @@ async def list_insights_board(
     db: AsyncSession, *, org_id: uuid.UUID, window: str = "30d", channel: str | None = None,
     status: str | None = None, sort: str = "published_at", sort_dir: str = "desc",
     cursor: str | None = None, limit: int = 50, now: datetime | None = None,
-    work_item_id: uuid.UUID | None = None,
+    work_item_id: uuid.UUID | None = None, include_deleted: bool = False,
 ) -> dict[str, Any]:
     if window not in _WINDOW_DAYS:
         raise InsightsBoardInvalidWindowError(window)
     now = now or datetime.now(timezone.utc)
     since = now - timedelta(days=_WINDOW_DAYS[window])
 
-    rows_cte = _build_union(org_id=org_id, channel=channel, since=since)
+    rows_cte = _build_union(org_id=org_id, channel=channel, since=since, include_deleted=include_deleted)
     query = select(rows_cte)
 
     # story #bf290f69(Phase2·BE, 페드루 PO 確定 2026-09-08) — story별 성과 대조. 기존

--- a/backend/tests/test_3502_insights_board.py
+++ b/backend/tests/test_3502_insights_board.py
@@ -131,6 +131,35 @@ async def _seed_channel_post_image(session, *, org_id, draft_id, version_id, pos
     return image
 
 
+# story #3734 AC3 후속(2026-09-09) — 원 초안이 보관되면 발행분도 성과 보드 기본에서
+# 빠져야 한다는 회귀를 재는 시딩 헬퍼 둘. 기존 파일의 다른 헬퍼와 동형(직접 모델
+# construct, API 경유 안 함).
+async def _seed_site_post_draft(
+    session, *, org_id, work_item_id, slug, deleted_at=None,
+):
+    from app.models.site_post_draft import SitePostDraft
+
+    draft = SitePostDraft(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, slug=slug,
+        deleted_at=deleted_at,
+    )
+    session.add(draft)
+    await session.commit()
+    return draft
+
+
+async def _seed_channel_post_draft_with_deleted_at(session, *, org_id, work_item_id, channel="instagram", deleted_at=None):
+    from app.models.channel_post_draft import ChannelPostDraft
+
+    draft = ChannelPostDraft(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, channel=channel,
+        connection_id=uuid.uuid4(), deleted_at=deleted_at,
+    )
+    session.add(draft)
+    await session.commit()
+    return draft
+
+
 async def _seed_snapshot(
     session, *, org_id, work_item_id, publication_id, publication_kind, channel,
     due_at, status="captured", normalized=None,
@@ -410,6 +439,120 @@ async def test_unpublished_site_post_excluded():
 
             result = await list_insights_board(s, org_id=org_id, window="30d")
         assert result["rows"] == []
+    finally:
+        await engine.dispose()
+
+
+# story #3734 AC3 후속(PO 라이브 판정 2026-09-09 10:16Z) — 보관은 초안 deleted_at만
+# 찍고 발행 기록(SitePost/ChannelPublication)은 무변인데(설계대로, #3291 정합) 이
+# 보드가 그 사실을 몰라 보관된 초안의 발행분이 그대로 남아 있었다(실측: 라이브 첫
+# 화면 20행 중 17이 스모크 표본). 기본 제외 + include_deleted=True로 복귀 확認.
+@pytest.mark.anyio
+async def test_site_post_excluded_when_source_draft_archived():
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            now = datetime.now(timezone.utc)
+            await _seed_site_post_draft(
+                s, org_id=org_id, work_item_id=story_id, slug="post-archived",
+                deleted_at=now,
+            )
+            sp = await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_id, slug="post-archived", title="보관된 글",
+                published_at=now - timedelta(days=1),
+            )
+
+            result_default = await list_insights_board(s, org_id=org_id, window="30d")
+            result_included = await list_insights_board(s, org_id=org_id, window="30d", include_deleted=True)
+
+        assert result_default["rows"] == []
+        assert [r["publication_id"] for r in result_included["rows"]] == [sp.id]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_site_post_not_excluded_when_no_matching_draft_exists():
+    """원 초안 매칭이 아예 안 되면(순수 발행 레코드만 있는 표본 등) 보관 여부를
+    판정할 수 없다 — "모른다≠보관됨"이라 배제하지 않는다(뮤테이션 표적: OR 절을
+    지우면 이 케이스도 신규 발행분처럼 빠져 버린다)."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            now = datetime.now(timezone.utc)
+            sp = await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_id, slug="post-no-draft", title="초안 없는 글",
+                published_at=now - timedelta(days=1),
+            )
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+
+        assert [r["publication_id"] for r in result["rows"]] == [sp.id]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_channel_publication_excluded_when_source_draft_archived():
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id)
+            draft = await _seed_channel_post_draft_with_deleted_at(
+                s, org_id=org_id, work_item_id=story_id, deleted_at=datetime.now(timezone.utc),
+            )
+            version_id = uuid.uuid4()
+            await _seed_channel_post_version(s, draft_id=draft.id, version_id=version_id)
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, channel="threads",
+                published_at=datetime.now(timezone.utc) - timedelta(days=1), version_id=version_id,
+            )
+
+            result_default = await list_insights_board(s, org_id=org_id, window="30d")
+            result_included = await list_insights_board(s, org_id=org_id, window="30d", include_deleted=True)
+
+        assert result_default["rows"] == []
+        assert [r["publication_id"] for r in result_included["rows"]] == [pub.id]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_channel_publication_not_excluded_when_draft_not_archived():
+    """짝 확認 — 보관 안 된(deleted_at=None) 초안의 발행분은 기본 목록에도 그대로
+    남는다(회귀 없음, 기존 5행 표본 테스트와 같은 축이지만 이 파일의 새 join 경로가
+    멀쩡한 행까지 실수로 안 뺀다는 걸 직접 pin)."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id)
+            draft = await _seed_channel_post_draft(s, org_id=org_id, work_item_id=story_id)
+            version_id = uuid.uuid4()
+            await _seed_channel_post_version(s, draft_id=draft.id, version_id=version_id)
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, channel="threads",
+                published_at=datetime.now(timezone.utc) - timedelta(days=1), version_id=version_id,
+            )
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+
+        assert [r["publication_id"] for r in result["rows"]] == [pub.id]
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## 요약(story #3734 AC3 후속, PO 라이브 판정 2026-09-09 10:16Z)

배포 뒤 PO 라이브 판정 — 목록 두 곳(블로그 포스트·채널 포스트)은 「보관」이 잘 동작했지만(AC1·AC2 통과), **성과 보드는 그 사실을 모른다**: 보관은 초안 `deleted_at`만 찍고 발행 기록(`SitePost`·`ChannelPublication`)은 무변(설계대로, #3291 승인 불변화와 정합)이라 — 라이브 첫 화면 20행 중 17이 여전히 `[SMOKE]`/`[dogfood]` 표본이었다.

## 처방

`insights_board.py::_build_union()`이 이제 원 초안까지 outer join해 보관 여부를 본다:
- `site_post_arm` → `SitePostDraft`(키 = `(org_id, work_item_id, slug)`, `site_post_drafts`의 unique 제약과 정확히 일치 — `SitePost`에 draft로의 FK가 없어 이 방식으로 되찾는다).
- `channel_pub_arm` → 이미 조인돼 있던 `ChannelPostVersion`(`channel_post_draft_id` 라벨의 출처)을 한 단계 더 뻗어 `ChannelPostDraft`까지.

`include_deleted`(기본 `False`) 파라미터 신설 — 목록 두 곳과 **같은 낱말·같은 파라미터명**(「보관됨 보기」 재사용) — `list_insights_board()` → 라우터 쿼리 파라미터까지 관통.

**"모른다≠보관됨"** — 매칭되는 초안이 아예 없으면(순수 발행 레코드만 있는 표본 등) 배제하지 않는다. outer join이라 자연히 그렇게 되고, 별도 테스트로 이 축을 직접 pin했다.

## 검증(real Postgres, `destructive_schema`)

- 신규 테스트 5개(제외 기본값 2·include_deleted 복귀 확認·매칭 없음 fail-open·짝 확認) + 기존 16개 = **21/21**.
- 다른 insights-board 테스트 파일(엔드포인트·work_item_id 필터) **12/12** 무회귀.
- **뮤테이션 킬** — 두 exclusion 필터(`site_post_arm`·`channel_pub_arm`)를 임시 제거해 신규 exclude 테스트 2개가 정확한 이유로 RED 확認 후 복원, 재확認 GREEN.

## 적기만(스토리 明示)

FE 토글은 이번 소 PR 스코프 밖 — BE 기본 동작만 고친다(라이브 표본이 조용히 다시 안 새는 게 핵심). 공개 사이트(public_site_posts) 쪽 처리는 story #3734 AC4에서 이미 별건으로 표기됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)