### PR TITLE
[SID:3750] 세션 stale 판정 초 절삭 단위 불일치 수정

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -323,12 +323,24 @@ def _is_session_stale_after_password_change(user: User, session_started_at: obje
     판정 대상 밖 — 과거 시점을 알 방법이 없어 백필은 거짓 신호(0290 locale과 동형
     논지, 무제약=무회귀). session_started_at이 없거나 int가 아니면(레거시 토큰·
     #3247 seam 이전 발급) totp/disable과 동일하게 fail-closed(세션 무효로 본다) —
-    "판별 불가"를 "안전하다"로 해석하지 않는다(보안 결함 규율)."""
+    "판별 불가"를 "안전하다"로 해석하지 않는다(보안 결함 규율).
+
+    story #3750(BE·보안·bug, 미르코 그라운딩 2026-09-09) — 좌변(`password_set_at.
+    timestamp()`, 소수부 있는 float)과 우변(`session_started_at`, 토큰 클레임에
+    실린 `int(datetime.now(...).timestamp())`, 초 단위 절삭)을 서로 다른 단위로
+    비교했었다. 가입 핸들러가 `password_set_at`을 찍은 뒤(:671) flush·메타데이터
+    조회 await를 거쳐 토큰을 발급하는데(:702), 그 처리가 같은 정수 초 안에
+    끝나면 `1757437200.87 > 1757437200`이 True가 되어 방금 만든 세션이 "비밀번호
+    변경 뒤 stale"로 오판됐다(로컬·CI처럼 처리가 빠른 환경에서 흔함) — refresh·
+    switch-account·switch-project·switch-org 4곳이 이 함수를 공유해 강제
+    재로그인으로 번졌다. 좌변도 같은 단위(초 절삭)로 맞춘다 — 클레임을 float로
+    넓히는 대안은 토큰 계약 변경이라 안 한다. "같은 초에 세션이 시작됐다"는
+    stale이 아니다(다음 초부터가 stale — 기존 보안 판정은 그대로 유지)."""
     if user.password_set_at is None:
         return False
     if not isinstance(session_started_at, int):
         return True
-    return user.password_set_at.timestamp() > session_started_at
+    return int(user.password_set_at.timestamp()) > session_started_at
 
 
 def _explicit_revoke_values(now: datetime) -> dict:

--- a/backend/tests/test_3649_session_invalidation_password_change_realdb.py
+++ b/backend/tests/test_3649_session_invalidation_password_change_realdb.py
@@ -190,6 +190,67 @@ async def test_refresh_with_session_started_after_password_change_succeeds_200_n
 
 
 @pytest.mark.anyio
+async def test_refresh_with_password_set_same_second_as_session_start_succeeds_200():
+    """story #3750(BE·보안·bug, 미르코 그라운딩 2026-09-09) — 좌변(password_set_at.
+    timestamp(), float)과 우변(session_started_at, 초 절삭 int)을 단위 안 맞추고
+    비교하던 결함의 정확히 그 경계. 가입 직후처럼 password_set_at과 토큰 발급이
+    같은 정수 초 안에 떨어지면(password_set_at의 소수부가 0보다 큼) 예전 코드는
+    `float > int`가 True로 나와(초 뒤 소수부만큼 항상 더 크므로) 방금 만든 세션을
+    즉시 stale로 오판했다 — 이 테스트가 그 경계를 정확히 pin한다. 되돌리면 RED."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        # 세션이 시작된 바로 그 정수 초 «안»에서(소수부가 0보다 크게) 비밀번호가
+        # 찍힌 경우 — 가입 핸들러의 실제 순서(password_set_at 먼저, 토큰 발급
+        # 나중)와 반대로 구성해도 "같은 초"라는 사실 자체가 핵심이라 무해하다.
+        session_started_at = int(datetime.now(timezone.utc).timestamp())
+        password_set_at = datetime.fromtimestamp(session_started_at + 0.87, tz=timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=session_started_at)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_with_password_set_next_second_after_session_start_401():
+    """story #3750 — 위 테스트의 반대쪽 경계(기존 보안 판정이 그대로 서 있는지).
+    비밀번호가 세션 시작 «다음 정수 초»에 찍혔으면(진짜로 나중에 바뀐 것) 여전히
+    stale이어야 한다 — 초 절삭 정정이 «항상 False»로 물러진 게 아님을 확認."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        session_started_at = int(datetime.now(timezone.utc).timestamp())
+        password_set_at = datetime.fromtimestamp(session_started_at + 1.01, tz=timezone.utc)
+        async with Session() as s:
+            user_id = await _seed_user_with_password(s, password_set_at=password_set_at)
+            raw_rt = await _seed_refresh_token(s, user_id, session_started_at=session_started_at)
+
+        await _setup_db_override(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_rt})
+            assert resp.status_code == 401, resp.text
+            assert resp.json()["error"]["code"] == "SESSION_INVALIDATED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_switch_project_with_stale_session_401():
     from app.main import app
 


### PR DESCRIPTION
## 요약
`_is_session_stale_after_password_change`(backend/app/routers/auth.py:314)가
`password_set_at.timestamp()`(소수부 있는 float)와 `session_started_at`(토큰
클레임의 초 절삭 int)을 서로 다른 단위로 비교하던 결함을 수정.

가입 핸들러가 `password_set_at`을 찍은 뒤(:671) flush·메타데이터 조회 await를
거쳐 토큰을 발급하는데(:702), 그 처리가 같은 정수 초 안에 끝나면
`float > int`가 True로 나와 방금 만든 세션이 "비밀번호 변경 뒤 stale"로
오판됐다(로컬·CI처럼 처리가 빠른 환경에서 흔함) — refresh·switch-account·
switch-project·switch-org 4곳이 이 함수를 공유해 강제 재로그인으로 번졌다.

story #3649(2026-09-07 착지)가 이 비교 로직을 도입한 원 커밋.

## 수정
좌변도 같은 단위(초 절삭)로 맞춤: `int(user.password_set_at.timestamp())`.
클레임을 float로 넓히는 대안은 토큰 계약 변경이라 채택 안 함. "같은 초에
세션이 시작됐다"는 stale이 아니다 — 다음 초부터가 stale(기존 보안 판정은
그대로 유지, before-password-change 401 케이스 등 무변경).

## 검증
- `test_3649_session_invalidation_password_change_realdb.py`에 신규 pin 2개
  추가 — 같은 초 경계(200 통과)/다음 초 경계(401 SESSION_INVALIDATED 유지).
  전체 12개 PASS
- 뮤테이션킬: `int()` 절삭을 임시로 되돌려 같은-초 pin 테스트가 정확히 그
  이유(401 응답, 200 기대 실패)로 RED되는 것을 실측 → 원복 → 재확인 GREEN
- `test_3649_create_tokens_session_started_at_pin.py` PASS(회귀 없음)
- 인접 auth 테스트 40개(`test_auth_switch_project`·`test_auth_security`·
  `test_auth_10_backend`·`test_auth_11`·`test_ab2a503f_set_password_reauth`)
  전부 PASS

## 범위
dev 브랜치 fix만. prod 프로모션(cherry-pick)은 별도 건 — 선생님 명시 허가
필요(스토리 AC3, 이 PR 범위 밖).

🤖 Generated with [Claude Code](https://claude.com/claude-code)