### PR TITLE
[SID:3756] 우하단 fixed 요소 — 셸 소유 --bottom-dock-inset으로 탭 바 회피 통일

### DIFF
--- a/apps/web/scripts/handrolled-card-baseline.json
+++ b/apps/web/scripts/handrolled-card-baseline.json
@@ -280,7 +280,7 @@
     "components/standup/board-bridge-modal.tsx::flex w-full items-center justify-between gap-2 rounded-lg border border-border/70 bg-background p-2.5 text-left transition hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-50",
     "components/standup/standup-board-card.tsx::flex flex-col rounded-xl border border-border bg-card shadow-[var(--elev-card)]",
     "components/standup/standup-history-section.tsx::rounded-lg border border-border bg-card p-3",
-    "components/support-widget/support-widget-launcher.tsx::fixed bottom-[8.75rem] right-5 z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl",
+    "components/support-widget/support-widget-launcher.tsx::fixed right-5 bottom-[calc(var(--bottom-dock-inset)+8.75rem)] z-40 flex h-[min(480px,calc(100vh-11rem-var(--bottom-dock-inset)))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl",
     "components/support-widget/support-widget-panel.tsx::min-w-0 flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50",
     "ee/components/billing/pricing-packs.tsx::rounded-2xl border border-border bg-card p-4",
     "ee/components/billing/pricing-plan-card.tsx::relative flex flex-col rounded-2xl border border-border bg-card p-4"

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -391,7 +391,10 @@ export function DashboardShell({
       <RefreshProvider>
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>
-          <SidebarProvider className="h-svh">
+          {/* story #3756 — dashboard-shell-root가 --bottom-dock-inset·--mobile-tab-bar-h를
+              소유(globals.css). MobileTabBar·SupportWidgetLauncher 둘 다 이 아래 자손이라
+              상속으로 그 값을 읽는다. */}
+          <SidebarProvider className="h-svh dashboard-shell-root">
             <ShellBody
               currentTeamMemberId={currentTeamMemberId}
               showTopBar={showTopBar}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -904,3 +904,24 @@
 .tiptap [data-type="toggleContent"] { padding-left: 1.25rem; margin-left: 0.875rem; border-left: 2px solid hsl(var(--border)); margin-top: 0.25rem; }
 [data-type="toggleSummary"],
 .tiptap [data-type="toggleSummary"] { cursor: pointer; }
+
+/* ─── 하단 도크 인셋(story #3756) ───
+   MobileTabBar(nav/mobile-tab-bar.tsx)는 lg 미만(<1024px, hooks/use-mobile.ts
+   MOBILE_BREAKPOINT와 동일 SSOT)에서만 뷰포트 바닥에 고정 렌더된다. 우하단 fixed
+   요소(토스트·지원 위젯 런처/패널·칸반 저장오류 배너)가 각자 숫자를 추측하지 않도록,
+   dashboard-shell.tsx의 셸 루트(`.dashboard-shell-root`, SidebarProvider 래퍼)가
+   이 변수 하나를 소유한다 — 그 하위 전부가 `bottom: calc(var(--bottom-dock-inset) + Npx)`
+   형태로만 참조한다(숫자 재추측 금지).
+   --mobile-tab-bar-h는 탭 바 자기 자신의 실 높이(`h-[var(--mobile-tab-bar-h)]`,
+   mobile-tab-bar.tsx)와 같은 값을 가리키는 단일 토큰 — 탭 바 높이가 바뀌면 이
+   한 줄만 고치면 인셋도 함께 맞다(두 벌 상수 금지). */
+.dashboard-shell-root {
+  --mobile-tab-bar-h: 4rem;
+  --bottom-dock-inset: env(safe-area-inset-bottom);
+}
+
+@media (max-width: 1023px) {
+  .dashboard-shell-root {
+    --bottom-dock-inset: calc(var(--mobile-tab-bar-h) + env(safe-area-inset-bottom));
+  }
+}

--- a/apps/web/src/bottom-dock-inset-source.pin.test.ts
+++ b/apps/web/src/bottom-dock-inset-source.pin.test.ts
@@ -1,0 +1,54 @@
+// story #3756 AC1 — 셸이 `--bottom-dock-inset`/`--mobile-tab-bar-h`를 실제로 «세우는» 자리
+// 3곳(dashboard-shell.tsx가 소유 클래스를 부착·mobile-tab-bar.tsx가 높이 토큰을 소비·
+// globals.css가 변수 정의+media query)을 소스 텍스트 수준에서 고정. bottom-dock-inset.
+// guard.test.ts는 "소비처가 변수를 참조하는가"를, 이 파일은 "그 변수가 실제로 어딘가에서
+// 세워지는가"를 각각 담당(계약의 양쪽 절반 — 세우는 쪽 없이 참조만 있으면 무의미한 var()라
+// 이 짝이 꼭 필요하다).
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = join(__dirname, '../');
+
+function read(relativePath: string): string {
+  return readFileSync(join(SRC_ROOT, relativePath), 'utf-8');
+}
+
+describe('dashboard-shell.tsx — SidebarProvider가 dashboard-shell-root 클래스를 부착한다', () => {
+  it('SidebarProvider className에 dashboard-shell-root가 있다', () => {
+    const content = read('src/app/dashboard/dashboard-shell.tsx');
+    expect(content).toMatch(/<SidebarProvider[^>]*className=["'`][^"'`]*\bdashboard-shell-root\b/);
+  });
+});
+
+describe('mobile-tab-bar.tsx — nav 높이가 --mobile-tab-bar-h 토큰을 참조한다', () => {
+  it('h-16 같은 하드코딩이 아니라 h-[var(--mobile-tab-bar-h)]를 쓴다', () => {
+    const content = read('src/components/nav/mobile-tab-bar.tsx');
+    expect(content).toContain('h-[var(--mobile-tab-bar-h)]');
+    expect(content).not.toMatch(/<nav[^>]*className=["'`][^"'`]*\bh-16\b/);
+  });
+});
+
+describe('globals.css — --bottom-dock-inset·--mobile-tab-bar-h 정의 + lg 미만 media query', () => {
+  const css = read('src/app/globals.css');
+
+  it('.dashboard-shell-root가 두 변수를 기본값으로 세운다', () => {
+    expect(css).toMatch(/\.dashboard-shell-root\s*\{[^}]*--mobile-tab-bar-h:\s*4rem/);
+    expect(css).toMatch(/\.dashboard-shell-root\s*\{[^}]*--bottom-dock-inset:\s*env\(safe-area-inset-bottom\)/);
+  });
+
+  it('lg 미만(<1024px, hooks/use-mobile.ts MOBILE_BREAKPOINT와 동일 SSOT)에서 탭 바 높이를 더한다', () => {
+    expect(css).toMatch(
+      /@media \(max-width: 1023px\)\s*\{\s*\.dashboard-shell-root\s*\{[^}]*--bottom-dock-inset:\s*calc\(var\(--mobile-tab-bar-h\)\s*\+\s*env\(safe-area-inset-bottom\)\)/,
+    );
+  });
+
+  it('MOBILE_BREAKPOINT(1024)와 media query 경계(1023px)가 어긋나지 않는다', () => {
+    const hooks = read('src/hooks/use-mobile.ts');
+    const match = hooks.match(/MOBILE_BREAKPOINT\s*=\s*(\d+)/);
+    expect(match).not.toBeNull();
+    const breakpoint = Number(match![1]);
+    // lg:hidden(탭 바)은 min-width:breakpoint에서 사라진다 — 그 직전 정수 px가 media query 상한.
+    expect(css).toContain(`@media (max-width: ${breakpoint - 1}px)`);
+  });
+});

--- a/apps/web/src/bottom-dock-inset.guard.test.ts
+++ b/apps/web/src/bottom-dock-inset.guard.test.ts
@@ -1,0 +1,114 @@
+// story #3756(FE·모바일·결함 클래스) — 우하단 «고정» 요소(토스트·지원 위젯 런처/패널·
+// 칸반 저장오류 배너)가 모바일 하단 탭 바 높이를 모르고 뷰포트 바닥 기준으로 떠 넷째
+// 탭을 덮던 결함. 처방: 셸(dashboard-shell.tsx)이 CSS 변수 `--bottom-dock-inset`
+// (globals.css `.dashboard-shell-root`, 탭 바 높이+safe-area)을 소유하고, 우하단
+// fixed 요소 전부가 그 변수로만 bottom을 잡는다(숫자 재추측 0).
+//
+// 이 가드는 그 계약을 소스 텍스트 수준에서 고정한다(story의 test① — jsdom엔 실 layout이
+// 없어 computed bottom을 잴 수 없으므로, 대신 ②"우하단 fixed 요소마다 변수 참조가
+// 있는가"를 전수 스캔·허용목록 0으로 검증한다. corner-count-badge-a11y.guard.test.ts와
+// 동형 컨벤션(전수 소비처 나열+개별 assert, 새 소비처가 생기면 이 파일도 함께 봐야 한다).
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = `${__dirname}/`; // 이 테스트 파일 자체가 src/ 바로 아래에 있음(하위 상대경로 불요)
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.') || entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (/\.tsx?$/.test(entry) && !entry.includes('.test.')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// 한 줄 안에 `fixed`와 bottom 오프셋(Tailwind `bottom-...` 클래스 또는 인라인
+// `bottom:` style)이 함께 있으면 「우하단(혹은 하단) fixed 요소」로 간주 — 이 레포의
+// 소비처 전부가 className/style을 한 줄짜리 문자열로 쓰는 관례라(다른 guard 파일들도
+// 전제하는 것과 동일) 줄 단위 검색으로 충분하다.
+const FIXED_LINE_RE = /\bfixed\b/;
+const BOTTOM_OFFSET_RE = /bottom-\S|bottom:\s*['"`]/;
+
+interface Hit { file: string; lineNumber: number; line: string }
+
+function findFixedBottomLines(): Hit[] {
+  const hits: Hit[] = [];
+  for (const file of listSourceFiles(SRC_ROOT)) {
+    const lines = readFileSync(file, 'utf-8').split('\n');
+    lines.forEach((line, idx) => {
+      if (FIXED_LINE_RE.test(line) && BOTTOM_OFFSET_RE.test(line)) {
+        hits.push({ file: file.replace(SRC_ROOT, ''), lineNumber: idx + 1, line });
+      }
+    });
+  }
+  return hits;
+}
+
+// story #3756 처방 밖 — 뷰포트 «전폭»으로 걸치는 하단 바/시트는 탭 바와 "겹쳐 가림" 문제의
+// 그 클래스가 아니다(전폭이라 탭 바 자체를 대체하거나 그 위에 늘 온전히 얹힌다, 우하단
+// «코너» 요소가 아님). 조용히 빼지 않고 파일+이유를 명시 등재한다.
+const FULL_WIDTH_ALLOWLIST: Record<string, string> = {
+  'components/ui/sheet.tsx':
+    'data-[side=bottom]:bottom-0 — inset-x-0 전폭 바텀시트 프리미티브(코너 요소 아님)',
+  'components/docs/doc-editor.tsx':
+    'fixed bottom-0 left-0 right-0 — 모바일 전폭 하단 편집 툴바(md:hidden), 코너 요소 아님',
+};
+
+const DOCK_INSET_VAR = '--bottom-dock-inset';
+
+describe('우하단 fixed 요소는 --bottom-dock-inset을 통해서만 bottom을 잡는다(story #3756)', () => {
+  const hits = findFixedBottomLines();
+
+  it('스캔 대상이 비어있지 않다(가드 자체가 죽은 채 항상 통과하는 것 방지)', () => {
+    expect(hits.length).toBeGreaterThan(0);
+  });
+
+  it('전폭 allowlist 밖 소비처가 정확히 4곳이다(새 소비처가 생기면 이 가드를 다시 본다)', () => {
+    const nonAllowlisted = hits.filter((h) => !(h.file in FULL_WIDTH_ALLOWLIST));
+    const files = [...new Set(nonAllowlisted.map((h) => h.file))].sort();
+    expect(files).toEqual([
+      'components/kanban/kanban-board.tsx',
+      'components/support-widget/support-widget-launcher.tsx',
+      'components/ui/toast.tsx',
+    ].sort());
+    expect(nonAllowlisted.length).toBe(4); // toast 1 + launcher 2(버튼+패널) + kanban 1
+  });
+
+  it('allowlist 밖 매치는 전부 --bottom-dock-inset을 참조한다(허용목록 0 — 숫자 재추측 없음)', () => {
+    const nonAllowlisted = hits.filter((h) => !(h.file in FULL_WIDTH_ALLOWLIST));
+    for (const hit of nonAllowlisted) {
+      expect(
+        hit.line.includes(DOCK_INSET_VAR),
+        `${hit.file}:${hit.lineNumber}가 --bottom-dock-inset을 참조하지 않음 — 숫자를 다시 추측한 것: ${hit.line}`,
+      ).toBe(true);
+    }
+  });
+
+  it('allowlist에 등재된 파일은 실제로 그 파일에 매치가 있다(죽은 allowlist 항목 방지)', () => {
+    const matchedFiles = new Set(hits.map((h) => h.file));
+    for (const file of Object.keys(FULL_WIDTH_ALLOWLIST)) {
+      expect(matchedFiles.has(file), `allowlist 항목 '${file}'이 실제 스캔에서 안 잡힘 — 죽은 항목`).toBe(true);
+    }
+  });
+});
+
+// ── 양성대조(AC3③) — 가드 자체가 실제로 걸리는지 자가 증명. 변수 참조 하나를 지운 합성
+// 문자열을 넣어 checker가 실제로 빨간불을 낸다는 것을 고정한다(mutation-kill의 반증 —
+// 코드에서 실제로 var(--bottom-dock-inset)를 지워보고 이 가드가 RED가 되는 것도 PR 작업
+// 中 직접 실측 확認했다: toast.tsx의 그 참조를 임시로 걷어내면 이 파일의 세 번째 it()가
+// 정확히 그 이유로 실패했다).
+describe('가드 자체의 탐지력(양성대조)', () => {
+  it('--bottom-dock-inset 참조가 없는 fixed+bottom 라인은 FIXED_LINE_RE·BOTTOM_OFFSET_RE 둘 다 걸리고, DOCK_INSET_VAR 포함 검사에서 false가 나온다', () => {
+    const syntheticBadLine = '    <div className="fixed right-4 bottom-4 z-50">';
+    expect(FIXED_LINE_RE.test(syntheticBadLine)).toBe(true);
+    expect(BOTTOM_OFFSET_RE.test(syntheticBadLine)).toBe(true);
+    expect(syntheticBadLine.includes(DOCK_INSET_VAR)).toBe(false);
+  });
+});

--- a/apps/web/src/bottom-dock-inset.guard.test.ts
+++ b/apps/web/src/bottom-dock-inset.guard.test.ts
@@ -56,9 +56,16 @@ function findFixedBottomLines(): Hit[] {
 // «코너» 요소가 아님). 조용히 빼지 않고 파일+이유를 명시 등재한다.
 const FULL_WIDTH_ALLOWLIST: Record<string, string> = {
   'components/ui/sheet.tsx':
-    'data-[side=bottom]:bottom-0 — inset-x-0 전폭 바텀시트 프리미티브(코너 요소 아님)',
+    'data-[side=bottom]:bottom-0 — inset-x-0 전폭 바텀시트 프리미티브. 이 카드의 축은 '
+    + '"탭 바를 덮나"인데, 시트는 뜨는 동안 탭 바 자체가 뒤에 있어도 화면 전체를 이미 '
+    + '전경으로 덮는 모달류라(z-50, 배경 스크림 동반) "탭 바가 가려지는가"라는 질문 자체가 '
+    + '무의미하다(가려지는 게 그 UI의 목적).',
   'components/docs/doc-editor.tsx':
-    'fixed bottom-0 left-0 right-0 — 모바일 전폭 하단 편집 툴바(md:hidden), 코너 요소 아님',
+    'fixed bottom-0 left-0 right-0 — 모바일 문서 편집기의 하단 툴바(md:hidden)는 '
+    + '`isFocused`(에디터 포커스, 즉 온스크린 키보드가 올라온 상태)일 때만 translate-y-0로 '
+    + '뜬다. 포커스 中엔 키보드 자체가 화면 하단을 이미 물리적으로 가리는 상태라 그 아래 '
+    + '있던 탭 바는 그 순간 애초에 눌리는 대상이 아니다 — "고정 요소가 탭 바를 새로 가린다"는 '
+    + '이 카드의 결함 축이 성립하지 않는다(키보드가 이미 가리고 있던 자리) — 이 카드 밖.',
 };
 
 const DOCK_INSET_VAR = '--bottom-dock-inset';

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1208,7 +1208,9 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
         // story #3007(로드맵 P2·PR-E, L1) — 토스트성 배너는 floating이라 --elev-overlay.
         // story 3466 후속(무효 유틸 4곳) — text-destructive-foreground는 이 테마에
         // 매핑이 없는 no-op(라이트 3.55·다크 3.00, AA 미달). trust-seal.tsx 선례.
-        <div key={transitionErrorNonce} role="alert" aria-live="assertive" aria-atomic="true" className="fixed bottom-4 right-4 z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-white dark:text-proof-bg shadow-[var(--elev-overlay)]">
+        // story #3756 — bottom = 셸 소유 --bottom-dock-inset 참조(toast.tsx와 동일 formula) —
+        // 탭 바 높이를 모르고 뷰포트 바닥 기준 bottom-4로 떠 넷째 탭을 덮던 결함 계열.
+        <div key={transitionErrorNonce} role="alert" aria-live="assertive" aria-atomic="true" className="fixed right-4 bottom-[calc(var(--bottom-dock-inset)+1rem)] z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-white dark:text-proof-bg shadow-[var(--elev-overlay)]">
           ⚠️ {transitionError}
         </div>
       )}

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -133,7 +133,10 @@ export function MobileTabBar({ chatUnreadTotal }: { chatUnreadTotal: number }) {
   return (
     <nav
       aria-label={t('navLabel')}
-      className="flex h-16 shrink-0 border-t border-border bg-card lg:hidden"
+      // story #3756 — 탭 바 높이는 이제 globals.css `.dashboard-shell-root`가 소유한
+      // `--mobile-tab-bar-h`(4rem, 기존 h-16과 동일값) 토큰을 참조한다(두 벌 상수 금지 —
+      // 이 값을 바꾸려면 globals.css 그 한 줄만 고치면 우하단 fixed 요소들의 인셋도 함께 맞다).
+      className="flex h-[var(--mobile-tab-bar-h)] shrink-0 border-t border-border bg-card lg:hidden"
     >
       {TABS.map(({ key, href, icon: Icon, labelKey }) => {
         const active = key === activeKey;

--- a/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
@@ -227,13 +227,13 @@ describe('SupportWidgetLauncher — story #3260 3차(3274로 우측 이전): 모
     expect(container.querySelector('[role="dialog"]')).toBeNull();
   });
 
-  it('모바일 + 채팅-리스트(/chats, id 없음) — 기존처럼 bottom-20에 그대로 뜬다', async () => {
+  it('모바일 + 채팅-리스트(/chats, id 없음) — 기존처럼 --bottom-dock-inset 기준 위치에 그대로 뜬다', async () => {
     setInnerWidth(500);
     usePathnameMock.mockReturnValue('/chats');
     await mount();
     const btn = container.querySelector('button') as HTMLButtonElement;
     expect(btn).toBeTruthy();
-    expect(btn.className).toContain('bottom-20');
+    expect(btn.className).toContain('bottom-[calc(var(--bottom-dock-inset)+5rem)]');
   });
 
   it('모바일 + 채팅과 무관한 라우트(/board) — 기존처럼 그대로 뜬다(채팅-상세만 예외)', async () => {
@@ -253,15 +253,17 @@ describe('SupportWidgetLauncher — story #3260 3차(3274로 우측 이전): 모
 });
 
 // story #3274(선생님 확定 2026-09-01) — 우하단 배치+토스트/저장오류 배너 corner 회피.
-// 사이드바 회피 로직을 걷은 대신 새 충돌축(toast.tsx·kanban-board.tsx 둘 다
-// `fixed bottom-4 right-4`)을 bottom-20으로 넘어선다 — 반응형 분기 없이 모바일/데스크톱
-// 동일 값(모바일=탭바 회피와 우연히 같은 값을 재사용).
+// 사이드바 회피 로직을 걷은 대신 새 충돌축(toast.tsx·kanban-board.tsx 둘 다 `fixed right-4`)을
+// 여유값으로 넘어선다 — 반응형 분기 없이 모바일/데스크톱 동일 formula.
+// story #3756 — 고정 bottom-20(5rem)이 safe-area-inset-bottom을 몰라 노치 기기에서 탭 바
+// 실 점유 구간을 못 따라갔다(토스트가 넷째 탭을 덮는 사고) — 이제 셸 소유
+// --bottom-dock-inset(탭 바 높이+safe-area, lg 이상은 safe-area만) 위에 같은 5rem 여유를 얹는다.
 describe('SupportWidgetLauncher — story #3274: 우하단 배치+토스트 corner 회피', () => {
-  it('데스크톱 — right-5·bottom-20 클래스로 뜬다(사이드바 관련 인라인 style 없음)', async () => {
+  it('데스크톱 — right-5·--bottom-dock-inset 기준 클래스로 뜬다(사이드바 관련 인라인 style 없음)', async () => {
     await mount();
     const btn = container.querySelector('button') as HTMLButtonElement;
     expect(btn.className).toContain('right-5');
-    expect(btn.className).toContain('bottom-20');
+    expect(btn.className).toContain('bottom-[calc(var(--bottom-dock-inset)+5rem)]');
     expect(btn.style.left).toBe('');
     expect(btn.style.right).toBe('');
   });

--- a/apps/web/src/components/support-widget/support-widget-launcher.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.tsx
@@ -25,9 +25,16 @@ const PANEL_ID = 'support-widget-panel';
  * 이유는 우측으로 옮기면 좌측 고정 사이드바와 애초에 안 겹쳐 그 회피 자체가 무의미해졌기
  * 때문(사이드바가 사라진 게 아니라 이 컴포넌트가 반대편으로 이동해 그 축이 통째로 안 걸리게
  * 됨). 새 충돌축은 우하단을 이미 쓰는 toast.tsx(`fixed right-4`)·kanban-board.tsx 저장오류
- * 배너(`fixed bottom-4 right-4`) — `bottom-20`(5rem)로 그 corner를 넘어 뜬다. 이 값은 모바일
- * MobileTabBar(h-16=64px) 회피에 쓰이던 것과 같은 값을 재사용한다(모바일=탭바, 데스크톱=
- * 토스트/배너 — 우연히 같은 오프셋이 둘 다 만족시켜 반응형 분기 자체가 불필요해졌다).
+ * 배너(`fixed right-4`) — 그 corner를 넘어 뜬다.
+ *
+ * story #3756 — 예전엔 `bottom-20`(5rem 고정)이 "모바일 탭 바 회피"와 "데스크톱 토스트/배너
+ * 회피" 둘 다를 우연히 만족시킨다고 여겼으나, safe-area-inset-bottom을 안 더해 노치 기기에서
+ * 실제 탭 바 점유 구간(4rem+safe-area)을 못 따라가 토스트가 넷째 탭을 덮는 사고가 났다(실측).
+ * 지금은 셸 소유 `--bottom-dock-inset`(globals.css `.dashboard-shell-root`, 탭 바 높이+
+ * safe-area — lg 이상은 safe-area만) 위에 이 런처 고유의 여유(5rem, toast.tsx 기준선보다
+ * 위)를 얹는다 — `bottom-[calc(var(--bottom-dock-inset)+5rem)]`. 패널은 그 위(런처+3.75rem,
+ * 기존 8.75rem-5rem 간격 그대로 보존)만 다시 참조 — 숫자 자체는 기존 시각 간격을 유지하되
+ * 원천이 이제 안전-영역을 아는 한 변수다.
  *
  * 마운트 자리는 apps/web/src/app/dashboard/dashboard-shell.tsx의 `<SidebarProvider>` 안
  * (ShellBody와 형제) — `useSidebar().isMobile`(모바일 채팅-상세 판정에 여전히 필요)을
@@ -109,7 +116,7 @@ export function SupportWidgetLauncher() {
         aria-expanded={open}
         aria-controls={PANEL_ID}
         aria-label={open ? t('closeLabel') : t('launcherLabel')}
-        className="fixed bottom-20 right-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+        className="fixed right-5 bottom-[calc(var(--bottom-dock-inset)+5rem)] z-40 flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
       >
         {open ? <X className="h-5 w-5" aria-hidden /> : <LifeBuoy className="h-5 w-5" aria-hidden />}
       </button>
@@ -118,7 +125,7 @@ export function SupportWidgetLauncher() {
           id={PANEL_ID}
           role="dialog"
           aria-label={t('panelTitle')}
-          className="fixed bottom-[8.75rem] right-5 z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl"
+          className="fixed right-5 bottom-[calc(var(--bottom-dock-inset)+8.75rem)] z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl"
         >
           <SupportWidgetPanelHeader onClose={() => setOpen(false)} />
           <SupportWidgetPanelBody session={session} />

--- a/apps/web/src/components/support-widget/support-widget-launcher.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.tsx
@@ -121,11 +121,18 @@ export function SupportWidgetLauncher() {
         {open ? <X className="h-5 w-5" aria-hidden /> : <LifeBuoy className="h-5 w-5" aria-hidden />}
       </button>
       {open ? (
+        // story #3756(카디르 QA·codex 동일 정적계산) — bottom은 --bottom-dock-inset만큼
+        // 올랐는데 높이 상한(11rem)이 그 인상분을 안 빼 375×667(iPhone SE급)에서 패널 상단이
+        // 화면 밖(-17px)으로 밀려났다. 11rem = 패널 bottom 오프셋(8.75rem) + 상단 여백(2.25rem)
+        // — bottom이 --bottom-dock-inset만큼 더 올라간 만큼 상한도 똑같이 그 값을 뺀다(100vh -
+        // 11rem - var(--bottom-dock-inset)). lg 이상(dock-inset=0)에선 기존 계산과 완전히
+        // 동일(회귀 0) — 값은 그대로, 원천만 인셋 인지로 교체(story #3759에서 컬럼 재설계 시
+        // 이 수 자체가 걷힐 예정, 임시 처방).
         <div
           id={PANEL_ID}
           role="dialog"
           aria-label={t('panelTitle')}
-          className="fixed right-5 bottom-[calc(var(--bottom-dock-inset)+8.75rem)] z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl"
+          className="fixed right-5 bottom-[calc(var(--bottom-dock-inset)+8.75rem)] z-40 flex h-[min(480px,calc(100vh-11rem-var(--bottom-dock-inset)))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl"
         >
           <SupportWidgetPanelHeader onClose={() => setOpen(false)} />
           <SupportWidgetPanelBody session={session} />

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -120,7 +120,11 @@ export function ToastContainer({
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed right-4 z-50 flex flex-col gap-2" style={{ bottom: 'max(1rem, calc(env(safe-area-inset-bottom) + 1rem))' }}>
+    // story #3756 — bottom은 셸 소유 --bottom-dock-inset(dashboard-shell.tsx 하위에서만
+    // 값이 세워짐, globals.css `.dashboard-shell-root`)을 참조한다. 이전엔 이 컴포넌트가
+    // safe-area-inset-bottom만 알고 모바일 탭 바 높이(4rem)를 몰라, 탭 바 위에 뜬 토스트가
+    // 넷째 탭을 덮었다 — 이제 lg 미만에서는 그 값이 자동으로 더해진다(추측 0).
+    <div className="fixed right-4 bottom-[calc(var(--bottom-dock-inset)+1rem)] z-50 flex flex-col gap-2">
       {toasts.map((t) => (
         <Toast key={t.id} item={t} onDismiss={onDismiss} />
       ))}


### PR DESCRIPTION
## 요약
토스트(`toast.tsx`)·지원 위젯 런처/패널(`support-widget-launcher.tsx`)·칸반
저장오류 배너(`kanban-board.tsx`) 넷 다 모바일 하단 탭 바(`mobile-tab-bar.tsx`,
`h-16`=4rem)의 존재를 모르고 뷰포트 바닥 기준 숫자를 각자 추측해 `bottom`을
잡았다. 토스트는 `safe-area-inset-bottom`만 알고 탭 바 높이를 몰라, 노치
기기의 실제 탭 바 점유 구간(4rem+safe-area)을 못 따라가 넷째 탭 「전체」를
덮었다. 런처는 `bottom-20`(5rem 고정)이 같은 이유로 safe-area를 안 더해
같은 결함 계열.

## 처방
`dashboard-shell.tsx`의 `SidebarProvider` 래퍼에 `dashboard-shell-root`
클래스를 부착 — `globals.css`가 그 클래스 스코프에 `--bottom-dock-inset`
(lg 미만은 탭 바 높이+safe-area, lg 이상은 safe-area만)과
`--mobile-tab-bar-h`(4rem, 탭 바 자신도 이 토큰을 `h-[var(--mobile-tab-bar-h)]`
로 참조 — 두 벌 상수 금지)를 소유한다. 우하단 fixed 요소 **4곳**(토스트·런처
버튼·런처 패널·칸반 배너) 전부가 Tailwind 임의값 클래스
(`bottom-[calc(var(--bottom-dock-inset)+Nrem)]`)로 그 변수만 참조 — 숫자
재추측 0. 데스크톱(lg) 값은 기존과 정확히 동일하게 보존(런처 5rem·패널
8.75rem 등 기존 간격 그대로, 원천만 안전-영역 인지로 교체).

전폭으로 걸치는 `sheet.tsx`(바텀시트)·`doc-editor.tsx`(모바일 편집 툴바)는
"우하단 코너" 요소가 아니라 명시 제외(가드 테스트에 사유와 함께 등재).

## 검증
- `bottom-dock-inset.guard.test.ts`(신규) — 우하단 fixed 요소 전수 스캔(허용
  목록 0, 전폭 2곳만 명시 제외+사유), 4곳 전부 `--bottom-dock-inset` 참조
  확認. 뮤테이션킬: `toast.tsx` 참조를 임시 제거 → 정확한 이유로 RED → 원복
  → GREEN
- `bottom-dock-inset-source.pin.test.ts`(신규) — 셸이 변수를 실제로 세우는
  3곳(클래스 부착·토큰 소비·CSS 정의+media query) 핀. 뮤테이션킬:
  `dashboard-shell-root` 클래스 제거 → RED → 원복 → GREEN
- 기존 `support-widget-launcher.test.tsx` 2개 테스트(`bottom-20` 하드코딩
  pin)를 새 클래스명으로 갱신(의도된 값 변경 반영, 회귀 아님)
- **라이브 CSS 역학 검증**(headless 브라우저, 실제 계산값): 모바일 390px에서
  toast bottom-edge(764px) < 탭바 top(780px)로 안 덮음 확認(구코드였다면
  828px로 탭바 속까지 파고듦 — 재현+수정 대조). 데스크톱 1280px에서
  `--bottom-dock-inset`=0px로 toast/launcher가 기존과 완전히 동일한 픽셀
  (16px/80px)로 폴백 — **데스크톱 회귀 0**
- `pnpm vitest run` 전체 **7230/7230 PASS** · `tsc --noEmit` clean · `pnpm lint`
  0 error(기존 무관 파일 warning 6개는 이 PR 범위 밖, 내가 만진 파일은 0) ·
  `pnpm build` 성공

## 범위 밖(다음 라운드 후보)
토스트-런처 동시노출 시 "되돌리기"↔런처 1px 근접(스토리 원문 AC3, 유나 定
비켜남 규칙을 명시 요구) — 데스크톱 기존 간격을 그대로 보존해 회귀는 없으나,
동적 충돌회피(토스트 표시 中 런처 이동) 메커니즘 자체는 새 cross-component
상태(어떤 토스트가 떠 있는지 공유하는 신호)가 필요해 이번 PR에서 발명하지
않았다. 유나 픽셀 라이브 회차(AC4)에서 확認 뒤 필요시 CHANGES로 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)