### PR TITLE
[SID:3762] 설정 admin 탭 로딩 스켈레톤 + 사이드바 스크롤 어포던스

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.test.tsx
@@ -144,3 +144,56 @@ describe('SettingsPage — story #3274: 설정 > 문의 탭', () => {
     expect(container.textContent).not.toContain(koMessages.supportWidget.panelTitle);
   });
 });
+
+// story #3762(그라운딩) — 진짜 결함은 「숨김 탭」이 아니라 adminChecked(/api/me 응답 전)
+// 구간에 걸린 비-숨김 admin 탭들(members·organization·projects 등)이 null로 빠져 레일이
+// 통째로 짧아지는 것이었다(로딩=권한없음 conflation). loadContext()의 /api/me가 아직
+// pending인 순간을 붙잡아 그 구간엔 「자리」(스켈레톤)가 있고, 응답 후에만 진짜 탭/숨김이
+// 확정되는지를 잰다.
+describe('SettingsPage — story #3762: adminChecked 로딩 vs 권한없음 분리', () => {
+  it('/api/me가 아직 pending인 동안 admin 탭 자리에 스켈레톤이 있고 레일이 비지 않는다', async () => {
+    let resolveMe: ((res: { ok: boolean; json: () => Promise<unknown> }) => void) | undefined;
+    const fetchWithAuthMock = vi.fn((url: string) => {
+      if (url === '/api/me') {
+        return new Promise((resolve) => { resolveMe = resolve; });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
+    });
+    vi.doMock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+
+    // /api/me가 아직 안 풀렸다 — adminChecked=false 구간.
+    expect(container.querySelectorAll('[data-testid="settings-tab-skeleton"]').length).toBeGreaterThan(0);
+    expect(container.textContent).not.toContain(koMessages.settings.tabMembers);
+
+    await act(async () => {
+      resolveMe?.({ ok: true, json: async () => ({ data: { role: 'admin', user_id: 'u1' } }) });
+      await Promise.resolve(); await Promise.resolve();
+    });
+
+    // 판정 후엔 스켈레톤이 걷히고 실제 admin 탭이 선다.
+    expect(container.querySelectorAll('[data-testid="settings-tab-skeleton"]').length).toBe(0);
+    expect(container.textContent).toContain(koMessages.settings.tabMembers);
+  });
+
+  // story c4980e70이 org-members 탭을 /organization/members로 승격했는데 트리거만
+  // HIDDEN_SETTINGS_TABS 가드가 빠져 있었다(story #3762 발견) — 판정 후에도 그 트리거
+  // 자체가 렌더되면 안 된다(딥링크는 next.config.ts redirects()가 서버에서 걷어가지만,
+  // Settings 안에서 탭 클릭으로는 여전히 도달 가능했던 별도 결함).
+  it('adminChecked 후에도 org-members 탭 트리거는 뜨지 않는다(승격 완료, 회귀 pin)', async () => {
+    const fetchWithAuthMock = vi.fn((url: string) => {
+      if (url === '/api/me') return Promise.resolve({ ok: true, json: async () => ({ data: { role: 'admin', user_id: 'u1', name: '테스트' } }) });
+      return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
+    });
+    vi.doMock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain(koMessages.settings.tabOrgMembers);
+    // 승격 목적지(조직·프로젝트) 트리거는 정상 렌더 — 가드가 그룹 전체를 과잉 차단하지 않는다.
+    expect(container.textContent).toContain(koMessages.settings.tabOrganization);
+    expect(container.textContent).toContain(koMessages.settings.tabProjects);
+  });
+});

--- a/apps/web/src/app/(authenticated)/settings/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.test.tsx
@@ -177,6 +177,35 @@ describe('SettingsPage — story #3762: adminChecked 로딩 vs 권한없음 분�
     expect(container.textContent).toContain(koMessages.settings.tabMembers);
   });
 
