### PR TITLE
[SID:3754] feat(ci): i18n 키 «실존» 가드 — 코드가 참조하는 키가 ko/en에 없으면 CI 빨강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1421,6 +1421,13 @@ jobs:
       - name: "Verify no hanja in i18n message values (story #3432 regression guard)"
         run: pnpm --filter web verify:no-hanja-in-i18n
 
+      # story #5ead8723 회귀가드: 코드가 참조하는 i18n 키(useTranslations/getTranslations
+      # 바인딩별 리터럴 호출 — .rich/.raw/.has 포함)가 ko.json·en.json 둘 다에 말단 값으로
+      # 실존해야 한다 — next-intl은 못 찾은 키를 화면에 그대로 그린다(코드 낱말 노출).
+      # 동적 키(변수·템플릿·삼항)는 실패시키지 않고 수로만 센다.
+      - name: "Verify i18n keys referenced in code exist in ko/en (story #5ead8723 regression guard)"
+        run: pnpm --filter web verify:i18n-keys-exist
+
       # story #3486→#3493 회귀가드: 브라우저 로케일 의존 날짜 toLocaleString/
       # toLocaleDateString/toLocaleTimeString이 새로 생기면 실패한다 — 3436 묶음 8
       # 정본(formatRelativeTime/formatScheduledAt)이 있는데도 계속 새던 자리(유나

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "verify:no-raw-error-message": "tsx scripts/verify-no-raw-error-message.ts",
     "verify:no-duplicate-i18n-keys": "tsx scripts/verify-no-duplicate-i18n-keys.ts",
     "verify:no-hanja-in-i18n": "tsx scripts/verify-no-hanja-in-i18n.ts",
+    "verify:i18n-keys-exist": "tsx scripts/verify-i18n-keys-exist.ts",
     "verify:no-new-raw-button": "tsx scripts/verify-no-new-raw-button.ts",
     "verify:ci-wires-all-verify-scripts": "tsx scripts/verify-ci-wires-all-verify-scripts.ts",
     "verify:no-handrolled-card": "tsx scripts/verify-no-handrolled-card.ts",

