### PR TITLE
[SID:3747] fix(FE): 콘텐츠 규칙 되돌리기가 저장 前 버전을 재사용해 항상 실패하던 결함

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5283,7 +5283,9 @@
     "generationBudgetLimitPlaceholder": "Limit (leave blank for no policy)",
     "generationBudgetSuspendedReadonly": "Suspended",
     "versionConflictFieldFact": "\"{field}\" changed after you opened this screen.",
-    "versionConflictFieldWithName": "{name} already saved a change to \"{field}\"."
+    "versionConflictFieldWithName": "{name} already saved a change to \"{field}\".",
+    "versionConflictFieldSelfOtherTab": "Another tab already saved a change to \"{field}\".",
+    "contentRulesUndoFailedPrefix": "Couldn't undo."
   },
   "insightsBoard": {
     "pageTitle": "Performance board",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -5283,7 +5283,9 @@
     "generationBudgetLimitPlaceholder": "한도(비우면 정책 없음)",
     "generationBudgetSuspendedReadonly": "정지",
     "versionConflictFieldFact": "이 화면을 연 뒤에 「{field}」이(가) 바뀌었습니다.",
-    "versionConflictFieldWithName": "{name}님이 「{field}」을(를) 먼저 저장했습니다."
+    "versionConflictFieldWithName": "{name}님이 「{field}」을(를) 먼저 저장했습니다.",
+    "versionConflictFieldSelfOtherTab": "다른 탭에서 「{field}」을(를) 먼저 저장했습니다.",
+    "contentRulesUndoFailedPrefix": "되돌리지 못했습니다."
   },
   "insightsBoard": {
     "pageTitle": "성과 보드",

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -382,6 +382,13 @@ export const EXEMPT_PAIRS = new Set<string>([
   // 예외였다 — 같은 개념의 새 키 쌍으로 교체.
   'contentRules.saveAction <-> contentRules.versionConflictFieldWithName',
   'contentRules.contentRulesRowSaveSuccessToast <-> contentRules.versionConflictFieldWithName',
+  // story #3747(되돌리기 결함 fast-follow, 2026-09-09) — 유나 定으로 신설된
+  // versionConflictFieldSelfOtherTab("다른 탭에서 「{field}」을(를) 먼저 저장했습니다.")도
+  // WithName과 같은 문구 골격(«…을(를) 먼저 저장했습니다»)이라 위와 동일한 근거로
+  // "저장"이라는 낱말만 겹친다 — 동사 버튼/성공 토스트 vs 과거 수동형 서술이라
+  // 헷갈릴 자리가 아니다.
+  'contentRules.saveAction <-> contentRules.versionConflictFieldSelfOtherTab',
+  'contentRules.contentRulesRowSaveSuccessToast <-> contentRules.versionConflictFieldSelfOtherTab',
   // story #3517(§22-②·⑨, 2026-09-05) — content.commentsSectionTitleWithCount
   // ("댓글 {count}", 목록 얼굴 제목)·content.commentsDeletedCountLabel("지워진 댓글
   // {count}건", 헤더 부속 줄)·content.commentsSectionTitle("댓글", 미수집/오류 얼굴

--- a/apps/web/src/app/(authenticated)/organization/content-rules/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/content-rules/page.test.tsx
@@ -100,9 +100,10 @@ function stubFetch(opts: {
   }));
 }
 
-async function mount(role: string) {
+async function mount(role: string, extra: Record<string, unknown> = {}) {
   useDashboardContextMock.mockReturnValue({
     orgId: ORG_ID, orgMemberships: [{ orgId: ORG_ID, orgName: 'Org', orgSlug: 'org', role }], projectMemberships: [],
+    ...extra,
   });
   await act(async () => { root.render(wrap(<ContentRulesPage />)); });
   await flush();
@@ -319,6 +320,108 @@ describe('ContentRulesPage — 행 저장(story #3747 AC2)', () => {
 
     expect(row('tone').textContent).toContain('친근하게');
     expect(putCount).toBe(2);
+  });
+
+  // 페드루 PO 라이브 결함(2026-09-09, 3747 배포 뒤 owner 실왕복) — 되돌리기 onClick
+  // 클로저가 `version` state를 직접 읽으면 그 저장을 시작시킨 saveField 호출 안에
+  // 갇힌 **저장 前** 값을 그대로 들고 있어, 되돌리기가 방금 자신이 만든 저장과 버전이
+  // 어긋나 항상 409였다(위 테스트는 onPut이 expected_version을 안 따져 이 버그를
+  // 놓쳤다 — 이 테스트는 실 서버처럼 expected_version 불일치 시 409를 낸다).
+  it('⭐되돌리기는 저장 응답의 새 버전을 쓴다(저장 前 버전 재사용 금지 — 실서버형 스텁으로 재현)', async () => {
+    let serverVersion = 3;
+    stubFetch({
+      onPut: (body) => {
+        const b = body as { rules: typeof RULES_V1; expected_version: number };
+        if (b.expected_version !== serverVersion) {
+          return { status: 409, body: { code: 'CONTENT_RULES_VERSION_CONFLICT', current_version: serverVersion, updated_by: { member_id: 'm', name: '송윤재' } } };
+        }
+        serverVersion += 1;
+        return { status: 200, body: { org_id: ORG_ID, rules: b.rules, version: serverVersion, updated_at: '2026-09-07T00:00:00Z', updated_by: { member_id: 'm', name: '송윤재' } } };
+      },
+    });
+    await mount('owner');
+    await expandRow('tone');
+    const toneInput = container.querySelector('#content-rules-tone') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(toneInput, '바뀐 톤');
+      toneInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { rowSaveButton().click(); });
+    await flush();
+    expect(row('tone').textContent).toContain('바뀐 톤');
+
+    const undoBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.contentRules.contentRulesUndoAction) as HTMLButtonElement;
+    await act(async () => { undoBtn.click(); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="content-rules-version-conflict"]')).toBeNull();
+    expect(row('tone').textContent).toContain('친근하게');
+  });
+
+  // 유나 定(2026-09-09) — 되돌리기가 실패하면 배너는 "누가 먼저 저장했다"만이 아니라
+  // "되돌리지 못했습니다"가 먼저(되돌리기를 누른 사람의 물음에 답함) + 그 사유가 붙는다.
+  it('⭐되돌리기가 겹침으로 실패하면 배너에 「되돌리지 못했습니다」가 사유보다 먼저 선다', async () => {
+    let putCalls = 0;
+    stubFetch({
+      onPut: () => {
+        putCalls += 1;
+        if (putCalls === 1) {
+          return { status: 200, body: { org_id: ORG_ID, rules: { ...RULES_V1, tone: '바뀐 톤' }, version: 4, updated_at: '2026-09-07T00:00:00Z', updated_by: { member_id: 'm', name: '송윤재' } } };
+        }
+        return { status: 409, body: { code: 'CONTENT_RULES_VERSION_CONFLICT', current_version: 5, updated_by: { member_id: 'm-2', name: '유나' } } };
+      },
+      getAfterConflict: { rules: { ...RULES_V1, tone: '서버가 또 바꾼 톤' }, version: 5 },
+    });
+    await mount('owner');
+    await expandRow('tone');
+    const toneInput = container.querySelector('#content-rules-tone') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(toneInput, '바뀐 톤');
+      toneInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { rowSaveButton().click(); });
+    await flush();
+
+    const undoBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.contentRules.contentRulesUndoAction) as HTMLButtonElement;
+    await act(async () => { undoBtn.click(); });
+    await flush();
+
+    const banner = container.querySelector('[data-testid="content-rules-version-conflict"]');
+    expect(banner).not.toBeNull();
+    const text = banner!.textContent ?? '';
+    const prefixIdx = text.indexOf(koMessages.contentRules.contentRulesUndoFailedPrefix);
+    const reasonIdx = text.indexOf(
+      koMessages.contentRules.versionConflictFieldWithName.replace('{name}', '유나').replace('{field}', koMessages.contentRules.toneLabel),
+    );
+    expect(prefixIdx).toBeGreaterThanOrEqual(0);
+    expect(reasonIdx).toBeGreaterThan(prefixIdx);
+  });
+
+  // 유나 定(2026-09-09) — 충돌한 값을 저장한 사람이 «나 자신»(다른 탭 등)이면 자기 이름을
+  // 대는 대신 "다른 탭에서 먼저 저장됐습니다"로 — 자기 이름을 보면 "내가 언제?"로 멈춘다.
+  it('⭐충돌 상대가 나 자신(다른 탭)이면 이름 대신 「다른 탭에서 먼저 저장됐습니다」', async () => {
+    stubFetch({
+      onPut: () => ({ status: 409, body: { code: 'CONTENT_RULES_VERSION_CONFLICT', current_version: 4, updated_by: { member_id: 'm-1', name: '유나' } } }),
+      getAfterConflict: { rules: { ...RULES_V1, tone: '서버가 먼저 바꾼 톤' }, version: 4 },
+    });
+    await mount('owner', { currentTeamMemberId: 'm-1' });
+    await expandRow('tone');
+    const toneInput = container.querySelector('#content-rules-tone') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(toneInput, '내가 고친 톤');
+      toneInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { rowSaveButton().click(); });
+    await flush();
+
+    const banner = container.querySelector('[data-testid="content-rules-version-conflict"]');
+    expect(banner?.textContent).toContain(
+      koMessages.contentRules.versionConflictFieldSelfOtherTab.replace('{field}', koMessages.contentRules.toneLabel),
+    );
+    expect(banner?.textContent).not.toContain('유나');
   });
 
   it('403 CONTENT_RULES_ADMIN_ONLY — 그 행 안에 인라인 오류', async () => {

--- a/apps/web/src/app/(authenticated)/organization/content-rules/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/content-rules/page.tsx
@@ -252,7 +252,7 @@ function hasFieldValue(field: FieldKey, rules: ContentRules): boolean {
 }
 
 export default function ContentRulesPage() {
-  const { orgId, orgMemberships } = useDashboardContext();
+  const { orgId, orgMemberships, currentTeamMemberId } = useDashboardContext();
   const currentRole = orgMemberships.find((o) => o.orgId === orgId)?.role ?? 'member';
   const canEditRules = currentRole === 'owner' || currentRole === 'admin';
   const t = useTranslations('contentRules');
@@ -262,17 +262,26 @@ export default function ContentRulesPage() {
 
   const [rules, setRules] = useState<ContentRules>(EMPTY_RULES);
   const [loadedRules, setLoadedRules] = useState<ContentRules>(EMPTY_RULES);
-  const [version, setVersion] = useState<number | null>(null);
   const [updatedAt, setUpdatedAt] = useState<string | null>(null);
   const [updatedBy, setUpdatedBy] = useState<UpdatedBy | null>(null);
   const [loadState, setLoadState] = useState<'loading' | 'error' | 'ready'>('loading');
   const [expandedField, setExpandedField] = useState<FieldKey | null>(null);
   const [savingField, setSavingField] = useState<FieldKey | null>(null);
   const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
-  const [conflictField, setConflictField] = useState<{ field: FieldKey; updatedByName: string | null } | null>(null);
+  const [conflictField, setConflictField] = useState<
+    { field: FieldKey; updatedByName: string | null; updatedByMemberId: string | null; viaUndo: boolean } | null
+  >(null);
   const [budget, setBudget] = useState<GenerationBudgetState>({ status: 'loading' });
   // story #3501(§20-3, 재사용) — 되돌리기(undo)용 직전 값 스냅샷(필드별 1개).
   const draftBeforeSave = useRef<Partial<ContentRules>>({});
+  // 페드루 PO 라이브 결함(2026-09-09, 3747 배포 뒤 직접 왕복 발견) — 되돌리기 버튼의
+  // onClick 클로저는 그 저장을 시작시킨 saveField 호출 안에서 만들어지므로, version을
+  // state로 두면 그 호출 동안 클로저에 갇힌 **저장 前** 값을 그대로 들고 있다(React
+  // state는 그 실행 안에서 스냅샷 — 리렌더로 안 바뀜). 되돌리기가 그 값으로 PUT하면
+  // 방금 자신이 만든 저장 자체와 버전이 어긋나 항상 409. version은 렌더에 안 쓰이므로
+  // (충돌 여부·성공/실패만 렌더에 영향) 아예 state가 아니라 ref로 — 모든 성공 응답에서
+  // 즉시 갱신돼 항상 "그 시점 최신"이 보인다.
+  const versionRef = useRef<number | null>(null);
 
   const load = useCallback(async () => {
     if (!orgId) return;
@@ -285,7 +294,7 @@ export default function ContentRulesPage() {
         const merged = mergeRulesResponse(json.data.rules);
         setRules(merged);
         setLoadedRules(merged);
-        setVersion(json.data.version);
+        versionRef.current = json.data.version;
         setUpdatedAt(json.data.updated_at);
         setUpdatedBy(json.data.updated_by);
         setLoadState('ready');
@@ -327,8 +336,10 @@ export default function ContentRulesPage() {
   // (저장소가 필드 단위 CAS를 못 함) 409면 겹침으로 가른다: 내가 고친 필드가 서버측
   // 변경과 겹치면 그 필드만 충돌 배너(재시도 안 함) · 안 겹치면 최신 버전으로 조용히
   // 한 번 재저장(사람 개입 없이 자동 rebase).
-  const saveField = useCallback(async (field: FieldKey, nextRules: ContentRules, previousValue: ContentRules[FieldKey]) => {
-    if (version === null) return;
+  const saveField = useCallback(async (
+    field: FieldKey, nextRules: ContentRules, previousValue: ContentRules[FieldKey], viaUndo = false,
+  ) => {
+    if (versionRef.current === null) return;
     setSavingField(field);
     setRowErrors((prev) => { const { [field]: _drop, ...rest } = prev; return rest; });
     // 되돌리기(undo)용 직전 값 스냅샷. field는 런타임에 실제 값과 짝이 맞지만
@@ -350,14 +361,15 @@ export default function ContentRulesPage() {
         const merged = mergeRulesResponse(json.data.rules);
         setRules(merged);
         setLoadedRules(merged);
-        setVersion(json.data.version);
+        versionRef.current = json.data.version;
         setUpdatedAt(json.data.updated_at);
         setUpdatedBy(json.data.updated_by);
         setConflictField(null);
         return { status: 'ok', rebased };
       }
       if (res.status === 409) {
-        const errBody = (await res.json().catch(() => null)) as { error?: { updated_by?: { name: string | null } | null } } | null;
+        const errBody = (await res.json().catch(() => null)) as
+          { error?: { updated_by?: { member_id: string | null; name: string | null } | null } } | null;
         const freshRes = await fetchWithAuth(`/api/organizations/${orgId}/content-rules`);
         const freshJson = freshRes.ok
           ? ((await freshRes.json().catch(() => null)) as { data?: ContentRulesResponse } | null)
@@ -367,10 +379,15 @@ export default function ContentRulesPage() {
         // §20-4 — 서버가 내가 로드한 이후 실제로 바꾼 필드 목록.
         const serverChanged = diffFieldNames(loadedRules, freshRules);
         if (serverChanged.includes(field)) {
-          setConflictField({ field, updatedByName: errBody?.error?.updated_by?.name ?? null });
+          setConflictField({
+            field,
+            updatedByName: errBody?.error?.updated_by?.name ?? null,
+            updatedByMemberId: errBody?.error?.updated_by?.member_id ?? null,
+            viaUndo,
+          });
           setRules((r) => ({ ...r, [field]: freshRules[field] }));
           setLoadedRules(freshRules);
-          setVersion(freshJson.data.version);
+          versionRef.current = freshJson.data.version;
           setUpdatedAt(freshJson.data.updated_at);
           setUpdatedBy(freshJson.data.updated_by);
           return { status: 'conflict-mine' };
@@ -400,7 +417,7 @@ export default function ContentRulesPage() {
 
     let outcome: AttemptOutcome;
     try {
-      outcome = await attempt(nextRules, version, false);
+      outcome = await attempt(nextRules, versionRef.current, false);
     } catch {
       setRowErrors((prev) => ({ ...prev, [field]: t('saveFailed') }));
       outcome = { status: 'error' };
@@ -413,11 +430,11 @@ export default function ContentRulesPage() {
         action: { label: t('contentRulesUndoAction'), onClick: () => {
           const prev = draftBeforeSave.current[field];
           if (prev === undefined) return;
-          void saveField(field, { ...rules, [field]: prev } as ContentRules, nextRules[field]);
+          void saveField(field, { ...rules, [field]: prev } as ContentRules, nextRules[field], true);
         } },
       });
     }
-  }, [orgId, version, loadedRules, rules, t, addToast]);
+  }, [orgId, loadedRules, rules, t, addToast]);
 
   const fieldTitle = useCallback((field: FieldKey) => {
     const KEYS: Record<FieldKey, string> = {
@@ -692,9 +709,12 @@ export default function ContentRulesPage() {
           {conflictField ? (
             <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true" data-testid="content-rules-version-conflict">
               <AlertDescription>
-                {conflictField.updatedByName
-                  ? t('versionConflictFieldWithName', { field: fieldTitle(conflictField.field), name: conflictField.updatedByName })
-                  : t('versionConflictFieldFact', { field: fieldTitle(conflictField.field) })}
+                {conflictField.viaUndo ? `${t('contentRulesUndoFailedPrefix')} ` : ''}
+                {conflictField.updatedByMemberId !== null && conflictField.updatedByMemberId === currentTeamMemberId
+                  ? t('versionConflictFieldSelfOtherTab', { field: fieldTitle(conflictField.field) })
+                  : conflictField.updatedByName
+                    ? t('versionConflictFieldWithName', { field: fieldTitle(conflictField.field), name: conflictField.updatedByName })
+                    : t('versionConflictFieldFact', { field: fieldTitle(conflictField.field) })}
               </AlertDescription>
             </Alert>
           ) : null}


### PR DESCRIPTION
## Summary
- 페드루 PO 라이브 결함(2026-09-09, 배포 뒤 owner 실왕복) — 톤 저장 성공 뒤 「되돌리기」를 누르면 항상 409(`CONTENT_RULES_VERSION_CONFLICT`)로 실패했다. 원인: 되돌리기 onClick 클로저가 `saveField`를 재귀 호출하며 `version` state를 읽었는데, 원래 저장을 시작시킨 호출 안에서 만들어진 클로저라 **저장 前** 값을 그대로 들고 있었다.
- 처방: `version`은 렌더에 안 쓰이는 값이라 state에서 걷어내 `ref`로 옮겼다 — 모든 성공 응답에서 즉시 갱신돼 재귀 호출(되돌리기 포함)이 항상 "그 시점 최신" 버전을 읽는다.
- 유나 定 둘 동봉: ① 되돌리기 실패 배너는 「되돌리지 못했습니다」가 먼저·사유가 그 뒤에 ② 충돌 상대가 나 자신(다른 탭)이면 이름 대신 「다른 탭에서 먼저 저장됐습니다」(새 키).
- 회귀 pin 테스트 3건 — 실서버형 스텁(expected_version 불일치 시 409)으로 원 버그 재현·되돌리기 실패 문구 순서·자기 자신 충돌 문구.

story: https://app.sprintable.ai (story_id 51fa5c63-097d-4a5c-984b-d46895d4e423)

## 로컬 실캡처 확認(head 15202d785)
- 실 브라우저 왕복(owner) — 톤 「고치기」→값 변경→저장 → 토스트 「저장했습니다 되돌리기」(`3747_undo_save_success_light`) → 「되돌리기」 클릭 → **200 성공, 값이 「친근하게」로 정확히 복원**·충돌 배너 0건(`3747_undo_after_revert_light`). 원 버그(저장 前 버전 재사용 → 항상 409)가 실 서버 왕복에서도 사라졌음을 확認.

## Test plan
- [x] `pnpm run verify:no-i18n-phrase-collision` — green(신규 충돌 0건)
- [x] `tsc --noEmit` — clean
- [x] `eslint` (변경 파일) — clean
- [x] 전체 vitest(749파일/7426테스트) — green
- [x] 뮤테이션 킬 — 초기 `attempt()` 호출을 다시 `version` state로 되돌려 새 회귀 테스트가 RED로 떨어짐을 확認 후 원복
- [x] 로컬 풀스택 실왕복(owner) — 저장→되돌리기 성공·값 복원 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)