+  // story #3762 CHANGES(카디르 QA 지적, probe 재현) — loadContext()의 /api/me가
+  // reject(네트워크 다운 등)하는 경로는 PR 최초본 테스트가 pending/성공만 덮어 커버 0이었다.
+  // try/catch로 isAdmin=false를 잡고 finally로 adminChecked=true를 확정하는 게 코드
+  // 계약이라 동작 자체는 정상(스켈레톤이 영원히 안 걷히고, admin 전용 탭만 숨는다)인데
+  // 그 경로가 테스트로 고정돼 있지 않았다 — 이 카드의 판정선("스켈레톤이 영원히 안
+  // 걷히지 않는다")이 실제로 reject 경로에서도 성립하는지 여기서 잰다.
+  it('/api/me가 reject해도(네트워크 다운) 스켈레톤이 걷히고 non-admin 탭은 서고 admin 전용 탭만 숨는다', async () => {
+    // 이 페이지에서 /api/me를 부르는 자리가 여럿(SettingsPage 자신의 loadContext()·
+    // MyProfileSection 등)이라 전부 reject시킨다 — my-profile-section.tsx가 이 테스트로
+    // 처음 드러난 자체 unhandled rejection 갭(별도 수정, 같은 PR)을 갖고 있었다.
+    const fetchWithAuthMock = vi.fn((url: string) => {
+      if (url === '/api/me') return Promise.reject(new Error('network down'));
+      return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
+    });
+    vi.doMock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    // 스켈레톤이 영원히 안 걷히지 않는다(finally가 adminChecked=true를 확정).
+    expect(container.querySelectorAll('[data-testid="settings-tab-skeleton"]').length).toBe(0);
+    // adminChecked만 요구하는 탭(members·organization·projects)은 선다.
+    expect(container.textContent).toContain(koMessages.settings.tabMembers);
+    expect(container.textContent).toContain(koMessages.settings.tabOrganization);
+    // adminChecked && isAdmin을 요구하는 admin 전용 탭은 숨는다(isAdmin=false로 확정).
+    expect(container.textContent).not.toContain(koMessages.settings.tabWorkflowPolicies);
+    expect(container.textContent).not.toContain(koMessages.settings.tabUsage);
+  });
+
   // story c4980e70이 org-members 탭을 /organization/members로 승격했는데 트리거만
   // HIDDEN_SETTINGS_TABS 가드가 빠져 있었다(story #3762 발견) — 판정 후에도 그 트리거
   // 자체가 렌더되면 안 된다(딥링크는 next.config.ts redirects()가 서버에서 걷어가지만,

