### PR TITLE
[SID:3760] App Router 라우트 파일 named export 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1428,6 +1428,14 @@ jobs:
       - name: "Verify i18n keys referenced in code exist in ko/en (story #5ead8723 regression guard)"
         run: pnpm --filter web verify:i18n-keys-exist
 
+      # story #3760 회귀가드: App Router 라우트 파일(page/layout/template/loading/error/
+      # not-found/default.tsx)의 named export가 Next.js 화이트리스트 밖이면 next build에서만
+      # 죽는다(tsc·vitest는 이 계약을 모른다 — 실물: #4105, publishHistorySenderLabel을
+      # page.tsx에 named export로 뒀다가 build만 빨강). route.ts는 대상 밖(HTTP 메서드 export가
+      # 정상).
+      - name: "Verify App Router route file named exports are whitelisted (story #3760 regression guard)"
+        run: pnpm --filter web verify:route-file-exports
+
       # story #3486→#3493 회귀가드: 브라우저 로케일 의존 날짜 toLocaleString/
       # toLocaleDateString/toLocaleTimeString이 새로 생기면 실패한다 — 3436 묶음 8
       # 정본(formatRelativeTime/formatScheduledAt)이 있는데도 계속 새던 자리(유나

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "verify:no-duplicate-i18n-keys": "tsx scripts/verify-no-duplicate-i18n-keys.ts",
     "verify:no-hanja-in-i18n": "tsx scripts/verify-no-hanja-in-i18n.ts",
     "verify:i18n-keys-exist": "tsx scripts/verify-i18n-keys-exist.ts",
+    "verify:route-file-exports": "tsx scripts/verify-route-file-exports.ts",
     "verify:no-new-raw-button": "tsx scripts/verify-no-new-raw-button.ts",
     "verify:ci-wires-all-verify-scripts": "tsx scripts/verify-ci-wires-all-verify-scripts.ts",
     "verify:no-handrolled-card": "tsx scripts/verify-no-handrolled-card.ts",

