### PR TITLE
[SID:3748] fix(FE): 조직 브리핑 — clusterViewAll 화살표 제거·안내 배너 Alert 이관

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -479,7 +479,7 @@
     "clusterSilentStallBucket1moPlus": "1mo+",
     "clusterSilentStallAgeDays": "{n}d",
     "clusterSilentStallUnassigned": "Unassigned",
-    "clusterViewAll": "View all {n} →",
+    "clusterViewAll": "View all {n}",
     "clusterViewLess": "Collapse",
     "clusterUnclosedTitle": "Loops never closed",
     "clusterUnclosedSub": "Past their measure date or missing an outcome verdict",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -479,7 +479,7 @@
     "clusterSilentStallBucket1moPlus": "1개월+",
     "clusterSilentStallAgeDays": "{n}일째",
     "clusterSilentStallUnassigned": "담당자 미배정",
-    "clusterViewAll": "{n}건 전체보기 →",
+    "clusterViewAll": "{n}건 전체보기",
     "clusterViewLess": "접기",
     "clusterUnclosedTitle": "결과를 안 적고 끝난 목표",
     "clusterUnclosedSub": "측정 기한이 지났거나 결과 판정이 없는 항목",

--- a/apps/web/scripts/handrolled-card-baseline.json
+++ b/apps/web/scripts/handrolled-card-baseline.json
@@ -13,7 +13,8 @@
     "grandfather한다). now-face.tsx·loop-face.tsx·attention-cluster-board.tsx 3개 키는 같은",
     "PR1이 Card primitive로 이관해 여기서 뺐다(story #3736 ⑪의 「원인 3파일」). 263키 → 270키",
     "(신규 26건 grandfather - 3건 이관 제거 - 중복/재구성에 따른 소폭 차이).",
