### PR TITLE
[SID:3722] feat(FE+MCP): PR2 — 실행 상세 도구 호출 재건 + MCP 이름표

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3714,7 +3714,18 @@
     "retryFailedTitle": "Retry failed",
     "retryFailedBody": "Could not schedule a retry. Please try again later.",
     "runHistory": "Run history",
-    "runHistoryDescription": "View past agent executions and their outcomes."
+    "runHistoryDescription": "View past agent executions and their outcomes.",
+    "toolCallsTitle": "Tool calls",
+    "toolCallsEmptyPending": "No records yet.",
+    "toolCallsEmptyNone": "This run didn't use any tools.",
+    "toolCallsLoadError": "Couldn't load tool call records.",
+    "toolCallsLoadingMore": "Loading…",
+    "toolCallsSuccessBadge": "Success",
+    "toolCallsFailedBadge": "Failed",
+    "toolCallsInputSummaryLabel": "Input summary",
+    "toolCallsErrorSummary": "This call failed",
+    "toolCallsErrorToggle": "View server response",
+    "toolCallsUnnamedCall": "Unnamed call"
   },
   "hypotheses": {
     "sectionTitle": "Hypotheses",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3714,7 +3714,18 @@
     "retryFailedTitle": "재시도 실패",
     "retryFailedBody": "재시도를 예약하지 못했습니다. 나중에 다시 시도해 주세요.",
     "runHistory": "실행 기록",
-    "runHistoryDescription": "에이전트 실행 이력과 결과를 확인합니다."
+    "runHistoryDescription": "에이전트 실행 이력과 결과를 확인합니다.",
+    "toolCallsTitle": "도구 호출",
+    "toolCallsEmptyPending": "아직 기록이 없습니다.",
+    "toolCallsEmptyNone": "이 실행은 도구를 쓰지 않았습니다.",
+    "toolCallsLoadError": "도구 호출 기록을 불러오지 못했습니다.",
+    "toolCallsLoadingMore": "불러오는 중…",
+    "toolCallsSuccessBadge": "성공",
+    "toolCallsFailedBadge": "실패",
+    "toolCallsInputSummaryLabel": "입력 요약",
+    "toolCallsErrorSummary": "이 호출이 실패했습니다",
+    "toolCallsErrorToggle": "서버 응답 보기",
+    "toolCallsUnnamedCall": "이름 없는 호출"
   },
   "hypotheses": {
     "sectionTitle": "가설",

--- a/apps/web/src/app/api/v1/agent-runs/[id]/tool-calls/route.test.ts
+++ b/apps/web/src/app/api/v1/agent-runs/[id]/tool-calls/route.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// story #3722(Trust·PR2) — [id]/route.test.ts와 동형 harness. 이 자리는 X-Total-Count를
+// meta.totalCount로 얹는 것까지가 계약(list_agent_runs route.ts의 "bare list 부채"를
+// 반복하지 않는다).
+const { proxyToFastapi } = vi.hoisted(() => ({ proxyToFastapi: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
+
+import { GET } from './route';
+
+const ID = 'run-1';
+const ctx = () => ({ params: Promise.resolve({ id: ID }) });
+const req = () => new Request(`http://localhost/x/${ID}/tool-calls`, { method: 'GET' });
+const okRes = (body: unknown, totalCount?: string) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+      ...(totalCount !== undefined ? { 'x-total-count': totalCount } : {}),
+    },
+  });
+
+describe('/api/v1/agent-runs/[id]/tool-calls (proxy 위임 + X-Total-Count 전달)', () => {
+  beforeEach(() => proxyToFastapi.mockReset());
+
+  it('delegates to /api/v2/agent-runs/{id}/tool-calls and wraps rows', async () => {
+    const rows = [{ id: 'tc-1', tool: 'sprintable_add_task' }];
+    proxyToFastapi.mockResolvedValue(okRes(rows, '3'));
+    const res = await GET(req(), ctx());
+    expect(res.status).toBe(200);
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), `/api/v2/agent-runs/${ID}/tool-calls`);
+    const json = await res.json();
+    expect(json.data).toEqual(rows);
+    expect(json.meta.totalCount).toBe(3);
+  });
+
+  it('⭐X-Total-Count 헤더 없으면 totalCount는 null(0으로 위장하지 않는다)', async () => {
+    proxyToFastapi.mockResolvedValue(okRes([]));
+    const json = await (await GET(req(), ctx())).json();
+    expect(json.meta.totalCount).toBeNull();
+  });
+
+  it('⭐X-Total-Count가 숫자가 아니면(계약 위반) NaN이 아니라 null(NaN===null 함정 재발 방지)', async () => {
+    proxyToFastapi.mockResolvedValue(okRes([], 'not-a-number'));
+    const json = await (await GET(req(), ctx())).json();
+    expect(json.meta.totalCount).toBeNull();
+  });
+
+  it('passes through proxy errors', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('e', { status: 404 }));
+    expect((await GET(req(), ctx())).status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/v1/agent-runs/[id]/tool-calls/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/[id]/tool-calls/route.ts
@@ -1,0 +1,23 @@
+import { apiSuccess } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// story #3722(Trust·PR2) — GET /agent-runs/{id}/tool-calls는 X-Total-Count를 준다(페드루 PO
+// 追加, 2026-09-09 — #3703/#3706류 "한 페이지=전부" 오판 재발 방지). list_agent_runs
+// route.ts(v1/agent-runs/route.ts)가 그 헤더를 버리는 부채와 달리, 이 신규 자리는 처음부터
+// meta.totalCount로 얹는다(goals/route.ts position 모드와 동형 — Number.isFinite 가드로
+// 계약 위반(NaN)도 null로 통일, "모르면 단정 안 함").
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}/tool-calls`);
+    if (!_r.ok) return _r;
+    const rows = (await _r.json()) as unknown[];
+    const totalHeader = _r.headers.get('x-total-count');
+    const parsed = totalHeader === null ? null : Number(totalHeader);
+    const totalCount = parsed !== null && Number.isFinite(parsed) ? parsed : null;
+    return apiSuccess(rows, { totalCount });
+  } catch (error) { return handleApiError(error); }
+}

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -14,6 +14,7 @@ import { fetchWithAuth } from '@/lib/db/client';
 import { formatRelativeTime } from '@/lib/storage/format';
 import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
 import { agentRunStatusBadgeVariant, type AgentRunStatus } from '@/lib/agent-run-status';
+import { AgentRunToolCallsSection } from './agent-run-tool-calls-section';
 
 interface RunDetail {
   id: string;
@@ -47,7 +48,9 @@ interface RunDetail {
   created_at: string;
 }
 
-function formatDuration(ms: number | null): string {
+// story #3722(Trust·PR2) — agent-run-tool-calls-section.tsx가 같은 포맷 규칙을 재사용(초 단위
+// duration_ms 표시). export해 중복 정의를 피한다.
+export function formatDuration(ms: number | null): string {
   if (ms == null) return '-';
   if (ms < 1000) return `${ms}ms`;
   const s = ms / 1000;
@@ -58,7 +61,7 @@ function formatDuration(ms: number | null): string {
 }
 
 // story #3493 — started_at/finished_at/entry.created_at은 "기록"(정본 formatRelativeTime).
-function toLocaleStr(iso: string | null, locale: string, displayTimezone: string): string {
+export function toLocaleStr(iso: string | null, locale: string, displayTimezone: string): string {
   if (!iso) return '-';
   return formatRelativeTime(iso, locale, displayTimezone);
 }
@@ -275,6 +278,13 @@ export function AgentRunDetail({
 
           </SectionCardBody>
         </SectionCard>
+
+        <AgentRunToolCallsSection
+          runId={run.id}
+          runStatus={run.status}
+          locale={locale}
+          displayTimezone={displayTimezone}
+        />
       </div>
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </>

--- a/apps/web/src/components/agents/agent-run-tool-calls-section.test.tsx
+++ b/apps/web/src/components/agents/agent-run-tool-calls-section.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+//
+// story #3722(Trust·PR2) — 確定 설계(단일 통합 섹션, PO 2026-09-09 09:13Z). 옛 Timeline+Tool
+// Audit Trail 두 판을 하나로 합친 새 자리라 옛 타입(ToolCallEntry/ToolAuditEntry)과 무관하게
+// 새로 짠다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { AgentRunToolCallsSection } from './agent-run-tool-calls-section';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'tc-1',
+    tool: null,
+    method: 'GET',
+    path: '/api/v2/stories',
+    status_code: 200,
+    duration_ms: 128,
+    started_at: '2026-09-09T00:00:00Z',
+    created_at: '2026-09-09T00:00:00Z',
+    input_summary: null,
+    error: null,
+    attribution_reason: 'header',
+    ...overrides,
+  };
+}
+
+function stubFetch(handler: (url: string) => { ok: boolean; status?: number; json: () => Promise<unknown>; headers?: Record<string, string> }) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => handler(String(input))));
+}
+
+function mountSection(runStatus: 'completed' | 'failed' | 'abandoned' | 'running' | 'queued' | 'held' | 'hitl_pending' = 'completed') {
+  return act(async () => {
+    root.render(wrap(
+      <AgentRunToolCallsSection runId="run-1" runStatus={runStatus} locale="ko" displayTimezone="Asia/Seoul" />,
+    ));
+  });
+}
+
+describe('AgentRunToolCallsSection', () => {
+  it('story #3722(빈 상태 축③) — 종료된 run·0건은 「도구를 쓰지 않았습니다」', async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({ data: [], meta: { totalCount: 0 } }) }));
+    await mountSection('completed');
+    await flush();
+    expect(container.textContent).toContain(koMessages.agentRuns.toolCallsEmptyNone);
+    expect(container.textContent).not.toContain(koMessages.agentRuns.toolCallsEmptyPending);
+  });
+
+  it('story #3722(빈 상태 축③) — 진행 중 run·0건은 「아직 기록이 없습니다」(다른 사실)', async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({ data: [], meta: { totalCount: 0 } }) }));
+    await mountSection('running');
+    await flush();
+    expect(container.textContent).toContain(koMessages.agentRuns.toolCallsEmptyPending);
+    expect(container.textContent).not.toContain(koMessages.agentRuns.toolCallsEmptyNone);
+  });
+
+  it('⭐story #3722(E절) — 제목 문자열엔 수가 없고 CountBadge에만 있다', async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({ data: [row()], meta: { totalCount: 7 } }) }));
+    await mountSection();
+    await flush();
+    const heading = container.querySelector('h2');
+    expect(heading?.textContent).not.toMatch(/\(\d+\)/);
+    expect(heading?.querySelector('span')?.textContent).toBe('7');
+  });
+
+  it('⭐페드루 PO 決(09:13Z) — tool 있으면 1차 라벨=tool, method+path는 부제로 демoted', async () => {
+    stubFetch(() => ({
+      ok: true,
+      json: async () => ({ data: [row({ tool: 'sprintable_add_task' })], meta: { totalCount: 1 } }),
+    }));
+    await mountSection();
+    await flush();
+    expect(container.textContent).toContain('sprintable_add_task');
+    expect(container.textContent).toContain('GET /api/v2/stories'); // 부제로는 여전히 보인다
+  });
+
+  // story #3722(페드루 PO 지적, #4089 리뷰 2026-09-09) — 최초 決(09:13Z, "method+path를
+  // 1차로 승격")은 다시 보니 코드 값(HTTP 경로)이 제목 자리에 서는 결함이었다(오늘 이벤트
+  // 키·stibee와 같은 클래스). 「이름 없는 호출」(모름을 모름이라 쓴다)로 정정 — 경로는
+  // tool 유무와 무관하게 항상 부제로만.
+  it('⭐tool 없으면 「이름 없는 호출」(고정 문구)이 1차, method+path는 부제로만(제목 자리에 raw 경로 금지)', async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({ data: [row({ tool: null })], meta: { totalCount: 1 } }) }));
+    await mountSection();
+    await flush();
+    expect(container.textContent).toContain(koMessages.agentRuns.toolCallsUnnamedCall);
+    expect(container.textContent).toContain('GET /api/v2/stories'); // 부제로는 여전히 보인다(D2/D3 관례)
+    // 1차 라벨 자리엔 고정 문구만 — raw 경로가 안 선다(경로는 부제 줄에만).
+    const primary = container.querySelector('[data-testid="tool-call-primary-tc-1"]');
+    expect(primary?.textContent).toBe(koMessages.agentRuns.toolCallsUnnamedCall);
+  });
+
+  it('status_code<400은 성공 배지, ≥400은 실패 배지', async () => {
+    stubFetch(() => ({
+      ok: true,
+      json: async () => ({
+        data: [row({ id: 'ok-1', status_code: 200 }), row({ id: 'fail-1', status_code: 500 })],
+        meta: { totalCount: 2 },
+      }),
+    }));
+    await mountSection();
+    await flush();
+    expect(container.textContent).toContain(koMessages.agentRuns.toolCallsSuccessBadge);
+    expect(container.textContent).toContain(koMessages.agentRuns.toolCallsFailedBadge);
+  });
+
+  it('행을 펼치면 input_summary·error가 보이고, 접으면 안 보인다', async () => {
+    stubFetch(() => ({
+      ok: true,
+      json: async () => ({
+        data: [row({ input_summary: { title: 'x' }, error: 'boom' })],
+        meta: { totalCount: 1 },
+      }),
+    }));
+    await mountSection();
+    await flush();
+    expect(container.textContent).not.toContain('boom');
+    const toggle = container.querySelector('[data-testid="tool-call-toggle-tc-1"]') as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+    await act(async () => { toggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    expect(container.textContent).toContain('boom');
+    expect(container.textContent).toContain('"title"');
+  });
+
+  // story #3722(페드루 PO 사전 스티어, PR2) — `error` raw 노출 금지. 사람이 읽는 한
+  // 줄(고정 문구)은 행을 펼치면 항상 보이고, 서버 원문(raw)은 그 안에서도 <details>로
+  // 한 번 더 접혀 있다(기본 닫힘) — textContent만으로는 hidden 여부를 못 가르므로
+  // <details>.open 프로퍼티로 직접 잰다.
+  it('⭐오류는 「이 호출이 실패했습니다」 고정 문구가 항상 먼저 보이고, 원문은 <details> 기본 닫힘 안에 있다', async () => {
+    stubFetch(() => ({
+      ok: true,
+      json: async () => ({ data: [row({ error: 'Traceback (most recent call last): boom' })], meta: { totalCount: 1 } }),
+    }));
+    await mountSection();
+    await flush();
+    const toggle = container.querySelector('[data-testid="tool-call-toggle-tc-1"]') as HTMLButtonElement;
+    await act(async () => { toggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    expect(container.textContent).toContain(koMessages.agentRuns.toolCallsErrorSummary);
+    const details = container.querySelector('details');
+    expect(details).toBeTruthy();
+    expect(details?.open).toBe(false);
+    // jsdom의 textContent는 <details> 닫힘과 무관하게 자식 텍스트를 그대로 반환한다
+    // (visual hidden과 DOM 존재는 다른 축) — 그래서 존재 자체가 아니라 .open으로 잰다.
+    expect(details?.querySelector('summary')?.textContent).toBe(koMessages.agentRuns.toolCallsErrorToggle);
+  });
+
+  it('입력요약·오류가 둘 다 없으면 펼침 컨트롤 자체가 없다(빈 디스클로저 방지)', async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({ data: [row()], meta: { totalCount: 1 } }) }));
+    await mountSection();
+    await flush();
+    expect(container.querySelector('[data-testid="tool-call-toggle-tc-1"]')).toBeNull();
+  });
+
+  it('⭐더 보기 — cursor는 마지막 행의 created_at, 응답을 이어붙인다', async () => {
+    const calls: string[] = [];
+    let page = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      page += 1;
+      if (page === 1) {
+        return { ok: true, json: async () => ({ data: [row({ id: 'p1', created_at: '2026-09-09T00:00:00Z' })], meta: { totalCount: 2 } }) };
+      }
+      return { ok: true, json: async () => ({ data: [row({ id: 'p2', created_at: '2026-09-08T00:00:00Z' })], meta: { totalCount: 2 } }) };
+    }));
+    await mountSection();
+    await flush();
+    const moreBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.agentRuns.loadMore);
+    expect(moreBtn).toBeTruthy();
+    await act(async () => { moreBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    expect(calls[1]).toContain(`cursor=${encodeURIComponent('2026-09-09T00:00:00Z')}`);
+    expect(container.querySelector('[data-testid="tool-call-row-p1"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="tool-call-row-p2"]')).toBeTruthy();
+  });
+
+  it('totalCount 未知(meta 없음)이어도 단정하지 않고 CountBadge를 안 그린다', async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({ data: [row()] }) }));
+    await mountSection();
+    await flush();
+    const heading = container.querySelector('h2');
+    expect(heading?.querySelector('span')).toBeNull();
+  });
+
+  it('로딩 실패는 에러 문구를 보이되 섹션 자체는 안 죽는다', async () => {
+    stubFetch(() => ({ ok: false, status: 500, json: async () => ({}) }));
+    await mountSection();
+    await flush();
+    expect(container.textContent).toContain(koMessages.agentRuns.toolCallsLoadError);
+  });
+});

--- a/apps/web/src/components/agents/agent-run-tool-calls-section.test.tsx
+++ b/apps/web/src/components/agents/agent-run-tool-calls-section.test.tsx
@@ -94,6 +94,20 @@ describe('AgentRunToolCallsSection', () => {
     expect(heading?.querySelector('span')?.textContent).toBe('7');
   });
 
+  // story #3722(카디르 QA changes, #4089 리뷰 2026-09-09) — 「attribution_reason 화면
+  // 미노출」 계약을 지키는 회귀 단언이 0개였다(뮤테이션: `<span>{row.attribution_reason}</span>`
+  // 넣어도 기존 17개 테스트가 그대로 통과). 값 자체를 뮤테이션 검출용 특이 문자열로 —
+  // 이 문자열이 화면 어디에도 안 서야 한다(입력 요약·에러 접기 등 어떤 자리로도).
+  it('⭐attribution_reason은 화면에 절대 안 그려진다(값을 렌더에 넣으면 이 단언이 RED)', async () => {
+    stubFetch(() => ({
+      ok: true,
+      json: async () => ({ data: [row({ attribution_reason: 'ambiguous_multi_run_same_story' })], meta: { totalCount: 1 } }),
+    }));
+    await mountSection();
+    await flush();
+    expect(container.textContent).not.toContain('ambiguous_multi_run_same_story');
+  });
+
   it('⭐페드루 PO 決(09:13Z) — tool 있으면 1차 라벨=tool, method+path는 부제로 демoted', async () => {
     stubFetch(() => ({
       ok: true,

--- a/apps/web/src/components/agents/agent-run-tool-calls-section.tsx
+++ b/apps/web/src/components/agents/agent-run-tool-calls-section.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { CountBadge } from '@/components/ui/count-badge';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { fetchWithAuth } from '@/lib/db/client';
+import { formatDuration, toLocaleStr } from './agent-run-detail';
+import type { AgentRunStatus } from '@/lib/agent-run-status';
+
+// story #3722(Trust·PR2) — 確定 설계(PO 05:52Z)의 "Timeline+Tool Audit Trail 재건" 대상.
+// PO 2026-09-09 09:13Z 決: 옛 화면이 같은 tool_call_history를 두 판(연대기·감사표)으로
+// 그렸을 뿐 소스가 하나였다 — 단일 통합 섹션으로 합친다(같은 데이터를 두 번 안 보여준다).
+interface ToolCallRow {
+  id: string;
+  tool: string | null;
+  method: string;
+  path: string;
+  status_code: number;
+  duration_ms: number;
+  started_at: string;
+  created_at: string;
+  input_summary: Record<string, unknown> | null;
+  error: string | null;
+  attribution_reason: string;
+}
+
+const LIMIT = 50;
+
+function isSuccessStatus(statusCode: number): boolean {
+  return statusCode < 400;
+}
+
+export function AgentRunToolCallsSection({
+  runId,
+  runStatus,
+  locale,
+  displayTimezone,
+}: {
+  runId: string;
+  runStatus: AgentRunStatus;
+  locale: string;
+  displayTimezone: string;
+}) {
+  const t = useTranslations('agentRuns');
+  const [rows, setRows] = useState<ToolCallRow[]>([]);
+  const [totalCount, setTotalCount] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setLoadError(false);
+      try {
+        const res = await fetchWithAuth(`/api/v1/agent-runs/${runId}/tool-calls?limit=${LIMIT}`);
+        const json = res.ok ? await res.json() : null;
+        if (cancelled) return;
+        if (res.ok && json) {
+          setRows(Array.isArray(json.data) ? json.data : []);
+          setTotalCount(typeof json.meta?.totalCount === 'number' ? json.meta.totalCount : null);
+        } else {
+          setLoadError(true);
+        }
+      } catch {
+        if (!cancelled) setLoadError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, [runId]);
+
+  const loadMore = async () => {
+    const last = rows[rows.length - 1];
+    if (!last) return;
+    setLoadingMore(true);
+    try {
+      const cursor = encodeURIComponent(last.created_at);
+      const res = await fetchWithAuth(`/api/v1/agent-runs/${runId}/tool-calls?limit=${LIMIT}&cursor=${cursor}`);
+      if (res.ok) {
+        const json = await res.json();
+        const more: ToolCallRow[] = Array.isArray(json.data) ? json.data : [];
+        setRows((prev) => [...prev, ...more]);
+        if (typeof json.meta?.totalCount === 'number') setTotalCount(json.meta.totalCount);
+      }
+    } catch {
+      // story #1989 — 로딩 실패는 목록을 비우지 않는다(이미 있는 행은 유지, 재시도는 버튼 재클릭).
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  // story #3722 — 빈 상태 두 사실을 가른다(유나 판정 축③): run이 아직 안 끝났으면(기록이
+  // 늦게 붙을 수 있음) "아직 기록이 없습니다", 끝났으면(더 안 늘어남이 확실) "도구를 안
+  // 썼습니다" — 서버가 관측 못 한 것과 애초에 쓴 적이 없는 것은 다른 사실이다.
+  // AGENT_RUN_STATUS_ORDER(agent-run-status.ts) 7종 중 더 안 늘어남이 확실한 셋만 terminal —
+  // running/queued/held/hitl_pending은 재개·진행 여지가 있어 "아직"이 맞는 사실이다.
+  const isTerminal = runStatus === 'completed' || runStatus === 'failed' || runStatus === 'abandoned';
+  const hasMore = totalCount != null ? rows.length < totalCount : rows.length === LIMIT && rows.length > 0;
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <h2 className="flex items-center gap-2 text-base font-semibold text-foreground">
+          {t('toolCallsTitle')}
+          {totalCount != null && <CountBadge count={totalCount} />}
+        </h2>
+      </SectionCardHeader>
+      <SectionCardBody>
+        {loading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map((i) => <div key={i} className="h-10 animate-pulse rounded-md bg-muted" />)}
+          </div>
+        ) : loadError ? (
+          <p className="text-sm text-muted-foreground">{t('toolCallsLoadError')}</p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {isTerminal ? t('toolCallsEmptyNone') : t('toolCallsEmptyPending')}
+          </p>
+        ) : (
+          <>
+            <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
+              {rows.map((row) => (
+                <ToolCallRowItem
+                  key={row.id}
+                  row={row}
+                  locale={locale}
+                  displayTimezone={displayTimezone}
+                  expanded={expandedId === row.id}
+                  onToggleExpand={() => setExpandedId((id) => (id === row.id ? null : row.id))}
+                  t={t}
+                />
+              ))}
+            </div>
+            {hasMore && (
+              <div className="mt-3 flex justify-center">
+                <Button variant="outline" size="sm" onClick={loadMore} disabled={loadingMore}>
+                  {loadingMore ? t('toolCallsLoadingMore') : t('loadMore')}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </SectionCardBody>
+    </SectionCard>
+  );
+}
+
+function ToolCallRowItem({
+  row,
+  locale,
+  displayTimezone,
+  expanded,
+  onToggleExpand,
+  t,
+}: {
+  row: ToolCallRow;
+  locale: string;
+  displayTimezone: string;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const success = isSuccessStatus(row.status_code);
+  // story #3722(유나 판정 축①·페드루 PO 지적 #4089 리뷰 2026-09-09) — method/path/
+  // duration_ms는 운영 지표에 가깝다: tool 이름이 있으면 그게 1차, method+path+duration은
+  // 부제로 демoted. tool이 없을 때(REST 직접 호출·구버전 클라이언트) 처음엔 method+path를
+  // 1차로 승격했었으나(D2/D3 "정직한 최후 수단"을 잘못 적용) — 그건 **모름을 정직히 쓰는
+  // 것이 아니라 코드 값(HTTP 경로)이 제목 자리에 서는 같은 클래스**였다(오늘 이벤트 키·
+  // stibee와 같은 결함). 「이름 없는 호출」(모름을 모름이라 쓴다 — 지어낸 이름 아님)로
+  // 고정하고, 경로는 tool 유무와 무관하게 항상 부제로만(행 형을 하나로 통일).
+  const hasDetail = row.input_summary != null || !!row.error;
+  const primaryLabel = row.tool ?? t('toolCallsUnnamedCall');
+  return (
+    <div className="p-3" data-testid={`tool-call-row-${row.id}`}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {hasDetail ? (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={onToggleExpand}
+                className="h-auto gap-1 truncate p-0 px-1 font-mono text-sm font-normal text-foreground"
+                data-testid={`tool-call-toggle-${row.id}`}
+              >
+                {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}
+                {primaryLabel}
+              </Button>
+            ) : (
+              <span className="truncate font-mono text-sm text-foreground" data-testid={`tool-call-primary-${row.id}`}>
+                {primaryLabel}
+              </span>
+            )}
+            <Badge variant={success ? 'success' : 'destructive'}>
+              {success ? t('toolCallsSuccessBadge') : t('toolCallsFailedBadge')}
+            </Badge>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span>{toLocaleStr(row.started_at, locale, displayTimezone)}</span>
+            <span>·</span>
+            <span>{formatDuration(row.duration_ms)}</span>
+            <span className="truncate font-mono">{row.method} {row.path}</span>
+          </div>
+        </div>
+      </div>
+      {expanded && hasDetail && (
+        <div className="mt-2 space-y-2 rounded-md border border-white/8 bg-white/4 p-3">
+          {row.input_summary != null && (
+            <div>
+              <p className="text-xs font-medium text-foreground">{t('toolCallsInputSummaryLabel')}</p>
+              <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-all font-mono text-[11px] text-muted-foreground">
+                {JSON.stringify(row.input_summary, null, 2)}
+              </pre>
+            </div>
+          )}
+          {row.error && (
+            // 페드루 PO 지적(2026-09-09, PR2 사전 스티어) — `error: str | None`(BE 원문 —
+            // 예외 메시지·트레이스백 조각일 수 있다)을 raw로 바로 안 올린다. 사람이 읽는
+            // 한 줄(고정 문구)은 항상 보이고, 원문은 접기(ConnectionRow의
+            // channelLastErrorToggle과 동형 <details>/<summary> 관례).
+            <div>
+              <p className="text-xs font-medium text-destructive">{t('toolCallsErrorSummary')}</p>
+              <details className="mt-1 text-xs text-muted-foreground">
+                <summary className="cursor-pointer">{t('toolCallsErrorToggle')}</summary>
+                <p className="mt-1 whitespace-pre-wrap break-all font-mono text-[11px]">{row.error}</p>
+              </details>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/agents/agent-run-tool-calls-section.tsx
+++ b/apps/web/src/components/agents/agent-run-tool-calls-section.tsx
@@ -188,8 +188,9 @@ function ToolCallRowItem({
               <Button
                 type="button"
                 variant="ghost"
+                size="sm"
                 onClick={onToggleExpand}
-                className="h-auto gap-1 truncate p-0 px-1 font-mono text-sm font-normal text-foreground"
+                className="gap-1 truncate p-0 px-1 font-mono text-sm font-normal text-foreground"
                 data-testid={`tool-call-toggle-${row.id}`}
               >
                 {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -25,6 +25,23 @@ def reset_project_override(token) -> None:
     _project_override.reset(token)
 
 
+# story #3722(Trust·PR2) — MCP=이름표만. call_tool 훅(server.py _flat wrapper)이 도구 호출
+# 스코프로 set/reset(_project_override와 동형 패턴) → request()가 X-Sprintable-Tool 헤더로
+# 실어 BE 미들웨어(tool_call_recording.py)가 기록 행의 tool 컬럼을 채운다. 미설정(REST 직접
+# 호출·구버전 클라이언트)이면 헤더 미전송 — BE는 tool=None으로 정직하게 기록(무회귀).
+_tool_name_override: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_tool_name_override", default=None
+)
+
+
+def set_tool_name_override(tool_name: str | None):
+    return _tool_name_override.set(tool_name or None)
+
+
+def reset_tool_name_override(token) -> None:
+    _tool_name_override.reset(token)
+
+
 # E-MCP-HTTP S1: per-request API 키 override(http 모드 멀티테넌트). http 미들웨어가 요청경계서
 # Authorization: Bearer <key> 를 set → request() 가 그 키로 백엔드 호출. 미설정(stdio)이면 env
 # 단일키(self._api_key) 사용(무회귀). contextvar 라 async 동시요청별 격리.
@@ -301,6 +318,16 @@ class SprintableClient:
         _override = _project_override.get()
         if _override:
             headers["X-Project-Id"] = _override
+
+        # story #3722(Trust·PR2) — X-Sprintable-Tool(call_tool 훅 ContextVar, _project_override와
+        # 동형) + X-Sprintable-Run-Id(런타임이 프로세스 env로 주입 — fleet wake 페이로드→env 관례,
+        # per-call override 불요). 둘 다 미설정이면 헤더 미전송(BE는 tool=None·run_id 미귀속으로
+        # 정직하게 기록 — 무회귀).
+        _tool = _tool_name_override.get()
+        if _tool:
+            headers["X-Sprintable-Tool"] = _tool
+        if _mcp_settings.sprintable_run_id:
+            headers["X-Sprintable-Run-Id"] = _mcp_settings.sprintable_run_id
 
         # POST/PUT/PATCH body에 context 필드 자동 주입. ee2f4e58: 프로퍼티 경유로 읽어 http per-key
         # 해소 default 까지 반영(stdio 는 self._* 우선이라 무회귀).

--- a/backend/sprintable_mcp/config.py
+++ b/backend/sprintable_mcp/config.py
@@ -10,6 +10,11 @@ class McpSettings(BaseSettings):
 
     sprintable_api_url: str = ""
     agent_api_key: str = ""
+    # story #3722(Trust·PR2) — 이 프로세스가 실행 중인 agent run의 id(런타임이 프로세스 시작 시
+    # env로 주입, fleet wake 페이로드→env 관례). MCP 요청마다 X-Sprintable-Run-Id 헤더로 실어
+    # BE 귀속 축 ⓐ(헤더 우선)를 태운다. 미설정(로컬 개발·run 문맥 밖)이면 헤더 미전송 → BE가
+    # ⓑ'/ⓑ/ⓒ로 자체 상관(무회귀).
+    sprintable_run_id: str = ""
     sse_seen_ids_max_size: int = 10000
     sse_seen_ids_ttl_seconds: int = 3600
     # E-MCP-HTTP S1: transport 선택(기본 stdio=로컬 에이전트 무회귀·http=외부/Poke Streamable HTTP).

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -24,7 +24,14 @@ from mcp.types import Tool as MCPTool
 from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.fields import PydanticUndefined
 
-from .api_client import _api_key_override, client, reset_project_override, set_project_override
+from .api_client import (
+    _api_key_override,
+    client,
+    reset_project_override,
+    reset_tool_name_override,
+    set_project_override,
+    set_tool_name_override,
+)
 from .config import settings
 from .response import ok
 from .schemas import SprintableInput
@@ -262,10 +269,16 @@ def _flat(name: str, doc: str, input_cls: type[BaseModel], fn):
         # 85429ee0: per-call project_id override → contextvar(tool 호출 스코프). client.project_id +
         # X-Project-Id 헤더에 반영(org-agent 멀티프로젝트 grant). 미지정이면 키 default(무회귀).
         _tok = set_project_override(kwargs.get("project_id"))
+        # story #3722(Trust·PR2) — 이 도구 이름(레지스트리 name, 118 도구 전부의 단일 지점)을
+        # 호출 스코프 contextvar에 실어 request()가 X-Sprintable-Tool 헤더로 BE에 전달(_project_
+        # override와 동형 set/reset 패턴). BE tool_call_recording 미들웨어가 기록 행의 tool
+        # 컬럼을 채우는 유일한 경로 — 도구 함수(fn)마다 손으로 태그하지 않는다.
+        _tool_tok = set_tool_name_override(name)
         try:
             result = await fn(input_cls(**kwargs))
         finally:
             reset_project_override(_tok)
+            reset_tool_name_override(_tool_tok)
         asyncio.create_task(_heartbeat_fire_forget())
         return result
 

--- a/backend/tests/test_3722_mcp_tool_run_id_headers.py
+++ b/backend/tests/test_3722_mcp_tool_run_id_headers.py
@@ -1,0 +1,138 @@
+"""story #3722(Trust·PR2) — MCP=이름표만. X-Sprintable-Tool(call_tool 훅 contextvar)·
+X-Sprintable-Run-Id(env) 두 헤더가 BE tool_call_recording 미들웨어의 tool/run_id 귀속 축
+ⓐ를 태운다. test_mcp_per_call_project_85429ee0.py(_project_override)와 동형 harness."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _seed_client():
+    from sprintable_mcp.api_client import client
+
+    client._base_url = "http://x"
+    client._api_key = "k"
+    client._project_id = "DEFAULT"
+    client._org_id = "ORG"
+    client._member_id = "MEM"
+    return client
+
+
+class _Resp:
+    status_code = 200
+    is_success = True
+    text = "{}"
+
+    def json(self):
+        return {"ok": 1}
+
+
+class _FakeClient:
+    def __init__(self, captured: dict):
+        self._captured = captured
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def request(self, method, url, json=None, params=None, headers=None):
+        self._captured["headers"] = headers
+        return _Resp()
+
+
+def test_run_id_env_name_contract(monkeypatch):
+    """⭐배포 env 이름 계약 고정(test_e_mcp_http_s1.py::test_deploy_relevant_env_names와 동형) —
+    필드명 sprintable_run_id ↔ env SPRINTABLE_RUN_ID 일치."""
+    from sprintable_mcp.config import McpSettings
+
+    monkeypatch.setenv("SPRINTABLE_RUN_ID", "run-xyz")
+    s = McpSettings()
+    assert s.sprintable_run_id == "run-xyz"
+
+
+def test_tool_name_override_contextvar():
+    from sprintable_mcp.api_client import reset_tool_name_override, set_tool_name_override
+
+    tok = set_tool_name_override("sprintable_add_task")
+    from sprintable_mcp.api_client import _tool_name_override
+
+    assert _tool_name_override.get() == "sprintable_add_task"
+    reset_tool_name_override(tok)
+    assert _tool_name_override.get() is None
+    tok2 = set_tool_name_override(None)  # None → 무회귀
+    assert _tool_name_override.get() is None
+    reset_tool_name_override(tok2)
+
+
+@pytest.mark.anyio
+async def test_request_sets_x_sprintable_tool_on_override():
+    from sprintable_mcp.api_client import (
+        client,
+        reset_tool_name_override,
+        set_tool_name_override,
+    )
+
+    _seed_client()
+    captured: dict = {}
+
+    with patch("sprintable_mcp.api_client.httpx.AsyncClient", return_value=_FakeClient(captured)):
+        # override 없음 → 헤더 미전송(REST 직접 호출·구버전 클라이언트와 무회귀)
+        await client.request("GET", "/api/v2/stories")
+        assert "X-Sprintable-Tool" not in captured["headers"]
+
+        tok = set_tool_name_override("sprintable_add_task")
+        await client.request("GET", "/api/v2/stories")
+        assert captured["headers"].get("X-Sprintable-Tool") == "sprintable_add_task"
+        reset_tool_name_override(tok)
+
+
+@pytest.mark.anyio
+async def test_request_sets_x_sprintable_run_id_from_env_setting():
+    from sprintable_mcp import config
+    from sprintable_mcp.api_client import client
+
+    _seed_client()
+    captured: dict = {}
+
+    with patch("sprintable_mcp.api_client.httpx.AsyncClient", return_value=_FakeClient(captured)):
+        # 미설정(기본값 "") → 헤더 미전송
+        await client.request("GET", "/api/v2/stories")
+        assert "X-Sprintable-Run-Id" not in captured["headers"]
+
+        # 설정 → 매 요청마다 실린다(개별 override 불요 — 프로세스 수명 동안 고정)
+        with patch.object(config.settings, "sprintable_run_id", "run-abc-123"):
+            await client.request("GET", "/api/v2/stories")
+            assert captured["headers"].get("X-Sprintable-Run-Id") == "run-abc-123"
+
+
+@pytest.mark.anyio
+async def test_flat_wrapper_sets_and_resets_tool_name_override():
+    """server.py _flat()의 단일 훅 — fn 호출 동안만 도구 이름이 실리고 끝나면 리셋된다."""
+    from pydantic import BaseModel
+
+    from sprintable_mcp.api_client import _tool_name_override
+    from sprintable_mcp.server import _flat
+
+    seen: dict = {}
+
+    class _Input(BaseModel):
+        x: int = 1
+
+    async def _fn(inp: _Input):
+        seen["during"] = _tool_name_override.get()
+        return []
+
+    w = _flat("my_tool_name", "doc", _Input, _fn)
+    assert _tool_name_override.get() is None  # 호출 전
+    with patch("sprintable_mcp.server._load_scope_for", return_value=[]):
+        await w(x=1)
+    assert seen["during"] == "my_tool_name"  # fn 실행 중엔 실린다
+    assert _tool_name_override.get() is None  # 끝나면 리셋(finally)


### PR DESCRIPTION
確定 설계(PO 05:52Z)의 "MCP=이름표만 · FE=Timeline+Tool Audit Trail 재건" — PR1(#4076, 착지 済 develop 3bbf1fdd8) 위 두 번째 조각.

## MCP — X-Sprintable-Tool/Run-Id 이름표
- `X-Sprintable-Tool`: 118 도구 전부의 단일 디스패치 지점(`server.py` `_flat()` wrapper)에서 ContextVar로 실어(`_project_override`와 동형 set/reset 패턴) `request()`가 헤더로 전달.
- `X-Sprintable-Run-Id`: 프로세스 env(`SPRINTABLE_RUN_ID`)를 매 요청마다 헤더로.
- 둘 다 미설정이면 헤더 미전송(REST 직접 호출·구버전 클라이언트 무회귀).

## FE — 실행 상세 「도구 호출」 단일 통합 섹션
PO 2026-09-09 09:13Z 決 — 옛 화면(Timeline+Tool Audit Trail)이 같은 `tool_call_history`를 두 판(연대기·감사표)으로 그렸을 뿐 소스가 하나였다는 판단에 따라, 새 데이터(`agent_run_tool_calls` 행)도 단일 통합 섹션(`AgentRunToolCallsSection`)으로 재건했다.

행 설계:
- **1차 라벨 = tool(있으면) · 없으면 「이름 없는 호출」(고정 문구)** — method/path는 tool 유무와 무관하게 항상 부제로만. (**정정**: 최초 決이던 「method+path를 1차로 승격」은 페드루 PO #4089 리뷰(2026-09-09)에서 뒤집힘 — HTTP 경로(코드 값)가 제목 자리에 서는 것은 오늘 이벤트 정의 키·stibee와 같은 「코드 키가 제목 자리」 결함 클래스였다. 「이름 없는 호출」은 모름을 모름이라 쓰는 것 — 지어낸 이름이 아니다.)
- `attribution_reason`은 화면에 안 올림 — 이 목록(`GET .../{id}/tool-calls`, run_id로 필터된 행만)이 구조적으로 항상 귀속 성공이라 값 노출 0.
- 빈 상태 두 사실: run 진행 중·0건="아직 기록이 없습니다" vs run 종료·0건="이 실행은 도구를 쓰지 않았습니다".
- 수를 제목 문자열에 안 넣는다(E절) — 제목 고정 + CountBadge(#4082와 동형 프리미티브).
- 성공/실패 배지(status_code<400) · 펼치면 input_summary(pretty JSON)+error · 커서 페이지네이션.

## 리뷰 반영(#4089, 유나/페드루)
- `error: str | None` raw 직접 노출 금지 — 「이 호출이 실패했습니다」 고정 문구를 항상 먼저 보이고, 서버 원문은 `<details>/<summary>`(기본 닫힘)로 접는다.
- 펼침 토글이 raw `<button>`이었다(verify-no-new-raw-button 가드 위반) → `Button variant="ghost"`로.
- 오류 접기 라벨 「서버 응답 원문 보기」는 집안에 이미 있는 「서버 응답 보기」와 다른 세 번째 이름이었다 → 통일.
- 1차 라벨 폴백 「method+path 승격」 → 「이름 없는 호출」로 정정(위 참조).

## 로컬 캡처(PR1+PR2 스택, develop 위 재확인 済)
- ①실 도구 호출: MCP `_flat` 훅 실경유로 `sprintable_my_dashboard` 실호출(200) → DB 실제 기록 → 실행 상세에 도구명+성공 배지+시각+20ms로 서는 것 확인(artifact 95f628d5).
- ②빈 상태(진행 중): artifact c78c9b19.
- ③빈 상태(종료): artifact 87c95496.
- ④메타 카드 5장+낱말 정합(rebase 뒤 재확인): artifact c2eb22dd.

## Test plan
- [x] MCP 신규 테스트 5개(ContextVar set/reset·헤더 전송·env 계약·server.py 훅 왕복).
- [x] FE 프록시 라우트 테스트 4개(X-Total-Count 전달·NaN 가드).
- [x] `AgentRunToolCallsSection` 신규 테스트(빈 상태 두 분기·E절·tool 없음 폴백·성공실패 배지·펼침·더 보기·에러 접기) — 뮤테이션-킬 직접 확인 済.
- [x] FE 전체 745파일/7325테스트 green · tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)