### PR TITLE
[SID:3745] fix(FE+BE): 이벤트 정의 name===key 잔존 — 화면 제목·생성/수정 API 둘 다 막는다

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/events/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/events/page.test.tsx
@@ -185,22 +185,25 @@ describe('OrganizationEventsPage', () => {
     expect(presetHeading?.querySelector('span')?.textContent).toBe('1');
   });
 
-  // 카디르 QA changes(#4082) — 부제 가드를 `def.name`만으로 완화(name!==key 비교 제거)하면
-  // name===key 행(org 커스텀 4행 name=key 방치 사례와 동형)에도 부제가 또 떠 이 테스트가
-  // RED가 된다(raw 값 한 줄 두 번 회귀 — 제목 자리 값(titleLabel)이 key와 같을 때만 안 뜬다).
-  // story #3745(페드루 PO 決·유나 定, #4090 이후 이어진 잔존 처방) — name이 아예 없는 행은
-  // 이제 제목이 「이름 없는 이벤트」(key가 아님)라 부제(key)가 정직하게 뜬다 — 옛
-  // `name || key` 폴백(raw 키가 제목 자리에 서던 결함)이 걷힌 결과.
-  it('story #3737(D2)+#3745 — name===key(백필 안 된 org 커스텀) 행만 부제 없음·이름 없는 행·name≠key 행은 부제(key)가 뜬다', async () => {
+  // story #3745(name===key 잔존, 페드루 PO 決·유나 定 2026-09-09) — `name || 폴백`(#4082
+  // 판정 당시 것)은 name===key 행(org 커스텀이 이름 자리에 코드 키를 그대로 등록한 옛
+  // 데이터)을 못 잡았다 — name이 빈 문자열이 아니라 "org.moonklabs.same_as_key" 자체라
+  // 폴백이 안 걸려 title=key로 서던 실 결함(디디 3745 첫 절 그라운딩·PO 라이브 실측
+  // 10:15Z). ⭐되돌리면 RED — titleLabel 판정에서 `!== def.key` 비교를 빼면 이 행의
+  // 제목이 다시 raw key로 서고 부제(key와 동값)가 억제돼 raw 값이 제목 자리에만 선다.
+  it('⭐story #3745 — name===key(org 커스텀 방치)·이름 없는 행 둘 다 「이름 없는 이벤트」+부제(key)·name≠key 행만 제 이름', async () => {
     mockFetches([
       customWithId({ id: 'def-samekey', key: 'org.moonklabs.same_as_key', name: 'org.moonklabs.same_as_key' }),
       customWithId({ id: 'def-nameless', key: 'org.moonklabs.no_name', name: '' }), // name 자체가 없음 → 「이름 없는 이벤트」
       customWithId({ id: 'def-named', key: 'org.moonklabs.named', name: '배포 완료' }),
     ]);
     await mount();
-    // title===key인 자리(name을 key 그대로 등록한 옛 데이터)만 부제 억제 — 여기서만 raw
-    // 값이 두 번 서는 것을 막는다.
-    expect(container.querySelector('[data-testid="event-def-key-subtitle-org.moonklabs.same_as_key"]')).toBeNull();
+    // name===key 행도 이제 「이름 없는 이벤트」(제목 자리에 코드 키가 서지 않는다) — 부제로
+    // key가 정직하게 뜬다(raw 값이 한 줄에 두 번 서는 것과는 다른 문제 — 여긴 애초에 라벨이
+    // 없어 부제 하나로만 진실을 말한다).
+    const samekeyToggle = container.querySelector('[data-testid="event-def-toggle-org.moonklabs.same_as_key"]');
+    expect(samekeyToggle?.textContent).toBe(koMessages.organization.eventUnnamedDefinition);
+    expect(container.querySelector('[data-testid="event-def-key-subtitle-org.moonklabs.same_as_key"]')?.textContent).toBe('org.moonklabs.same_as_key');
     // name이 없으면 제목이 「이름 없는 이벤트」(key가 아니다) — 부제로 key가 정직하게 뜬다.
     expect(container.querySelector('[data-testid="event-def-key-subtitle-org.moonklabs.no_name"]')?.textContent).toBe('org.moonklabs.no_name');
     expect(container.textContent).toContain(koMessages.organization.eventUnnamedDefinition);

--- a/apps/web/src/app/(authenticated)/organization/events/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/events/page.tsx
@@ -293,8 +293,11 @@ function EventDefRow({
   // 붙을 stage가 아예 없으면 적용할 게 없다) — isCyclicDefinition()(loop-create-dialog SSOT)
   // 그대로 재사용. id 필요조건은 canMutate와 동일 이유(ApplyRecipeDialog가 /apply 호출에 id 필요).
   const canApply = isAdmin && !!def.id && isCyclicDefinition(def as unknown as EventDefinitionResponse);
-  // story #3745 — 제목 자리 값을 한 곳에서 계산해 아래 부제 판정도 같은 값을 본다.
-  const titleLabel = def.name || t('eventUnnamedDefinition');
+  // story #3745(name===key 잔존, 페드루 PO 決 2026-09-09) — `name || 폴백`만으론 org
+  // 커스텀 정의가 name=key로(코드 키를 그대로 이름 자리에) 등록된 옛 데이터를 못 잡는다
+  // (name이 빈 문자열이 아니라 truthy라 폴백이 안 걸림). 제목 자리 값을 한 곳에서
+  // 계산해 아래 부제 판정도 같은 값을 본다.
+  const titleLabel = def.name && def.name !== def.key ? def.name : t('eventUnnamedDefinition');
   return (
     <div className="p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator
 from sqlalchemy import String, and_, cast, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -2225,11 +2225,18 @@ class CreateEventDefinitionRequest(BaseModel):
     # 가드①) — 비어 있으면(신호형/측정형) 검증 스킵.
     stage_metadata: dict = {}
 
+    # story #3745(name===key 잔존, 페드루 PO 決 2026-09-09) — 빈 이름을 막아도 org 커스텀
+    # 정의가 name=key로(코드 키를 그대로 이름 자리에) 등록되면 화면 제목 자리에 코드 키가
+    # 그대로 서는 같은 결함이 재발한다 — 빈 문자열과 "같은 결함 클래스"라 같은 필드
+    # validator에서 나란히 막는다(에러 loc도 name 그대로).
     @field_validator("name")
     @classmethod
-    def _name_not_blank(cls, v: str) -> str:
+    def _name_not_blank(cls, v: str, info: ValidationInfo) -> str:
         if not v.strip():
             raise ValueError("name은 비울 수 없습니다(공백뿐인 값도 안 됨)")
+        key = info.data.get("key")
+        if key is not None and v.strip() == key:
+            raise ValueError("name은 key와 같을 수 없습니다(코드 키를 이름으로 쓸 수 없음)")
         return v
 
 
@@ -2421,6 +2428,16 @@ async def update_event_definition(
     )).scalar_one_or_none()
     if definition is None:
         raise HTTPException(status_code=404, detail="event definition not found")
+
+    # story #3745(name===key 잔존, 페드루 PO 決 2026-09-09) — `UpdateEventDefinitionRequest`
+    # 스키마엔 key가 없어(PATCH는 key를 안 바꾼다) 이 규칙을 Pydantic field_validator로 못
+    # 건다 — DB에서 방금 읽은 `definition.key`와 대조해 여기서 막는다. POST의 빈 이름
+    # 검증(`_name_not_blank`)과 같은 결함 클래스라 코드도 그 이웃에 등록.
+    if body.name is not None and body.name.strip() == definition.key:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "definition_name_equals_key", "message": "name은 key와 같을 수 없습니다(코드 키를 이름으로 쓸 수 없음)"},
+        )
 
     # story #2792 가드① — stage_metadata는 payload_schema와 짝인 검증이라, 둘 중 하나만
     # 바뀌어도 **유효 조합**(새 값 있으면 새 값·없으면 기존 값)으로 재검증한다. payload_schema만

--- a/backend/tests/test_2636_custom_event_registration.py
+++ b/backend/tests/test_2636_custom_event_registration.py
@@ -342,6 +342,50 @@ async def test_patch_payload_schema_bumps_version_and_revalidates():
         await engine.dispose()
 
 
+# story #3745(name===key 잔존, 페드루 PO 決 2026-09-09) — PATCH 스키마엔 key가 없어(PATCH가
+# key를 안 바꿈) Pydantic field_validator로 POST와 같은 검증을 못 건다 — 엔드포인트가 DB에서
+# 방금 읽은 definition.key와 대조해 막는다. ⭐되돌리면 RED — 이 엔드포인트 체크를 빼면
+# name=key로 PATCH가 그대로 통과해 화면 제목 자리에 코드 키가 다시 선다.
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_patch_name_equals_key_rejected_422():
+    from app.routers.events import (
+        CreateEventDefinitionRequest, UpdateEventDefinitionRequest,
+        create_event_definition, update_event_definition,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            created = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme.widget.made", name="위젯 제작 완료", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+                ),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await update_event_definition(
+                    uuid.UUID(created.id),
+                    UpdateEventDefinitionRequest(name="org.acme.widget.made"),
+                    db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "definition_name_equals_key"
+
+            # 다른 필드와 함께 name만 바뀌지 않는 PATCH는 그대로 통과한다(회귀 없음).
+            updated = await update_event_definition(
+                uuid.UUID(created.id),
+                UpdateEventDefinitionRequest(name="위젯 제작 완료(개정)"),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert updated.name == "위젯 제작 완료(개정)"
+    finally:
+        await engine.dispose()
+
+
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
 async def test_patch_cross_org_definition_404():

--- a/backend/tests/test_3745_event_definition_name_required.py
+++ b/backend/tests/test_3745_event_definition_name_required.py
@@ -56,6 +56,21 @@ class TestCreateEventDefinitionRequestNameRequired:
             CreateEventDefinitionRequest(**_create_kwargs(name="   "))
         assert any(e["loc"] == ("name",) for e in ei.value.errors())
 
+    # ⭐되돌리면 RED④ — name===key(org 커스텀이 코드 키를 그대로 이름 자리에 등록한 옛
+    # 데이터와 동형 입력)도 거부. 빈 이름과 같은 결함 클래스(화면 제목 자리에 코드 키가
+    # 그대로 서게 만든다) — 페드루 PO 라이브 실측(10:15Z) 4건이 이 갈래.
+    def test_name_equals_key_rejected(self):
+        with pytest.raises(ValidationError) as ei:
+            CreateEventDefinitionRequest(**_create_kwargs(key="org.acme.widget.made", name="org.acme.widget.made"))
+        assert any(e["loc"] == ("name",) for e in ei.value.errors())
+
+    # name===key 검증이 strip 前 원문이 아니라 strip 後 값으로 도는지(앞뒤 공백만 다른
+    # name="  org.acme.widget.made  "도 사실상 key와 같다) 확認.
+    def test_name_equals_key_with_surrounding_whitespace_rejected(self):
+        with pytest.raises(ValidationError) as ei:
+            CreateEventDefinitionRequest(**_create_kwargs(key="org.acme.widget.made", name="  org.acme.widget.made  "))
+        assert any(e["loc"] == ("name",) for e in ei.value.errors())
+
 
 class TestUpdateEventDefinitionRequestNameOptionalButNotBlank:
     # ⭐되돌리면 RED③ — PATCH는 name 생략(None)이 "이 필드는 안 건드림"이라 유효하다.


### PR DESCRIPTION
## Summary
- 페드루 PO 라이브 실측(10:15Z, 배포 62) — 라이브 19개 정의 중 4개(org 커스텀)가 빈 이름이 아니라 **name===key**(코드 키를 그대로 이름 자리에 등록)였다. #4092가 닫은 건 「빈 name」 갈래뿐이라 이 갈래는 제목 자리에 코드 키가 그대로 섰다.
- ① FE(`events/page.tsx`) — `titleLabel` 판정을 `def.name || 폴백`에서 `def.name && def.name !== def.key ? def.name : 폴백`으로. 부제 규칙(`titleLabel !== def.key`)은 그대로 재사용해 name===key 행도 「이름 없는 이벤트」+부제(key)로 정직하게 선다.
- ② BE — POST(`CreateEventDefinitionRequest`)는 field_validator에 key와의 동일성 검사 추가(`ValidationInfo`로 key 접근). PATCH(`UpdateEventDefinitionRequest`)는 스키마에 key가 없어 엔드포인트에서 DB의 `definition.key`와 대조 — 422(`definition_name_equals_key`).
- ③ 마이그레이션 0(PO 決 — 데이터는 사람이 편집 UI로 직접 고친다).

story: https://app.sprintable.ai (story_id 62edec15-0d3c-4a2a-b828-109369053bd3)

## 로컬 캡처 확認
정의 목록 — org 커스텀 4행 전부 「이름 없는 이벤트」+부제(key)로 정직하게 서고, 정상 이름 행(「배포 완료」)은 그 이름 그대로. story artifact: `3745_unnamed_list_light`

## Test plan
- [x] FE: `tsc --noEmit` — clean
- [x] FE: `eslint`(변경 파일) — clean
- [x] FE: 전체 vitest(749파일/7423테스트) — green(name===key 행 회귀 테스트 갱신 포함)
- [x] BE: `pytest -m "not destructive_schema" tests/test_3745_event_definition_name_required.py` — green(POST 순수 Pydantic pin)
- [x] BE: `pytest -m destructive_schema tests/test_2636_custom_event_registration.py` — green(PATCH 422 pin 포함 13건)
- [x] 뮤테이션 킬 — PATCH 엔드포인트 체크를 제거해 새 pin 테스트가 RED로 떨어짐을 확認 후 원복
- [x] 로컬 풀스택 실캡처 — 4행 모두 정직 표시 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)