--- a/apps/web/scripts/verify-route-file-exports.test.ts
+++ b/apps/web/scripts/verify-route-file-exports.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { APP_ROUTER_EXPORT_WHITELIST, ROUTE_FILE_BASENAME_RE, scanFileContent, scanRepo } from './verify-route-file-exports';
+
+const APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/app');
+
+describe('ROUTE_FILE_BASENAME_RE — story #3760 AC1', () => {
+  it('page/layout/template/loading/error/not-found/default.tsx 전부 매치한다', () => {
+    for (const name of ['page.tsx', 'layout.tsx', 'template.tsx', 'loading.tsx', 'error.tsx', 'not-found.tsx', 'default.tsx']) {
+      expect(ROUTE_FILE_BASENAME_RE.test(name)).toBe(true);
+    }
+  });
+
+  // route.ts는 HTTP 메서드 named export가 정상 계약이라 이 가드의 대상 밖이어야 한다.
+  it('route.ts는 매치하지 않는다(스캔 대상 밖 — HTTP 메서드 export가 정상)', () => {
+    expect(ROUTE_FILE_BASENAME_RE.test('route.ts')).toBe(false);
+  });
+
+  it('무관 파일명은 매치하지 않는다', () => {
+    expect(ROUTE_FILE_BASENAME_RE.test('component.tsx')).toBe(false);
+    expect(ROUTE_FILE_BASENAME_RE.test('page.test.tsx')).toBe(false);
+  });
+});
+
+describe('scanFileContent — story #3760 AC1/AC2(셀프테스트)', () => {
+  // 양성대조(AC2) — 화이트리스트 밖 named export(#4105 실사고 재현: publishHistorySenderLabel류
+  // 헬퍼)는 반드시 RED여야 한다.
+  it('⭐화이트리스트 밖 named export function → RED(#4105 실사고 재현)', () => {
+    const src = `
+      export default function Page() { return null; }
+      export function helper() { return 1; }
+    `;
+    const violations = scanFileContent(src, 'fake/page.tsx');
+    expect(violations).toEqual([{ file: 'fake/page.tsx', line: 3, name: 'helper' }]);
+  });
+
+  it('⭐화이트리스트 밖 named export const → RED', () => {
+    const src = `
+      export default function Page() { return null; }
+      export const notAllowed = 42;
+    `;
+    const violations = scanFileContent(src, 'fake/page.tsx');
+    expect(violations).toEqual([{ file: 'fake/page.tsx', line: 3, name: 'notAllowed' }]);
+  });
+
+  // 음성대조(AC2) — Next.js 화이트리스트 4종(metadata·revalidate·viewport·generateMetadata)은
+  // 전부 GREEN이어야 한다(지금 develop의 실제 9건과 동형).
+  it('metadata/revalidate/viewport/generateMetadata → 전부 GREEN(위반 0)', () => {
+    const src = `
+      export const metadata = { title: 'x' };
+      export const revalidate = 300;
+      export const viewport = { width: 'device-width' };
+      export async function generateMetadata() { return {}; }
+      export default function Page() { return null; }
+    `;
+    expect(scanFileContent(src, 'fake/page.tsx')).toEqual([]);
+  });
+
+  it('나머지 화이트리스트(dynamic·dynamicParams·fetchCache·runtime·preferredRegion·maxDuration·generateStaticParams·experimental_ppr·generateViewport) 전부 GREEN', () => {
+    const src = `
+      export const dynamic = 'force-static';
+      export const dynamicParams = true;
+      export const fetchCache = 'auto';
+      export const runtime = 'nodejs';
+      export const preferredRegion = 'auto';
+      export const maxDuration = 5;
+      export async function generateStaticParams() { return []; }
+      export const experimental_ppr = true;
+      export function generateViewport() { return {}; }
+    `;
+    expect(scanFileContent(src, 'fake/page.tsx')).toEqual([]);
+  });
+
+  // 재수출 형(AC2) — `export { x }`가 화이트리스트 밖 이름이면 RED, 안이면 GREEN. 재명명
+  // (`export { y as metadata }`)은 "밖에서 보이는 이름"(metadata) 기준으로 판정한다.
+  it('⭐export { x } 재수출 — 화이트리스트 밖이면 RED', () => {
+    const src = `
+      const helper = () => 1;
+      export { helper };
+      export default function Page() { return null; }
+    `;
+    const violations = scanFileContent(src, 'fake/page.tsx');
+    expect(violations).toEqual([{ file: 'fake/page.tsx', line: 3, name: 'helper' }]);
+  });
+
+  it('export { x as metadata } 재명명 — 밖에서 보이는 이름이 화이트리스트면 GREEN', () => {
+    const src = `
+      const meta = { title: 'x' };
+      export { meta as metadata };
+      export default function Page() { return null; }
+    `;
+    expect(scanFileContent(src, 'fake/page.tsx')).toEqual([]);
+  });
+
+  // export * from(AC2) — 타깃을 resolve 안 하므로 뭐가 나가는지 모른다. fail-closed RED.
+  it('⭐export * from — 재수출 대상을 모르므로 fail-closed RED', () => {
+    const src = `
+      export * from './helpers';
+      export default function Page() { return null; }
+    `;
+    const violations = scanFileContent(src, 'fake/page.tsx');
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.file).toBe('fake/page.tsx');
+  });
+
+  it('export default function/class/화살표(ExportAssignment) 전부 "default" 이름으로 화이트리스트 통과', () => {
+    expect(scanFileContent('export default function Page() { return null; }', 'a.tsx')).toEqual([]);
+    expect(scanFileContent('export default class Page {}', 'b.tsx')).toEqual([]);
+    expect(scanFileContent('const Page = () => null;\nexport default Page;', 'c.tsx')).toEqual([]);
+  });
+
+  // 주석 속 가짜 export — AST가 주석을 노드로 안 보므로 오탐 0(구조적, 별도 필터 불요).
+  it('⭐주석 안의 export는 안 잡힌다(오탐 0 — AST가 comment를 trivia로 자연 배제)', () => {
+    const src = `
+      // export function fakeCommentExport() {}
+      /* export const alsoFake = 1; */
+      export default function Page() { return null; }
+    `;
+    expect(scanFileContent(src, 'fake/page.tsx')).toEqual([]);
+  });
+
+  it('파싱 실패(문법 오류)면 조용히 통과하지 않고 throw한다(story #2710 AC4 동형)', () => {
+    expect(() => scanFileContent('export function {{{ broken', 'broken.tsx')).toThrow(/파싱 실패/);
+  });
+});
+
+describe('scanRepo — story #3760 AC1/AC4(실 트리 실행)', () => {
+  // AC4 — 지금 develop 위반 0건(PO 실측 2026-09-09 23:37Z: 파일 100·named export 9·전부
+  // 화이트리스트) pin. 되돌리면(화이트리스트 밖 export가 실 트리에 들어오면) RED.
+  it('실 트리(apps/web/src/app) — 라우트 파일 100개·위반 0건', () => {
+    const { violations, fileCount } = scanRepo(APP_ROOT);
+    expect(fileCount).toBe(100);
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('APP_ROUTER_EXPORT_WHITELIST — story #3760 AC1', () => {
+  it('카드 본문이 명시한 14개와 정확히 일치한다(수 자체가 회귀가드 — 조용히 늘거나 줄면 걸림)', () => {
+    expect([...APP_ROUTER_EXPORT_WHITELIST].sort()).toEqual([
+      'default',
+      'dynamic',
+      'dynamicParams',
+      'experimental_ppr',
+      'fetchCache',
+      'generateMetadata',
+      'generateStaticParams',
+      'generateViewport',
+      'maxDuration',
+      'metadata',
+      'preferredRegion',
+      'revalidate',
+      'runtime',
+      'viewport',
+    ]);
+  });
+});

--- a/apps/web/scripts/verify-route-file-exports.test.ts
+++ b/apps/web/scripts/verify-route-file-exports.test.ts
@@ -72,6 +72,50 @@ describe('scanFileContent — story #3760 AC1/AC2(셀프테스트)', () => {
     expect(scanFileContent(src, 'fake/page.tsx')).toEqual([]);
   });
 
+  // story #3760 CHANGES(카디르 QA, #4108) — export type/interface는 «놓친» 게 아니라
+  // 의도된 정책(타입 전용 export는 컴파일 시 완전히 지워져 Next가 검사하는 런타임 export
+  // 객체에 애초에 안 나타난다)이다. 이전 diff엔 이 정책이 셀프테스트로 박혀있지 않아
+  // "잡든 안 잡든 표시가 안 됐다" — 이 테스트가 그 정책을 명시로 고정한다.
+  it('export type/export interface는 정책상 무시된다(GREEN — 타입 전용은 런타임 export 객체에 안 나타남)', () => {
+    const src = `
+      export type PageProps = { params: { id: string } };
+      export interface Metadata2 { title: string; }
+      export default function Page() { return null; }
+    `;
+    expect(scanFileContent(src, 'fake/page.tsx')).toEqual([]);
+  });
+
+  // story #3760 CHANGES(카디르 QA, #4108) — export enum은 타입이 아니라 런타임 객체(값)로
+  // 컴파일된다 — export type/interface와 다른 축, 화이트리스트 밖이면 잡혀야 한다.
+  it('⭐export enum(런타임 객체) — 화이트리스트 밖이면 RED', () => {
+    const src = `
+      export enum Status { Draft, Published }
+      export default function Page() { return null; }
+    `;
+    const violations = scanFileContent(src, 'fake/page.tsx');
+    expect(violations).toEqual([{ file: 'fake/page.tsx', line: 2, name: 'Status' }]);
+  });
+
+  // story #3760 CHANGES(카디르 QA, #4108) — `export * as ns from '...'`은 `export * from`
+  // (타깃을 못 읽어 fail-closed)과 다르다: 로컬 이름(ns)이 정적으로 있으므로 화이트리스트와
+  // 직접 대조 가능하다 — 화이트리스트 밖이면 RED.
+  it('⭐export * as ns from(네임스페이스 값 재수출) — 화이트리스트 밖이면 RED', () => {
+    const src = `
+      export * as helpers from './helpers';
+      export default function Page() { return null; }
+    `;
+    const violations = scanFileContent(src, 'fake/page.tsx');
+    expect(violations).toEqual([{ file: 'fake/page.tsx', line: 2, name: 'helpers' }]);
+  });
+
+  it('export * as metadata from — 이름이 화이트리스트 안이면 GREEN(이례적이지만 정직하게 통과)', () => {
+    const src = `
+      export * as metadata from './metadata-namespace';
+      export default function Page() { return null; }
+    `;
+    expect(scanFileContent(src, 'fake/page.tsx')).toEqual([]);
+  });
+
   // 재수출 형(AC2) — `export { x }`가 화이트리스트 밖 이름이면 RED, 안이면 GREEN. 재명명
   // (`export { y as metadata }`)은 "밖에서 보이는 이름"(metadata) 기준으로 판정한다.
   it('⭐export { x } 재수출 — 화이트리스트 밖이면 RED', () => {

--- a/apps/web/scripts/verify-route-file-exports.ts
+++ b/apps/web/scripts/verify-route-file-exports.ts
@@ -1,0 +1,217 @@
+/**
+ * story #3760(가드·별건 ⑰) — App Router 라우트 파일(page/layout/template/loading/error/
+ * not-found/default.tsx)의 named export가 Next.js 화이트리스트 밖이면 `next build`에서만
+ * 죽는다(`tsc`·`vitest`는 이 계약을 모른다 — 실물: #4105 21:18Z, `organization/events/
+ * page.tsx`에 `publishHistorySenderLabel`을 named export로 두자 build만 빨강,
+ * "\"publishHistorySenderLabel\" is not a valid Page export field" — [[feedback_where_you_ran_the_check_is_also_a_value]]).
+ *
+ * ## 기전 — AST(verify-i18n-keys-exist.ts·verify-no-handrolled-card.ts와 동형, 새 기전
+ * 발명 금지) — 정규식 줄 스캔이 아니라 TypeScript AST를 walk한다. `route.ts`는 스캔 밖
+ * (HTTP 메서드 named export가 그 파일 형에선 정상 계약이다 — page/layout류와 다른 파일
+ * 형).
+ *
+ * ## 화이트리스트(Next.js App Router route export contract, story 카드 본문 명시)
+ * `default`·`metadata`·`generateMetadata`·`viewport`·`generateViewport`·`revalidate`·
+ * `dynamic`·`dynamicParams`·`fetchCache`·`runtime`·`preferredRegion`·`maxDuration`·
+ * `generateStaticParams`·`experimental_ppr`.
+ *
+ * ## 완전성(fail-closed) — [[feedback_a_guard_iterating_over_extracted_not_expected_fails_silent]]
+ * glob으로 센 파일 수와 실제로 walk한 파일 수가 어긋나면(추출 로직이 일부를 건너뛴 것)
+ * 조용한 통과 대신 죽는다 — «추출된 것만 순회»가 아니라 «기대한 수만큼 순회했는가»를
+ * 스스로 잰다.
+ *
+ * ## `export * from '...'` — 못 판정하면 RED
+ * 와일드카드 재수출은 그 타깃 모듈을 resolve하지 않는 한 실제로 무엇이 나가는지 정적으로
+ * 알 수 없다 — 「모르면 안전하다고 가정」이 아니라 「모르면 위반」으로 fail-closed(이
+ * 파일군 전체의 관례와 동형, cross-module 추론은 하지 않는다).
+ *
+ * ## 못 잡는 것(⚠️)
+ *   ㉠ 동적으로 계산된 export 이름(`export const [computed] = ...`)은 TS 문법상 존재하지
+ *      않으므로 해당 없음.
+ *   ㉡ `.d.ts` 파일은 스캔 대상 glob(`{page,layout,...}.tsx`)에 애초에 안 걸린다.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+export const ROUTE_FILE_BASENAME_RE = /^(page|layout|template|loading|error|not-found|default)\.tsx$/;
+
+export const APP_ROUTER_EXPORT_WHITELIST: ReadonlySet<string> = new Set([
+  'default',
+  'metadata',
+  'generateMetadata',
+  'viewport',
+  'generateViewport',
+  'revalidate',
+  'dynamic',
+  'dynamicParams',
+  'fetchCache',
+  'runtime',
+  'preferredRegion',
+  'maxDuration',
+  'generateStaticParams',
+  'experimental_ppr',
+]);
+
+export interface ExportViolation {
+  file: string;
+  line: number;
+  name: string;
+}
+
+function hasExportModifier(node: ts.HasModifiers): boolean {
+  return (ts.getModifiers(node) ?? []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+}
+
+function hasDefaultModifier(node: ts.HasModifiers): boolean {
+  return (ts.getModifiers(node) ?? []).some((m) => m.kind === ts.SyntaxKind.DefaultKeyword);
+}
+
+// 구조분해 export(`export const { a, b } = obj;`)의 바인딩 이름을 전부 뽑는다 — 라우트
+// 파일에 실측 0건이지만(문법상 가능은 하므로) fail-closed로 각 이름을 개별 판정한다.
+function bindingNames(name: ts.BindingName): string[] {
+  if (ts.isIdentifier(name)) return [name.text];
+  const out: string[] = [];
+  const elements = ts.isObjectBindingPattern(name) ? name.elements : name.elements;
+  for (const el of elements) {
+    if (ts.isBindingElement(el)) out.push(...bindingNames(el.name));
+  }
+  return out;
+}
+
+export function scanFileContent(content: string, file: string): ExportViolation[] {
+  const sf = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const parseDiagnostics = (sf as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics;
+  if (parseDiagnostics === undefined) {
+    throw new Error(
+      `FAIL: ${file} — ts.createSourceFile의 parseDiagnostics 필드가 사라짐(TS 내부 API 변경 의심) — ` +
+        '이 가드의 전제(파싱 실패를 스스로 감지할 수 있다는 전제)가 깨졌다(story #2710 동형).',
+    );
+  }
+  if (parseDiagnostics.length > 0) {
+    throw new Error(
+      `FAIL: ${file} 파싱 실패(${parseDiagnostics.length}건) — 이 가드가 이 파일의 export를 못 읽는다 ` +
+        `(재료 소실을 조용한 통과로 두지 않는다, story #2710 AC4 동형): ` +
+        parseDiagnostics.map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' ')).join('; '),
+    );
+  }
+
+  const violations: ExportViolation[] = [];
+  function report(name: string, node: ts.Node): void {
+    if (APP_ROUTER_EXPORT_WHITELIST.has(name)) return;
+    const line = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+    violations.push({ file, line, name });
+  }
+
+  for (const stmt of sf.statements) {
+    if ((ts.isFunctionDeclaration(stmt) || ts.isClassDeclaration(stmt)) && hasExportModifier(stmt)) {
+      const name = hasDefaultModifier(stmt) ? 'default' : (stmt.name?.text ?? '(anonymous)');
+      report(name, stmt);
+      continue;
+    }
+    if (ts.isVariableStatement(stmt) && hasExportModifier(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        for (const name of bindingNames(decl.name)) report(name, stmt);
+      }
+      continue;
+    }
+    // `export default <expr>;` — FunctionDeclaration/ClassDeclaration이 아닌 형
+    // (화살표 함수·객체 리터럴 등)은 ExportAssignment로 표현된다.
+    if (ts.isExportAssignment(stmt) && !stmt.isExportEquals) {
+      report('default', stmt);
+      continue;
+    }
+    if (ts.isExportDeclaration(stmt)) {
+      if (stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+        for (const spec of stmt.exportClause.elements) {
+          report(spec.name.text, spec); // spec.name = 외부에서 보이는 이름(재명명 후).
+        }
+      } else if (!stmt.exportClause) {
+        // `export * from '...'` — 타깃을 resolve 안 하므로 뭐가 나가는지 모른다 → fail-closed RED.
+        report('* (export * from — 재수출 대상 이름을 정적으로 모름, fail-closed)', stmt);
+      }
+      continue;
+    }
+  }
+
+  return violations;
+}
+
+function walkRouteFiles(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkRouteFiles(full, out);
+    } else if (ROUTE_FILE_BASENAME_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+export interface ScanRepoResult {
+  violations: ExportViolation[];
+  fileCount: number;
+}
+
+const MIN_EXPECTED_FILES = 50;
+
+export function scanRepo(appRoot: string): ScanRepoResult {
+  const files: string[] = [];
+  walkRouteFiles(appRoot, files);
+  if (files.length < MIN_EXPECTED_FILES) {
+    throw new Error(`FAIL: 검사 대상 라우트 파일이 ${files.length}개뿐(appRoot=${appRoot}) — 가드가 헛돌고 있다.`);
+  }
+
+  const violations: ExportViolation[] = [];
+  let scannedCount = 0;
+  for (const abs of files) {
+    const rel = path.relative(appRoot, abs).split(path.sep).join('/');
+    const content = readFileSync(abs, 'utf8');
+    violations.push(...scanFileContent(content, rel));
+    scannedCount += 1;
+  }
+
+  // 완전성(fail-closed) — glob이 찾은 파일 수와 실제로 scanFileContent를 돌린 파일 수가
+  // 어긋나면(예: 루프 중간에 예외를 삼키는 변경이 몰래 들어오면) 위반 0건이 「진짜 0건」이
+  // 아니라 「덜 본 것」일 수 있다 — 그 둘을 구분 못 하게 두지 않는다.
+  if (scannedCount !== files.length) {
+    throw new Error(
+      `FAIL: glob이 찾은 라우트 파일 ${files.length}개 중 ${scannedCount}개만 실제로 스캔됨 — ` +
+        '추출 누락(fail-closed, [[feedback_a_guard_iterating_over_extracted_not_expected_fails_silent]]).',
+    );
+  }
+
+  return { violations, fileCount: files.length };
+}
+
+const APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/app');
+
+function main(): number {
+  const { violations, fileCount } = scanRepo(APP_ROOT);
+
+  console.log(
+    `[가드] App Router 라우트 파일 named export 스캔 — 파일 ${fileCount}개 · ` +
+      `화이트리스트 밖 export ${violations.length}건.`,
+  );
+
+  if (violations.length > 0) {
+    console.error(`\nFAIL: App Router 화이트리스트 밖 named export ${violations.length}건 — next build에서만 죽는다:`);
+    for (const v of violations) console.error(`  ${v.file}:${v.line} "${v.name}"`);
+    console.error(
+      '\n→ page/layout/template/loading/error/not-found/default.tsx는 Next.js가 정한 export 이름만 ' +
+        '허용한다(default·metadata·generateMetadata·viewport·generateViewport·revalidate·dynamic·' +
+        'dynamicParams·fetchCache·runtime·preferredRegion·maxDuration·generateStaticParams·' +
+        'experimental_ppr). 공유 헬퍼는 라우트 파일 밖(lib/ 등)으로 옮길 것.',
+    );
+    return 1;
+  }
+
+  console.log('\nOK: 모든 라우트 파일의 named export가 App Router 화이트리스트 안에 있다.');
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/apps/web/scripts/verify-route-file-exports.ts
+++ b/apps/web/scripts/verify-route-file-exports.ts
@@ -25,6 +25,14 @@
  * 알 수 없다 — 「모르면 안전하다고 가정」이 아니라 「모르면 위반」으로 fail-closed(이
  * 파일군 전체의 관례와 동형, cross-module 추론은 하지 않는다).
  *
+ * ## `export type`/`export interface` — 의도적으로 무시(정책, 사각 아님)
+ * TypeScript의 타입 전용 export는 컴파일 시점에 완전히 지워진다(`isolatedModules` 하의
+ * `export type` 명시형은 물론, 일반 `export interface`도 값으로 내려오지 않는다) — Next.js가
+ * 라우트 export 계약을 검사하는 대상은 «컴파일된 모듈의 런타임 export 객체»이므로 타입
+ * 전용 이름은 애초에 그 객체에 나타나지 않는다. 이 가드가 `ts.isInterfaceDeclaration`·
+ * `ts.isTypeAliasDeclaration`을 walk에서 아예 건드리지 않는 것은 «놓친» 게 아니라 이
+ * 정책을 그대로 구현한 것 — 셀프테스트가 그 정책 자체를 픽스처로 고정한다(아래 참조).
+ *
  * ## 못 잡는 것(⚠️)
  *   ㉠ 동적으로 계산된 export 이름(`export const [computed] = ...`)은 TS 문법상 존재하지
  *      않으므로 해당 없음.
@@ -110,6 +118,13 @@ export function scanFileContent(content: string, file: string): ExportViolation[
       report(name, stmt);
       continue;
     }
+    // story #3760 CHANGES(카디르 QA, #4108) — `export enum X {}`은 타입이 아니라 «런타임
+    // 객체»(값)로 컴파일된다 — export type/interface와 다른 축(위 정책 참조), 이름을
+    // 판정해야 하는 값 export다.
+    if (ts.isEnumDeclaration(stmt) && hasExportModifier(stmt)) {
+      report(stmt.name.text, stmt);
+      continue;
+    }
     if (ts.isVariableStatement(stmt) && hasExportModifier(stmt)) {
       for (const decl of stmt.declarationList.declarations) {
         for (const name of bindingNames(decl.name)) report(name, stmt);
@@ -127,6 +142,11 @@ export function scanFileContent(content: string, file: string): ExportViolation[
         for (const spec of stmt.exportClause.elements) {
           report(spec.name.text, spec); // spec.name = 외부에서 보이는 이름(재명명 후).
         }
+      } else if (stmt.exportClause && ts.isNamespaceExport(stmt.exportClause)) {
+        // story #3760 CHANGES(카디르 QA, #4108) — `export * as ns from '...'`은 `export *
+        // from`(타깃을 못 읽어 fail-closed)과 다르다: 이 형은 로컬 이름(`ns`)이 정적으로
+        // 있으므로 그 이름을 화이트리스트와 직접 대조할 수 있다(모르는 값이 아니다).
+        report(stmt.exportClause.name.text, stmt.exportClause);
       } else if (!stmt.exportClause) {
         // `export * from '...'` — 타깃을 resolve 안 하므로 뭐가 나가는지 모른다 → fail-closed RED.
         report('* (export * from — 재수출 대상 이름을 정적으로 모름, fail-closed)', stmt);


### PR DESCRIPTION
## 변경 사항
App Router 라우트 파일(`page`/`layout`/`template`/`loading`/`error`/`not-found`/`default.tsx`)의 named export가 Next.js 화이트리스트 밖이면 `next build`에서만 죽는 클래스(tsc·vitest는 이 계약을 모름)를 정적 가드로 닫습니다.

**실물 사고**: #4105(2026-09-09 21:18Z) — `organization/events/page.tsx`에 `publishHistorySenderLabel`을 named export로 두자 `next build`만 `"publishHistorySenderLabel" is not a valid Page export field`로 빨강. tsc/vitest는 통과했고, 카디르가 PR CI의 실빌드 스텝에서 직접 잡아 `lib/member-display.ts`로 이관.

## 처방
- `apps/web/scripts/verify-route-file-exports.ts` — TS AST(`verify-i18n-keys-exist.ts`와 동형 관례)로 라우트 파일 전수(100개)의 top-level export를 뽑아 Next App Router 화이트리스트(`default`·`metadata`·`generateMetadata`·`viewport`·`generateViewport`·`revalidate`·`dynamic`·`dynamicParams`·`fetchCache`·`runtime`·`preferredRegion`·`maxDuration`·`generateStaticParams`·`experimental_ppr`)와 대조. `route.ts`는 대상 밖. `export * from`은 재수출 대상을 정적으로 모르므로 fail-closed RED. 완전성 체크(glob 파일 수 == 스캔 수)로 추출 누락을 조용한 통과로 두지 않음.
- `apps/web/scripts/verify-route-file-exports.test.ts` — 셀프테스트 15개(양성/음성대조·재수출·`export * from`·주석 오탐 0·파싱 실패 throw·실 트리 스캔 파일100/위반0 pin).
- `package.json` `verify:route-file-exports` + `ci.yml` 배선(`verify:ci-wires-all-verify-scripts` PASS).

## 검증
- **가드 mutation-kill**: 실 트리에 `#4105`와 동일한 `export function publishHistorySenderLabel(){}`를 `organization/events/page.tsx`에 임시로 넣고 가드 실행 → RED(`(authenticated)/organization/events/page.tsx:873 "publishHistorySenderLabel"`) 확認 후 원복.
- **실빌드 mutation-kill**: 같은 변경으로 `pnpm build` 실행 → 실제로 `next build`가 `"publishHistorySenderLabel" is not a valid Page export field`로 실패(#4105 원 사고 메시지와 정확히 일치) 확認 후 원복.
- 원복 후 `pnpm build` 재실행 → 성공.
- `pnpm vitest run` 7273/7273 통과.
- `pnpm exec tsc --noEmit` 클린.
- `pnpm lint` 0 errors.
- `pnpm run verify:ci-wires-all-verify-scripts` PASS.

### 뮤테이션 출력(가드)
```
[가드] App Router 라우트 파일 named export 스캔 — 파일 100개 · 화이트리스트 밖 export 1건.

FAIL: App Router 화이트리스트 밖 named export 1건 — next build에서만 죽는다:
  (authenticated)/organization/events/page.tsx:873 "publishHistorySenderLabel"
```

### 뮤테이션 출력(실빌드)
```
Failed to type check.

src/app/(authenticated)/organization/events/page.tsx
Type error: Page "src/app/(authenticated)/organization/events/page.tsx" does not match the required types of a Next.js Page.
  "publishHistorySenderLabel" is not a valid Page export field.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)