-    "story #3743 그라운딩 前 잔존(2026-09-09, 페드루 PO 지적·배포 60 실픽셀) — org-briefing-shell.tsx(FaceSkeletonPanel)·workforce-face.tsx 2건이 loop-face.tsx와 같은 카드인데 Card primitive 이관에서 빠져 있었다(#3736 ⑪ 「원인 3파일」 당시 이 둘은 안 걸렸던 것으로 보임) — 이번에 마저 이관, 여기서 뺀다. 270키 → 268키."
+    "story #3743 그라운딩 前 잔존(2026-09-09, 페드루 PO 지적·배포 60 실픽셀) — org-briefing-shell.tsx(FaceSkeletonPanel)·workforce-face.tsx 2건이 loop-face.tsx와 같은 카드인데 Card primitive 이관에서 빠져 있었다(#3736 ⑪ 「원인 3파일」 당시 이 둘은 안 걸렸던 것으로 보임) — 이번에 마저 이관, 여기서 뺀다. 270키 → 268키.",
+    "story #3748(잔여②, 페드루 PO 確定 2026-09-09) — org-briefing-shell.tsx:65 안내 배너는 손코딩 카드가 아니라 Card도 아닌 안내 패널이었다(판정: 집안 Alert role=\"status\"로 이관, default variant 값이 이 리터럴과 동일). 이관 뒤 이 키 소멸 — 새 부품·새 키 0. 268키 → 267키."
   ],
   "keys": [
     "app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx::mx-2 mt-1.5 space-y-1.5 rounded-lg border border-border bg-card p-2",
@@ -235,7 +236,6 @@
     "components/meetings/audio-recorder.tsx::rounded-lg border bg-background p-4",
     "components/nav/context-switcher-chip.tsx::h-11 min-h-0 min-w-0 max-w-[190px] shrink-0 justify-start gap-2 overflow-hidden rounded-xl border border-border bg-card px-2 py-1.5 text-left font-normal hover:bg-muted disabled:opacity-60 lg:hidden",
     "components/nav/notification-bell.tsx::absolute right-0 top-full z-50 mt-1 hidden w-80 overflow-hidden rounded-lg border bg-background shadow-[var(--elev-overlay)] lg:flex lg:flex-col",
-    "components/org-briefing/org-briefing-shell.tsx::rounded-xl border border-border bg-muted/40 px-4 py-3 text-sm text-foreground",
     "components/organization/event-definer-form.tsx::flex items-center gap-1 rounded-xl border border-border bg-background pl-3",
     "components/organization/event-definer-form.tsx::flex items-center gap-2 rounded-lg border border-border bg-background px-2.5 py-1.5",
     "components/organization/event-definer-form.tsx::mt-3 rounded-xl border border-dashed border-border bg-muted/40 p-3",

--- a/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
@@ -98,6 +98,24 @@ describe('AttentionClusterBoard', () => {
     expect(container.textContent).toContain(koMessages.orgBriefing.clusterFalsifiedResultUnknown);
   });
 
+  // story #3748(잔여①, 페드루 PO 確定 2026-09-09) — clusterViewAll(「{n}건 전체보기」)의
+  // 실 동작은 ViewAllToggle의 제자리 펼침 <button>이지 화면을 떠나는 링크가 아니다.
+  // 「→」는 집안에서 "여길 떠난다"는 뜻으로 쓰는 기호라 여기 붙어 있으면 거짓 신호다.
+  // ⭐되돌리면 RED — clusterViewAll 값에 「→」가 남으면 이 버튼 텍스트에 그대로 찍힌다.
+  it('⭐top-N(3) 초과 시 나오는 「전체보기」 버튼에 화살표(→)가 없다(제자리 펼침, 링크 아님)', async () => {
+    const items: FalsifiedClusterItem[] = Array.from({ length: 4 }, (_, i) => ({
+      id: `h${i}`, title: `가설 ${i}`, target: 50, actual: 30, hasOutcome: true,
+      supersededId: null, href: `/flow?hypothesis=h${i}`, crossProjectLabel: null,
+    }));
+    await act(async () => {
+      root.render(wrap(<AttentionClusterBoard falsified={items} silentStall={EMPTY_SILENT_STALL} {...NO_LOOP} />));
+    });
+    const toggle = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('전체보기'));
+    expect(toggle).toBeTruthy();
+    expect(toggle?.textContent).toBe(koMessages.orgBriefing.clusterViewAll.replace('{n}', '1'));
+    expect(toggle?.textContent).not.toContain('→');
+  });
+
   // story #93b076c8(2250) FE — 「침묵의 정체」 4구간 요약(top-N 펼침이 아니라 구간별 접힘행).
   describe('silent stall cluster (story #93b076c8/#2250)', () => {
     it('빈 구간은 행 자체를 그리지 않는다(0건을 굳이 그리지 않음)', async () => {

--- a/apps/web/src/components/org-briefing/org-briefing-shell.test.tsx
+++ b/apps/web/src/components/org-briefing/org-briefing-shell.test.tsx
@@ -98,4 +98,15 @@ describe('OrgBriefingShell — 프로젝트 안내 배너 (story #2212, 유나�
     await mount();
     expect(container.textContent).not.toContain('프로젝트를 선택하면');
   });
+
+  // story #3748(잔여②, 페드루 PO 確定 2026-09-09) — 손코딩 rounded-xl div를 집안 `Alert`
+  // role="status"로 이관. ⭐되돌리면 RED — role="status" 사라지거나 손코딩 div로 되돌아가면 실패.
+  it('⭐배너는 손코딩 div가 아니라 role="status" Alert다', async () => {
+    useDashboardContextMock.mockReturnValue({ projectMemberships: [], orgMemberships: [], projectId: undefined });
+    await mount();
+    const statusEl = container.querySelector('[role="status"]');
+    expect(statusEl).toBeTruthy();
+    expect(statusEl?.textContent).toBe('프로젝트를 선택하면 여기에 현황이 표시됩니다.');
+    expect(container.querySelector('.rounded-xl.border.border-border.bg-muted\\/40')).toBeNull();
+  });
 });

--- a/apps/web/src/components/org-briefing/org-briefing-shell.tsx
+++ b/apps/web/src/components/org-briefing/org-briefing-shell.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Card } from '@/components/ui/card';
 import { NowFace } from './now-face';
 import { LoopFace } from './loop-face';