--- a/apps/web/src/app/(authenticated)/settings/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.test.tsx
@@ -184,9 +184,18 @@ describe('SettingsPage — story #3762: adminChecked 로딩 vs 권한없음 분�
   // 그 경로가 테스트로 고정돼 있지 않았다 — 이 카드의 판정선("스켈레톤이 영원히 안
   // 걷히지 않는다")이 실제로 reject 경로에서도 성립하는지 여기서 잰다.
   it('/api/me가 reject해도(네트워크 다운) 스켈레톤이 걷히고 non-admin 탭은 서고 admin 전용 탭만 숨는다', async () => {
-    // 이 페이지에서 /api/me를 부르는 자리가 여럿(SettingsPage 자신의 loadContext()·
-    // MyProfileSection 등)이라 전부 reject시킨다 — my-profile-section.tsx가 이 테스트로
-    // 처음 드러난 자체 unhandled rejection 갭(별도 수정, 같은 PR)을 갖고 있었다.
+    // story #3762 CHANGES(카디르 QA 재지적) — 이 파일 최상단 mock이 tab=appearance라
+    // MyProfileSection(activeTab==='profile'일 때만 마운트, page.tsx:847-849)이 애초
+    // 렌더되지 않아, my-profile-section.tsx의 try/catch를 빼는 뮤테이션을 돌려도 이
+    // 테스트가 그 파일을 안 재서 그대로 통과했다("이 테스트로 처음 드러난 갭"이라던
+    // 앞 회차 커밋 메시지가 부정확했다 — 실제로는 처음부터 그 세 파일을 재지 못했다).
+    // tab=profile로 마운트해 MyProfileSection·SetPasswordSection·LinkedAccountsSection
+    // 셋 다 실제로 마운트되는 경로에서 reject를 잰다.
+    vi.doMock('next/navigation', () => ({
+      useRouter: () => ({ replace: vi.fn(), refresh: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+      useSearchParams: () => new URLSearchParams('tab=profile'),
+      usePathname: () => '/settings',
+    }));
     const fetchWithAuthMock = vi.fn((url: string) => {
       if (url === '/api/me') return Promise.reject(new Error('network down'));
       return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
@@ -195,6 +204,12 @@ describe('SettingsPage — story #3762: adminChecked 로딩 vs 권한없음 분�
     const { default: SettingsPage } = await import('./page');
     await mount(<SettingsPage />);
     await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    // MyProfileSection이 실제로 마운트돼(tab=profile) fetchProfile()의 reject 경로가
+    // 실행됐는지부터 확認한다 — 이게 없으면 아래 스켈레톤/탭 단언이 통과해도 이
+    // 테스트가 my-profile-section.tsx를 안 잰 것일 수 있다.
+    expect(fetchWithAuthMock.mock.calls.some((c) => c[0] === '/api/me')).toBe(true);
+    expect(container.textContent).toContain(koMessages.settings.tabProfile);
 
     // 스켈레톤이 영원히 안 걷히지 않는다(finally가 adminChecked=true를 확정).
     expect(container.querySelectorAll('[data-testid="settings-tab-skeleton"]').length).toBe(0);

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -100,6 +100,19 @@ const NOTIFICATION_CATEGORIES = [
 
 type NotificationCategoryKey = typeof NOTIFICATION_CATEGORIES[number]['key'];
 
+// story #3762 — adminChecked(/api/me 응답 전) 구간엔 이 자리가 "권한 없음"이 아니라
+// "아직 모름"이다. null로 비우면 콜드 진입 시 레일이 통째로 짧아져 그 탭들이 애초에 없던
+// 것처럼 보인다(로딩≠권한없음 클래스 결함) — 판정 전엔 자리만 스켈레톤으로 지키고,
+// 판정 뒤에만 null(진짜 숨김)로 확정한다.
+function SettingsTabSkeleton() {
+  return (
+    <div className="flex h-8 items-center gap-2 px-3" data-testid="settings-tab-skeleton" aria-hidden="true">
+      <div className="size-4 animate-pulse rounded bg-muted" />
+      <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+    </div>
+  );
+}
+
 function isWebhookUrlAllowed(url: string): boolean {
   if (!url) return true;
   if (/^https:\/\//i.test(url)) return true;
@@ -713,18 +726,21 @@ export default function SettingsPage() {
                 {t('tabAiAgents')}
               </TabsTrigger>
             ) : null}
+            {!adminChecked ? <SettingsTabSkeleton /> : null}
             {adminChecked ? (
               <TabsTrigger value="members">
                 <Users className="h-4 w-4" />
                 {t('tabMembers')}
               </TabsTrigger>
             ) : null}
+            {!adminChecked && !HIDDEN_SETTINGS_TABS.has('workflow') ? <SettingsTabSkeleton /> : null}
             {adminChecked && isAdmin && !HIDDEN_SETTINGS_TABS.has('workflow') ? (
               <TabsTrigger value="workflow">
                 <GitBranch className="h-4 w-4" />
                 {t('tabWorkflow')}
               </TabsTrigger>
             ) : null}
+            {!adminChecked ? <SettingsTabSkeleton /> : null}
             {adminChecked && isAdmin ? (
               <TabsTrigger value="workflow-policies">
                 <ShieldCheck className="h-4 w-4" />
@@ -732,6 +748,14 @@ export default function SettingsPage() {
               </TabsTrigger>
             ) : null}
 
+            {!adminChecked ? (
+              <>
+                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('organizationSettings')}</span>
+                <SettingsTabSkeleton />
+                <SettingsTabSkeleton />
+                {!HIDDEN_SETTINGS_TABS.has('org-members') ? <SettingsTabSkeleton /> : null}
+              </>
+            ) : null}
             {adminChecked ? (
               <>
                 <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('organizationSettings')}</span>
@@ -739,10 +763,15 @@ export default function SettingsPage() {
                   <FolderKanban className="h-4 w-4" />
                   {t('tabOrganization')}
                 </TabsTrigger>
-                <TabsTrigger value="org-members">
-                  <Users className="h-4 w-4" />
-                  {t('tabOrgMembers')}
-                </TabsTrigger>
+                {/* story c4980e70: org-members = /organization/members로 승격(딥링크는 next.config.ts
+                    redirects()가 서버에서 걷어간다) — 트리거·콘텐츠 둘 다 HIDDEN_SETTINGS_TABS에서
+                    차단해야 하는데 트리거만 빠져 있었다(story #3762 발견·회귀 pin). */}
+                {!HIDDEN_SETTINGS_TABS.has('org-members') ? (
+                  <TabsTrigger value="org-members">
+                    <Users className="h-4 w-4" />
+                    {t('tabOrgMembers')}
+                  </TabsTrigger>
+                ) : null}
                 <TabsTrigger value="projects">
                   <FolderKanban className="h-4 w-4" />
                   {t('tabProjects')}
@@ -751,6 +780,13 @@ export default function SettingsPage() {
               </>
             ) : null}
 
+            {!adminChecked ? (
+              <>
+                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('billing')}</span>
+                <SettingsTabSkeleton />
+                <SettingsTabSkeleton />
+              </>
+            ) : null}
             {adminChecked && isAdmin ? (
               <>
                 <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('billing')}</span>

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -451,4 +451,28 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     const toggles = [...container.querySelectorAll('button[aria-expanded]')];
     expect(toggles.some((b) => b.textContent?.includes('설정'))).toBe(false);
   });
+
+  // story #3762(그라운딩·유나 §定) — 4구역+관리 프레임 전체 높이가 흔한 뷰포트(≤900px)를
+  // 넘어서는데 전역 스크롤바 숨김(#2165, globals.css:733-737)까지 겹쳐 신뢰 아래 구역이
+  // 스크롤 가능한데도 "없다"로 보였다(그라운딩: org/role 무관 재현, orgMemberships/
+  // adminChecked와 무관한 순수 CSS overflow affordance 결함). .scrollbar-visible은
+  // globals.css:755의 기존 옵트인(#2528과 동일 패턴) — 새 CSS 없이 클래스만 얹는다.
+  it('SidebarContent가 scrollbar-visible 옵트인 클래스를 쓴다(전역 스크롤바 숨김 하 어포던스, 되돌리면 RED)', async () => {
+    await mount();
+    const content = container.querySelector('[data-slot="sidebar-content"]');
+    expect(content?.className).toContain('scrollbar-visible');
+  });
+
+  // story #3762 — 딥링크·새로고침으로 신뢰 이후 구역(스크롤해야 보이는 영역)에 바로
+  // 들어와도 활성 항목을 찾을 신호가 없었다. channels/page.tsx:1057과 동형 패턴
+  // (jsdom 미구현이라 스파이로 호출 자체를 잰다) — block:'nearest'만 검증한다
+  // ('start'로 되돌아가면 페이지 전체가 불필요하게 점프하는 회귀).
+  it('활성 항목이 있으면 scrollIntoView({block:"nearest"})가 불린다(딥링크 진입 시 활성 항목 자동 노출)', async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    pathnameRef.current = '/organization/events';
+    expandAllGroups();
+    await mount();
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'nearest' });
+  });
 });

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -157,6 +157,17 @@ export function AppSidebar({
     if (isMobile) setOpenMobile(false);
   }, [pathname, isMobile, setOpenMobile]);
 
+  // story #3762(유나 §定) — SidebarContent가 흔한 뷰포트(≤900px)보다 길어져(신뢰 이후
+  // 구역이 스크롤해야 보인다, .scrollbar-visible로 어포던스는 확보) 딥링크/새로고침으로
+  // 그 구역에 바로 들어와도 활성 항목이 화면 밖이면 여전히 못 찾는다 — 활성 경로가
+  // 바뀔 때 그 항목만 뷰로 당겨온다. channels/page.tsx:1057과 동형(jsdom엔
+  // scrollIntoView 자체가 없어 메서드까지 옵셔널 체이닝) — block:'nearest'(페이지
+  // 자체는 안 흔들고 사이드바 내부만 스크롤, 'start'는 항목을 상단에 박아 불필요한 점프).
+  const activeMenuItemRef = useRef<HTMLAnchorElement | null>(null);
+  useEffect(() => {
+    activeMenuItemRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [pathname]);
+
   // story #1981 — GNB 결재함 배지 semantic 교체: "안 읽은 알림 수"(/api/notifications/count)
   // 대신 "내가 승인 가능한 pending 게이트 수"(/api/gates?status=pending&assigned_to_me=true)로.
   // mobile-tab-bar.tsx가 이미 같은 계약으로 쓰던 것(story #1974 개인화·#1960 held fix 반영,
@@ -346,13 +357,17 @@ export function AppSidebar({
         </Link>
       </div>
 
-      <SidebarContent>
+      <SidebarContent className="scrollbar-visible">
         {/* story #2681 — 데스크톱 GNB와 모바일 /more 허브(S2)가 한 정의(NAV_GROUPS)에서
             파생된다(doc mobile-ia-full-completion-2678 §2.5-3). 그룹·항목 목록 자체는
             nav-config.ts가 유일한 출처이고, 여기선 오직 순회+렌더만 한다 — 순서·라벨·아이콘·
             그룹핑은 이 리팩터 전과 동일(시각 회귀 0, AC1). story #2930 I1 — 이제 4구역+관리
             프레임 순서(오늘→워크스페이스→신뢰→지식→조직→설정)로 재편됐다. chats는 위
-            챗 center로 승격돼 이 순회 밖이라 badgeKey는 이제 'inbox' 하나만 실질 도달한다. */}
+            챗 center로 승격돼 이 순회 밖이라 badgeKey는 이제 'inbox' 하나만 실질 도달한다.
+            story #3762 — 4구역+관리 프레임 전체 높이가 흔한 뷰포트(≤900px)를 넘어서며
+            전역 스크롤바 숨김(#2165)까지 겹쳐 신뢰 아래 구역이 스크롤 가능한데도 "없다"로
+            보였다(그라운딩: org/role 무관 재현 — CSS overflow affordance 결함, 컨텍스트
+            문제 아님). .scrollbar-visible은 story #2528과 동일한 기존 옵트인 패턴. */}
         {NAV_GROUPS.map((group) => {
           // story #d986fd6c(IA·S4) — 라벨 없는 유틸 그룹(설정)은 접기 대상이 아니다(항목
           // 1개뿐이라 접어 봤자 얻는 게 없고, ia-4zone 확定이 이미 "라벨 없는 유틸 그룹"
@@ -399,7 +414,7 @@ export function AppSidebar({
                   return (
                     <SidebarMenuItem key={item.id}>
                       <SidebarMenuButton
-                        render={<Link href={link.href} />}
+                        render={<Link href={link.href} ref={link.isActive ? activeMenuItemRef : undefined} />}
                         isActive={link.isActive}
                         tooltip={label}
                       >

--- a/apps/web/src/components/settings/linked-accounts-section.tsx
+++ b/apps/web/src/components/settings/linked-accounts-section.tsx
@@ -33,8 +33,12 @@ export function LinkedAccountsSection() {
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   const refresh = async () => {
-    const res = await fetchWithAuth('/api/me');
-    if (!res.ok) return;
+    // story #3762 CHANGES(카디르 QA — /api/me reject 경로 테스트 中 발견, my-profile-
+    // section.tsx와 동형 갭) — 네트워크 자체가 죽으면(HTTP 에러 응답이 아니라)
+    // fetchWithAuth가 reject해 이 아래 await가 그대로 throw, `void refresh()`(:44) 밖으로
+    // unhandled rejection이 샜다.
+    const res = await fetchWithAuth('/api/me').catch(() => null);
+    if (!res?.ok) return;
     const json = await res.json() as { data?: { linked_providers?: ProviderId[]; has_password?: boolean } };
     setLinkedProviders(json.data?.linked_providers ?? []);
     setHasPassword(json.data?.has_password ?? null);

--- a/apps/web/src/components/settings/linked-accounts-section.tsx
+++ b/apps/web/src/components/settings/linked-accounts-section.tsx
@@ -34,11 +34,13 @@ export function LinkedAccountsSection() {
 
   const refresh = async () => {
     // story #3762 CHANGES(카디르 QA — /api/me reject 경로 테스트 中 발견, my-profile-
-    // section.tsx와 동형 갭) — 네트워크 자체가 죽으면(HTTP 에러 응답이 아니라)
-    // fetchWithAuth가 reject해 이 아래 await가 그대로 throw, `void refresh()`(:44) 밖으로
-    // unhandled rejection이 샜다.
-    const res = await fetchWithAuth('/api/me').catch(() => null);
-    if (!res?.ok) return;
+    // section.tsx와 동형 갭·페드루 PO 정정 — verify:no-fetch-response-without-ok-check
+    // (#3688) 가드가 읽는 try/catch+res.ok 형으로) — 네트워크 자체가 죽으면(HTTP 에러
+    // 응답이 아니라) fetchWithAuth가 reject해 이 아래 await가 그대로 throw,
+    // `void refresh()`(:44) 밖으로 unhandled rejection이 샜다.
+    let res: Response;
+    try { res = await fetchWithAuth('/api/me'); } catch { return; }
+    if (!res.ok) return;
     const json = await res.json() as { data?: { linked_providers?: ProviderId[]; has_password?: boolean } };
     setLinkedProviders(json.data?.linked_providers ?? []);
     setHasPassword(json.data?.has_password ?? null);

--- a/apps/web/src/components/settings/my-profile-section.tsx
+++ b/apps/web/src/components/settings/my-profile-section.tsx
@@ -38,13 +38,14 @@ export function MyProfileSection() {
   const [error, setError] = useState<string | null>(null);
 
   const fetchProfile = useCallback(async () => {
-    // story #3762 CHANGES(카디르 QA — /api/me reject 경로 테스트 中 발견) — 네트워크
-    // 자체가 죽어 fetchWithAuth가 reject하면(HTTP 에러 응답이 아니라) 이 아래 await가
-    // 그대로 throw해 `void fetchProfile()`(:49) 밖으로 unhandled rejection이 샜다.
-    // org-members-section.tsx의 fetchOrgImpact와 동형 — 최소 방어만(빈 폴백, 별도 에러
-    // 배너는 이 섹션 범위 밖).
-    const res = await fetchWithAuth('/api/me').catch(() => null);
-    if (!res?.ok) return;
+    // story #3762 CHANGES(카디르 QA — /api/me reject 경로 테스트 中 발견, 페드루 PO
+    // 정정 — verify:no-fetch-response-without-ok-check(#3688) 가드가 읽는 try/catch+
+    // res.ok 형으로) — 네트워크 자체가 죽어 fetchWithAuth가 reject하면(HTTP 에러 응답이
+    // 아니라) 이 아래 await가 그대로 throw해 `void fetchProfile()`(:49) 밖으로
+    // unhandled rejection이 샜다. 최소 방어만(빈 폴백, 별도 에러 배너는 이 섹션 범위 밖).
+    let res: Response;
+    try { res = await fetchWithAuth('/api/me'); } catch { return; }
+    if (!res.ok) return;
     const json = await res.json() as { data: MyProfile };
     setProfile(json.data);
     setEditName(json.data.name);

--- a/apps/web/src/components/settings/my-profile-section.tsx
+++ b/apps/web/src/components/settings/my-profile-section.tsx
@@ -38,8 +38,13 @@ export function MyProfileSection() {
   const [error, setError] = useState<string | null>(null);
 
   const fetchProfile = useCallback(async () => {
-    const res = await fetchWithAuth('/api/me');
-    if (!res.ok) return;
+    // story #3762 CHANGES(카디르 QA — /api/me reject 경로 테스트 中 발견) — 네트워크
+    // 자체가 죽어 fetchWithAuth가 reject하면(HTTP 에러 응답이 아니라) 이 아래 await가
+    // 그대로 throw해 `void fetchProfile()`(:49) 밖으로 unhandled rejection이 샜다.
+    // org-members-section.tsx의 fetchOrgImpact와 동형 — 최소 방어만(빈 폴백, 별도 에러
+    // 배너는 이 섹션 범위 밖).
+    const res = await fetchWithAuth('/api/me').catch(() => null);
+    if (!res?.ok) return;
     const json = await res.json() as { data: MyProfile };
     setProfile(json.data);
     setEditName(json.data.name);

--- a/apps/web/src/components/settings/set-password-section.tsx
+++ b/apps/web/src/components/settings/set-password-section.tsx
@@ -48,10 +48,12 @@ export function SetPasswordSection() {
   useEffect(() => {
     (async () => {
       // story #3762 CHANGES(카디르 QA — /api/me reject 경로 테스트 中 발견, my-profile-
-      // section.tsx와 동형 갭) — 네트워크 자체가 죽으면(HTTP 에러 응답이 아니라)
-      // fetchWithAuth가 reject해 이 IIFE 밖으로 unhandled rejection이 샜다.
-      const res = await fetchWithAuth('/api/me').catch(() => null);
-      if (!res?.ok) return;
+      // section.tsx와 동형 갭·페드루 PO 정정 — verify:no-fetch-response-without-ok-check
+      // (#3688) 가드가 읽는 try/catch+res.ok 형으로) — 네트워크 자체가 죽으면(HTTP 에러
+      // 응답이 아니라) fetchWithAuth가 reject해 이 IIFE 밖으로 unhandled rejection이 샜다.
+      let res: Response;
+      try { res = await fetchWithAuth('/api/me'); } catch { return; }
+      if (!res.ok) return;
       const json = await res.json() as { data?: { has_password?: boolean } };
       setHasPassword(json.data?.has_password ?? null);
     })();

--- a/apps/web/src/components/settings/set-password-section.tsx
+++ b/apps/web/src/components/settings/set-password-section.tsx
@@ -47,8 +47,11 @@ export function SetPasswordSection() {
 
   useEffect(() => {
     (async () => {
-      const res = await fetchWithAuth('/api/me');
-      if (!res.ok) return;
+      // story #3762 CHANGES(카디르 QA — /api/me reject 경로 테스트 中 발견, my-profile-
+      // section.tsx와 동형 갭) — 네트워크 자체가 죽으면(HTTP 에러 응답이 아니라)
+      // fetchWithAuth가 reject해 이 IIFE 밖으로 unhandled rejection이 샜다.
+      const res = await fetchWithAuth('/api/me').catch(() => null);
+      if (!res?.ok) return;
       const json = await res.json() as { data?: { has_password?: boolean } };
       setHasPassword(json.data?.has_password ?? null);
     })();


### PR DESCRIPTION
## 요약
story #3762 그라운딩 결과, 원 가설(컨텍스트/권한 문제)과 실제 원인이 갈려 스코프를 재조정해 구현했다(자세한 실측은 스토리 카드 참고).

- **① 설정 admin 탭 로딩 레이스**: `adminChecked`(`/api/me` 응답 전) 구간에 `null`이던 admin 탭(members·organization·projects·workflow-policies·billing·usage)을 스켈레톤(`SettingsTabSkeleton`)으로 대체 — 로딩 中과 권한 없음을 가른다.
- **부수 발견**: `org-members` 탭 트리거만 `HIDDEN_SETTINGS_TABS` 가드가 빠져 있었다(ai·workflow는 체크하는데 이것만 없음) — c4980e70 승격 이후에도 Settings 안에서 탭 클릭으로는 여전히 노출·진입 가능했다. 같은 블록이라 함께 수정.
- **② 사이드바 구역 "실종"은 컨텍스트 문제가 아니라 CSS overflow affordance 결함**: 뭉클랩(기존 admin)·E2E Test Corp(신규 0프로젝트 seed) 양쪽 1440×900에서 동일하게 재현 — org 종류 무관. `app-sidebar.tsx` `SidebarContent`(`overflow-auto`)의 `scrollHeight`(1040) > `clientHeight`(589)인데 전역 스크롤바 숨김(#2165)까지 겹쳐 스크롤 가능한데도 "없다"로 보였다. 기존 옵트인 `.scrollbar-visible`(#2528과 동일 패턴, 유나 §定)을 호출부(`app-sidebar.tsx:349`)에만 적용 — 공유 프리미티브(`ui/sidebar.tsx`)는 무변.
- **활성 항목 자동 노출**: 딥링크/새로고침으로 스크롤 필요 구역에 바로 들어와도 활성 항목이 화면 밖이면 여전히 못 찾는 문제 — 활성 경로가 바뀔 때 `scrollIntoView({block:'nearest'})`(기존 `channels/page.tsx:1057` 패턴과 동형, jsdom 미구현 대비 옵셔널 체이닝).
- ~~숨김 탭 URL 리다이렉트~~ — 그라운딩 결과 `next.config.ts` `redirects()`(c4980e70)로 이미 배포되어 있음을 확인, 신규 작업 없음(`curl -sI '/settings?tab=org-members'` → 308 확인).

## 그라운딩 근거
스토리 카드([SID:3762]) 본문에 실측 상세(curl 결과·scrollHeight/clientHeight·org별 재현 스크린샷 근거) 기록. 페드루(PO)·유나(디자인) 사전 합의 완료(어포던스 형=`.scrollbar-visible`, 페이드 기각).

## 테스트
- `app-sidebar.test.tsx`: `scrollbar-visible` 클래스 구조 단언 + `scrollIntoView({block:'nearest'})` 스파이 (26개 전체 통과)
- `settings/page.test.tsx`: adminChecked pending 구간 스켈레톤 존재·판정 후 걷힘, org-members 트리거 미노출 회귀 pin, **`/api/me` reject(네트워크 다운) 경로**(스켈레톤이 영원히 안 걷히고 non-admin 탭은 서고 admin 전용 탭만 숨음) — 카디르 QA probe 재현 반영(9개 전체 통과)
- **부수 발견**: `my-profile-section.tsx`·`linked-accounts-section.tsx`·`set-password-section.tsx` 셋 다 `/api/me` 호출에 `.catch()`가 없어 네트워크 reject 시 unhandled promise rejection이 샜다(HTTP 에러 응답은 `!res.ok`로 이미 방어했으나 reject 자체는 무방비). `org-members-section.tsx`·`my-notification-channel-section.tsx`가 이미 쓰던 패턴으로 통일.
  - ⚠️정정(카디르 QA 재지적) — 최초 커밋의 테스트는 파일 최상단 mock이 `tab=appearance`라 이 세 컴포넌트가 애초 마운트되지 않아(`page.tsx:845-849`, `tab==='profile'`에서만 렌더) "이 테스트로 처음 드러난 갭"이 아니라 **처음부터 그 세 파일을 안 재고 있었다** — 뮤테이션(try/catch 제거)을 돌려도 그린이었다. `tab=profile`로 마운트하도록 정정하고 `/api/me` 실호출·profile 탭 콘텐츠 렌더 확認 단언을 추가, 뮤테이션 자가검산(제거→RED·복원→GREEN)으로 직접 재현해 실제로 세 파일을 재는지 검증했다.
- `pnpm build` 성공, `tsc --noEmit` 오류 0개, 이 PR **신규** lint 경고 0개(카디르 QA 지적 정정 — 전체 lint는 6건이지만 전부 이 PR과 무관한 기존 4파일 소재, 이 PR이 건드린 파일 기준 0)

## 스크린샷
로컬 백엔드 없이 재현이 불가해(라이브 검증=배포 dev FE 표준) before 상태는 dev 라이브 puppeteer로 이미 캡처 완료(스토리 카드 실측 근거). after 스크린샷(모바일/데스크톱)은 dev 배포 후 라이브 픽셀로 이어서 확인·카디르 QA 요청 시 첨부.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ

