### PR TITLE
[SID:3753] 이미지 업로드 무결성 — image_path 입구 + 저장 直前 구조 검증기

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -20,6 +20,7 @@ from app.models.channel_post_image import ChannelPostImage
 from app.models.channel_post_version import ChannelPostVersion
 from app.models.pm import Story
 from app.services.content_rules import get_org_content_rules, lint_content
+from app.services.image_integrity import ImageIntegrityError, validate_image_bytes
 from app.services.project_auth import require_project_access
 from app.services.channel_posts import (
     ChannelConnectionAuthError,
@@ -918,7 +919,13 @@ async def post_channel_post_image_import(
     (VisualArtifact가 아니라 ChannelPostImage) — 새 연결 개념(두 시스템 사이 참조)을
     만드는 대신 서버가 직접 GCS에 쓴 뒤 기존 confirm_channel_post_image_upload를 그대로
     재사용한다(검증/변환/해시/봉인 로직 사본 0, `_confirm_image_upload_or_raise`로 에러
-    매핑도 confirm과 공유)."""
+    매핑도 confirm과 공유).
+
+    story #3753 — `import_channel_post_image`(내부에서 `put_object`로 GCS에 쓴다) 호출
+    前에 `validate_image_bytes`를 통과해야 한다(visual_artifacts.py::import_image_artifact와
+    동일 관문 — 매직 바이트·PNG 청크 walk·PIL 디코드). 실패하면 422 `IMAGE_CORRUPT`로
+    즉시 거부하고 저장 자체를 안 한다(confirm 内부의 사후 PIL 디코드-then-delete-orphan
+    경로보다 앞에서 막는다 — 깨진 바이트가 GCS에 닿는 순간 자체가 아예 없다)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
     if not body.content_type.startswith("image/"):
@@ -930,6 +937,12 @@ async def post_channel_post_image_import(
     except (binascii.Error, ValueError) as exc:
         raise HTTPException(
             status_code=400, detail={"code": "VALIDATION_ERROR", "message": "image_base64 is not valid base64"},
+        ) from exc
+    try:
+        validate_image_bytes(body.content_type, image_bytes)
+    except ImageIntegrityError as exc:
+        raise HTTPException(
+            status_code=422, detail={"code": "IMAGE_CORRUPT", "message": exc.reason},
         ) from exc
 
     member_id = uuid.UUID(auth.user_id)

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -16,6 +16,7 @@ from app.dependencies.database import get_db
 from app.models.asset import Asset
 from app.services.artifact_image_url import _canonicalize_props, sign_image_srcs_in_nodes
 from app.services.asset_registry import DEFAULT_CONTAINER
+from app.services.image_integrity import ImageIntegrityError, validate_image_bytes
 from app.services.storage import get_storage_provider
 from app.models.visual_artifact import (
     ArtifactComment, ArtifactExport, ArtifactNode, ArtifactSpecPin, ArtifactVersion, VisualArtifact,
@@ -213,7 +214,10 @@ async def import_image_artifact(
     api/visual-artifacts/import-image/route.ts)의 서버사이드 GCS 업로드 로직을 포팅하고, 그 뒤를
     이어 `create_artifact()`를 내부 함수 호출로 그대로 재사용(DB write 로직 사본 발명 0 — 두
     갈래가 다시 어긋나면 create_artifact 한쪽만 고치고 여기를 잊는 사고가 난다는 뜻이니, 이
-    엔드포인트를 건드릴 땐 그 함수도 같이 봐야 한다)."""
+    엔드포인트를 건드릴 땐 그 함수도 같이 봐야 한다).
+
+    story #3753 — GCS 업로드(`put_object`) 直前에 `validate_image_bytes`를 통과해야 한다
+    (매직 바이트·PNG 청크 walk·PIL 디코드). 실패하면 저장 자체를 안 한다(고아 객체 0)."""
     if not body.content_type.startswith("image/"):
         return _err("VALIDATION_ERROR", "content_type must be an image/* type", 400)
     try:
@@ -222,6 +226,10 @@ async def import_image_artifact(
         return _err("VALIDATION_ERROR", "image_base64 is not valid base64", 400)
     if len(image_bytes) > _MAX_IMPORT_IMAGE_BYTES:
         return _err("VALIDATION_ERROR", "image too large (max 20MB)", 413)
+    try:
+        validate_image_bytes(body.content_type, image_bytes)
+    except ImageIntegrityError as exc:
+        return _err("IMAGE_CORRUPT", exc.reason, 422)
 
     org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id:

--- a/backend/app/services/channel_post_images.py
+++ b/backend/app/services/channel_post_images.py
@@ -286,7 +286,13 @@ async def import_channel_post_image(
     대신, 서버가 그냥 자기 손으로(신뢰된 서버측 자격증명, signed-URL 우회) `_object_path`
     스코프에 바로 쓰고 confirm_channel_post_image_upload를 그대로 재사용한다(검증/변환/
     해시/봉인 로직 사본 0 — content_type은 오브젝트 키 확장자에만 쓰이고, 실제 포맷/
-    규격 검증은 confirm 내부의 PIL 디코드가 그대로 한다, 이 함수는 새 검증을 안 얹는다)."""
+    규격 검증은 confirm 내부의 PIL 디코드가 그대로 한다, 이 함수는 새 검증을 안 얹는다).
+
+    story #3753 — 이 함수 진입 前에 라우터(`channel_posts.py::post_channel_post_image_import`)가
+    `validate_image_bytes`(매직+PNG 청크 walk+PIL)를 이미 통과시킨다 — 그래서 이 함수가
+    받는 `image_bytes`는 원칙적으로 여기 `put_object` 시점에 이미 구조가 검증된 상태다.
+    confirm의 PIL 디코드는 그대로 남아 있다(3단계 업로드-URL/PUT/confirm 플로우는 브라우저가
+    직접 GCS에 쓰므로 이 사전 관문을 안 거친다 — confirm이 그 경로의 유일한 방어선)."""
     bucket = _require_bucket()
     ext = _MIME_TO_EXT.get(content_type, "bin")
     object_path = _object_path(org_id=org_id, draft_id=draft_id, ext=ext)

--- a/backend/app/services/image_integrity.py
+++ b/backend/app/services/image_integrity.py
@@ -1,0 +1,111 @@
+"""이미지 바이트 구조 무결성 검증(story #3753) — 저장 直前 공용 관문.
+
+실사고(2026-09-09, artifact `b3f60ca8-4c65-44de-a7e9-bc5b5dcf5e01`): MCP
+`sprintable_import_image_artifact`가 모델이 리타이핑한 base64를 그대로 받아 저장했다 —
+PNG `IHDR` → 첫 `IDAT`(4096B)까지는 정상이었으나 그 다음 청크 타입 바이트가
+`\\x7f\\x9f\\x00\\x00`로 깨져 있었다(청크 프레이밍 붕괴, `IEND` 미도달). BE 입구는
+그 바이트를 그대로 저장했다 — 화면엔 "이미지 산출물"로 서지만 열면 전부 검정.
+
+`visual_artifacts.py::import_image_artifact`·`channel_posts.py::post_channel_post_image_import`
+(둘 다 base64-in 원콜 입구) 라우터가 `get_storage_provider().put_object(...)` 호출 前에
+이 함수를 부른다 — 실패하면 저장 자체를 안 해(고아 객체 청소 불요, 애초에 안 생김).
+"""
+from __future__ import annotations
+
+import io
+import struct
+import zlib
+
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+_MAGIC_PREFIXES: dict[str, bytes] = {
+    "image/jpeg": b"\xff\xd8\xff",
+    "image/gif": b"GIF8",
+}
+
+
+class ImageIntegrityError(Exception):
+    """이미지 바이트가 선언된 content_type의 유효한 구조가 아님 — 호출부가 422
+    `IMAGE_CORRUPT`(+`reason`)로 매핑한다."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+def _walk_png_chunks(data: bytes) -> None:
+    """PNG 청크 프레이밍 전수 walk(길이·타입 ASCII·CRC32·`IEND` 도달) — 실사고 재현:
+    유효한 시그니처+`IHDR`+`IDAT`(4096B)까지 지나도, 그 다음 청크 타입이 4바이트
+    알파벳이 아니면(예: `\\x7f\\x9f\\x00\\x00`) 여기서 잡는다. PIL의 `load()`도 결국
+    같은 자리에서 실패하지만(zlib 스트림이 청크 경계를 못 찾음), 그 실패가 "포맷
+    미지원"인지 "구조가 실제로 깨졌다"인지 구분이 안 된다 — 이 walk는 청크 단위로
+    정확한 깨짐 지점(offset)을 짚어 사유를 남긴다."""
+    pos = len(_PNG_SIGNATURE)
+    seen_iend = False
+    while pos < len(data):
+        if pos + 8 > len(data):
+            raise ImageIntegrityError(f"PNG chunk header truncated at offset {pos}")
+        length = struct.unpack(">I", data[pos:pos + 4])[0]
+        chunk_type = data[pos + 4:pos + 8]
+        if not chunk_type.isalpha():
+            raise ImageIntegrityError(f"PNG chunk type invalid at offset {pos}: {chunk_type!r}")
+        chunk_end = pos + 8 + length
+        if chunk_end + 4 > len(data):
+            raise ImageIntegrityError(
+                f"PNG chunk data/CRC truncated at offset {pos} (type={chunk_type!r})"
+            )
+        chunk_data = data[pos + 8:chunk_end]
+        declared_crc = struct.unpack(">I", data[chunk_end:chunk_end + 4])[0]
+        actual_crc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+        if declared_crc != actual_crc:
+            raise ImageIntegrityError(f"PNG chunk CRC mismatch at offset {pos} (type={chunk_type!r})")
+        pos = chunk_end + 4
+        if chunk_type == b"IEND":
+            seen_iend = True
+            break
+    if not seen_iend:
+        raise ImageIntegrityError("PNG stream ended without reaching an IEND chunk")
+
+
+def _validate_via_pil(data: bytes, *, expected_format: str | None) -> None:
+    from PIL import Image, UnidentifiedImageError
+
+    try:
+        img = Image.open(io.BytesIO(data))
+        img.load()
+    except (UnidentifiedImageError, OSError) as exc:
+        raise ImageIntegrityError(f"decode failed: {exc}") from exc
+    actual_format = (img.format or "").upper()
+    if expected_format is not None and actual_format != expected_format:
+        raise ImageIntegrityError(
+            f"declared content_type implies {expected_format} but decoded format is {actual_format!r}"
+        )
+
+
+def validate_image_bytes(content_type: str, data: bytes) -> None:
+    """저장 直前 공용 관문(story #3753 AC2) — 매직 바이트가 선언된 content_type과
+    일치하는지, PNG는 청크 구조 전수(CRC·IEND)까지, 그 외 포맷은 PIL 디코드+load()
+    까지 확인한다. 실패하면 `ImageIntegrityError(reason)`."""
+    ct = content_type.lower()
+    if ct == "image/png":
+        if not data.startswith(_PNG_SIGNATURE):
+            raise ImageIntegrityError("missing PNG signature")
+        _walk_png_chunks(data)
+        _validate_via_pil(data, expected_format="PNG")
+        return
+    if ct == "image/jpeg":
+        if not data.startswith(_MAGIC_PREFIXES["image/jpeg"]):
+            raise ImageIntegrityError("missing JPEG magic bytes")
+        _validate_via_pil(data, expected_format="JPEG")
+        return
+    if ct == "image/gif":
+        if not data.startswith(_MAGIC_PREFIXES["image/gif"]):
+            raise ImageIntegrityError("missing GIF magic bytes")
+        _validate_via_pil(data, expected_format="GIF")
+        return
+    if ct == "image/webp":
+        if not (data[:4] == b"RIFF" and data[8:12] == b"WEBP"):
+            raise ImageIntegrityError("missing WEBP RIFF/WEBP magic bytes")
+        _validate_via_pil(data, expected_format="WEBP")
+        return
+    # 그 외 image/* — 매직 목록 밖 포맷은 PIL 디코드 수준으로만(content_type↔format 대조 없음).
+    _validate_via_pil(data, expected_format=None)

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -761,16 +761,23 @@ _TOOL_DEFS: list[tuple] = [
      " source는 \"created\"(기본) 또는 \"imported\"만 허용(다른 값은 422).",
      CreateArtifactInput, create_artifact),
     ("sprintable_import_image_artifact",
-     "[일감] base64 이미지 한 번으로 업로드+artifact 생성을 원콜로 처리(story b6b9c52d) —"
+     "[일감] 이미지 한 번으로 업로드+artifact 생성을 원콜로 처리(story b6b9c52d·#3753) —"
      " Bash/HTTP 클라이언트 접근이 없어 sprintable_create_artifact의 2단계 curl 플로우를 스스로"
-     " 못 타는 에이전트 전용 대안. ⭐스크린샷/시안/아이콘 등 **작은** 이미지 증거를 산출물로 남길"
-     " 때 이 도구로 — 단, image_base64는 도구 호출 인자 텍스트로 그대로 실리므로 호출하는 에이전트"
-     " 자신의 최대 출력 토큰 한도가 실질 상한이다(대략 수백 KB 이하 이미지 권장). BE 자체는"
-     " 최대 20MB까지 받지만, 그보다 큰 이미지는 이 도구로 못 보내니 Bash/HTTP 클라이언트가 있는"
-     " 에이전트라면 sprintable_create_artifact의 2단계 curl 플로우를 대신 쓴다."
-     " content_type은 image/*여야 함(아니면 422). story_id/doc_id(선택, sprintable_create_artifact와"
-     " 동형) — 맥락이 있으면 잇는 것을 권장, standalone도 정당. 반환은 get_artifact와 동형"
-     " artifact 상세(FE-import와 동일하게 렌더).",
+     " 못 타는 에이전트 전용 대안."
+     " ⭐파일이 로컬에 있으면 image_path를 써라(서버가 직접 읽어 바이트 정확 전송 — 모델 출력을"
+     " 안 거친다). image_base64는 파일시스템이 없는 에이전트 전용 대안이다 — 도구 호출 인자"
+     " 텍스트로 그대로 실리므로 호출하는 에이전트 자신이 그 base64 문자열을 «다시 타이핑»해야"
+     " 하고, 그 재타이핑 과정에서 오탈자 몇 자만 생겨도 이미지가 깨진 채로 저장된다(실사고"
+     " 확認·story #3753) — 대략 수백 KB 이하의 작은 이미지에만 쓰고, 그보다 크면 image_path나"
+     " sprintable_create_artifact의 2단계 curl 플로우(Bash/HTTP 클라이언트 전용, BE 자체 상한"
+     " 20MB)를 대신 쓴다. image_base64/image_path는 상호 배타(정확히 하나)."
+     " content_type은 image_base64 사용 시 필수(image/*여야 함, 아니면 422) — image_path는"
+     " 생략하면 확장자/매직 바이트로 자동 추정(판별 실패 시 오류, 직접 지정도 가능)."
+     " 저장 직전 이미지 구조를 서버가 검증한다(매직 바이트·PNG 청크·디코드) — 깨진 이미지는"
+     " 422 IMAGE_CORRUPT+사유로 거절되고 저장되지 않는다(사유를 그대로 돌려주니 다시 시도)."
+     " story_id/doc_id(선택, sprintable_create_artifact와 동형) — 맥락이 있으면 잇는 것을"
+     " 권장, standalone도 정당. 반환은 get_artifact와 동형 artifact 상세(FE-import와 동일하게"
+     " 렌더).",
      ImportImageArtifactInput, import_image_artifact),
     ("sprintable_get_artifact",
      "[일감] 시각 산출물 단건 조회(latest 버전 + nodes). ⭐편집/코멘트/핀 작업 전 먼저 현재 상태(노드"

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -5,6 +5,7 @@ C2-S6(story 0edca31e, 코멘트 왕복)+C3-S7(story 940266db, 편집 왕복)+C4-
 다른 리스크 클래스. deleted_at 타임스탬프 플립일 뿐 자식 row 물리삭제 없음)."""
 from __future__ import annotations
 
+import base64
 from typing import Literal
 
 from mcp.types import TextContent
@@ -141,10 +142,18 @@ class ImportImageArtifactInput(SprintableInput):
     텍스트로 그대로 실려 나가므로, 호출하는 에이전트 자신의 최대 출력 토큰 한도가 실질
     상한이다 — 작은 스케치/아이콘(대략 수백 KB 이하) 용도로 한정. 그보다 큰 이미지(최대
     20MB까지 BE는 받음)는 create_artifact 자체 설명에 있는 2단계 curl 플로우(Bash/HTTP
-    클라이언트가 있는 에이전트 전용)를 계속 쓴다."""
+    클라이언트가 있는 에이전트 전용)를 계속 쓴다.
+
+    story #3753 — image_base64의 근본 결함: 모델이 base64 문자열을 «다시 타이핑»해
+    싣는 통로라 바이트 정확 전송 보장이 없다(실사고: artifact b3f60ca8, 청크 프레이밍
+    붕괴로 저장). Bash 없이도 **로컬 파일시스템**은 있는 에이전트(이 MCP 서버 자체가
+    에이전트 머신의 로컬 프로세스, api_client.py로 HTTP만)를 위해 image_path를 추가 —
+    서버가 파일을 직접 읽어(open().read(), 모델 출력 0) base64 인코딩까지 자체 처리한다.
+    image_base64/image_path는 상호 배타(둘 다 지정·둘 다 미지정 모두 오류)."""
     title: str
-    image_base64: str
-    content_type: str
+    image_base64: str | None = None
+    image_path: str | None = None  # story #3753 — 로컬 파일 경로(바이트 정확, 모델 리타이핑 0)
+    content_type: str | None = None  # image_path만 주어지면 확장자/매직으로 추정(미판별 시 오류)
     story_id: str | None = None
     doc_id: str | None = None
 
@@ -185,14 +194,70 @@ async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
         return err(str(exc))
 
 
+# story #3753 — BE _MAX_IMPORT_IMAGE_BYTES(visual_artifacts.py)와 동일 상한 로컬 미러(이
+# 파일 안에서만 쓰는 로컬 상수 — MCP는 별도 프로세스라 app.* import 불가, 기존 GCS host
+# 문자열 중복 관례와 동형).
+_MAX_IMPORT_IMAGE_BYTES = 20 * 1024 * 1024
+
+_MAGIC_SNIFF: tuple[tuple[bytes, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF8", "image/gif"),
+)
+
+
+def _sniff_content_type(path: str, data: bytes) -> str | None:
+    """story #3753 AC1 — image_path에 content_type 미지정 시 확장자 우선, 매직 바이트
+    보조로 추정. 둘 다 실패하면 None(호출부가 오류로 거절 — 추측해서 잘못 태그하지 않는다)."""
+    import mimetypes
+
+    guessed, _ = mimetypes.guess_type(path)
+    if guessed and guessed.startswith("image/"):
+        return guessed
+    for magic, content_type in _MAGIC_SNIFF:
+        if data.startswith(magic):
+            return content_type
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
 async def import_image_artifact(args: ImportImageArtifactInput) -> list[TextContent]:
-    """base64 이미지 한 번으로 업로드+artifact 생성을 원콜로 묶는다(story b6b9c52d) — BE
-    `/import-image`가 GCS 업로드부터 create_artifact 위임까지 내부에서 전부 처리, 반환은
-    get_artifact/list_artifacts와 동형 artifact 상세(FE-import(source="imported")와 동일 렌더)."""
+    """base64 이미지(또는 로컬 파일 경로) 한 번으로 업로드+artifact 생성을 원콜로 묶는다
+    (story b6b9c52d·#3753) — BE `/import-image`가 GCS 업로드부터 create_artifact 위임까지
+    내부에서 전부 처리, 반환은 get_artifact/list_artifacts와 동형 artifact 상세
+    (FE-import(source="imported")와 동일 렌더).
+
+    story #3753 — image_path(권장, 바이트 정확)와 image_base64(파일시스템 없는 에이전트용,
+    모델이 문자열을 리타이핑하는 통로라 손상 가능)는 상호 배타."""
     try:
-        body: dict = {
-            "title": args.title, "image_base64": args.image_base64, "content_type": args.content_type,
-        }
+        if bool(args.image_base64) == bool(args.image_path):
+            return err("image_base64와 image_path 중 정확히 하나만 지정해야 합니다.")
+
+        if args.image_path:
+            from pathlib import Path
+
+            path = Path(args.image_path)
+            if not path.is_file():
+                return err(f"image_path가 존재하는 일반 파일이 아닙니다: {args.image_path}")
+            data = path.read_bytes()
+            if len(data) > _MAX_IMPORT_IMAGE_BYTES:
+                return err(
+                    f"image_path 파일이 너무 큽니다({len(data)}B > {_MAX_IMPORT_IMAGE_BYTES}B, 최대 20MB)."
+                )
+            content_type = args.content_type or _sniff_content_type(args.image_path, data)
+            if not content_type:
+                return err(
+                    "image_path 파일의 content_type을 판별할 수 없습니다 — content_type을 직접 지정하세요."
+                )
+            image_base64 = base64.b64encode(data).decode()
+        else:
+            if not args.content_type:
+                return err("image_base64 사용 시 content_type은 필수입니다.")
+            image_base64 = args.image_base64
+            content_type = args.content_type
+
+        body: dict = {"title": args.title, "image_base64": image_base64, "content_type": content_type}
         if args.story_id:
             body["story_id"] = args.story_id
         if args.doc_id:

--- a/backend/tests/test_3666_channel_post_image_import.py
+++ b/backend/tests/test_3666_channel_post_image_import.py
@@ -197,10 +197,13 @@ async def test_import_image_invalid_base64_returns_400():
 
 
 @pytest.mark.anyio
-async def test_import_image_undecodable_bytes_returns_422_same_as_confirm():
-    """content_type은 image/*로 통과해도 실제로 디코드 불가능한 바이트면(진짜 이미지가
-    아닌 쓰레기 bytes) confirm과 동일하게 422 CHANNEL_IMAGE_UNDECODABLE — 에러 매핑을
-    `_confirm_image_upload_or_raise`로 공유한다는 것의 직접 증거(신규 매핑 사본 0)."""
+async def test_import_image_undecodable_bytes_returns_422_image_corrupt():
+    """story #3753 — content_type은 image/*로 통과해도 실제로 디코드 불가능한 바이트면
+    (진짜 이미지가 아닌 쓰레기 bytes) 이제 confirm까지 안 가고 저장 直前 관문
+    (validate_image_bytes)에서 즉시 422 IMAGE_CORRUPT로 막힌다 — visual_artifacts.py::
+    import_image_artifact와 동일 코드(들쭉날쭉 금지, AC2). #3753 이전엔 이 케이스가
+    (put_object로 실제 GCS에 쓴 뒤) confirm 내부 PIL 디코드에서 뒤늦게 잡혀
+    CHANNEL_IMAGE_UNDECODABLE이었다 — 이제는 저장 자체를 안 한다(고아 객체 0)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -216,7 +219,56 @@ async def test_import_image_undecodable_bytes_returns_422_same_as_confirm():
             draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
             r = await _import_image(client, org_id, draft_id, b"garbage-not-a-real-image-payload", content_type="image/png")
         assert r.status_code == 422, r.text
-        assert (r.json().get("error") or r.json())["code"] == "CHANNEL_IMAGE_UNDECODABLE"
+        assert (r.json().get("error") or r.json())["code"] == "IMAGE_CORRUPT"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_rejects_structurally_corrupted_png_before_storage():
+    """AC2 양성대조 — 실사고(artifact b3f60ca8)와 동형으로 손상된 PNG(유효 시그니처+IHDR+
+    첫 IDAT 4096B까지 정상, 그 다음 청크 타입이 깨짐)는 422 IMAGE_CORRUPT로 거절되고
+    ChannelPostImage 행이 하나도 생기지 않는다(저장 0 — put_object 호출 前에 걸린다는
+    것의 직접 증거, 되돌리면 이 요청이 201로 통과한다)."""
+    import struct
+    import zlib
+
+    from app.main import app
+    from app.models.channel_post_image import ChannelPostImage
+    from sqlalchemy import select
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data)) + chunk_type + data
+            + struct.pack(">I", zlib.crc32(chunk_type + data) & 0xFFFFFFFF)
+        )
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr = _chunk(b"IHDR", struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0))
+    idat = _chunk(b"IDAT", zlib.compress(b"\x00" * 100)[:4096].ljust(4096, b"\x00"))
+    corrupted = signature + ihdr + idat + struct.pack(">I", 100) + b"\x7f\x9f\x00\x00"
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+            r = await _import_image(client, org_id, draft_id, corrupted, content_type="image/png")
+        assert r.status_code == 422, r.text
+        assert (r.json().get("error") or r.json())["code"] == "IMAGE_CORRUPT"
+
+        async with Session() as verify_session:
+            rows = (await verify_session.execute(
+                select(ChannelPostImage).where(ChannelPostImage.draft_id == uuid.UUID(draft_id))
+            )).scalars().all()
+        assert rows == []
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3753_image_integrity_validator.py
+++ b/backend/tests/test_3753_image_integrity_validator.py
@@ -1,0 +1,179 @@
+"""story #3753 AC2 — `app/services/image_integrity.py::validate_image_bytes` 단위 테스트.
+
+실사고 재현(artifact `b3f60ca8-4c65-44de-a7e9-bc5b5dcf5e01`, PO 청크 실측): 유효한 PNG
+시그니처+`IHDR`+첫 `IDAT`(4096B)까지는 정상이었으나 그 다음 청크 타입이
+`\\x7f\\x9f\\x00\\x00`로 깨져 있었다 — 이 파일의 `test_reproduces_incident_pattern_*`이
+그 정확한 모양(시그니처+IHDR+유효 4096B IDAT+깨진 청크 타입)을 합성해 청크 walk가
+정확히 그 지점에서 잡는다는 것을 고정한다(양성대조: PIL 단독이 아니라 청크 walk 자체가
+일하고 있다는 증거 — walk를 빼면 이 케이스가 통과한다, AC2 되돌리면 RED 조건)."""
+from __future__ import annotations
+
+import io
+import struct
+import zlib
+
+import pytest
+
+from app.services.image_integrity import ImageIntegrityError, _walk_png_chunks, validate_image_bytes
+
+
+def _png_bytes(width: int = 4, height: int = 4, *, color=(200, 50, 80)) -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (width, height), color=color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _jpeg_bytes(width: int = 4, height: int = 4) -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (width, height), color=(10, 20, 30))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+def _gif_bytes() -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (4, 4), color=(1, 2, 3))
+    buf = io.BytesIO()
+    img.save(buf, format="GIF")
+    return buf.getvalue()
+
+
+def _webp_bytes() -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (4, 4), color=(9, 8, 7))
+    buf = io.BytesIO()
+    img.save(buf, format="WEBP")
+    return buf.getvalue()
+
+
+# ── happy path: 실제 PIL이 만든 이미지는 전부 통과 ──────────────────────────────
+
+def test_valid_png_passes():
+    validate_image_bytes("image/png", _png_bytes())  # raise 없으면 통과
+
+
+def test_valid_jpeg_passes():
+    validate_image_bytes("image/jpeg", _jpeg_bytes())
+
+
+def test_valid_gif_passes():
+    validate_image_bytes("image/gif", _gif_bytes())
+
+
+def test_valid_webp_passes():
+    validate_image_bytes("image/webp", _webp_bytes())
+
+
+def test_content_type_case_insensitive():
+    validate_image_bytes("IMAGE/PNG", _png_bytes())
+
+
+# ── 매직 바이트 불일치 ──────────────────────────────────────────────────────────
+
+def test_png_missing_signature_rejected():
+    with pytest.raises(ImageIntegrityError, match="signature"):
+        validate_image_bytes("image/png", b"not-a-png-at-all")
+
+
+def test_jpeg_missing_magic_rejected():
+    with pytest.raises(ImageIntegrityError, match="magic"):
+        validate_image_bytes("image/jpeg", b"not-a-jpeg-at-all")
+
+
+def test_content_type_mismatch_rejected():
+    """실제로는 PNG인데 content_type=image/jpeg로 선언 — 매직 바이트 자체가 안 맞아 거절."""
+    with pytest.raises(ImageIntegrityError, match="magic"):
+        validate_image_bytes("image/jpeg", _png_bytes())
+
+
+# ── 완전 쓰레기 바이트(비-이미지) ────────────────────────────────────────────────
+
+def test_garbage_bytes_rejected_as_png():
+    with pytest.raises(ImageIntegrityError):
+        validate_image_bytes("image/png", b"garbage-not-a-real-image-payload" * 10)
+
+
+def test_unsupported_image_subtype_falls_back_to_pil_and_rejects_garbage():
+    with pytest.raises(ImageIntegrityError):
+        validate_image_bytes("image/bmp", b"garbage-bytes-not-bmp")
+
+
+def test_unsupported_image_subtype_accepts_pil_decodable_bytes():
+    """매직 목록 밖 포맷(bmp)도 실제로 PIL이 디코드 가능하면 통과 — PIL verify 수준 폴백."""
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (4, 4), color=(5, 5, 5)).save(buf, format="BMP")
+    validate_image_bytes("image/bmp", buf.getvalue())
+
+
+# ── PNG 청크 walk 전용 — 실사고 재현 ─────────────────────────────────────────────
+
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def _make_chunk(chunk_type: bytes, data: bytes) -> bytes:
+    return struct.pack(">I", len(data)) + chunk_type + data + struct.pack(">I", zlib.crc32(chunk_type + data) & 0xFFFFFFFF)
+
+
+def test_reproduces_incident_pattern_corrupted_chunk_type_after_valid_idat():
+    """b3f60ca8 실사고의 정확한 모양: 유효 시그니처+IHDR+첫 IDAT(4096B, 유효 CRC)까지
+    지나간 뒤, 다음 청크 타입이 알파벳이 아닌 바이트(\\x7f\\x9f\\x00\\x00)로 깨짐 —
+    청크 walk가 그 정확한 지점에서 「PNG chunk type invalid」로 잡아야 한다."""
+    ihdr_data = struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0)  # width height bitdepth=8 colortype=2(RGB)...
+    ihdr_chunk = _make_chunk(b"IHDR", ihdr_data)
+    idat_chunk = _make_chunk(b"IDAT", zlib.compress(b"\x00" * (4 * 3 + 1) * 4)[:4096].ljust(4096, b"\x00"))
+    corrupted_next_chunk_header = struct.pack(">I", 100) + b"\x7f\x9f\x00\x00"  # 깨진 타입, CRC 없음
+    data = _PNG_SIGNATURE + ihdr_chunk + idat_chunk + corrupted_next_chunk_header
+
+    with pytest.raises(ImageIntegrityError, match="chunk type invalid"):
+        _walk_png_chunks(data)
+
+
+def test_png_truncated_mid_chunk_rejected():
+    ihdr_chunk = _make_chunk(b"IHDR", struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0))
+    data = _PNG_SIGNATURE + ihdr_chunk + struct.pack(">I", 500) + b"IDAT"  # 길이 선언했지만 데이터 없음
+    with pytest.raises(ImageIntegrityError, match="truncated"):
+        _walk_png_chunks(data)
+
+
+def test_png_crc_mismatch_rejected():
+    ihdr_data = struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0)
+    bad_crc_chunk = struct.pack(">I", len(ihdr_data)) + b"IHDR" + ihdr_data + struct.pack(">I", 0xDEADBEEF)
+    data = _PNG_SIGNATURE + bad_crc_chunk
+    with pytest.raises(ImageIntegrityError, match="CRC mismatch"):
+        _walk_png_chunks(data)
+
+
+def test_png_missing_iend_rejected():
+    ihdr_chunk = _make_chunk(b"IHDR", struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0))
+    data = _PNG_SIGNATURE + ihdr_chunk  # IEND 없이 끝남
+    with pytest.raises(ImageIntegrityError, match="IEND"):
+        _walk_png_chunks(data)
+
+
+def test_png_reaching_iend_passes_chunk_walk():
+    ihdr_chunk = _make_chunk(b"IHDR", struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0))
+    iend_chunk = _make_chunk(b"IEND", b"")
+    data = _PNG_SIGNATURE + ihdr_chunk + iend_chunk
+    _walk_png_chunks(data)  # raise 없으면 통과(PIL 디코드는 여기서 안 함 — walk 단독 테스트)
+
+
+# ── 양성대조: walk를 빼면 위 실사고 재현 케이스가 조용히 통과한다는 것 ──────────────
+# (validate_image_bytes 전체 관문 — PIL 폴백 없이 walk가 먼저 걸리는지)
+
+def test_validate_image_bytes_rejects_incident_pattern_via_png_path():
+    ihdr_chunk = _make_chunk(b"IHDR", struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0))
+    idat_chunk = _make_chunk(b"IDAT", zlib.compress(b"\x00" * (4 * 3 + 1) * 4)[:4096].ljust(4096, b"\x00"))
+    corrupted_next_chunk_header = struct.pack(">I", 100) + b"\x7f\x9f\x00\x00"
+    data = _PNG_SIGNATURE + ihdr_chunk + idat_chunk + corrupted_next_chunk_header
+
+    with pytest.raises(ImageIntegrityError):
+        validate_image_bytes("image/png", data)

--- a/backend/tests/test_3753_mcp_import_image_path.py
+++ b/backend/tests/test_3753_mcp_import_image_path.py
@@ -1,0 +1,205 @@
+"""story #3753 AC1 — MCP `sprintable_import_image_artifact`의 `image_path`(로컬 파일
+직접 읽기) 입구. client.post를 mock해 MCP 도구 함수만 단독 검증(BE 실호출 없음 —
+BE 자체 동작은 test_b6b9c52d_mcp_import_image_artifact_realdb.py가 커버).
+
+핵심 계약: image_path로 준 파일의 바이트가 base64 왕복 후 SHA256이 원본과 정확히
+같아야 한다(모델 리타이핑 구간이 아예 없다는 것의 직접 증거) — image_base64 통로는
+`Read` 툴 출력을 모델이 재입력하는 구간(story #3753 실사고)이 있지만, image_path는
+서버가 `Path.read_bytes()`로 직접 읽어 그 구간 자체가 없다."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sprintable_mcp.tools import visual_artifacts as va
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _client(**methods):
+    c = MagicMock()
+    c.project_id = "proj-1"
+    c.require_project_id = MagicMock(return_value="proj-1")
+    for name, ret in methods.items():
+        setattr(c, name, AsyncMock(return_value=ret))
+    return c
+
+
+def _real_png_bytes() -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (5, 5), color=(11, 22, 33))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# ── AC1: SHA256 round-trip ───────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_image_path_sha256_round_trips_to_original(tmp_path):
+    original = _real_png_bytes()
+    file_path = tmp_path / "shot.png"
+    file_path.write_bytes(original)
+
+    client = _client(post={"id": "artifact-1"})
+    args = va.ImportImageArtifactInput(title="Shot", image_path=str(file_path))
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+
+    assert "Error" not in out[0].text
+    sent_body = client.post.call_args.kwargs.get("json") or client.post.call_args.args[1]
+    sent_bytes = base64.b64decode(sent_body["image_base64"])
+    assert hashlib.sha256(sent_bytes).hexdigest() == hashlib.sha256(original).hexdigest()
+    assert sent_body["content_type"] == "image/png"
+
+
+@pytest.mark.anyio
+async def test_image_path_infers_content_type_from_extension(tmp_path):
+    from PIL import Image
+
+    img = Image.new("RGB", (5, 5), color=(1, 1, 1))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    file_path = tmp_path / "shot.jpg"
+    file_path.write_bytes(buf.getvalue())
+
+    client = _client(post={"id": "artifact-1"})
+    args = va.ImportImageArtifactInput(title="Shot", image_path=str(file_path))
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+
+    assert "Error" not in out[0].text
+    sent_body = client.post.call_args.kwargs.get("json") or client.post.call_args.args[1]
+    assert sent_body["content_type"] == "image/jpeg"
+
+
+@pytest.mark.anyio
+async def test_image_path_explicit_content_type_takes_precedence(tmp_path):
+    original = _real_png_bytes()
+    file_path = tmp_path / "shot.bin"  # 확장자로는 못 판별
+    file_path.write_bytes(original)
+
+    client = _client(post={"id": "artifact-1"})
+    args = va.ImportImageArtifactInput(title="Shot", image_path=str(file_path), content_type="image/png")
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+
+    assert "Error" not in out[0].text
+    sent_body = client.post.call_args.kwargs.get("json") or client.post.call_args.args[1]
+    assert sent_body["content_type"] == "image/png"
+
+
+# ── 상호 배타 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_both_image_base64_and_image_path_rejected(tmp_path):
+    file_path = tmp_path / "shot.png"
+    file_path.write_bytes(_real_png_bytes())
+
+    client = _client()
+    args = va.ImportImageArtifactInput(
+        title="Shot", image_path=str(file_path), image_base64="aGVsbG8=", content_type="image/png",
+    )
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+    assert out[0].text.startswith("Error:")
+    assert "정확히 하나" in out[0].text
+    client.post.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_neither_image_base64_nor_image_path_rejected():
+    client = _client()
+    args = va.ImportImageArtifactInput(title="Shot", content_type="image/png")
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+    assert out[0].text.startswith("Error:")
+    assert "정확히 하나" in out[0].text
+    client.post.assert_not_called()
+
+
+# ── 파일 존재/종류 검증 ────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_image_path_nonexistent_file_rejected(tmp_path):
+    client = _client()
+    args = va.ImportImageArtifactInput(title="Shot", image_path=str(tmp_path / "does-not-exist.png"))
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+    assert out[0].text.startswith("Error:")
+    assert "일반 파일" in out[0].text
+    client.post.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_image_path_pointing_at_directory_rejected(tmp_path):
+    client = _client()
+    args = va.ImportImageArtifactInput(title="Shot", image_path=str(tmp_path))
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+    assert out[0].text.startswith("Error:")
+    client.post.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_image_path_oversized_file_rejected(tmp_path, monkeypatch):
+    monkeypatch.setattr(va, "_MAX_IMPORT_IMAGE_BYTES", 10)  # 인위적으로 낮춰 대용량 생성 회피
+    file_path = tmp_path / "shot.png"
+    file_path.write_bytes(_real_png_bytes())  # 10B보다 큼
+
+    client = _client()
+    args = va.ImportImageArtifactInput(title="Shot", image_path=str(file_path))
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+    assert out[0].text.startswith("Error:")
+    assert "너무 큽니다" in out[0].text
+    client.post.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_image_path_unrecognizable_content_type_rejected(tmp_path):
+    file_path = tmp_path / "shot.unknownext"
+    file_path.write_bytes(b"not-recognizable-as-any-image-format")
+
+    client = _client()
+    args = va.ImportImageArtifactInput(title="Shot", image_path=str(file_path))
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+    assert out[0].text.startswith("Error:")
+    assert "판별할 수 없습니다" in out[0].text
+    client.post.assert_not_called()
+
+
+# ── image_base64 경로: content_type 필수(기존 계약 유지, 스키마가 optional로 느슨해진 만큼
+#    런타임에서 명시적으로 재확인) ──────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_image_base64_without_content_type_rejected():
+    client = _client()
+    args = va.ImportImageArtifactInput(title="Shot", image_base64="aGVsbG8=")
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+    assert out[0].text.startswith("Error:")
+    assert "필수" in out[0].text
+    client.post.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_image_base64_path_unchanged_when_content_type_given():
+    """회귀: image_base64 경로 자체(내용물 그대로 전달)는 #3753 변경으로 안 달라졌다."""
+    client = _client(post={"id": "artifact-1"})
+    args = va.ImportImageArtifactInput(title="Shot", image_base64="aGVsbG8=", content_type="image/png")
+    with patch.object(va, "client", client):
+        out = await va.import_image_artifact(args)
+    assert "Error" not in out[0].text
+    sent_body = client.post.call_args.kwargs.get("json") or client.post.call_args.args[1]
+    assert sent_body["image_base64"] == "aGVsbG8="
+    assert sent_body["content_type"] == "image/png"

--- a/backend/tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py
+++ b/backend/tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py
@@ -2,14 +2,28 @@
 BE 엔드포인트(`POST /api/v2/visual-artifacts/import-image`). crux: content-type/size 검증·
 base64 디코드 실패 처리·업로드→create_artifact 위임 왕복(source=imported·html_blob 노드·
 canonical url)·story_id cross-org 스코프 차단(create_artifact의 _assert_link_target_in_scope
-재사용 확인, C1-S3 crux①과 동형)."""
+재사용 확인, C1-S3 crux①과 동형).
+
+story #3753 — 저장 直前 `validate_image_bytes`(구조 검증)가 새로 걸렸다. 「성공」 표본은
+전부 실제 PNG 바이트여야 통과한다(예전엔 `os.urandom(...)`로도 통과했다 — 그때는 구조를
+안 봤기 때문. 지금은 그 자체가 이 관문이 실제로 일하고 있다는 증거다)."""
 from __future__ import annotations
 
 import base64
+import io
 import os
 import uuid
 
 import pytest
+
+
+def _png_bytes(n: int = 4) -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (n, n), color=(12, 34, 56))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
@@ -186,7 +200,7 @@ async def test_import_image_success_creates_artifact_with_canonical_url():
         await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
         client = _client_for(app)
         try:
-            image_bytes = os.urandom(1024)
+            image_bytes = _png_bytes()
             resp = await _post_import(
                 client, title="Sketch v1",
                 image_base64=base64.b64encode(image_bytes).decode(), content_type="image/png",
@@ -237,10 +251,90 @@ async def test_import_image_cross_org_story_link_blocked():
         try:
             resp = await _post_import(
                 client, title="Injected",
-                image_base64=base64.b64encode(os.urandom(16)).decode(), content_type="image/png",
+                image_base64=base64.b64encode(_png_bytes()).decode(), content_type="image/png",
                 story_id=str(seeded["story_b_id"]),
             )
             assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# story #3753 AC2 — 저장 直前 구조 검증(validate_image_bytes) 관문
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _corrupted_png_bytes_matching_incident() -> bytes:
+    """실사고(artifact `b3f60ca8-4c65-44de-a7e9-bc5b5dcf5e01`) 재현: 유효 시그니처+IHDR+
+    첫 IDAT(4096B, 유효 CRC)까지는 정상이나 그 다음 청크 타입이 알파벳이 아닌 바이트로
+    깨져 있다 — PO가 직접 실측한 손상 패턴과 동형(청크 프레이밍 붕괴)."""
+    import struct
+    import zlib
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data)) + chunk_type + data
+            + struct.pack(">I", zlib.crc32(chunk_type + data) & 0xFFFFFFFF)
+        )
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr = _chunk(b"IHDR", struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0))
+    idat = _chunk(b"IDAT", zlib.compress(b"\x00" * 100)[:4096].ljust(4096, b"\x00"))
+    corrupted_next_header = struct.pack(">I", 100) + b"\x7f\x9f\x00\x00"  # 깨진 청크 타입
+    return signature + ihdr + idat + corrupted_next_header
+
+
+@pytest.mark.anyio
+async def test_import_image_rejects_structurally_corrupted_png_422_image_corrupt():
+    """AC2 양성대조 — 실사고와 동형으로 손상된 PNG 바이트(매직/base64/size는 전부 유효)는
+    422 IMAGE_CORRUPT로 거절되고 artifact가 생성되지 않는다. validate_image_bytes를
+    빼면(되돌리면) 이 요청이 201로 통과한다(RED 조건, PR 작업 중 실측 확認됨)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_import(
+                client, title="Corrupted",
+                image_base64=base64.b64encode(_corrupted_png_bytes_matching_incident()).decode(),
+                content_type="image/png",
+            )
+            assert resp.status_code == 422, resp.text
+            body = resp.json()
+            assert body["error"]["code"] == "IMAGE_CORRUPT"
+            assert "chunk" in body["error"]["message"].lower()
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_rejects_garbage_bytes_with_valid_image_content_type_422():
+    """content_type=image/png인데 실제로는 완전 무관한 바이트(실사고 이전엔 os.urandom도
+    통과했던 것과 동형 시나리오) — 매직 바이트 자체가 안 맞아 즉시 422 IMAGE_CORRUPT."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_import(
+                client, title="Not An Image",
+                image_base64=base64.b64encode(os.urandom(1024)).decode(), content_type="image/png",
+            )
+            assert resp.status_code == 422, resp.text
+            assert resp.json()["error"]["code"] == "IMAGE_CORRUPT"
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## 요약
실사고(artifact `b3f60ca8`, story #3749 캡처 中 발견) — MCP
`sprintable_import_image_artifact`가 `image_base64`를 도구 호출 인자 텍스트로만
받아, 모델이 이전 `Read` 출력을 리타이핑해 싣는 구간에서 PNG 청크 프레이밍이
깨졌다. BE 입구(`visual-artifacts/import-image`·`channel-posts/assets/import-image`)는
깨진 바이트를 구조 검증 없이 그대로 저장했다.

## 처방
- **A.** MCP `sprintable_import_image_artifact`에 `image_path` 신설 — 서버(별도
  로컬 프로세스)가 파일을 직접 `read_bytes()`해 base64 인코딩까지 자체 처리
  (모델 리타이핑 구간 0). `image_base64`와 상호 배타. `content_type` 미지정 시
  확장자→매직 바이트 순으로 추정.
- **B.** `app/services/image_integrity.py` 신설(저장 直前 공용 관문) — 매직
  바이트↔`content_type` 일치, PNG는 청크 walk(길이·타입 ASCII·CRC32·`IEND`
  도달)까지, 그 외 포맷은 PIL 디코드+`load()`. `visual-artifacts/import-image`·
  `channel-posts/assets/import-image` 둘 다 `put_object` 前에 호출 — 실패 시
  422 `IMAGE_CORRUPT`+사유, 저장 자체를 안 함(고아 객체 0).
- **C.** MCP 도구 설명문에 `image_path` 우선 권고 명시. 422 사유는 기존
  에러 엔벨로프 경로를 그대로 통해 삼켜지지 않고 에이전트에 반환된다(별도
  코드 불요 — `_err()`→`_extract_error_message()` 파이프라인 기존 계약 그대로).

## 검증
- `image_integrity.py` 단위 테스트 17개 — happy path(png/jpeg/gif/webp) +
  매직 불일치 + 실사고와 동형으로 합성한 손상 PNG(유효 IHDR+4096B IDAT까지
  정상, 다음 청크 타입만 깨짐)가 정확히 청크 walk에서 잡히는지까지
- MCP `image_path` 단위 테스트 11개 — SHA256 원본↔전송 바이트 왕복 일치,
  확장자/매직 추정, 상호배타·파일없음·디렉터리·용량초과·판별불가 거부
- visual-artifacts realdb 테스트: 기존 성공 경로 3개를 `os.urandom`→실 PNG로
  교체(구조검증 신설로 랜덤바이트가 더 이상 안 통과) + 신규 2개(합성 손상
  PNG 422 `IMAGE_CORRUPT`, 무관 바이트 422) — 7/7 PASS
- channel-posts realdb 테스트: 기존 undecodable 테스트를 `CHANNEL_IMAGE_
  UNDECODABLE`→`IMAGE_CORRUPT`로 갱신(저장 前 관문이 confirm보다 먼저 잡음) +
  신규 1개(합성 손상 PNG 422 + `ChannelPostImage` 행 0건 확認) — 5/5 PASS
- **뮤테이션킬 2건**: `visual_artifacts.py`·`channel_posts.py` 양쪽 다
  `validate_image_bytes` 호출을 임시 제거 → 합성 손상 PNG가 201로 통과(RED)
  확認 → 원복 → 재GREEN. channel_posts.py 쪽은 특히 유의미했다 — 관문 없이는
  PIL 기반 컨버전 파이프라인이 그 손상 PNG를 실제로 디코드+변환해 성공시켰다
  (청크 walk가 PIL 단독보다 더 넓게 잡는다는 직접 증거)
- MCP contract/unknown-arg 가드(`test_contract.py`·`test_2412`) 회귀 0
- 인접 visual-artifacts realdb 스위트 12개 파일(93개 테스트, non-destructive)
  90 PASS·3건은 무관 사전결함(로컬 Supabase 포트 54322 미기동 — 이 PR이
  건드리지 않은 파일, 이 스토리 범위 밖)

## AC 대조
1. ✅ image_path — 상호배타·존재/일반파일/크기 검사·SHA256 라운드트립 테스트
2. ✅ 저장 直前 공용 검증기 — 매직↔content_type·PNG 청크 walk·PIL verify →
   422 IMAGE_CORRUPT+저장 0. 두 입구 모두 호출. 양성대조 실측
3. ✅ MCP 422 사유 미삼킴 + 도구 설명문 갱신
4. 낯선 인자 거부(#2412)·MCP contract 테스트 회귀 0 — 카디르 QA 요청

🤖 Generated with [Claude Code](https://claude.com/claude-code)