@@ -62,9 +63,14 @@ export function OrgBriefingShell() {
   return (
     <div className="mx-auto max-w-7xl space-y-6 p-4 lg:p-6">
       {showProjectBanner && (
-        <div className="rounded-xl border border-border bg-muted/40 px-4 py-3 text-sm text-foreground" role="status">
-          {projectBannerText}
-        </div>
+        // story #3748(잔여②, 페드루 PO 確定 2026-09-09) — 손코딩 카드가 아니라 안내
+        // 배너다. 집안 `Alert`의 default variant 값(border-border·bg-muted/40·
+        // text-foreground)이 이 리터럴과 그대로 같다 — role="status"만 명시로
+        // 유지(default variant의 자동 유도값은 role="alert", 이 배너는 그대로
+        // status가 맞다 — 사용자 조작을 막는 오류가 아니라 안내다).
+        <Alert role="status">
+          <AlertDescription>{projectBannerText}</AlertDescription>
+        </Alert>
       )}
       <div>
         <h1 className="text-lg font-semibold tracking-tight text-foreground">

--- a/apps/web/src/components/ui/alert.test.tsx
+++ b/apps/web/src/components/ui/alert.test.tsx
@@ -80,6 +80,19 @@ describe('Alert 접근성 (story #2149)', () => {
     expect(container.querySelector('[role="status"]')).toBeNull();
   });
 
+  // 카디르 QA 지적(story #3748, 2026-09-09) — aria-live 기본값은 variant가 아니라 실제
+  // role을 따라야 한다. variant="default"라도 호출부가 role="status"를 명시하면(예:
+  // org-briefing-shell.tsx 안내 배너) 옛 손코딩 div(aria-live 없음=암묵 polite)와 동형으로
+  // polite여야 옳다 — 되돌리면 이관이 접근성 회귀(assertive)를 만든다.
+  it('⭐variant=default라도 role="status"를 명시하면 aria-live 기본값은 polite다(variant 아닌 role 기준)', async () => {
+    await act(async () => {
+      root.render(<Alert role="status"><AlertDescription>안내</AlertDescription></Alert>);
+    });
+    const el = container.querySelector('[role="status"]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('aria-live')).toBe('polite');
+  });
+
   it('destructive와 status가 동시에 잡히지 않는다(이중 낭독 방지)', async () => {
     await act(async () => {
       root.render(<Alert variant="destructive"><AlertDescription>에러</AlertDescription></Alert>);

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -39,23 +39,31 @@ function getAlertRole(variant?: string | null): 'alert' | 'status' {
   return variant && POLITE_ALERT_VARIANTS.has(variant) ? 'status' : 'alert';
 }
 
-function getAlertAriaLive(variant?: string | null): 'assertive' | 'polite' {
-  return variant && POLITE_ALERT_VARIANTS.has(variant) ? 'polite' : 'assertive';
+// 카디르 QA 지적(story #3748, 2026-09-09) — aria-live 기본값은 variant가 아니라 **실제
+// role**을 따라야 한다. variant가 default/warning/destructive라도 호출부가 role="status"를
+// 명시(§WAI-ARIA — status는 그 자체로 polite 의미)하면 aria-live도 polite여야 옳다(옛
+// 손코딩 div는 aria-live 자체가 없어 암묵 polite였다 — Alert 이관이 이걸 assertive로
+// 뒤집으면 접근성 회귀). role="alert"를 명시한 호출부는 여전히 assertive.
+function getAlertAriaLive(effectiveRole: React.AriaRole | undefined): 'assertive' | 'polite' {
+  return effectiveRole === 'status' ? 'polite' : 'assertive';
 }
 
 const Alert = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, role, 'aria-live': ariaLive, 'aria-atomic': ariaAtomic, ...props }, ref) => (
-  <div
-    ref={ref}
-    role={role ?? getAlertRole(variant)}
-    aria-live={ariaLive ?? getAlertAriaLive(variant)}
-    aria-atomic={ariaAtomic ?? 'true'}
-    className={cn(alertVariants({ variant }), className)}
-    {...props}
-  />
-));
+>(({ className, variant, role, 'aria-live': ariaLive, 'aria-atomic': ariaAtomic, ...props }, ref) => {
+  const effectiveRole = role ?? getAlertRole(variant);
+  return (
+    <div
+      ref={ref}
+      role={effectiveRole}
+      aria-live={ariaLive ?? getAlertAriaLive(effectiveRole)}
+      aria-atomic={ariaAtomic ?? 'true'}
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+});
 Alert.displayName = 'Alert';
 
 // 유나 지적(error-display 폴리시) — 공백 없는 초장문(토큰·URL·해시 등)이 grid의


### PR DESCRIPTION
## Summary
- ① `clusterViewAll`("{n}건 전체보기 →")에서 화살표 제거 — 실제 동작은 제자리 펼침(ViewAllToggle)이지 화면을 떠나는 링크가 아니다. 집안에서 「→」는 "여길 떠난다"는 뜻이라 거짓 신호. KO/EN 둘 다 수정.
- ② `org-briefing-shell.tsx:65`의 손코딩 안내 배너(`rounded-xl border border-border bg-muted/40`)를 집안 `<Alert role="status">`로 이관 — 페드루 PO 判(2026-09-09): Card도 baseline 잔류 대상도 아닌 안내 패널, default variant 리터럴 값이 이 배너와 동일해 새 부품·새 키 0. `handrolled-card-baseline.json`에서 해당 키 소멸(268→267).
- ③ 카디르 QA 지적 — ②의 `<Alert role="status">`(variant="default")가 명시 `aria-live` 없이 렌더되면서, `alert.tsx`의 aria-live 기본값 판정이 variant만 보고 골라 default variant는 항상 assertive로 떨어졌다. `alert.tsx`를 variant가 아니라 **실제 role**(명시 prop 우선, 없으면 variant 유도값) 기준으로 고쳐 role="status"면 항상 polite가 되도록 수정. 같은 클래스로 이미 있던 `channel-posts/[draftId]:2723`·`:2870`·`channel-connect/app-credentials-card.tsx`(×3)도 함께 correct(assertive→polite) — DOM 속성 변경만이라 재캡처 불필요.
- 회귀 pin 테스트 3건 추가.

story: https://app.sprintable.ai (story_id 3b7e4fa2-42f6-4ec9-a1f0-b810c00ab83d)

## 로컬 캡처 확認(head f77a6d9cd)
- KO 조직 브리핑, `?next=` 배너 표본, **scrollY 0**(페이지 상단 — 이전 캡처는 스크롤된 자리였다는 PO 지적 반영) — 안내 배너 role="status" Alert가 헤더 바로 아래·「가설 반증」 무리(top-3 초과분 "1건 전체보기", 화살표 0) 같이 보임.
- story artifact: `3748_top_scrollzero_light`(신규, 이 head) · `3748_arrow_alert_light`(이전 라운드, 스크롤된 자리)

## Test plan
- [x] `pnpm run verify:no-handrolled-card` — green(새 손코딩 카드 0건, baseline 267)
- [x] `pnpm run verify:no-i18n-phrase-collision` — green(신규 충돌 0건)
- [x] `tsc --noEmit` — clean
- [x] `eslint` (변경 파일) — clean
- [x] 전체 vitest(749파일/7426테스트) — green
- [x] 로컬 풀스택 실캡처 — 화살표 0·안내 배너 Alert(role=status) 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)