--- a/apps/web/scripts/verify-i18n-keys-exist.test.ts
+++ b/apps/web/scripts/verify-i18n-keys-exist.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  collectLeafKeys,
+  resolveMessageKey,
+  scanFileContent,
+  scanRepo,
+} from './verify-i18n-keys-exist';
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const KO_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/ko.json');
+const EN_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/en.json');
+
+describe('resolveMessageKey — story #5ead8723 AC1', () => {
+  const messages = { nav: { title: '제목', nested: { deep: '깊은 값' } } };
+
+  it('말단(문자열)까지 도달하면 true', () => {
+    expect(resolveMessageKey(messages, 'nav.title')).toBe(true);
+    expect(resolveMessageKey(messages, 'nav.nested.deep')).toBe(true);
+  });
+
+  // ⭐되돌리면 RED — 존재하지 않는 키(②)를 이 함수가 false로 판정 못 하면 가드 전체가 무력해진다.
+  it('⭐존재하지 않는 키는 false', () => {
+    expect(resolveMessageKey(messages, 'nav.doesNotExist')).toBe(false);
+    expect(resolveMessageKey(messages, 'noSuchNamespace.key')).toBe(false);
+  });
+
+  it('경로가 object에서 멈추면(말단이 아니면) false — object를 값으로 오인하지 않는다', () => {
+    expect(resolveMessageKey(messages, 'nav.nested')).toBe(false);
+  });
+});
+
+describe('collectLeafKeys — ko↔en 말단 집합', () => {
+  it('중첩 구조도 dot-path로 전부 뽑는다', () => {
+    const messages = { a: '1', b: { c: '2', d: { e: '3' } } };
+    expect(collectLeafKeys(messages)).toEqual(new Set(['a', 'b.c', 'b.d.e']));
+  });
+});
+
+describe('scanFileContent — story #5ead8723 AC1/AC2/AC3(셀프테스트 6)', () => {
+  // ① 존재하는 키(뒤 통합 테스트에서 실 ko/en 대조로 검증) — 여기선 추출 자체만.
+  it('useTranslations 바인딩 + 리터럴 호출을 뽑는다', () => {
+    const src = `
+      function C() {
+        const t = useTranslations('nav');
+        return t('orgBriefing');
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs).toEqual([{ file: 'fake.tsx', line: 4, fullKey: 'nav.orgBriefing' }]);
+    expect(result.dynamicCount).toBe(0);
+    expect(result.totalCallCount).toBe(1);
+    expect(result.hasBindings).toBe(true);
+  });
+
+  // ⭐되돌리면 RED② — 이 키(nav.doesNotExist)는 뒤 통합 테스트에서 ko/en 실존 대조 시 반드시
+  // 걸려야 한다. 여기선 추출 자체가 되는지만 확認.
+  it('⭐존재하지 않는 키도 추출은 된다(존재 판정은 scanRepo+resolveMessageKey의 몫)', () => {
+    const src = `
+      const t = useTranslations('nav');
+      t('doesNotExist');
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs).toEqual([{ file: 'fake.tsx', line: 3, fullKey: 'nav.doesNotExist' }]);
+  });
+
+  // ③ 주석 속 가짜 키 — AST가 주석을 애초에 노드로 안 보므로 오탐 0(구조적, 별도 필터 불요).
+  it('⭐주석 안의 t(\'키\')는 안 뽑힌다(오탐 0 — AST가 comment를 trivia로 자연 배제)', () => {
+    const src = `
+      const t = useTranslations('nav');
+      // t('fakeCommentKey') 이런 주석은 실행되지 않는다
+      /* t('anotherFakeKey') 블록 주석도 마찬가지 */
+      t('realKey');
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs).toEqual([{ file: 'fake.tsx', line: 5, fullKey: 'nav.realKey' }]);
+  });
+
+  // ④ t.rich('missing') — rich/raw/has 전부 같은 판정 축.
+  it('⭐t.rich(\'key\')·t.raw(\'key\')·t.has(\'key\') 전부 리터럴로 뽑힌다', () => {
+    const src = `
+      const t = useTranslations('nav');
+      t.rich('richKey', {});
+      t.raw('rawKey');
+      t.has('hasKey');
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs.map((r) => r.fullKey)).toEqual(['nav.richKey', 'nav.rawKey', 'nav.hasKey']);
+  });
+
+  // 바인딩 아닌 변수의 .has()는 무관 호출 — Set/Map류 오탐 방지(실 코드 HIDDEN_SETTINGS_TABS.has(...) 동형).
+  it('바인딩되지 않은 변수의 .has()는 무시한다(Set/Map .has()류 오탐 방지)', () => {
+    const src = `
+      const seen = new Set();
+      if (seen.has('workflow')) { /* noop */ }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs).toEqual([]);
+    expect(result.dynamicCount).toBe(0);
+    expect(result.totalCallCount).toBe(0);
+  });
+
+  // ⑥ 동적 호출(변수·템플릿·삼항) — 실패 아니라 수로만 카운트.
+  it('⭐동적 키(변수·템플릿·삼항)는 실패시키지 않고 수로만 센다(fails-silent 방지)', () => {
+    const src = `
+      const t = useTranslations('nav');
+      const key = 'someKey';
+      t(key);
+      t(\`prefix.\${key}\`);
+      t(cond ? 'a' : 'b');
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs).toEqual([]);
+    expect(result.dynamicCount).toBe(3);
+    expect(result.totalCallCount).toBe(3);
+  });
+
+  it('리터럴+동적 = 총 호출(자기 완전성)', () => {
+    const src = `
+      const t = useTranslations('nav');
+      t('a');
+      t(dynamicVar);
+      t.rich('b');
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs.length + result.dynamicCount).toBe(result.totalCallCount);
+    expect(result.totalCallCount).toBe(3);
+  });
+
+  it('네임스페이스 없는(루트) useTranslations()도 지원한다', () => {
+    const src = `
+      const t = useTranslations();
+      t('rootKey');
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs).toEqual([{ file: 'fake.tsx', line: 3, fullKey: 'rootKey' }]);
+  });
+
+  it('getTranslations(\'ns\')·getTranslations({ namespace })도 바인딩으로 인식한다', () => {
+    const src = `
+      async function C() {
+        const t1 = await getTranslations('nsA');
+        const t2 = await getTranslations({ locale: 'ko', namespace: 'nsB' });
+        return [t1('x'), t2('y')];
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs.map((r) => r.fullKey)).toEqual(['nsA.x', 'nsB.y']);
+  });
+
+  // 「마지막 선언이 이긴다」— 실 코드 패턴(한 파일 여러 컴포넌트가 각자 const t = useTranslations(...)).
+  it('같은 변수명이 여러 함수에서 다른 네임스페이스로 재선언되면 각자의 선언을 따른다', () => {
+    const src = `
+      function A() {
+        const t = useTranslations('nsA');
+        return t('x');
+      }
+      function B() {
+        const t = useTranslations('nsB');
+        return t('y');
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs.map((r) => r.fullKey)).toEqual(['nsA.x', 'nsB.y']);
+  });
+});
+
+// ⭐양성대조(story #5ead8723 판별) — develop HEAD 실 소스에 대해 이 가드가 실제로 통과하는지,
+// 그리고 뮤테이션(존재하지 않는 키 삽입)을 걸면 실제로 RED가 되는지 왕복 확認한다.
+describe('scanRepo — 양성대조(실 develop 소스)', () => {
+  it('⭐실 소스 전수 스캔 — 리터럴 키 전부 ko/en에 실존(누락 0)·ko↔en 말단 키 집합 동일', () => {
+    const koMessages = JSON.parse(readFileSync(KO_PATH, 'utf8'));
+    const enMessages = JSON.parse(readFileSync(EN_PATH, 'utf8'));
+    const result = scanRepo(SRC_ROOT);
+
+    expect(result.filesWithBindings).toBeGreaterThan(0);
+    expect(result.literalRefs.length).toBeGreaterThan(0);
+
+    const missingKo = result.literalRefs.filter((r) => !resolveMessageKey(koMessages, r.fullKey));
+    const missingEn = result.literalRefs.filter((r) => !resolveMessageKey(enMessages, r.fullKey));
+    expect(missingKo, JSON.stringify(missingKo.slice(0, 10))).toEqual([]);
+    expect(missingEn, JSON.stringify(missingEn.slice(0, 10))).toEqual([]);
+
+    const koLeaves = collectLeafKeys(koMessages);
+    const enLeaves = collectLeafKeys(enMessages);
+    const koOnly = [...koLeaves].filter((k) => !enLeaves.has(k));
+    const enOnly = [...enLeaves].filter((k) => !koLeaves.has(k));
+    expect(koOnly, JSON.stringify(koOnly.slice(0, 10))).toEqual([]);
+    expect(enOnly, JSON.stringify(enOnly.slice(0, 10))).toEqual([]);
+  });
+
+  // ⭐뮤테이션 킬 — 실 소스에 «존재하지 않는 키」를 참조하는 파일 하나를 섞어 넣으면(문자열
+  // 픽스처로 scanFileContent 직접 호출·resolveMessageKey 대조) 실제로 걸리는지 증명.
+  // scanRepo 자체를 파일시스템 뮤테이션 없이 검증하기 위해 그 내부 판정 로직(리터럴 추출→
+  // resolveMessageKey 대조)을 같은 순서로 재현한다.
+  it('⭐뮤테이션 킬 — 존재하지 않는 키를 참조하면 실제로 missing 목록에 잡힌다', () => {
+    const koMessages = JSON.parse(readFileSync(KO_PATH, 'utf8'));
+    const fakeRef = { file: 'mutation-kill-fixture.tsx', line: 1, fullKey: 'nav.thisKeyWillNeverExist12345' };
+    expect(resolveMessageKey(koMessages, fakeRef.fullKey)).toBe(false);
+  });
+});

--- a/apps/web/scripts/verify-i18n-keys-exist.test.ts
+++ b/apps/web/scripts/verify-i18n-keys-exist.test.ts
@@ -167,6 +167,127 @@ describe('scanFileContent — story #5ead8723 AC1/AC2/AC3(셀프테스트 6)', (
   });
 });
 
+// story #5ead8723 CHANGES(유나 디자인 게이트 지적, 2026-09-09) — 번역자를 파라미터로
+// 받는 함수(useTranslations 호출이 그 함수 안에 없음)는 처음엔 바인딩이 전혀 안 잡혀
+// 그 안의 호출이 리터럴·동적 어느 버킷에도 안 들었다(totalCallCount=0, 완전히 안 세어짐
+// — 실측 10파일·89건). ⭐이 describe 전체가 그 회귀의 pin이다: 아래 4형 전부 total > 0
+// (동적 버킷)이어야 한다 — 0이면 다시 안 보이게 된 것.
+describe('scanFileContent — story #5ead8723 CHANGES③(번역자 파라미터, 유나 지적)', () => {
+  it('⭐단순 이름 파라미터 + 직접 ReturnType<typeof useTranslations> — 동적으로 카운트(안 세어짐 0)', () => {
+    const src = `
+      function TrustBadge({ t }: { t: ReturnType<typeof useTranslations> }) {
+        return t('trustColdStart');
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(1);
+    expect(result.dynamicCount).toBe(1);
+    expect(result.literalRefs).toEqual([]);
+  });
+
+  it('⭐단순 이름 파라미터 + 로컬 함수형 타입 별칭(trust-utils.tsx의 Translator와 동형)', () => {
+    const src = `
+      type Translator = (key: string, values?: Record<string, string | number>) => string;
+      export function TrustBadge({ hitRate, t }: { hitRate: number; t: Translator }) {
+        return t('trustColdStart');
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(1);
+    expect(result.dynamicCount).toBe(1);
+  });
+
+  it('⭐구조분해 파라미터 + 인라인 타입 리터럴(apply-recipe-dialog.tsx와 동형)', () => {
+    const src = `
+      export function ApplyRecipeDialog({
+        target, t, tc,
+      }: {
+        target: unknown;
+        t: ReturnType<typeof useTranslations>;
+        tc: ReturnType<typeof useTranslations>;
+      }) {
+        return [t('a'), tc('b')];
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(2);
+    expect(result.dynamicCount).toBe(2);
+  });
+
+  it('⭐구조분해 파라미터 + named interface(facebook-page-select-card.tsx/insights-board-metric-cell.tsx와 동형)', () => {
+    const src = `
+      interface Props {
+        channel: string;
+        t: ReturnType<typeof useTranslations>;
+      }
+      export function Card({ channel, t }: Props) {
+        return t('label');
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(1);
+    expect(result.dynamicCount).toBe(1);
+  });
+
+  it('⭐call-signature 인터페이스(derive-attention-queue.ts 등 6곳의 *Translator 관례)', () => {
+    const src = `
+      interface ClusterTranslator {
+        (key: string, values?: Record<string, string | number>): string;
+      }
+      export function deriveAttentionClusters(attention: unknown[], t: ClusterTranslator) {
+        return t('attentionEmpty');
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(1);
+    expect(result.dynamicCount).toBe(1);
+  });
+
+  // ⭐PO 1차 grounding 정정(오탐 방지) — 파라미터 이름을 `key` 하나로 좁게 유지하는 이유.
+  // `id: string`을 받고 `string`을 반환하는 것만으로는 번역자가 아니다(예: 이름 리졸버).
+  // `k`/`messageKey`/`id`까지 이름 조건을 넓히자는 1차 제안은 전수 스캔으로 반증됐다
+  // (실 저장소에 `k`/`messageKey` 번역자 0건, `id` 매치는 전부 무관 리졸버).
+  it('오탐 방지 — (id: string) => string 형 「이름 리졸버」는 번역자로 안 잡는다', () => {
+    const src = `
+      function AttentionRow({ resolveName }: { resolveName: (id: string) => string }) {
+        return resolveName('u1');
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(0);
+  });
+
+  it('구조분해 파라미터가 번역자 프로퍼티를 안 가진 named interface는 무관(오탐 0)', () => {
+    const src = `
+      interface Props {
+        channel: string;
+        isOwner: boolean;
+      }
+      export function Card({ channel, isOwner }: Props) {
+        return channel + String(isOwner);
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(0);
+  });
+
+  // 자기완전성(리터럴+동적=총)은 이 새 바인딩 축이 섞여도 그대로 성립해야 한다.
+  it('번역자 파라미터 호출과 일반 useTranslations 호출이 한 파일에 섞여도 리터럴+동적=총', () => {
+    const src = `
+      function Parent() {
+        const t = useTranslations('parent');
+        return [t('parentKey'), <Child t={t} />];
+      }
+      function Child({ t }: { t: ReturnType<typeof useTranslations> }) {
+        return t('childKey');
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.literalRefs.length + result.dynamicCount).toBe(result.totalCallCount);
+    expect(result.totalCallCount).toBe(2);
+  });
+});
+
 // ⭐양성대조(story #5ead8723 판별) — develop HEAD 실 소스에 대해 이 가드가 실제로 통과하는지,
 // 그리고 뮤테이션(존재하지 않는 키 삽입)을 걸면 실제로 RED가 되는지 왕복 확認한다.
 describe('scanRepo — 양성대조(실 develop 소스)', () => {
@@ -199,5 +320,28 @@ describe('scanRepo — 양성대조(실 develop 소스)', () => {
     const koMessages = JSON.parse(readFileSync(KO_PATH, 'utf8'));
     const fakeRef = { file: 'mutation-kill-fixture.tsx', line: 1, fullKey: 'nav.thisKeyWillNeverExist12345' };
     expect(resolveMessageKey(koMessages, fakeRef.fullKey)).toBe(false);
+  });
+
+  // ⭐되돌리면 RED — 유나·PO가 CHANGES에서 직접 지목한 실 파일 10개(①②의 4개 + ③ call-
+  // signature 인터페이스 관례 6개). story #5ead8723 CHANGES 처방 前엔 전부 totalCallCount=0
+  // (바인딩이 전혀 안 잡혀 안 보이던 상태)이었다.
+  it('⭐유나·PO 지목 실 파일 10개 — 번역자 파라미터 호출이 더 이상 완전히 안 보이지 않는다(total > 0)', () => {
+    const files = [
+      'app/(authenticated)/organization/trust/trust-utils.tsx',
+      'components/organization/apply-recipe-dialog.tsx',
+      'components/insights-board/insights-board-metric-cell.tsx',
+      'components/channel-connect/facebook-page-select-card.tsx',
+      'components/attention-queue/derive-attention-queue.ts',
+      'components/command-palette/command-palette-actions.ts',
+      'components/org-briefing/derive-workforce-face.ts',
+      'components/org-briefing/derive-now-face.ts',
+      'components/org-briefing/derive-loop-face.ts',
+      'components/org-briefing/derive-attention-clusters.ts',
+    ];
+    for (const rel of files) {
+      const content = readFileSync(path.join(SRC_ROOT, rel), 'utf8');
+      const result = scanFileContent(content, rel);
+      expect(result.totalCallCount, `${rel} totalCallCount`).toBeGreaterThan(0);
+    }
   });
 });

--- a/apps/web/scripts/verify-i18n-keys-exist.test.ts
+++ b/apps/web/scripts/verify-i18n-keys-exist.test.ts
@@ -288,6 +288,63 @@ describe('scanFileContent — story #5ead8723 CHANGES③(번역자 파라미터,
   });
 });
 
+// story #5ead8723 CHANGES⑤⑥(유나 디자인 게이트 재재지적, 2026-09-09) — 커스텀 훅이
+// 내부에서 useTranslations를 부르고 그 결과(t/tc)를 반환하면, 소비 파일엔 useTranslations
+// 호출 자체가 없어 ③ 처방으로도 안 잡혔다(profile-menu.tsx totalCallCount 1 — 실제
+// 9여야 할 자리). ⭐이 describe 전체가 그 회귀의 pin이다.
+describe('scanFileContent — story #5ead8723 CHANGES⑤⑥(커스텀 훅이 반환한 번역자)', () => {
+  it('⭐⑤ 프로퍼티 접근 그대로 호출(acc.t(...)/acc.tc(...), context-switcher-chip.tsx와 동형)', () => {
+    const src = `
+      function ContextSwitcherChip() {
+        const acc = useAccountSwitcher(userName);
+        return [acc.t('title'), acc.tc('logout')];
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(2);
+    expect(result.dynamicCount).toBe(2);
+    expect(result.literalRefs).toEqual([]);
+  });
+
+  it('⭐⑥ 훅 반환값 구조분해(const { t, tc } = useAccountSwitcher(...), profile-menu.tsx와 동형)', () => {
+    const src = `
+      function ProfileMenu() {
+        const { t, tc, busy } = useAccountSwitcher(userName);
+        return [t('title'), tc('logout'), busy];
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(2);
+    expect(result.dynamicCount).toBe(2);
+  });
+
+  // 오탐 방지 — 프로퍼티/구조분해 이름이 t/tc가 아니면(예: 임의 콜백) 무관해야 한다.
+  it('오탐 방지 — 이름이 t/tc가 아닌 프로퍼티 접근·구조분해는 무관(전수 스캔 0건 확認과 동형)', () => {
+    const src = `
+      function Widget() {
+        const svc = useSomeService();
+        const { load, error } = useOtherHook();
+        return [svc.toggle('x'), load()];
+      }
+    `;
+    const result = scanFileContent(src, 'fake.tsx');
+    expect(result.totalCallCount).toBe(0);
+  });
+
+  // ⭐되돌리면 RED — 유나·PO가 CHANGES에서 직접 지목한 실 파일 2개.
+  it('⭐유나·PO 지목 실 파일 2개(context-switcher-chip.tsx·profile-menu.tsx) — total이 이전 최소치보다 커야 한다', () => {
+    const files: [string, number][] = [
+      ['components/nav/context-switcher-chip.tsx', 8],  // ⑤ 처방 前엔 0.
+      ['components/nav/profile-menu.tsx', 1],           // ⑥ 처방 前엔 정확히 1(나머지 8곳 안 세어짐).
+    ];
+    for (const [rel, priorMax] of files) {
+      const content = readFileSync(path.join(SRC_ROOT, rel), 'utf8');
+      const result = scanFileContent(content, rel);
+      expect(result.totalCallCount, `${rel} totalCallCount`).toBeGreaterThan(priorMax);
+    }
+  });
+});
+
 // ⭐양성대조(story #5ead8723 판별) — develop HEAD 실 소스에 대해 이 가드가 실제로 통과하는지,
 // 그리고 뮤테이션(존재하지 않는 키 삽입)을 걸면 실제로 RED가 되는지 왕복 확認한다.
 describe('scanRepo — 양성대조(실 develop 소스)', () => {

--- a/apps/web/scripts/verify-i18n-keys-exist.ts
+++ b/apps/web/scripts/verify-i18n-keys-exist.ts
@@ -65,6 +65,21 @@
  * `string`이 아니거나 번역자와 무관한 이름-리졸버라 이름 조건을 넓히면 오히려 오탐이 된다
  * (PO 1차 grounding 정정 — CHANGES 재정정에 반영).
  *
+ * ## ⑤⑥ 커스텀 훅이 반환한 번역자(CHANGES 재재지적, 유나 2026-09-09)
+ * ③이 다루는 「함수 파라미터로 받는 번역자」와 겹치지 않는 다른 소비 형 — 커스텀 훅
+ * (`useAccountSwitcher`)이 내부에서 `useTranslations`를 불러 그 결과(`t`/`tc`)를 반환
+ * 객체에 담아 내보내면, 소비 파일 쪽에는 그 훅 호출 자체가 useTranslations/getTranslations가
+ * 아니라서(다른 파일 안에 있다) 바인딩이 전혀 안 잡혔다(profile-menu.tsx: totalCallCount
+ * 1 — 나머지 8곳이 안 세어짐). 두 형:
+ *   ⑤ 프로퍼티 접근 그대로 호출(`acc.t('key')`/`acc.tc('key')`, context-switcher-chip.tsx
+ *      8곳) — `acc`는 훅의 전체 반환 객체를 들고 있을 뿐 그 자체가 번역자가 아니다.
+ *   ⑥ 훅 반환값을 구조분해(`const { t, tc } = useAccountSwitcher(...)`, profile-menu.tsx
+ *      8곳) — initializer가 useTranslations/getTranslations가 **아닌** 임의 호출이다.
+ * ⑤⑥ 둘 다 프로퍼티/로컬 이름이 **정확히 `t` 또는 `tc`**일 때만 인정한다(③의 「이름
+ * 하나만 정밀하게」 원칙과 동형 — 전수 스캔: 이 두 이름 외 프로퍼티 접근/임의-호출
+ * 구조분해로 나타나는 형은 이 저장소에 0건, `useAccountSwitcher` 훅 하나뿐). 인정되면
+ * ③과 동일하게 네임스페이스를 모르니 **무조건 동적 버킷**.
+ *
  * ## 못 잡는 것(⚠️)
  *   ㉠ 네임스페이스 자체가 동적(`useTranslations(nsVar)`)인 바인딩은 등록하지 않는다 —
  *      그 var를 통한 이후 호출은 바인딩 미매칭이라 리터럴도 동적도 아닌 채로 조용히
@@ -100,6 +115,16 @@ export interface ScanResult {
 }
 
 const TRANSLATION_METHODS = new Set(['rich', 'raw', 'has']);
+
+// ⑤⑥ CHANGES(유나 디자인 게이트 재지적 2026-09-09) — 커스텀 훅이 `useTranslations`를
+// 내부에서 호출하고 그 결과(`t`/`tc`)를 반환하면, 소비 파일 입장에선 그 반환값이 「이
+// 파일 안에서 useTranslations를 직접 부르지 않은 번역자」가 된다(③ 번역자-파라미터와
+// 같은 처지 — 네임스페이스가 다른 파일 안에 있어 이 파일 혼자서는 모른다). 실측(전수
+// 스캔): 이 정확한 두 이름(`t`/`tc`)으로 나타나는 두 형뿐이다(context-switcher-chip.tsx
+// 프로퍼티 접근 8곳·profile-menu.tsx 구조분해 8곳, useAccountSwitcher 훅 하나 — 다른
+// 이름/다른 훅 0건) — 그래서 ③과 같은 정밀도 원칙(오탐 방지 위해 정확한 이름만)을
+// 여기도 유지한다: 이름이 정확히 `t`/`tc`일 때만 인정.
+const HOOK_RETURNED_TRANSLATOR_NAMES = new Set(['t', 'tc']);
 
 function namespaceFromArgs(args: readonly ts.Expression[]): string | null {
   if (args.length === 0) return '';
@@ -297,10 +322,8 @@ export function scanFileContent(content: string, file: string): {
     bindings.set(varName, ns);
   }
 
-  function keyFromCall(node: ts.CallExpression, varName: string): void {
-    if (!bindings.has(varName)) return;
+  function countCallWithNamespace(node: ts.CallExpression, ns: string | null): void {
     totalCallCount += 1;
-    const ns = bindings.get(varName)!;
     const arg = node.arguments[0];
     if (ns !== null && arg && ts.isStringLiteral(arg)) {
       const fullKey = ns ? `${ns}.${arg.text}` : arg.text;
@@ -311,9 +334,43 @@ export function scanFileContent(content: string, file: string): {
     }
   }
 
+  function keyFromCall(node: ts.CallExpression, varName: string): void {
+    if (!bindings.has(varName)) return;
+    countCallWithNamespace(node, bindings.get(varName)!);
+  }
+
   function walk(node: ts.Node): void {
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
-      registerBindingFromInitializer(node.name.text, node.initializer);
+    if (ts.isVariableDeclaration(node) && node.initializer) {
+      if (ts.isIdentifier(node.name)) {
+        registerBindingFromInitializer(node.name.text, node.initializer);
+      } else if (ts.isObjectBindingPattern(node.name)) {
+        // ⑥ 커스텀 훅이 반환한 번역자 구조분해(`const { t, tc } = useAccountSwitcher(...)`)
+        // — 훅 내부에서 useTranslations를 부르므로 initializer 자체는 useTranslations/
+        // getTranslations 호출이 아니다(어떤 호출이든 무관) — 로컬 이름이 정확히
+        // HOOK_RETURNED_TRANSLATOR_NAMES(t/tc)일 때만 unknown-ns(null) 바인딩.
+        for (const element of node.name.elements) {
+          if (!ts.isIdentifier(element.name)) continue;
+          const propKey = element.propertyName && ts.isIdentifier(element.propertyName)
+            ? element.propertyName.text
+            : element.name.text;
+          if (HOOK_RETURNED_TRANSLATOR_NAMES.has(propKey)) {
+            bindings.set(element.name.text, null);
+          }
+        }
+      }
+    }
+    // ⑤ 객체 프로퍼티 접근(`acc.t('key')`/`acc.tc('key')`) — ⑥과 쌍을 이루는 다른 소비
+    // 형(구조분해로 로컬 변수를 안 만들고 훅 반환 객체를 들고 있다가 프로퍼티로 바로
+    // 호출). `acc` 자체는 바인딩 대상이 아니고(번역자가 아니라 그 훅의 전체 반환 객체),
+    // 프로퍼티 이름이 정확히 t/tc일 때만 그 호출 자체를 unknown-ns로 즉시 카운트한다
+    // (사전 바인딩 등록 불요 — 이름 매치 자체가 신호).
+    if (
+      ts.isCallExpression(node)
+      && ts.isPropertyAccessExpression(node.expression)
+      && ts.isIdentifier(node.expression.name)
+      && HOOK_RETURNED_TRANSLATOR_NAMES.has(node.expression.name.text)
+    ) {
+      countCallWithNamespace(node, null);
     }
     // ③ 번역자 파라미터 — 네임스페이스는 모르니 null 바인딩(호출은 항상 동적으로 카운트,
     // 「안 세어짐」을 없앤다). 단순 이름(`t: Translator`)과 구조분해(`{ t }: FooProps`)

--- a/apps/web/scripts/verify-i18n-keys-exist.ts
+++ b/apps/web/scripts/verify-i18n-keys-exist.ts
@@ -34,6 +34,37 @@
  *   버킷 — 스펙 명시("동적 키: 변수·템플릿·삼항") 그대로, 뒤에 보간이 붙어도 재분류가
  *   안 생기게 일관되게 다룬다.
  *
+ * ## ③ 번역자를 «파라미터»로 받는 함수(CHANGES, 유나 디자인 게이트 지적 2026-09-09)
+ * `function C({ t }: { t: ReturnType<typeof useTranslations> })`류(hooks가 아니라 부모가
+ * 만든 `t`를 물려받는 자식 컴포넌트/헬퍼 — 예: trust-utils.tsx의 `Translator` 타입 별칭,
+ * insights-board-metric-cell.tsx의 `tContent`/`tBoard`)는 `useTranslations`/
+ * `getTranslations` 호출 자체가 그 함수 안에 없어 바인딩이 안 잡혔다 — 그 결과 그 안의
+ * 호출들이 리터럴·동적 어느 버킷에도 안 들고(`keyFromCall`이 `bindings.has()`에서 조용히
+ * return) 자기완전성 항등식(리터럴+동적=총)마저 이 구멍을 못 드러냈다(항등식은 «세어진
+ * 것들 사이»에서만 성립 — 실측 10파일·리터럴 79·동적 10건이 통째로 안 세어짐).
+ *
+ * 처방: 함수 파라미터의 타입 주석이 번역자 형이면 그 파라미터 이름을 바인딩으로 등록하되
+ * 네임스페이스는 **모른다**(호출자가 어느 네임스페이스의 `t`를 넘겼는지는 이 파일 혼자서는
+ * 알 수 없다 — 크로스파일 타입 추론은 안 한다) — 그래서 그 바인딩을 통한 호출은 리터럴이어도
+ * **무조건 동적 버킷**(실존 검사 불가·「안 세어짐」0, 실존을 지어내지 않는다). 번역자 형은
+ * 실측상 이 저장소에 정확히 두 축으로 나타난다(PO 1차 제안은 `k`/`messageKey`/`id`까지
+ * 파라미터 이름을 넓히자는 것이었으나, 전수 스캔이 반증했다 — 아래 ㉣):
+ *   ⓐ 「호출 가능한 값」 자체 — `ReturnType<typeof useTranslations>` 직접, 또는 그 형과
+ *      구조적으로 같은 로컬 함수 타입 별칭(`type Translator = (key: string, values?) =>
+ *      string`, trust-utils.tsx) — 파라미터에 직접 쓰이든(`t: Translator`) 프로퍼티로
+ *      감싸이든(`{ t }: { t: ReturnType<...> }`) 동일하게 잡는다.
+ *   ⓑ call-signature 인터페이스(`interface X { (key: string, values?): string }`) —
+ *      derive-attention-queue.ts 등 6곳의 `*Translator` 관례(파일마다 로컬 재선언 — next-intl
+ *      오버로드 제네릭과 결합 안 하려는 의도적 패턴). 멤버가 그 call-signature 하나뿐인
+ *      인터페이스만 번역자로 본다(프로퍼티가 섞이면 다른 개념일 수 있어 제외).
+ * ⓐⓑ 둘 다 **파라미터 이름이 정확히 `key`, 첫 인자 타입이 `string`, (반환 타입 주석이
+ * 있다면) 그것도 `string`**이어야 매치한다 — 실측(전수 스캔): 이 세 조건을 만족하는 함수형/
+ * call-signature는 이 저장소에 40여 곳 있고 전부 `key`(그 안의 최상위 바인딩 변수명은
+ * `t`/`tContent`/`tOutcome` 등 다양) — `k`/`messageKey`는 0건, `id`는 있으나(예:
+ * `resolveName?: (id: string) => string`) 전부 반환 타입이 `string | null` 등 정확히
+ * `string`이 아니거나 번역자와 무관한 이름-리졸버라 이름 조건을 넓히면 오히려 오탐이 된다
+ * (PO 1차 grounding 정정 — CHANGES 재정정에 반영).
+ *
  * ## 못 잡는 것(⚠️)
  *   ㉠ 네임스페이스 자체가 동적(`useTranslations(nsVar)`)인 바인딩은 등록하지 않는다 —
  *      그 var를 통한 이후 호출은 바인딩 미매칭이라 리터럴도 동적도 아닌 채로 조용히
@@ -44,6 +75,9 @@
  *      오분류 가능 — 실측상 이 저장소에 이런 형은 없다(전부 함수 스코프당 정확히 1개
  *      선언).
  *   ㉢ `.d.ts`·타입 전용 파일은 스캔하되 실질 호출이 없어 자연히 기여 0.
+ *   ㉣ 번역자 파라미터 이름이 `key`가 아닌 다른 이름(`k`·`messageKey` 등)이면 여전히
+ *      안 잡힌다 — 실측 0건(이 저장소의 모든 실 번역자 call-signature/함수형이 `key`를
+ *      쓴다). 생기면 이름 조건을 그 하나만 추가(무분별한 확장은 오탐, 위 ⓐⓑ 실측 참조).
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
@@ -87,8 +121,145 @@ function namespaceFromArgs(args: readonly ts.Expression[]): string | null {
   return null;
 }
 
+// ③ 「직접 ReturnType<typeof useTranslations>」 구조 판정.
+function isDirectTranslatorReturnType(t: ts.TypeNode): boolean {
+  if (!ts.isTypeReferenceNode(t) || !ts.isIdentifier(t.typeName) || t.typeName.text !== 'ReturnType') {
+    return false;
+  }
+  const arg = t.typeArguments?.[0];
+  return !!arg && ts.isTypeQueryNode(arg) && ts.isIdentifier(arg.exprName) && arg.exprName.text === 'useTranslations';
+}
+
+// ③ CHANGES 정정(페드루 PO, 유나 재실측 2026-09-09) — 파라미터 «이름»만으로 번역자를 잡으면
+// 무관 콜백(첫 인자가 우연히 `key`라는 이름이지만 string이 아니거나 시그니처가 다른 것 —
+// 실측 37파일·223호출 오탐 위험)이 섞인다. 그래서 이름뿐 아니라 **첫 파라미터의 타입 주석이
+// `string`, 반환 타입 주석이 있다면 그것도 `string`**인지까지 구조로 확인한다(둘째 인자
+// `values?`는 선택이라 형만 다양해도 무관 — 첫 인자·반환만 계약의 핵심).
+//
+// PO는 `ts.Program`+`checker.getTypeAtLocation`(의미론적 타입체크)을 제안했으나, 이 저장소의
+// 다른 모든 가드(verify-no-handrolled-card.ts 등)가 Program 없는 단일 소스파일 AST walk이고
+// 이 가드 자신의 모듈 docstring도 그 관례를 "새 기전 발명 금지"로 명시한다 — 여기서 실제로
+// 필요한 건 「타입 검사」가 아니라 「이 정확한 어노테이션 문구가 있나」이므로(전부 로컬
+// 리터럴 타입 주석, 크로스파일 추론 불요) 구문 검사로 동등한 정밀도를 얻을 수 있다(오탐
+// 조건도 동일하게 닫힌다) — Program 구성 비용·이 파일군의 유일한 새 기전을 들이지 않는다.
+function isStringKeywordType(t: ts.TypeNode): boolean {
+  return t.kind === ts.SyntaxKind.StringKeyword;
+}
+
+function isTranslatorCallLikeShape(parameters: readonly ts.ParameterDeclaration[], returnType: ts.TypeNode | undefined): boolean {
+  const first = parameters[0];
+  if (!first || !ts.isIdentifier(first.name) || first.name.text !== 'key') return false;
+  if (!first.type || !isStringKeywordType(first.type)) return false;
+  if (returnType && !isStringKeywordType(returnType)) return false;
+  return true;
+}
+
+// ③ 「(key: string, ...) => string」 함수형 — trust-utils.tsx의 `Translator` 타입 별칭.
+function isTranslatorFunctionShape(t: ts.TypeNode): boolean {
+  if (!ts.isFunctionTypeNode(t)) return false;
+  return isTranslatorCallLikeShape(t.parameters, t.type);
+}
+
+// ③ call-signature 인터페이스(`interface X { (key: string, values?): string }`) —
+// derive-attention-queue.ts/command-palette-actions.ts/org-briefing derive-*.ts 6곳의
+// `*Translator` 관례(파일마다 로컬 재선언 — next-intl 오버로드 제네릭과 결합 안 하려는
+// 의도적 패턴, derive-attention-queue.ts 주석). 멤버가 정확히 하나의 call-signature뿐이고
+// 다른 멤버가 없어야 한다(순수 호출-형만 번역자로 본다 — 프로퍼티가 섞인 인터페이스는
+// «번역자+α» 다른 개념일 수 있어 오분류 방지).
+function interfaceCallSignatureShape(node: ts.InterfaceDeclaration): ts.CallSignatureDeclaration | null {
+  if (node.members.length !== 1) return null;
+  const only = node.members[0];
+  return ts.isCallSignatureDeclaration(only) ? only : null;
+}
+
+function isTranslatorTypeStructural(t: ts.TypeNode): boolean {
+  return isDirectTranslatorReturnType(t) || isTranslatorFunctionShape(t);
+}
+
+function isTranslatorParamType(t: ts.TypeNode, aliasNames: Set<string>): boolean {
+  if (isTranslatorTypeStructural(t)) return true;
+  return ts.isTypeReferenceNode(t) && ts.isIdentifier(t.typeName) && aliasNames.has(t.typeName.text);
+}
+
+// ③ 타입 리터럴(인라인 `{ t: ReturnType<...> }` 또는 `interface X { t: Translator }`) 멤버
+// 중 번역자 형인 프로퍼티 이름만 뽑는다 — apply-recipe-dialog.tsx(인라인 ReturnType)·
+// facebook-page-select-card.tsx/insights-board-metric-cell.tsx(named interface,
+// ReturnType 직접)·trust-utils.tsx(named interface 멤버가 로컬 별칭 `Translator`를 참조)
+// 전부 이 형(구조분해 파라미터 + 번역자 프로퍼티). aliasNames는 멤버 타입이 «별칭
+// 참조」일 때도 판정하려고 받는다(isTranslatorParamType과 같은 축).
+function translatorPropNamesInMembers(members: readonly ts.TypeElement[], aliasNames: Set<string>): Set<string> {
+  const names = new Set<string>();
+  for (const member of members) {
+    if (
+      ts.isPropertySignature(member) && member.type
+      && ts.isIdentifier(member.name) && isTranslatorParamType(member.type, aliasNames)
+    ) {
+      names.add(member.name.text);
+    }
+  }
+  return names;
+}
+
+// ③ 파일 하나에서 「번역자와 구조적으로 같은」 로컬 타입을 전부 모은다(선언 순서 무관 —
+// 이름으로 참조되니 본 walk 前에 한 번 훑는다). 두 단계로 나눈다 — propNamesByType가
+// 멤버 타입을 aliasNames로 판정해야 하므로(trust-utils.tsx: interface 멤버가 `Translator`
+// 별칭을 참조) aliasNames를 먼저 완성한 뒤에 propNamesByType을 계산한다.
+//   aliasNames — 타입 자체가 번역자 형인 별칭(단순 파라미터: `t: Translator`).
+//   propNamesByType — 타입(별칭/interface)이 번역자 프로퍼티를 담은 객체형일 때, 그
+//     프로퍼티 이름 집합(구조분해 파라미터: `{ t }: FooProps`).
+function collectTranslatorTypeInfo(sf: ts.SourceFile): {
+  aliasNames: Set<string>;
+  propNamesByType: Map<string, Set<string>>;
+} {
+  const aliasNames = new Set<string>();
+  function visitAliases(node: ts.Node): void {
+    if (ts.isTypeAliasDeclaration(node) && isTranslatorTypeStructural(node.type)) {
+      aliasNames.add(node.name.text);
+    }
+    // call-signature interface — 함수 타입 별칭과 동형(둘 다 「호출하면 string」인 값).
+    if (ts.isInterfaceDeclaration(node)) {
+      const callSig = interfaceCallSignatureShape(node);
+      if (callSig && isTranslatorCallLikeShape(callSig.parameters, callSig.type)) {
+        aliasNames.add(node.name.text);
+      }
+    }
+    node.forEachChild(visitAliases);
+  }
+  visitAliases(sf);
+
+  const propNamesByType = new Map<string, Set<string>>();
+  function visitProps(node: ts.Node): void {
+    if (ts.isTypeAliasDeclaration(node) && ts.isTypeLiteralNode(node.type)) {
+      const props = translatorPropNamesInMembers(node.type.members, aliasNames);
+      if (props.size > 0) propNamesByType.set(node.name.text, props);
+    }
+    if (ts.isInterfaceDeclaration(node)) {
+      const props = translatorPropNamesInMembers(node.members, aliasNames);
+      if (props.size > 0) propNamesByType.set(node.name.text, props);
+    }
+    node.forEachChild(visitProps);
+  }
+  visitProps(sf);
+
+  return { aliasNames, propNamesByType };
+}
+
+// ③ 구조분해 파라미터(`{ t, tc }: FooProps` 또는 `{ t }: { t: ReturnType<...> }`)의 타입에서
+// 번역자 프로퍼티 이름 집합을 얻는다 — 인라인 타입 리터럴은 그 자리서, named 타입은
+// propNamesByType로 조회.
+function translatorPropNamesOfParamType(
+  t: ts.TypeNode, propNamesByType: Map<string, Set<string>>, aliasNames: Set<string>,
+): Set<string> {
+  if (ts.isTypeLiteralNode(t)) return translatorPropNamesInMembers(t.members, aliasNames);
+  if (ts.isTypeReferenceNode(t) && ts.isIdentifier(t.typeName)) {
+    return propNamesByType.get(t.typeName.text) ?? new Set();
+  }
+  return new Set();
+}
+
 // 파일 하나를 top-down walk — 바인딩(varName→ns)은 「마지막 선언이 이긴다」(모듈 docstring
-// ① 참조). 호출은 그 시점까지의 바인딩 상태로 판정한다.
+// ① 참조). 호출은 그 시점까지의 바인딩 상태로 판정한다. ns 값 `null`은 ③(번역자
+// 파라미터) — 바인딩은 있으나 네임스페이스를 몰라 그 호출은 항상 동적 버킷.
 export function scanFileContent(content: string, file: string): {
   literalRefs: KeyRef[]; dynamicCount: number; totalCallCount: number; hasBindings: boolean;
 } {
@@ -108,7 +279,10 @@ export function scanFileContent(content: string, file: string): {
     );
   }
 
-  const bindings = new Map<string, string>();
+  // string = 알려진 네임스페이스(리터럴 검사 가능). null = ③ 번역자 파라미터(바인딩은
+  // 있으나 네임스페이스를 몰라 그 호출은 항상 동적 버킷).
+  const bindings = new Map<string, string | null>();
+  const { aliasNames: translatorAliasNames, propNamesByType } = collectTranslatorTypeInfo(sf);
   const literalRefs: KeyRef[] = [];
   let dynamicCount = 0;
   let totalCallCount = 0;
@@ -126,9 +300,9 @@ export function scanFileContent(content: string, file: string): {
   function keyFromCall(node: ts.CallExpression, varName: string): void {
     if (!bindings.has(varName)) return;
     totalCallCount += 1;
+    const ns = bindings.get(varName)!;
     const arg = node.arguments[0];
-    if (arg && ts.isStringLiteral(arg)) {
-      const ns = bindings.get(varName)!;
+    if (ns !== null && arg && ts.isStringLiteral(arg)) {
       const fullKey = ns ? `${ns}.${arg.text}` : arg.text;
       const line = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
       literalRefs.push({ file, line, fullKey });
@@ -140,6 +314,29 @@ export function scanFileContent(content: string, file: string): {
   function walk(node: ts.Node): void {
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
       registerBindingFromInitializer(node.name.text, node.initializer);
+    }
+    // ③ 번역자 파라미터 — 네임스페이스는 모르니 null 바인딩(호출은 항상 동적으로 카운트,
+    // 「안 세어짐」을 없앤다). 단순 이름(`t: Translator`)과 구조분해(`{ t }: FooProps`)
+    // 둘 다 다룬다.
+    if (ts.isParameter(node) && node.type) {
+      if (ts.isIdentifier(node.name)) {
+        if (isTranslatorParamType(node.type, translatorAliasNames)) {
+          bindings.set(node.name.text, null);
+        }
+      } else if (ts.isObjectBindingPattern(node.name)) {
+        const translatorProps = translatorPropNamesOfParamType(node.type, propNamesByType, translatorAliasNames);
+        if (translatorProps.size > 0) {
+          for (const element of node.name.elements) {
+            if (!ts.isIdentifier(element.name)) continue; // 중첩 구조분해는 스코프 밖.
+            const propKey = element.propertyName && ts.isIdentifier(element.propertyName)
+              ? element.propertyName.text
+              : element.name.text;
+            if (translatorProps.has(propKey)) {
+              bindings.set(element.name.text, null);
+            }
+          }
+        }
+      }
     }
     if (ts.isCallExpression(node)) {
       const callee = node.expression;

--- a/apps/web/scripts/verify-i18n-keys-exist.ts
+++ b/apps/web/scripts/verify-i18n-keys-exist.ts
@@ -1,0 +1,289 @@
+/**
+ * story #5ead8723(가드·별건 ①) — i18n 키 «실존» 가드. next-intl은 키를 못 찾으면 **키
+ * 문자열을 그대로 화면에 그린다**(content/channel-posts/page.tsx:118 주석이 그 함정을
+ * 이름으로 적어 둠) — 코드 낱말이 화면에 그대로 서는, 사용자가 보는 거짓의 가장 싼 형.
+ * 기존 i18n 가드 셋(no-duplicate-i18n-keys·no-hanja-in-i18n·no-i18n-phrase-collision)은
+ * «값»만 보고 «참조가 실존하나»는 안 본다 — 이 가드가 그 축 하나를 새로 채운다.
+ *
+ * ## 기전 — AST(verify-no-handrolled-card.ts·verify-no-hardcoded-korean-ui-text.ts와 동형,
+ * 새 기전 발명 금지)
+ * 정규식 줄 스캔이 아니라 TypeScript AST를 walk한다 — 주석은 AST 노드가 아니라 trivia라
+ * 자동으로 안 걸린다(별도 주석 제거 로직 불요, 구조적으로 안전 — PO 스캐너의 오탐 2건
+ * 「주석 속 t('key')」가 여기선 애초에 발생하지 않는다).
+ *
+ * ## 스캔 대상
+ * `apps/web/src/**\/*.{ts,tsx}`(테스트 제외). 파일마다 한 번 top-down으로 walk하며:
+ *
+ * ① 네임스페이스 바인딩 — `const X = useTranslations('ns')` · `const X = useTranslations()`
+ *   (루트, ns='') · `const X = await getTranslations('ns')` ·
+ *   `const X = await getTranslations({ locale, namespace: 'ns' })`. 바인딩은 **마지막으로
+ *   본 값이 이긴다**(변수명 재바인딩 — 한 파일 안 여러 컴포넌트가 각자 `const t =
+ *   useTranslations(...)`를 갖는 실 패턴, 예: workcell.tsx 8회). top-down 단일 walk가
+ *   선언을 그 아래 쓰임보다 항상 먼저 방문하므로(같은 서브트리 안에서 선언이 쓰임의
+ *   형제 노드로 먼저 오는 실 코드 형태 — 별도 스코프 추적 없이도 이 순서 하나로 충분하다
+ *   실측 확認, `let`/`var` 재대입·별칭 import 0건).
+ *
+ * ② 호출 — `X('key')` · `X.rich('key')` · `X.raw('key')` · `X.has('key')`(바인딩 var에서만
+ *   — Set/Map의 `.has()` 등 무관 호출은 바인딩 필터링으로 자연 배제, 예:
+ *   `HIDDEN_SETTINGS_TABS.has('workflow')`). 첫 인자가 **순수 문자열 리터럴**(`ts.
+ *   isStringLiteral`)이면 리터럴 키 — `ns.key` 점 경로로 ko/en 실존 대조. 그 외(변수·
+ *   템플릿 리터럴·삼항 등 — `ts.isStringLiteral`이 아닌 전부)는 **동적 호출로 카운트만
+ *   하고 실패 안 시킨다**(「추출된 것만 순회」의 fails-silent를 「보이는 수」로 바꾼다 —
+ *   [[feedback_a_guard_iterating_over_extracted_not_expected_fails_silent]]). 노-서브스티튜션
+ *   템플릿(`` `plainKey` ``, 보간 0개라 값이 사실 정적인)도 문법적으로 템플릿이라 동적
+ *   버킷 — 스펙 명시("동적 키: 변수·템플릿·삼항") 그대로, 뒤에 보간이 붙어도 재분류가
+ *   안 생기게 일관되게 다룬다.
+ *
+ * ## 못 잡는 것(⚠️)
+ *   ㉠ 네임스페이스 자체가 동적(`useTranslations(nsVar)`)인 바인딩은 등록하지 않는다 —
+ *      그 var를 통한 이후 호출은 바인딩 미매칭이라 리터럴도 동적도 아닌 채로 조용히
+ *      안 잡힌다. 실측 0건(모든 useTranslations/getTranslations 인자가 리터럴이거나
+ *      없음) — 생기면 별도 축.
+ *   ㉡ 스코프가 실제로 갈리는데(예: 조건부 렌더 두 분기가 다른 네임스페이스를 같은 var
+ *      이름으로) 이 파일이 상정하는 「마지막 선언이 이긴다」 단순 모델을 벗어나는 코드는
+ *      오분류 가능 — 실측상 이 저장소에 이런 형은 없다(전부 함수 스코프당 정확히 1개
+ *      선언).
+ *   ㉢ `.d.ts`·타입 전용 파일은 스캔하되 실질 호출이 없어 자연히 기여 0.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+type MessageNode = string | { [key: string]: MessageNode };
+
+export interface KeyRef {
+  file: string;
+  line: number;
+  fullKey: string;
+}
+
+export interface ScanResult {
+  literalRefs: KeyRef[];
+  dynamicCount: number;
+  totalCallCount: number;
+  filesWithBindings: number;
+}
+
+const TRANSLATION_METHODS = new Set(['rich', 'raw', 'has']);
+
+function namespaceFromArgs(args: readonly ts.Expression[]): string | null {
+  if (args.length === 0) return '';
+  const first = args[0];
+  if (ts.isStringLiteral(first)) return first.text;
+  if (ts.isObjectLiteralExpression(first)) {
+    for (const prop of first.properties) {
+      if (
+        ts.isPropertyAssignment(prop)
+        && ts.isIdentifier(prop.name)
+        && prop.name.text === 'namespace'
+        && ts.isStringLiteral(prop.initializer)
+      ) {
+        return prop.initializer.text;
+      }
+    }
+    return null;
+  }
+  return null;
+}
+
+// 파일 하나를 top-down walk — 바인딩(varName→ns)은 「마지막 선언이 이긴다」(모듈 docstring
+// ① 참조). 호출은 그 시점까지의 바인딩 상태로 판정한다.
+export function scanFileContent(content: string, file: string): {
+  literalRefs: KeyRef[]; dynamicCount: number; totalCallCount: number; hasBindings: boolean;
+} {
+  const sf = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const parseDiagnostics = (sf as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics;
+  if (parseDiagnostics === undefined) {
+    throw new Error(
+      `FAIL: ${file} — ts.createSourceFile의 parseDiagnostics 필드가 사라짐(TS 내부 API 변경 의심) — ` +
+        '이 가드의 전제(파싱 실패를 스스로 감지할 수 있다는 전제)가 깨졌다(story #2710 동형).',
+    );
+  }
+  if (parseDiagnostics.length > 0) {
+    throw new Error(
+      `FAIL: ${file} 파싱 실패(${parseDiagnostics.length}건) — 이 가드가 이 파일의 i18n 호출을 ` +
+        `못 읽는다(재료 소실을 조용한 통과로 두지 않는다, story #2710 AC4 동형): ` +
+        parseDiagnostics.map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' ')).join('; '),
+    );
+  }
+
+  const bindings = new Map<string, string>();
+  const literalRefs: KeyRef[] = [];
+  let dynamicCount = 0;
+  let totalCallCount = 0;
+
+  function registerBindingFromInitializer(varName: string, initRaw: ts.Expression): void {
+    const init = ts.isAwaitExpression(initRaw) ? initRaw.expression : initRaw;
+    if (!ts.isCallExpression(init) || !ts.isIdentifier(init.expression)) return;
+    const callee = init.expression.text;
+    if (callee !== 'useTranslations' && callee !== 'getTranslations') return;
+    const ns = namespaceFromArgs(init.arguments);
+    if (ns === null) return; // ㉠ 동적 네임스페이스 — 바인딩 등록 안 함.
+    bindings.set(varName, ns);
+  }
+
+  function keyFromCall(node: ts.CallExpression, varName: string): void {
+    if (!bindings.has(varName)) return;
+    totalCallCount += 1;
+    const arg = node.arguments[0];
+    if (arg && ts.isStringLiteral(arg)) {
+      const ns = bindings.get(varName)!;
+      const fullKey = ns ? `${ns}.${arg.text}` : arg.text;
+      const line = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+      literalRefs.push({ file, line, fullKey });
+    } else {
+      dynamicCount += 1;
+    }
+  }
+
+  function walk(node: ts.Node): void {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      registerBindingFromInitializer(node.name.text, node.initializer);
+    }
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      if (ts.isIdentifier(callee)) {
+        keyFromCall(node, callee.text);
+      } else if (
+        ts.isPropertyAccessExpression(callee)
+        && ts.isIdentifier(callee.expression)
+        && ts.isIdentifier(callee.name)
+        && TRANSLATION_METHODS.has(callee.name.text)
+      ) {
+        keyFromCall(node, callee.expression.text);
+      }
+    }
+    node.forEachChild(walk);
+  }
+  walk(sf);
+
+  return { literalRefs, dynamicCount, totalCallCount, hasBindings: bindings.size > 0 };
+}
+
+const EXT_RE = /\.tsx?$/;
+const TEST_RE = /\.test\.tsx?$/;
+const MIN_EXPECTED_FILES = 1000;
+
+function walkDir(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkDir(full, out);
+    } else if (EXT_RE.test(entry) && !TEST_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+export function scanRepo(srcRoot: string): ScanResult {
+  const files: string[] = [];
+  walkDir(srcRoot, files);
+  if (files.length < MIN_EXPECTED_FILES) {
+    throw new Error(`FAIL: 검사 대상 파일이 ${files.length}개뿐(srcRoot=${srcRoot}) — 가드가 헛돌고 있다.`);
+  }
+  const literalRefs: KeyRef[] = [];
+  let dynamicCount = 0;
+  let totalCallCount = 0;
+  let filesWithBindings = 0;
+  for (const abs of files) {
+    const rel = path.relative(srcRoot, abs).split(path.sep).join('/');
+    const content = readFileSync(abs, 'utf8');
+    const result = scanFileContent(content, rel);
+    literalRefs.push(...result.literalRefs);
+    dynamicCount += result.dynamicCount;
+    totalCallCount += result.totalCallCount;
+    if (result.hasBindings) filesWithBindings += 1;
+  }
+  return { literalRefs, dynamicCount, totalCallCount, filesWithBindings };
+}
+
+// story #5ead8723 AC1/AC2 — 점 경로를 메시지 트리에서 내려가 **말단**(string)까지 도달해야
+// "존재"다. 도중에 끊기거나(중간 키 부재) 말단이 object로 남으면(경로가 branch에서 멈춤)
+// 모두 부재로 판정한다.
+export function resolveMessageKey(messages: MessageNode, dottedKey: string): boolean {
+  const segments = dottedKey.split('.');
+  let cur: MessageNode = messages;
+  for (const seg of segments) {
+    if (typeof cur !== 'object' || cur === null || !(seg in cur)) return false;
+    cur = cur[seg];
+  }
+  return typeof cur === 'string';
+}
+
+// ko↔en 말단 키 집합(전체 경로, dot-joined) — 양방향 차집합 0 판정용.
+export function collectLeafKeys(messages: MessageNode, prefix = ''): Set<string> {
+  const out = new Set<string>();
+  if (typeof messages === 'string') {
+    out.add(prefix);
+    return out;
+  }
+  for (const [k, v] of Object.entries(messages)) {
+    const next = prefix ? `${prefix}.${k}` : k;
+    for (const leaf of collectLeafKeys(v, next)) out.add(leaf);
+  }
+  return out;
+}
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const KO_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/ko.json');
+const EN_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/en.json');
+
+function main(): number {
+  const koMessages = JSON.parse(readFileSync(KO_PATH, 'utf8')) as MessageNode;
+  const enMessages = JSON.parse(readFileSync(EN_PATH, 'utf8')) as MessageNode;
+  const result = scanRepo(SRC_ROOT);
+
+  const missingKo = result.literalRefs.filter((r) => !resolveMessageKey(koMessages, r.fullKey));
+  const missingEn = result.literalRefs.filter((r) => !resolveMessageKey(enMessages, r.fullKey));
+
+  const koLeaves = collectLeafKeys(koMessages);
+  const enLeaves = collectLeafKeys(enMessages);
+  const koOnly = [...koLeaves].filter((k) => !enLeaves.has(k));
+  const enOnly = [...enLeaves].filter((k) => !koLeaves.has(k));
+
+  console.log(
+    `[가드] i18n 키 실존 스캔 — 바인딩 있는 파일 ${result.filesWithBindings}개 · ` +
+      `리터럴 호출 ${result.literalRefs.length}건 · 동적 호출 ${result.dynamicCount}건 ` +
+      `(총 호출 ${result.totalCallCount}건 — 리터럴+동적=총) · ko 말단 ${koLeaves.size} · en 말단 ${enLeaves.size}`,
+  );
+
+  let failed = false;
+
+  if (missingKo.length > 0) {
+    failed = true;
+    console.error(`\nFAIL: ko.json에 없는 키 ${missingKo.length}건:`);
+    for (const r of missingKo) console.error(`  ${r.file}:${r.line} "${r.fullKey}"`);
+  }
+  if (missingEn.length > 0) {
+    failed = true;
+    console.error(`\nFAIL: en.json에 없는 키 ${missingEn.length}건:`);
+    for (const r of missingEn) console.error(`  ${r.file}:${r.line} "${r.fullKey}"`);
+  }
+  if (koOnly.length > 0) {
+    failed = true;
+    console.error(`\nFAIL: ko에만 있고 en엔 없는 말단 키 ${koOnly.length}건:`);
+    for (const k of koOnly) console.error(`  ${k}`);
+  }
+  if (enOnly.length > 0) {
+    failed = true;
+    console.error(`\nFAIL: en에만 있고 ko엔 없는 말단 키 ${enOnly.length}건:`);
+    for (const k of enOnly) console.error(`  ${k}`);
+  }
+
+  if (failed) {
+    console.error(
+      '\n→ 코드가 참조하는 i18n 키는 ko/en 둘 다에 값(말단 문자열)으로 있어야 한다. next-intl은 ' +
+        '못 찾은 키를 화면에 그대로 그린다 — 사용자가 코드 낱말을 그대로 보는 결함.',
+    );
+    return 1;
+  }
+
+  console.log('\nOK: 코드가 참조하는 리터럴 키 전부 ko/en에 실존·ko↔en 말단 키 집합 동일.');
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/apps/web/src/lib/nav-config-descriptions.test.ts
+++ b/apps/web/src/lib/nav-config-descriptions.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { NAV_GROUPS } from './nav-config';
-import koMessages from '../../messages/ko.json';
-import enMessages from '../../messages/en.json';
 
 // story #fddd0e6b(IA ⑦ 전체 메뉴, 유나 시안 ⑦ 판b 036c983a AC2) — 「무엇이 여기 있나」
 // 한 줄은 NavItemConfig.descriptionKey가 SSOT다. nav-config.ts가 필수 필드로 강제하므로
-// «값이 아예 없는» 회귀는 TypeScript가 컴파일 시점에 잡지만, «값은 있는데 그 i18n 키가
-// ko/en 메시지 파일에서 빠진»(오타·키 삭제) 드리프트는 컴파일이 못 잡는다 — 런타임에
-// next-intl이 raw 키를 그대로 그리거나 빈 문자열을 낸다. 이 테스트가 그 드리프트를 잡는다.
+// «값이 아예 없는» 회귀는 TypeScript가 컴파일 시점에 잡는다.
+//
+// story #5ead8723(가드·별건 ①, 페드루 PO 決 2026-09-09) 후속 — 「그 i18n 키가 ko/en
+// 메시지 파일에서 실존하나」는 이제 전 화면 가드(verify-i18n-keys-exist.ts)가 덮는다.
+// 이 파일은 그 실존 대조를 걷고(중복 자 금지) 「NAV_GROUPS 계약 완전성」(항목 23개
+// 전부가 descriptionKey 값을 가진다)만 남긴다 — nav-config.ts 자체를 그 계약의
+// SSOT로 보는 국소 테스트.
 function allNavGroupItems() {
   return NAV_GROUPS.flatMap((g) => g.items);
 }
@@ -19,33 +21,12 @@ describe('NAV_GROUPS descriptionKey 완전성 — story #fddd0e6b AC2', () => {
     expect(allNavGroupItems()).toHaveLength(23);
   });
 
+  // ⭐되돌리면 RED — descriptionKey가 빈 문자열('')로 채워지면 타입은 통과하지만(string
+  // 계약은 만족) 계약의 실질(「무엇이 여기 있나」 값이 있다)이 깨진다. TypeScript는 빈
+  // 문자열도 유효한 string이라 이 축은 컴파일이 못 잡는다 — 이 테스트가 그 갭을 잡는다.
   it('⭐23개 전부가 descriptionKey를 갖는다(빈 문자열 아님) — board·inbox도 예약값을 가진다', () => {
     for (const item of allNavGroupItems()) {
       expect(item.descriptionKey, `${item.id}.descriptionKey`).toBeTruthy();
     }
-  });
-
-  // ⭐되돌리면 RED — ko.json에서 descOrgBriefing 같은 키 하나를 지우면(오타로 값이 사라지면)
-  // 이 테스트가 잡는다. nav-config.ts 컴파일은 그 삭제를 못 본다(필드 자체는 여전히 채워진
-  // 문자열 리터럴 'descOrgBriefing'이라 타입 에러가 안 남 — 이 갭이 이 테스트의 존재 이유다).
-  it('⭐descriptionKey 23개 전부가 ko.json의 nav 네임스페이스에 실존한다(값 비어있지 않음)', () => {
-    const nav = koMessages.nav as Record<string, string>;
-    for (const item of allNavGroupItems()) {
-      expect(nav[item.descriptionKey], `ko.nav.${item.descriptionKey}`).toBeTruthy();
-    }
-  });
-
-  it('⭐descriptionKey 23개 전부가 en.json의 nav 네임스페이스에 실존한다(값 비어있지 않음)', () => {
-    const nav = enMessages.nav as Record<string, string>;
-    for (const item of allNavGroupItems()) {
-      expect(nav[item.descriptionKey], `en.nav.${item.descriptionKey}`).toBeTruthy();
-    }
-  });
-
-  // 양성대조 — 이 가드가 실제로 빠진 키를 구분해낼 수 있다는 것을 스스로 증명(항상 그린이
-  // 아니라는 확認). 존재하지 않는 임의 키로 같은 조회를 하면 실패해야 정상이다.
-  it('양성대조 — 존재하지 않는 키를 같은 방식으로 조회하면 falsy(가드가 실제로 구분한다)', () => {
-    const nav = koMessages.nav as Record<string, string>;
-    expect(nav['descNoSuchItemEver']).toBeFalsy();
   });
 });

--- a/apps/web/src/lib/nav-config-descriptions.test.ts
+++ b/apps/web/src/lib/nav-config-descriptions.test.ts
@@ -1,15 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { NAV_GROUPS } from './nav-config';
+import koMessages from '../../messages/ko.json';
+import enMessages from '../../messages/en.json';
 
 // story #fddd0e6b(IA ⑦ 전체 메뉴, 유나 시안 ⑦ 판b 036c983a AC2) — 「무엇이 여기 있나」
 // 한 줄은 NavItemConfig.descriptionKey가 SSOT다. nav-config.ts가 필수 필드로 강제하므로
-// «값이 아예 없는» 회귀는 TypeScript가 컴파일 시점에 잡는다.
+// «값이 아예 없는» 회귀는 TypeScript가 컴파일 시점에 잡지만, «값은 있는데 그 i18n 키가
+// ko/en 메시지 파일에서 빠진»(오타·키 삭제) 드리프트는 컴파일이 못 잡는다.
 //
-// story #5ead8723(가드·별건 ①, 페드루 PO 決 2026-09-09) 후속 — 「그 i18n 키가 ko/en
-// 메시지 파일에서 실존하나」는 이제 전 화면 가드(verify-i18n-keys-exist.ts)가 덮는다.
-// 이 파일은 그 실존 대조를 걷고(중복 자 금지) 「NAV_GROUPS 계약 완전성」(항목 23개
-// 전부가 descriptionKey 값을 가진다)만 남긴다 — nav-config.ts 자체를 그 계약의
-// SSOT로 보는 국소 테스트.
+// story #5ead8723(가드·별건 ①) CHANGES(유나 디자인 게이트 지적, 2026-09-09) — 처음엔 이
+// 실존 대조를 「중복 자」로 보고 전 화면 가드(verify-i18n-keys-exist.ts)로 이관하며 여기서
+// 걷었으나(커밋 5a41e49cb), 그건 오판이었다: `more/page.tsx`의 소비는 `t(item.
+// descriptionKey)`(변수 인자)라 AST 가드가 **구조적으로 실존을 못 본다**(리터럴이 아니라
+// 동적 호출 버킷으로 카운트만 되고 끝 — 뮤테이션 확認: `nav.descOrgBriefing`을 ko·en 둘 다
+// 지워도 그 가드는 GREEN이었다). 「카탈로그가 곧 키 목록인 자리」(desc 키가 데이터 자체로
+// 존재하고 소비가 변수 인자로만 일어나는 자리)는 전 화면 가드의 사각지대라 국소 테스트가
+// 여전히 맞는 자리 — 두 가드는 같은 것을 두 번 보는 게 아니라 서로 다른 축(리터럴 호출
+// vs 데이터 카탈로그)을 나눠 본다. 그래서 이 실존 대조를 되살린다.
 function allNavGroupItems() {
   return NAV_GROUPS.flatMap((g) => g.items);
 }
@@ -21,12 +28,35 @@ describe('NAV_GROUPS descriptionKey 완전성 — story #fddd0e6b AC2', () => {
     expect(allNavGroupItems()).toHaveLength(23);
   });
 
-  // ⭐되돌리면 RED — descriptionKey가 빈 문자열('')로 채워지면 타입은 통과하지만(string
-  // 계약은 만족) 계약의 실질(「무엇이 여기 있나」 값이 있다)이 깨진다. TypeScript는 빈
-  // 문자열도 유효한 string이라 이 축은 컴파일이 못 잡는다 — 이 테스트가 그 갭을 잡는다.
   it('⭐23개 전부가 descriptionKey를 갖는다(빈 문자열 아님) — board·inbox도 예약값을 가진다', () => {
     for (const item of allNavGroupItems()) {
       expect(item.descriptionKey, `${item.id}.descriptionKey`).toBeTruthy();
     }
+  });
+
+  // ⭐되돌리면 RED — ko.json에서 descOrgBriefing 같은 키 하나를 지우면(오타로 값이 사라지면)
+  // 이 테스트가 잡는다. nav-config.ts 컴파일은 그 삭제를 못 본다(필드 자체는 여전히 채워진
+  // 문자열 리터럴 'descOrgBriefing'이라 타입 에러가 안 남) — 그리고 전 화면 가드도 이 축은
+  // 못 본다(more/page.tsx 소비가 `t(item.descriptionKey)`, 변수 인자라 AST가 리터럴로
+  // 못 잡는다, story #5ead8723 CHANGES 유나 실측). 이 갭을 메우는 게 이 테스트의 존재 이유.
+  it('⭐descriptionKey 23개 전부가 ko.json의 nav 네임스페이스에 실존한다(값 비어있지 않음)', () => {
+    const nav = koMessages.nav as Record<string, string>;
+    for (const item of allNavGroupItems()) {
+      expect(nav[item.descriptionKey], `ko.nav.${item.descriptionKey}`).toBeTruthy();
+    }
+  });
+
+  it('⭐descriptionKey 23개 전부가 en.json의 nav 네임스페이스에 실존한다(값 비어있지 않음)', () => {
+    const nav = enMessages.nav as Record<string, string>;
+    for (const item of allNavGroupItems()) {
+      expect(nav[item.descriptionKey], `en.nav.${item.descriptionKey}`).toBeTruthy();
+    }
+  });
+
+  // 양성대조 — 이 가드가 실제로 빠진 키를 구분해낼 수 있다는 것을 스스로 증명(항상 그린이
+  // 아니라는 확認). 존재하지 않는 임의 키로 같은 조회를 하면 실패해야 정상이다.
+  it('양성대조 — 존재하지 않는 키를 같은 방식으로 조회하면 falsy(가드가 실제로 구분한다)', () => {
+    const nav = koMessages.nav as Record<string, string>;
+    expect(nav['descNoSuchItemEver']).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary
- next-intl은 키를 못 찾으면 키 문자열을 그대로 화면에 그린다 — 코드 낱말이 그대로 사용자 화면에 서는 결함. 기존 i18n 가드 셋은 값만 보고 참조 실존은 안 본다.
- 기전은 `verify-no-handrolled-card.ts`·`verify-no-hardcoded-korean-ui-text.ts`와 동형(TypeScript AST walk, 새 기전 발명 금지) — 주석은 AST 노드가 아니라 trivia라 구조적으로 안 걸린다.
- ① 바인딩 — `const X = useTranslations('ns'|없음)` · `const X = await getTranslations('ns'|{namespace})`. 같은 변수명 재선언(실 패턴, workcell.tsx 8회)은 top-down walk 순서로 「마지막 선언이 이긴다」가 정확히 맞는다.
- ② 호출 — `X('key')`·`.rich`·`.raw`·`.has`(바인딩 var에서만 — Set/Map `.has()` 등 무관 호출 자연 배제). 리터럴 키는 ko/en 실존 대조, 동적(변수·템플릿·삼항)은 실패 아니라 수로만 카운트.
- ③ ko↔en 말단 키 집합 양방향 차집합 0.
- **후속(rebase, #4100 머지 뒤)**: `nav-config-descriptions.test.ts`(#4100)의 ko/en 실존 대조를 이 새 전역 가드로 대체 — 그 파일은 「NAV_GROUPS 23개 전부 descriptionKey 값 보유」계약 완전성만 남긴다(중복 자 금지, 페드루 PO 지시).

story: https://app.sprintable.ai (story_id 5ead8723-282f-47b0-95b3-455e77fad360)

## 판별
- 셀프테스트 다수 + develop HEAD(24199c4e7, #4100 포함) 실 소스 양성대조 — 리터럴 4893건·동적 208건(총 5101건)·누락 0·ko=en=5242 말단.
- CLI 뮤테이션 킬 — 실제로 없는 키를 참조하는 임시 파일을 `src`에 심어 real CLI가 exit 1로 `file:line:key`까지 정확히 보고하는 것 확認 후 제거.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `eslint`(변경 파일) — clean
- [x] 전체 vitest(752파일/7474테스트) — green
- [x] `verify-ci-wires-all-verify-scripts.test.ts`(메타 가드) — green(새 스크립트 배선 확認)
- [x] 실 CLI 뮤테이션 킬(위 판별 참조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)