### PR TITLE
[SID:3751] fix(ci): Contrast guard 잡 — 러너 기본 google-chrome apt 소스 제거(플레이크)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1751,10 +1751,23 @@ jobs:
       # 빨갛게 만든다(같은 head가 그 전엔 초록이었다 — 외부 미러 동기화 타이밍 문제).
       # 우리는 google-chrome apt 패키지를 안 쓴다(playwright가 자체 번들 chromium을 깐다) —
       # 그 소스 자체를 지워 이 미러 의존을 0으로 만든다.
-      - name: Remove flaky google-chrome apt source (story #3751)
+      # story #3751 v2(페드루 PO 실측 2026-09-09 18:14Z) — v1(`rm google-chrome*.list`)이
+      # 불발이었다: 잡이 초록이어도 apt update 로그에 `Get:* dl.google.com`이 그대로 서
+      # (미러가 그 사이 회복해 초록이었을 뿐, 처방 덕이 아니다 — "잡 초록"은 이 처방의
+      # 양성대조가 못 된다). 원인 짐작 — noble 러너 이미지는 소스가 `.list` 파일이 아니라
+      # deb822(`google-chrome.sources`) 형태이거나 `/etc/apt/sources.list` 본문에 직접 있어
+      # 이름 글롭이 빈 매치였을 수 있다. 이름이 아니라 **내용**(dl.google.com 문자열)으로
+      # 찾아 지우고, 지운 뒤에도 apt update가 그 호스트를 당기면 **fail-closed**(양성대조를
+      # 이 스텝 자체가 강제) — 미러가 멀쩡해도 소스가 안 지워졌으면 빨강이어야 한다.
+      - name: Remove google-chrome apt source (story #3751)
         run: |
-          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
-          sudo apt-get update
+          sudo grep -rlE 'dl\.google\.com' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null | tee /tmp/google-src.txt
+          xargs -r -a /tmp/google-src.txt sudo rm -f
+          sudo apt-get update 2>&1 | tee /tmp/apt-update.log
+          if grep -q 'dl\.google\.com' /tmp/apt-update.log; then
+            echo '::error title=google-chrome apt source still active::제거 뒤에도 apt update가 dl.google.com을 당긴다 (story #3751)'
+            exit 1
+          fi
 
       - name: Install Playwright chromium
         run: pnpm --filter web exec playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1745,6 +1745,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # story #3751(PO 실측 2026-09-09 17:31Z~) — `playwright install --with-deps`가 내부
+      # `apt-get update`를 돌리는데, GH 러너 이미지에 기본 등록된 google-chrome apt 소스
+      # (dl.google.com)가 이따금 Hash Sum mismatch로 죽어 코드와 무관하게 이 잡을 통째로
+      # 빨갛게 만든다(같은 head가 그 전엔 초록이었다 — 외부 미러 동기화 타이밍 문제).
+      # 우리는 google-chrome apt 패키지를 안 쓴다(playwright가 자체 번들 chromium을 깐다) —
+      # 그 소스 자체를 지워 이 미러 의존을 0으로 만든다.
+      - name: Remove flaky google-chrome apt source (story #3751)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+          sudo apt-get update
+
       - name: Install Playwright chromium
         run: pnpm --filter web exec playwright install --with-deps chromium
 


### PR DESCRIPTION
## Summary
- v1(`rm google-chrome*.list`)은 불발이었다 — 페드루 PO 실측(18:14Z): 잡이 초록이어도 apt update 로그에 `Get:* dl.google.com`이 그대로 서(v1 스텝이 빈 매치). 미러가 그 사이 회복해 초록이었을 뿐 처방 덕이 아니었다 — "잡 초록"은 이 처방의 양성대조가 못 된다.
- 원인 짐작 — noble 러너 이미지는 소스가 `.list` 파일이 아니라 deb822(`google-chrome.sources`) 형태이거나 `/etc/apt/sources.list` 본문에 직접 있어 이름 글롭이 빈 매치였을 수 있다.
- **처방 v2**: 이름이 아니라 **내용**(`dl\.google\.com` 문자열)으로 실제 소스 파일을 찾아 지우고(`tee`로 어느 파일이었는지 로그에 남겨 짐작 자체를 확認), 지운 뒤에도 apt update가 그 호스트를 당기면 **fail-closed**(exit 1 + `::error`) — 미러가 멀쩡해도 소스가 안 지워졌으면 이 스텝 자체가 빨강이어야 양성대조가 선다.
- story #3739 메타 가드(ci.yml verify:* 배선 count-pin) 무변경 — 테스트 green 재확認.

story: https://app.sprintable.ai (story_id 2ae4a9d1-d885-4947-a5bc-a1d8a301a8e4)

## 양성대조
- 처방 前 실패(같은 원인): https://github.com/moonklabs/sprintable/actions/runs/34383451018 · https://github.com/moonklabs/sprintable/actions/runs/34383453750
- v1 불발 확認(같은 원인이 잡 초록 속에서도 재현): run 34386911268(페드루 실측 — `Get:7 dl.google.com` 잔존)
- v2 판별축: 「잡 초록」이 아니라 **apt update 출력에 `Get:*dl.google.com` 0줄** + `/tmp/google-src.txt`에 실 파일 경로가 찍혔는지(짐작 확認) — 소스가 안 지워지면 이 스텝이 exit 1로 fail-closed.

## Test plan
- [x] YAML 파싱 유효성 확認
- [x] `verify-ci-wires-all-verify-scripts.test.ts`(story #3739 메타 가드) — green(무변경 확認)
- [ ] CI 런에서 이 스텝의 로그로 `google-src.txt` 실 경로·apt update 출력 dl.google.com 0줄 확認(카디르 QA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)