### PR TITLE
[SID:3757] feat(FE): 죽은 i18n 키 messages→코드 역방향 ns 단위 가드 신설

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1428,6 +1428,15 @@ jobs:
       - name: "Verify i18n keys referenced in code exist in ko/en (story #5ead8723 regression guard)"
         run: pnpm --filter web verify:i18n-keys-exist
 
+      # story #3757 회귀가드 — messages→코드 역방향(죽은 키), 최상위 네임스페이스 단위.
+      # `check-i18n-keys.js`(#2371, 루트 정규식 스캐너)가 「여섯 표기」 중 넷을 몰라 다수를
+      # 거짓 사망으로 잡던 것 대신, verify-i18n-keys-exist.ts(위 스텝, 여섯 표기 검증됨)를
+      # 재사용해 A(리터럴)·A′(unknown-ns 낱말)·B(동적 ns 보류)·C(데이터 카탈로그)·D(비공개
+      # SaaS 오버레이 정적 스냅샷) 네 신호 중 하나도 없는 ns만 fail-closed로 잡는다(키 단위
+      # 삭제 판정은 이 가드 밖 — story #3757 AC2, 사람이 직접 읽는다).
+      - name: "Verify every top-level i18n namespace has at least one reference signal (story #3757 regression guard)"
+        run: pnpm --filter web verify:i18n-namespace-referenced
+
       # story #3760 회귀가드: App Router 라우트 파일(page/layout/template/loading/error/
       # not-found/default.tsx)의 named export가 Next.js 화이트리스트 밖이면 next build에서만
       # 죽는다(tsc·vitest는 이 계약을 모른다 — 실물: #4105, publishHistorySenderLabel을

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -28,22 +28,15 @@
     "goToLogin": "Go to Login",
     "enable_all": "Enable all",
     "disable_all": "Disable all",
-    "deletedUser": "Deleted User",
     "memberUnnamed": "Unnamed member",
-    "unassigned": "Unassigned",
     "unknown": "Unknown",
     "noData": "No data",
     "loading": "Loading...",
     "loadMore": "Load more",
     "error": "An error occurred",
     "errorDescription": "An error occurred while loading the page.",
-    "locale_en": "English",
-    "locale_ko": "한국어",
     "upgradeRequired": "Upgrade Required",
     "upgradePlan": "Upgrade Plan",
-    "operatorSurface": "Operator surface",
-    "back": "Back",
-    "next": "Next",
     "close": "Close",
     "add": "Add",
     "confirm": "Confirm"
@@ -66,7 +59,6 @@
     "addAccount": "Add account",
     "signOutThis": "Sign out this account",
     "signOutAll": "Sign out all accounts",
-    "switching": "Switching…",
     "switchFailed": "Failed to switch account. Please try again.",
     "reloginRequired": "Re-login required",
     "capReached": "Account limit reached",
@@ -313,23 +305,7 @@
   },
   "dashboard": {
     "title": "Dashboard",
-    "noProjectTitle": "No projects in this organization yet",
-    "noProjectDescription": "Create a project to start using boards and sprints.",
-    "noProjectAction": "Create a project",
     "projects": "Projects",
-    "activeSprints": "Active Sprints",
-    "viewAll": "View all →",
-    "kanbanBoard": "Kanban Board →",
-    "noProjects": "No projects",
-    "noActiveSprints": "No active sprints",
-    "orgFallback": "Organization",
-    "commandCenter": "Command center",
-    "commandCenterDescription": "Everything you need to unblock work, see sprint health, and jump to docs.",
-    "ccFleet": "Fleet {count}",
-    "ccFleetBreakdownPending": "Status breakdown pending",
-    "ccFleetOnlineWorking": "Online {online} · Working {working}",
-    "ccFlowTooltip": "See the project flow",
-    "ccLoading": "Loading…",
     "ccZoneActions": "Your actions now",
     "ccClearTitle": "All clear",
     "ccClearBody": "Nothing needs your attention right now",
@@ -351,6 +327,24 @@
     "ccChangedSince": "{count} of your items changed",
     "ccLastSeenSuffix": "last seen {ago}",
     "ccGateGeneric": "gate",
+    "ccAgentStuck": "Waiting on {gate}",
+    "ccAttentionAuthFailure": "{count} auth failures",
+    "ccAttentionDays": "{days} days",
+    "ccAttentionGeneric": "Needs review",
+    "ccRiskFailedRuns": "Failed runs (7d)",
+    "ccCycleTitle": "Cycle time",
+    "ccCycleValue": "Avg {days}d (last 30d · n={n})",
+    "ccCycleEmpty": "No completions in last 30d",
+    "ccContributionTitle": "Done contribution",
+    "ccContributionValue": "Agent {agent} · Human {human} · Unassigned {unassigned}",
+    "ccMinAgo": "{n}m ago",
+    "ccHourAgo": "{n}h ago",
+    "ccDayAgo": "{n}d ago",
+    "recentDocs": "Recent docs",
+    "inProgress": "In Progress",
+    "inReview": "In Review",
+    "blocked": "Blocked",
+    "standup": "Standup",
     "ccGateTypeQa": "QA",
     "ccGateTypePrReview": "PR review",
     "ccGateTypeMerge": "merge",
@@ -363,78 +357,7 @@
     "ccGateTypeArtifactCanonicalize": "anchor approval",
     "ccGateTypeAgentDecisionRequest": "decision request",
     "ccGateTypeSupportEscalationReview": "support review",
-    "ccGateTypeConceptApproval": "concept approval",
-    "ccAgentStuck": "Waiting on {gate}",
-    "ccAttentionAuthFailure": "{count} auth failures",
-    "ccAttentionDays": "{days} days",
-    "ccAttentionGeneric": "Needs review",
-    "ccZoneOverview": "Project status",
-    "ccEpicsTitle": "Goal progress",
-    "ccOutcome": "Hypotheses hit",
-    "ccEpicsEmpty": "No goals in progress",
-    "ccRiskPending": "Risk metrics pending",
-    "ccRiskFailedRuns": "Failed runs (7d)",
-    "ccCyclePending": "Cycle time pending",
-    "ccCycleTitle": "Cycle time",
-    "ccCycleValue": "Avg {days}d (last 30d · n={n})",
-    "ccCycleEmpty": "No completions in last 30d",
-    "ccContributionPending": "Contribution pending",
-    "ccContributionTitle": "Done contribution",
-    "ccContributionValue": "Agent {agent} · Human {human} · Unassigned {unassigned}",
-    "ccItemOverdue": "overdue metric",
-    "ccItemCostTrend": "cost trend",
-    "ccNotYetShownLabel": "Not yet shown — {items}",
-    "ccNotYetShownFooter": "Shown as soon as it's ready.",
-    "ccRecentTitle": "Recent changes",
-    "ccRecentEmpty": "No recent changes",
-    "ccChangeStoryCreated": "Story created",
-    "ccChangeStoryStatus": "Story status changed",
-    "ccChangeSprintStarted": "Sprint started",
-    "ccChangeSprintClosed": "Sprint closed",
-    "ccChangeDocCreated": "Doc created",
-    "ccChangeRunCompleted": "Run completed",
-    "ccChangeRunFailed": "Run failed",
-    "ccChangeGeneric": "{object} changed",
-    "ccMinAgo": "{n}m ago",
-    "ccHourAgo": "{n}h ago",
-    "ccDayAgo": "{n}d ago",
-    "projectsHint": "Go to board or docs.",
-    "activeSprintsHint": "Focus on the active delivery window.",
-    "pendingWork": "Pending work",
-    "openBoard": "Open board",
-    "projectEntryDescription": "Command-center entry point for delivery",
-    "createProjectHint": "Create a project to unlock the command center.",
-    "sprintHealth": "Sprint health",
-    "noActiveSprintsDescription": "No active sprint is currently blocking the team.",
-    "recentDocs": "Recent docs",
-    "noDocsYet": "No docs yet",
-    "noDocsYetDescription": "Use docs to capture decisions and handoffs.",
-    "policyDocs": "Policy docs",
-    "noPolicyDocs": "No policy docs",
-    "noPolicyDocsDescription": "Policy documents will appear here once attached to a sprint or goal.",
-    "noProjectAccess": "No accessible projects yet",
-    "noProjectAccessDescription": "You joined the organization, but you have not been assigned to a project yet. Ask an administrator to assign project access.",
-    "currentProjectHome": "Current project home",
-    "statusActive": "Active",
-    "inProgress": "In Progress",
-    "inReview": "In Review",
-    "blocked": "Blocked",
-    "openStories": "Open Stories",
-    "assignedToMe": "Assigned to Me",
-    "noAssignedStories": "No assigned stories",
-    "startSprint": "Start a sprint",
-    "viewBoard": "View board",
-    "writeDocs": "Write a doc",
-    "noAgentBanner": "Connect an AI agent to delegate more work automatically",
-    "noAgentBannerCta": "Connect agent",
-    "newStory": "New story",
-    "standup": "Standup",
-    "sprintCycle": "Sprint cycle",
-    "inProgressStories": "In-progress stories",
-    "hitlPending": "HITL pending",
-    "hitlPendingDesc": "Approval gate waiting (coming soon)",
-    "sprintCycleProgress": "Time elapsed",
-    "agentsActive": "{count} active"
+    "ccGateTypeConceptApproval": "concept approval"
   },
   "proofCapsule": {
     "claim": {
@@ -1886,15 +1809,9 @@
     "runtimeTypeSaved": "Runtime type saved"
   },
   "shell": {
-    "workspaceLabel": "Intelligence Workspace",
-    "projectLabel": "Project",
-    "projectAttached": "Current project connected",
-    "projectPending": "Project context pending",
     "projects": "Projects",
     "projectSelectPrompt": "Select current project",
-    "projectSelectDescription": "Choose the current project from the header switcher to activate this surface.",
-    "searchPlaceholder": "Search tasks, docs, and operator surfaces...",
-    "primaryCta": "Open board"
+    "projectSelectDescription": "Choose the current project from the header switcher to activate this surface."
   },
   "standup": {
     "orgLevelTitle": "Today's standup",
@@ -2968,26 +2885,66 @@
         "advanced": "Advanced"
       },
       "items": {
-        "heading1": { "description": "Big heading" },
-        "heading2": { "description": "Medium heading" },
-        "heading3": { "description": "Small heading" },
-        "bulletList": { "description": "Unordered list" },
-        "orderedList": { "description": "Ordered list" },
-        "checklist": { "description": "Checklist" },
-        "codeBlock": { "description": "Code block" },
-        "blockquote": { "description": "Quote block" },
-        "callout": { "description": "Highlighted box" },
-        "table": { "description": "Insert table" },
-        "image": { "description": "Insert image" },
-        "file": { "description": "Attach file" },
-        "embed": { "description": "Embed external URL" },
-        "mermaidDiagram": { "description": "Insert diagram" },
-        "columns": { "description": "2/3-column layout" },
-        "mathBlock": { "description": "LaTeX block formula" },
-        "mathInline": { "description": "LaTeX inline formula" },
-        "toggle": { "description": "Collapsible block" },
-        "pageEmbed": { "description": "Embed another doc" },
-        "horizontalRule": { "description": "Divider" }
+        "heading1": {
+          "description": "Big heading"
+        },
+        "heading2": {
+          "description": "Medium heading"
+        },
+        "heading3": {
+          "description": "Small heading"
+        },
+        "bulletList": {
+          "description": "Unordered list"
+        },
+        "orderedList": {
+          "description": "Ordered list"
+        },
+        "checklist": {
+          "description": "Checklist"
+        },
+        "codeBlock": {
+          "description": "Code block"
+        },
+        "blockquote": {
+          "description": "Quote block"
+        },
+        "callout": {
+          "description": "Highlighted box"
+        },
+        "table": {
+          "description": "Insert table"
+        },
+        "image": {
+          "description": "Insert image"
+        },
+        "file": {
+          "description": "Attach file"
+        },
+        "embed": {
+          "description": "Embed external URL"
+        },
+        "mermaidDiagram": {
+          "description": "Insert diagram"
+        },
+        "columns": {
+          "description": "2/3-column layout"
+        },
+        "mathBlock": {
+          "description": "LaTeX block formula"
+        },
+        "mathInline": {
+          "description": "LaTeX inline formula"
+        },
+        "toggle": {
+          "description": "Collapsible block"
+        },
+        "pageEmbed": {
+          "description": "Embed another doc"
+        },
+        "horizontalRule": {
+          "description": "Divider"
+        }
       },
       "embedPrompt": "Enter the URL to embed (YouTube, Figma, etc.):",
       "mermaidDefault": {
@@ -3014,7 +2971,6 @@
     "noData": "No data",
     "noHistory": "No transactions",
     "unknown": "Unknown",
-    "adminOnly": "Admin access required",
     "grantFailed": "Grant failed",
     "adminOnlyHint": "Only org admin/owner can grant rewards"
   },
@@ -3038,14 +2994,8 @@
     "actionMerge": "Merge",
     "actionDecide": "Decide",
     "actionCoordinate": "Coordinate",
-    "kindApproval": "Approval needed",
-    "kindDecision": "Steer needed",
-    "kindBlocker": "Blocked",
-    "kindMention": "Reply needed",
     "actionApprove": "Approve",
-    "actionConfirm": "Confirm",
-    "actionResolve": "Resolve",
-    "actionReply": "Reply"
+    "actionConfirm": "Confirm"
   },
   "inbox": {
     "attentionTabLabel": "Today",
@@ -3137,13 +3087,11 @@
   },
   "invite": {
     "title": "Organization Invitation",
-    "description": "Accept this invitation to join the organization.",
     "accept": "Accept Invitation",
     "success": "Welcome!",
     "redirecting": "Redirecting to dashboard...",
     "loading": "Loading...",
     "invalidToken": "Invalid invitation link.",
-    "acceptFailed": "Failed to accept invitation.",
     "accepting": "Accepting invitation...",
     "authFailed": "Authentication failed. Please try again.",
     "inviteNotFound": "We couldn't find that invite.",
@@ -3162,7 +3110,8 @@
     "submit": "Join",
     "invitedByOrg": "Invited by {org}.",
     "signupEmail": "You'll sign up with {email}.",
-    "decline": "Decline (for now)"
+    "decline": "Decline (for now)",
+    "acceptFailed": "Failed to accept invitation."
   },
   "resetPassword": {
     "title": "Set a new password",
@@ -3261,28 +3210,7 @@
   "billing": {
     "title": "Billing",
     "loading": "Loading...",
-    "currentPlan": "Current Plan",
-    "nextBilling": "Next billing date",
-    "via": "Via",
-    "updatePaymentMethod": "Update Payment Method",
-    "grandfathered": "You are on a grandfathered plan with price guarantee.",
-    "upgradeCtaDesc": "Upgrade to Team or Pro to unlock more features.",
-    "upgradeCta": "Upgrade Now",
-    "invoices": "Invoice History",
-    "cancelSubscription": "Cancel Subscription",
-    "cancelDesc": "After cancellation, your plan will revert to Free at the end of the billing period.",
-    "cancelBtn": "Cancel Subscription",
-    "cancelModalTitle": "Cancel Subscription",
-    "cancelModalDesc": "Choose how you want to cancel.",
-    "cancelEndOfPeriod": "Cancel at end of billing period",
-    "cancelImmediately": "Cancel immediately (no refund)",
-    "keep": "Keep Subscription",
-    "confirmCancel": "Confirm Cancel",
-    "cancelFailed": "Cancellation failed",
-    "statusBilled": "Paid",
     "statusPending": "Pending",
-    "statusRefunded": "Refunded",
-    "statusFailed": "Failed",
     "auWarnTitle": "Automation usage has reached {pct}%",
     "auWarnDesc": "This month's automation (AU) usage has passed 80% of your limit. Upgrade your plan or wait for next month's reset.",
     "auWarn90Title": "Automation usage near limit ({pct}%) — admin email notice",
@@ -4150,7 +4078,6 @@
   "sprints": {
     "title": "Sprints",
     "loading": "Loading...",
-    "noProject": "No project selected.",
     "noSprints": "No sprints started yet",
     "noSprintsDescription": "A sprint is one focused cycle. Declare a hypothesis when you start, then bring together what you learned when it ends.",
     "noSprintsCta": "Start your first sprint",
@@ -4171,7 +4098,6 @@
     "startDate": "Start date",
     "endDate": "End date",
     "cancel": "Cancel",
-    "create": "Create",
     "createError": "Failed to create sprint.",
     "activate": "Start Sprint",
     "close": "Close Sprint",
@@ -4192,7 +4118,6 @@
     "goalPlaceholder": "What will the team complete this sprint?",
     "capacityLabel": "Capacity",
     "teamSizeLabel": "Team Size",
-    "hypothesisSection": "Outcome Hypothesis",
     "delete": "Delete Sprint",
     "deleteConfirmTitle": "Delete this sprint?",
     "deleteConfirmBody": "This action cannot be undone. Linked stories move to the backlog, and retro and standup links are cleared.",
@@ -4214,7 +4139,6 @@
     "declareStatementLabel": "Hypothesis statement",
     "declareStatementPlaceholder": "What this sprint is testing",
     "declareDraftCta": "Start from AI draft",
-    "declareDrafting": "Drafting...",
     "declareDraftNoteTitle": "AI draft — review and edit before confirming.",
     "declareDraftNoteBody": "You confirm it — edit it or leave it as is.",
     "declareGa4DateRangePlaceholder": "Measurement window (days)",
@@ -4490,13 +4414,6 @@
   },
   "activityLog": {
     "title": "Activity Log",
-    "eyebrow": "ACTIVITY",
-    "description": "Browse project activity — who did what, when, and on which entity.",
-    "colTime": "Time",
-    "colActor": "Actor",
-    "colAction": "Action",
-    "colEntity": "Entity",
-    "colContext": "Context",
     "filterAll": "All",
     "filterActor": "Actor",
     "filterAction": "Action (type to filter)",
@@ -4508,8 +4425,7 @@
     "reload": "Reload",
     "loadMore": "Load more",
     "forbiddenTitle": "Access denied",
-    "forbiddenDescription": "You do not have permission to view the activity log.",
-    "noProject": "No project selected."
+    "forbiddenDescription": "You do not have permission to view the activity log."
   },
   "teamActivity": {
     "title": "Activity",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -28,22 +28,15 @@
     "goToLogin": "로그인으로 이동",
     "enable_all": "전체 켜기",
     "disable_all": "전체 끄기",
-    "deletedUser": "삭제된 사용자",
     "memberUnnamed": "이름 없는 구성원",
-    "unassigned": "미할당",
     "unknown": "알 수 없음",
     "noData": "데이터 없음",
     "loading": "로딩 중...",
     "loadMore": "더 보기",
     "error": "문제가 발생했습니다",
     "errorDescription": "페이지를 불러오는 중 오류가 발생했습니다.",
-    "locale_en": "English",
-    "locale_ko": "한국어",
     "upgradeRequired": "업그레이드가 필요합니다",
     "upgradePlan": "요금제 업그레이드",
-    "operatorSurface": "운영 표면",
-    "back": "이전",
-    "next": "다음",
     "close": "닫기",
     "add": "추가",
     "confirm": "확인"
@@ -66,7 +59,6 @@
     "addAccount": "계정 추가",
     "signOutThis": "이 계정 로그아웃",
     "signOutAll": "모든 계정 로그아웃",
-    "switching": "전환 중…",
     "switchFailed": "계정 전환에 실패했습니다. 다시 시도해 주세요.",
     "reloginRequired": "재로그인 필요",
     "capReached": "계정 한도에 도달했습니다",
@@ -313,23 +305,7 @@
   },
   "dashboard": {
     "title": "대시보드",
-    "noProjectTitle": "이 조직에는 아직 프로젝트가 없어요",
-    "noProjectDescription": "새 프로젝트를 만들면 보드와 스프린트를 시작할 수 있어요.",
-    "noProjectAction": "새 프로젝트 만들기",
     "projects": "프로젝트",
-    "activeSprints": "활성 스프린트",
-    "viewAll": "전체 보기 →",
-    "kanbanBoard": "칸반 보드 →",
-    "noProjects": "프로젝트가 없습니다",
-    "noActiveSprints": "활성 스프린트가 없습니다",
-    "orgFallback": "조직",
-    "commandCenter": "커맨드 센터",
-    "commandCenterDescription": "업무를 막는 요소를 풀고, 스프린트 상태를 확인하고, 문서로 바로 이동할 수 있는 운영 허브입니다.",
-    "ccFleet": "함대 {count}",
-    "ccFleetBreakdownPending": "상태 집계 준비중",
-    "ccFleetOnlineWorking": "온라인 {online} · 작업중 {working}",
-    "ccFlowTooltip": "프로젝트 흐름 보기",
-    "ccLoading": "불러오는 중…",
     "ccZoneActions": "지금 내 할 일",
     "ccClearTitle": "괜찮습니다",
     "ccClearBody": "지금 처리할 일이 없습니다",
@@ -351,6 +327,24 @@
     "ccChangedSince": "내 것 {count}건에 변경이 있었습니다",
     "ccLastSeenSuffix": "마지막으로 본 것은 {ago}입니다",
     "ccGateGeneric": "게이트",
+    "ccAgentStuck": "{gate} 대기 중",
+    "ccAttentionAuthFailure": "인증 실패 {count}회",
+    "ccAttentionDays": "{days}일째",
+    "ccAttentionGeneric": "확인 필요",
+    "ccRiskFailedRuns": "최근 7일 실패 실행",
+    "ccCycleTitle": "사이클 타임",
+    "ccCycleValue": "평균 {days}일 (최근 30일 · {n}건)",
+    "ccCycleEmpty": "최근 30일 완료 없음",
+    "ccContributionTitle": "완료 기여",
+    "ccContributionValue": "에이전트 {agent} · 사람 {human} · 미배정 {unassigned}",
+    "ccMinAgo": "{n}분 전",
+    "ccHourAgo": "{n}시간 전",
+    "ccDayAgo": "{n}일 전",
+    "recentDocs": "최근 문서",
+    "inProgress": "진행 중",
+    "inReview": "리뷰 중",
+    "blocked": "차단됨",
+    "standup": "스탠드업",
     "ccGateTypeQa": "QA",
     "ccGateTypePrReview": "PR 리뷰",
     "ccGateTypeMerge": "머지",
@@ -363,78 +357,7 @@
     "ccGateTypeArtifactCanonicalize": "정본화",
     "ccGateTypeAgentDecisionRequest": "판단 요청",
     "ccGateTypeSupportEscalationReview": "고객지원 검토",
-    "ccGateTypeConceptApproval": "컨셉 결재",
-    "ccAgentStuck": "{gate} 대기 중",
-    "ccAttentionAuthFailure": "인증 실패 {count}회",
-    "ccAttentionDays": "{days}일째",
-    "ccAttentionGeneric": "확인 필요",
-    "ccZoneOverview": "프로젝트 현황",
-    "ccEpicsTitle": "목표 진척",
-    "ccOutcome": "가설 적중",
-    "ccEpicsEmpty": "진행 중인 목표가 없습니다",
-    "ccRiskPending": "리스크 지표 준비중",
-    "ccRiskFailedRuns": "최근 7일 실패 실행",
-    "ccCyclePending": "사이클 타임 준비중",
-    "ccCycleTitle": "사이클 타임",
-    "ccCycleValue": "평균 {days}일 (최근 30일 · {n}건)",
-    "ccCycleEmpty": "최근 30일 완료 없음",
-    "ccContributionPending": "기여 지표 준비중",
-    "ccContributionTitle": "완료 기여",
-    "ccContributionValue": "에이전트 {agent} · 사람 {human} · 미배정 {unassigned}",
-    "ccItemOverdue": "기한 초과 지표",
-    "ccItemCostTrend": "비용 추세",
-    "ccNotYetShownLabel": "아직 표시하지 않는 것 — {items}",
-    "ccNotYetShownFooter": "준비되는 대로 표시됩니다.",
-    "ccRecentTitle": "최근 변화",
-    "ccRecentEmpty": "최근 변화가 없습니다",
-    "ccChangeStoryCreated": "스토리 생성",
-    "ccChangeStoryStatus": "스토리 상태 변경",
-    "ccChangeSprintStarted": "스프린트 시작",
-    "ccChangeSprintClosed": "스프린트 종료",
-    "ccChangeDocCreated": "문서 생성",
-    "ccChangeRunCompleted": "실행 완료",
-    "ccChangeRunFailed": "실행 실패",
-    "ccChangeGeneric": "{object} 변경",
-    "ccMinAgo": "{n}분 전",
-    "ccHourAgo": "{n}시간 전",
-    "ccDayAgo": "{n}일 전",
-    "projectsHint": "보드나 문서로 바로 이동하는 시작점입니다.",
-    "activeSprintsHint": "현재 전달 구간에 집중해 주세요",
-    "pendingWork": "대기 중 작업",
-    "openBoard": "보드 열기",
-    "projectEntryDescription": "전달 작업으로 진입하는 커맨드 센터 진입점",
-    "createProjectHint": "프로젝트를 만들면 커맨드 센터가 열립니다.",
-    "sprintHealth": "스프린트 상태",
-    "noActiveSprintsDescription": "현재 팀을 막고 있는 활성 스프린트가 없습니다.",
-    "recentDocs": "최근 문서",
-    "noDocsYet": "문서가 아직 없습니다",
-    "noDocsYetDescription": "결정과 핸드오프를 문서로 쌓습니다.",
-    "policyDocs": "정책 문서",
-    "noPolicyDocs": "정책 문서가 없습니다",
-    "noPolicyDocsDescription": "스프린트나 목표에 연결되면 여기 나타납니다.",
-    "noProjectAccess": "아직 접근 가능한 프로젝트가 없습니다",
-    "noProjectAccessDescription": "조직에는 합류했지만 아직 프로젝트 배정이 없는 상태입니다. 관리자신에게 프로젝트 배정을 요청하면 됩니다.",
-    "currentProjectHome": "현재 프로젝트 홈",
-    "statusActive": "활성",
-    "inProgress": "진행 중",
-    "inReview": "리뷰 중",
-    "blocked": "차단됨",
-    "openStories": "전체 열림",
-    "assignedToMe": "나에게 할당됨",
-    "noAssignedStories": "할당된 스토리가 없습니다",
-    "startSprint": "스프린트 시작하기",
-    "viewBoard": "보드 보기",
-    "writeDocs": "문서 작성",
-    "noAgentBanner": "AI 에이전트를 연결하면 더 많은 일을 위임할 수 있어요",
-    "noAgentBannerCta": "에이전트 연결",
-    "newStory": "새 스토리",
-    "standup": "스탠드업",
-    "sprintCycle": "스프린트 사이클",
-    "inProgressStories": "처리 중 스토리",
-    "hitlPending": "HITL 대기",
-    "hitlPendingDesc": "승인 게이트 대기 (준비 중)",
-    "sprintCycleProgress": "기간 진행",
-    "agentsActive": "{count}명 활성"
+    "ccGateTypeConceptApproval": "컨셉 결재"
   },
   "proofCapsule": {
     "claim": {
@@ -1886,15 +1809,9 @@
     "runtimeTypeSaved": "런타임 타입 저장됨"
   },
   "shell": {
-    "workspaceLabel": "운영 워크스페이스",
-    "projectLabel": "프로젝트",
-    "projectAttached": "현재 프로젝트 연결됨",
-    "projectPending": "프로젝트 컨텍스트 연결 대기",
     "projects": "프로젝트",
     "projectSelectPrompt": "현재 프로젝트 선택",
-    "projectSelectDescription": "헤더의 프로젝트 스위처에서 현재 프로젝트를 선택하면 이 화면이 활성화됩니다.",
-    "searchPlaceholder": "작업, 문서, 운영 표면 검색 준비 중...",
-    "primaryCta": "보드 열기"
+    "projectSelectDescription": "헤더의 프로젝트 스위처에서 현재 프로젝트를 선택하면 이 화면이 활성화됩니다."
   },
   "standup": {
     "orgLevelTitle": "오늘의 스탠드업",
@@ -2968,26 +2885,66 @@
         "advanced": "고급"
       },
       "items": {
-        "heading1": { "description": "큰 제목" },
-        "heading2": { "description": "중간 제목" },
-        "heading3": { "description": "작은 제목" },
-        "bulletList": { "description": "순서 없는 목록" },
-        "orderedList": { "description": "순서 있는 목록" },
-        "checklist": { "description": "체크리스트" },
-        "codeBlock": { "description": "코드 블록" },
-        "blockquote": { "description": "인용구" },
-        "callout": { "description": "강조 박스" },
-        "table": { "description": "표 삽입" },
-        "image": { "description": "이미지 삽입" },
-        "file": { "description": "파일 첨부" },
-        "embed": { "description": "외부 URL 임베드" },
-        "mermaidDiagram": { "description": "다이어그램 삽입" },
-        "columns": { "description": "2단/3단 컬럼 레이아웃" },
-        "mathBlock": { "description": "LaTeX 블록 수식" },
-        "mathInline": { "description": "LaTeX 인라인 수식" },
-        "toggle": { "description": "접기/펼치기 블록" },
-        "pageEmbed": { "description": "다른 문서 임베드" },
-        "horizontalRule": { "description": "구분선" }
+        "heading1": {
+          "description": "큰 제목"
+        },
+        "heading2": {
+          "description": "중간 제목"
+        },
+        "heading3": {
+          "description": "작은 제목"
+        },
+        "bulletList": {
+          "description": "순서 없는 목록"
+        },
+        "orderedList": {
+          "description": "순서 있는 목록"
+        },
+        "checklist": {
+          "description": "체크리스트"
+        },
+        "codeBlock": {
+          "description": "코드 블록"
+        },
+        "blockquote": {
+          "description": "인용구"
+        },
+        "callout": {
+          "description": "강조 박스"
+        },
+        "table": {
+          "description": "표 삽입"
+        },
+        "image": {
+          "description": "이미지 삽입"
+        },
+        "file": {
+          "description": "파일 첨부"
+        },
+        "embed": {
+          "description": "외부 URL 임베드"
+        },
+        "mermaidDiagram": {
+          "description": "다이어그램 삽입"
+        },
+        "columns": {
+          "description": "2단/3단 컬럼 레이아웃"
+        },
+        "mathBlock": {
+          "description": "LaTeX 블록 수식"
+        },
+        "mathInline": {
+          "description": "LaTeX 인라인 수식"
+        },
+        "toggle": {
+          "description": "접기/펼치기 블록"
+        },
+        "pageEmbed": {
+          "description": "다른 문서 임베드"
+        },
+        "horizontalRule": {
+          "description": "구분선"
+        }
       },
       "embedPrompt": "임베드할 URL을 입력하세요 (YouTube, Figma 등):",
       "mermaidDefault": {
@@ -3014,7 +2971,6 @@
     "noData": "데이터 없음",
     "noHistory": "거래 내역 없음",
     "unknown": "알 수 없음",
-    "adminOnly": "관리자 권한 필요",
     "grantFailed": "지급 실패",
     "adminOnlyHint": "조직 관리자/소유자만 리워드 지급 가능"
   },
@@ -3038,14 +2994,8 @@
     "actionMerge": "병합",
     "actionDecide": "결정",
     "actionCoordinate": "조율",
-    "kindApproval": "결재 필요",
-    "kindDecision": "방향 확인 필요",
-    "kindBlocker": "막힘",
-    "kindMention": "응답 필요",
     "actionApprove": "결재",
-    "actionConfirm": "확인",
-    "actionResolve": "해소",
-    "actionReply": "답"
+    "actionConfirm": "확인"
   },
   "inbox": {
     "attentionTabLabel": "오늘",
@@ -3137,13 +3087,11 @@
   },
   "invite": {
     "title": "조직 초대",
-    "description": "초대를 수락하면 해당 조직에 합류합니다.",
     "accept": "초대 수락",
     "success": "합류 완료!",
     "redirecting": "대시보드로 이동 중...",
     "loading": "로딩 중...",
     "invalidToken": "유효하지 않은 초대 링크입니다.",
-    "acceptFailed": "초대 수락에 실패했습니다.",
     "accepting": "수락 중...",
     "authFailed": "인증에 실패했습니다. 다시 시도해주세요.",
     "inviteNotFound": "초대를 찾을 수 없습니다.",
@@ -3162,7 +3110,8 @@
     "submit": "합류하기",
     "invitedByOrg": "{org}에서 초대했습니다.",
     "signupEmail": "{email} 계정으로 가입됩니다.",
-    "decline": "거절 (나중에)"
+    "decline": "거절 (나중에)",
+    "acceptFailed": "초대 수락에 실패했습니다."
   },
   "resetPassword": {
     "title": "새 비밀번호 설정",
@@ -3261,28 +3210,7 @@
   "billing": {
     "title": "결제 관리",
     "loading": "불러오는 중...",
-    "currentPlan": "현재 플랜",
-    "nextBilling": "다음 결제일",
-    "via": "결제 수단:",
-    "updatePaymentMethod": "결제 수단 변경",
-    "grandfathered": "기존 구독자 혜택이 적용된 플랜입니다 (가격 보장)",
-    "upgradeCtaDesc": "Team 또는 Pro로 업그레이드하여 더 많은 기능을 사용하세요",
-    "upgradeCta": "업그레이드",
-    "invoices": "인보이스 내역",
-    "cancelSubscription": "구독 취소",
-    "cancelDesc": "구독을 취소하면 결제 기간 만료 후 무료 플랜으로 전환됩니다.",
-    "cancelBtn": "구독 취소",
-    "cancelModalTitle": "구독 취소",
-    "cancelModalDesc": "취소 방식을 선택하세요.",
-    "cancelEndOfPeriod": "현재 결제 기간 만료 후 취소",
-    "cancelImmediately": "즉시 취소 (환불 없음)",
-    "keep": "유지하기",
-    "confirmCancel": "취소 확인",
-    "cancelFailed": "구독 취소 실패",
-    "statusBilled": "결제 완료",
     "statusPending": "대기 중",
-    "statusRefunded": "환불됨",
-    "statusFailed": "실패",
     "auWarnTitle": "자동화 사용량이 {pct}%에 도달했습니다",
     "auWarnDesc": "이번 달 자동화(AU) 사용량이 한도의 80%를 넘었습니다. 플랜을 업그레이드하거나 다음 달 초기화를 기다려 주세요.",
     "auWarn90Title": "자동화 사용량 한도 임박({pct}%) — 관리자 메일 안내",
@@ -4150,7 +4078,6 @@
   "sprints": {
     "title": "스프린트",
     "loading": "로딩 중...",
-    "noProject": "프로젝트가 선택되지 않았습니다.",
     "noSprints": "아직 시작한 스프린트가 없어요",
     "noSprintsDescription": "스프린트는 한 번의 집중 사이클이에요. 시작할 때 가설을 선언하고, 끝나면 배운 것을 종합합니다.",
     "noSprintsCta": "첫 스프린트 시작하기",
@@ -4171,7 +4098,6 @@
     "startDate": "시작일",
     "endDate": "종료일",
     "cancel": "취소",
-    "create": "생성",
     "createError": "스프린트 생성에 실패했습니다.",
     "activate": "스프린트 시작",
     "close": "스프린트 종료",
@@ -4192,7 +4118,6 @@
     "goalPlaceholder": "이번 스프린트에서 무엇을 완수하는가?",
     "capacityLabel": "공수",
     "teamSizeLabel": "인원",
-    "hypothesisSection": "효과 가설",
     "delete": "스프린트 삭제",
     "deleteConfirmTitle": "스프린트를 삭제할까요?",
     "deleteConfirmBody": "이 작업은 되돌릴 수 없습니다. 연결된 스토리는 백로그로 이동되고 회고·스탠드업 연결이 해제됩니다.",
@@ -4214,7 +4139,6 @@
     "declareStatementLabel": "가설 statement",
     "declareStatementPlaceholder": "이 스프린트에서 무엇을 검증하는지",
     "declareDraftCta": "AI 초안으로 시작",
-    "declareDrafting": "제안 중...",
     "declareDraftNoteTitle": "AI 초안 — 검토·수정 후 확정하세요.",
     "declareDraftNoteBody": "확정은 당신이 한다 — 편집하거나 그대로 두세요.",
     "declareGa4DateRangePlaceholder": "측정 기간(일)",
@@ -4490,13 +4414,6 @@
   },
   "activityLog": {
     "title": "활동 로그",
-    "eyebrow": "활동",
-    "description": "프로젝트 활동 내역 — 누가, 언제, 어떤 엔티티에 무엇을 했는지 확인합니다.",
-    "colTime": "시간",
-    "colActor": "수행자",
-    "colAction": "액션",
-    "colEntity": "엔티티",
-    "colContext": "컨텍스트",
     "filterAll": "전체",
     "filterActor": "수행자",
     "filterAction": "액션 (입력하여 필터)",
@@ -4508,8 +4425,7 @@
     "reload": "새로고침",
     "loadMore": "더 보기",
     "forbiddenTitle": "접근 권한 없음",
-    "forbiddenDescription": "활동 로그를 조회할 권한이 없습니다.",
-    "noProject": "선택된 프로젝트가 없습니다."
+    "forbiddenDescription": "활동 로그를 조회할 권한이 없습니다."
   },
   "teamActivity": {
     "title": "활동",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "verify:no-duplicate-i18n-keys": "tsx scripts/verify-no-duplicate-i18n-keys.ts",
     "verify:no-hanja-in-i18n": "tsx scripts/verify-no-hanja-in-i18n.ts",
     "verify:i18n-keys-exist": "tsx scripts/verify-i18n-keys-exist.ts",
+    "verify:i18n-namespace-referenced": "tsx scripts/verify-i18n-namespace-referenced.ts",
     "verify:route-file-exports": "tsx scripts/verify-route-file-exports.ts",
     "verify:no-new-raw-button": "tsx scripts/verify-no-new-raw-button.ts",
     "verify:ci-wires-all-verify-scripts": "tsx scripts/verify-ci-wires-all-verify-scripts.ts",

--- a/apps/web/scripts/i18n-overlay-consumed-namespaces.json
+++ b/apps/web/scripts/i18n-overlay-consumed-namespaces.json
@@ -2,7 +2,7 @@
   "_comment": "story #3757 — 비공개 SaaS 오버레이(moonklabs/sprintable-saas)가 여는 최상위 i18n 네임스페이스 목록. CI는 그 저장소에 접근할 수 없어(private repo, 별도 접근권) 이 저장소 안에 정적으로 등재한다 — 등재≠배선(그 자체가 실시간 검증이 아니라는 뜻, 아래 만료 조건 참고).",
   "overlay_commit_sha": "eea5a6dd90750413f9371ed6126905dd00f9f9d4",
   "overlay_commit_date": "2026-05-01",
-  "measured_by": "디캄포 은두카쿠, 2026-09-10 — shallow clone(`git clone --depth 1 https://github.com/moonklabs/sprintable-saas.git`) 뒤 `useTranslations\\(['\"][a-zA-Z.]+['\"]\\)|getTranslations\\(...\\)` 정규식 전수 스캔(유나 표 v2/v3 6ns와 일치 재확認: common 3·settings 2·usage 1·pricing 1·nav 1·meeting 1 호출부).",
+  "measured_by": "디캄포 은두카쿠, 2026-09-10 — shallow clone(`git clone --depth 1 https://github.com/moonklabs/sprintable-saas.git`) 뒤 `useTranslations\\(['\"][a-zA-Z.]+['\"]\\)|getTranslations\\(...\\)` 정규식 전수 스캔(유나 표 v2/v3 6ns와 일치 재확認: common 3·settings 2·usage 1·pricing 1·nav 1·meeting 1 호출부). 유나가 독립 재확認(2026-09-10) — 자기 로컬 HEAD sha `75079f8`(같은 커밋 메시지, `eea5a6d`와 46초 차 — amend/rebase로 재작성된 동일 내용 커밋으로 추정)에서도 같은 6ns를 얻어 재현.",
   "namespaces": ["common", "settings", "usage", "pricing", "nav", "meeting"],
-  "expiry_condition": "오버레이 저장소의 최신 커밋 sha가 위 overlay_commit_sha와 달라지면 이 목록은 만료된 것으로 간주 — 재측정(같은 방법론) 없이 이 파일만 믿고 ns 가드 판정을 내리면 안 된다. 재측정 시 이 파일 전체(sha·date·namespaces)를 갱신할 것. 오버레이 저장소 접근권이 없는 세션(대부분의 CI 실행)은 이 파일을 그대로 신뢰하되, 그 신뢰가 '최종 커밋이 2026-05-01로 멈춰 있다'는 사실에 기반한 잠정치임을 verify-i18n-namespace-referenced.ts 콘솔 출력에 항상 명시한다."
+  "expiry_condition": "유나 지적(2026-09-10, design review) — sha 불일치를 '즉시 만료'로 두면 이 파일이 실제로 유효한 채로도 거짓 만료가 난다(위 measured_by 사례가 실증: 두 세션이 다른 sha를 봤지만 ns 목록은 완전히 동일했다). 만료의 진짜 축은 '오버레이가 여는 ns 목록이 바뀌었나'이지 'sha 문자열이 같은가'가 아니다 — sha 불일치는 **즉시 만료가 아니라 재측정 트리거**로 다룬다: 같은 방법론으로 다시 재보고 namespaces 배열이 실제로 달라졌을 때만 이 파일 전체(sha·date·namespaces)를 갱신한다. 오버레이 저장소 접근권이 없는 세션(대부분의 CI 실행)은 이 파일을 그대로 신뢰하되, 그 신뢰가 '최종 커밋이 2026-05-01 전후로 멈춰 있다'는 사실에 기반한 잠정치임을 verify-i18n-namespace-referenced.ts 콘솔 출력에 항상 명시한다."
 }

--- a/apps/web/scripts/i18n-overlay-consumed-namespaces.json
+++ b/apps/web/scripts/i18n-overlay-consumed-namespaces.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "story #3757 — 비공개 SaaS 오버레이(moonklabs/sprintable-saas)가 여는 최상위 i18n 네임스페이스 목록. CI는 그 저장소에 접근할 수 없어(private repo, 별도 접근권) 이 저장소 안에 정적으로 등재한다 — 등재≠배선(그 자체가 실시간 검증이 아니라는 뜻, 아래 만료 조건 참고).",
+  "overlay_commit_sha": "eea5a6dd90750413f9371ed6126905dd00f9f9d4",
+  "overlay_commit_date": "2026-05-01",
+  "measured_by": "디캄포 은두카쿠, 2026-09-10 — shallow clone(`git clone --depth 1 https://github.com/moonklabs/sprintable-saas.git`) 뒤 `useTranslations\\(['\"][a-zA-Z.]+['\"]\\)|getTranslations\\(...\\)` 정규식 전수 스캔(유나 표 v2/v3 6ns와 일치 재확認: common 3·settings 2·usage 1·pricing 1·nav 1·meeting 1 호출부).",
+  "namespaces": ["common", "settings", "usage", "pricing", "nav", "meeting"],
+  "expiry_condition": "오버레이 저장소의 최신 커밋 sha가 위 overlay_commit_sha와 달라지면 이 목록은 만료된 것으로 간주 — 재측정(같은 방법론) 없이 이 파일만 믿고 ns 가드 판정을 내리면 안 된다. 재측정 시 이 파일 전체(sha·date·namespaces)를 갱신할 것. 오버레이 저장소 접근권이 없는 세션(대부분의 CI 실행)은 이 파일을 그대로 신뢰하되, 그 신뢰가 '최종 커밋이 2026-05-01로 멈춰 있다'는 사실에 기반한 잠정치임을 verify-i18n-namespace-referenced.ts 콘솔 출력에 항상 명시한다."
+}

--- a/apps/web/scripts/verify-i18n-keys-exist.test.ts
+++ b/apps/web/scripts/verify-i18n-keys-exist.test.ts
@@ -129,6 +129,87 @@ describe('scanFileContent — story #5ead8723 AC1/AC2/AC3(셀프테스트 6)', (
     expect(result.totalCallCount).toBe(3);
   });
 
+  // story #3757 — dynamicNamespaces(ns 단위 죽은 키 가드가 「이 ns는 동적 호출이 있어
+  // 하위 전부 보류」를 판단하는 재료). ns가 알려진 바인딩을 통한 동적 호출만 담는다.
+  describe('dynamicNamespaces — story #3757', () => {
+    it('⭐ns가 알려진 바인딩의 동적 호출은 그 ns를 dynamicNamespaces에 담는다', () => {
+      const src = `
+        const t = useTranslations('loops');
+        t(\`status\${s}\`);
+      `;
+      const result = scanFileContent(src, 'fake.tsx');
+      expect(result.dynamicNamespaces).toEqual(new Set(['loops']));
+    });
+
+    it('리터럴 호출만 있으면 dynamicNamespaces는 비어 있다', () => {
+      const src = `
+        const t = useTranslations('nav');
+        t('dashboard');
+      `;
+      const result = scanFileContent(src, 'fake.tsx');
+      expect(result.dynamicNamespaces).toEqual(new Set());
+    });
+
+    it('unknown-ns(③ 번역자 파라미터) 동적 호출은 dynamicNamespaces에 안 담긴다(어느 ns인지 모름)', () => {
+      const src = `
+        function C({ t }: { t: ReturnType<typeof useTranslations> }) {
+          return t(dynamicKey);
+        }
+      `;
+      const result = scanFileContent(src, 'fake.tsx');
+      expect(result.dynamicNamespaces).toEqual(new Set());
+      expect(result.dynamicCount).toBe(1);
+    });
+
+    it('한 파일에 여러 ns가 각각 동적 호출을 가지면 전부 담는다', () => {
+      const src = `
+        const t = useTranslations('a');
+        const t2 = useTranslations('b');
+        t(dynamicVar);
+        t2(dynamicVar);
+      `;
+      const result = scanFileContent(src, 'fake.tsx');
+      expect(result.dynamicNamespaces).toEqual(new Set(['a', 'b']));
+    });
+  });
+
+  // story #3757 — unknownNsLiteralWords(층 A′). unknown-ns(③/⑤/⑥) 바인딩을 통한 호출이라도
+  // 인자가 리터럴이면 그 낱말은 안다 — 정확한 namespace.key는 못 지어도 "이 낱말 자체는
+  // 죽지 않았다"를 죽은-키 판정 쪽에 넘긴다.
+  describe('unknownNsLiteralWords — story #3757', () => {
+    it('⭐번역자 파라미터를 통한 리터럴 호출은 그 낱말을 unknownNsLiteralWords에 담는다(member-display.ts 실 형)', () => {
+      const src = `
+        function memberDisplayLabel(name: string | null, t: (key: string) => string): string {
+          return name ? name : t('memberUnnamed');
+        }
+      `;
+      const result = scanFileContent(src, 'fake.tsx');
+      expect(result.unknownNsLiteralWords).toEqual(new Set(['memberUnnamed']));
+      expect(result.literalRefs).toEqual([]); // ns를 모르니 전체경로 리터럴로는 안 잡힘(동적 카운트로만)
+      expect(result.dynamicCount).toBe(1);
+    });
+
+    it('알려진 ns 바인딩의 리터럴 호출은 unknownNsLiteralWords에 안 담긴다(literalRefs로 이미 잡힘)', () => {
+      const src = `
+        const t = useTranslations('nav');
+        t('dashboard');
+      `;
+      const result = scanFileContent(src, 'fake.tsx');
+      expect(result.unknownNsLiteralWords).toEqual(new Set());
+    });
+
+    it('unknown-ns 바인딩이라도 인자가 동적(변수)이면 낱말을 못 얻으므로 안 담긴다', () => {
+      const src = `
+        function C(t: (key: string) => string, dynamicKey: string) {
+          return t(dynamicKey);
+        }
+      `;
+      const result = scanFileContent(src, 'fake.tsx');
+      expect(result.unknownNsLiteralWords).toEqual(new Set());
+      expect(result.dynamicCount).toBe(1);
+    });
+  });
+
   it('네임스페이스 없는(루트) useTranslations()도 지원한다', () => {
     const src = `
       const t = useTranslations();

--- a/apps/web/scripts/verify-i18n-keys-exist.ts
+++ b/apps/web/scripts/verify-i18n-keys-exist.ts
@@ -112,6 +112,19 @@ export interface ScanResult {
   dynamicCount: number;
   totalCallCount: number;
   filesWithBindings: number;
+  // story #3757(별건 ⑤ 후속) — 「동적 호출이 하나라도 있는 네임스페이스」 집합. ns가
+  // 알려진(문자열) 바인딩을 통한 동적 호출만 담는다 — ③/⑤/⑥(번역자 파라미터·훅 반환)의
+  // unknown-ns(null) 동적 호출은 애초에 「어느 ns를 held back할지」를 모르므로 여기 안
+  // 들어간다(그쪽은 개별 낱말 축 A′로 별도 다룸, 이 필드와는 다른 축).
+  dynamicNamespaces: Set<string>;
+  // story #3757 — 층 A′(유나 정의): unknown-ns(③/⑤/⑥ 번역자 파라미터/훅 반환) 바인딩을
+  // 통한 호출이라도 인자가 여전히 문자열 리터럴이면(가장 흔한 실 패턴 — member-display.ts의
+  // `memberDisplayLabel(name, t)`가 `t('memberUnnamed')`를 리터럴로 부른다), 정확한
+  // namespace.key 전체경로는 못 지어도 그 "낱말"(마지막 세그먼트) 자체는 안다 — 그 낱말이
+  // «어느 네임스페이스 밑에도» 죽었다고 오판되지 않게(과소살해 방지, 정확한 ns를 못 좁히는
+  // 대가로 관대하게 살린다). ko/en 어느 네임스페이스의 말단이든 이 집합의 문자열과 정확히
+  // 같으면 「죽지 않았다」로 본다 — 죽은-키 판정(이 파일 밖 소비처)이 쓰는 재료.
+  unknownNsLiteralWords: Set<string>;
 }
 
 const TRANSLATION_METHODS = new Set(['rich', 'raw', 'has']);
@@ -287,6 +300,7 @@ function translatorPropNamesOfParamType(
 // 파라미터) — 바인딩은 있으나 네임스페이스를 몰라 그 호출은 항상 동적 버킷.
 export function scanFileContent(content: string, file: string): {
   literalRefs: KeyRef[]; dynamicCount: number; totalCallCount: number; hasBindings: boolean;
+  dynamicNamespaces: Set<string>; unknownNsLiteralWords: Set<string>;
 } {
   const sf = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
   const parseDiagnostics = (sf as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics;
@@ -311,6 +325,8 @@ export function scanFileContent(content: string, file: string): {
   const literalRefs: KeyRef[] = [];
   let dynamicCount = 0;
   let totalCallCount = 0;
+  const dynamicNamespaces = new Set<string>();
+  const unknownNsLiteralWords = new Set<string>();
 
   function registerBindingFromInitializer(varName: string, initRaw: ts.Expression): void {
     const init = ts.isAwaitExpression(initRaw) ? initRaw.expression : initRaw;
@@ -331,6 +347,11 @@ export function scanFileContent(content: string, file: string): {
       literalRefs.push({ file, line, fullKey });
     } else {
       dynamicCount += 1;
+      if (ns !== null) {
+        dynamicNamespaces.add(ns);
+      } else if (arg && ts.isStringLiteral(arg)) {
+        unknownNsLiteralWords.add(arg.text);
+      }
     }
   }
 
@@ -412,7 +433,10 @@ export function scanFileContent(content: string, file: string): {
   }
   walk(sf);
 
-  return { literalRefs, dynamicCount, totalCallCount, hasBindings: bindings.size > 0 };
+  return {
+    literalRefs, dynamicCount, totalCallCount, hasBindings: bindings.size > 0,
+    dynamicNamespaces, unknownNsLiteralWords,
+  };
 }
 
 const EXT_RE = /\.tsx?$/;
@@ -431,16 +455,21 @@ function walkDir(dir: string, out: string[]): void {
   }
 }
 
-export function scanRepo(srcRoot: string): ScanResult {
+// story #3757 — minExpectedFiles 오버라이드 가능(기본값=실 저장소 기준 MIN_EXPECTED_FILES).
+// 임시 픽스처 디렉터리(파일 수십 개 미만)로 이 함수를 끝까지 돌리는 통합 테스트가
+// 이 자기방어 체크에 걸리지 않게 여는 것 — 실 저장소 스캔(인자 생략)의 안전판은 그대로.
+export function scanRepo(srcRoot: string, minExpectedFiles: number = MIN_EXPECTED_FILES): ScanResult {
   const files: string[] = [];
   walkDir(srcRoot, files);
-  if (files.length < MIN_EXPECTED_FILES) {
+  if (files.length < minExpectedFiles) {
     throw new Error(`FAIL: 검사 대상 파일이 ${files.length}개뿐(srcRoot=${srcRoot}) — 가드가 헛돌고 있다.`);
   }
   const literalRefs: KeyRef[] = [];
   let dynamicCount = 0;
   let totalCallCount = 0;
   let filesWithBindings = 0;
+  const dynamicNamespaces = new Set<string>();
+  const unknownNsLiteralWords = new Set<string>();
   for (const abs of files) {
     const rel = path.relative(srcRoot, abs).split(path.sep).join('/');
     const content = readFileSync(abs, 'utf8');
@@ -449,8 +478,13 @@ export function scanRepo(srcRoot: string): ScanResult {
     dynamicCount += result.dynamicCount;
     totalCallCount += result.totalCallCount;
     if (result.hasBindings) filesWithBindings += 1;
+    for (const ns of result.dynamicNamespaces) dynamicNamespaces.add(ns);
+    for (const w of result.unknownNsLiteralWords) unknownNsLiteralWords.add(w);
   }
-  return { literalRefs, dynamicCount, totalCallCount, filesWithBindings };
+  return {
+    literalRefs, dynamicCount, totalCallCount, filesWithBindings,
+    dynamicNamespaces, unknownNsLiteralWords,
+  };
 }
 
 // story #5ead8723 AC1/AC2 — 점 경로를 메시지 트리에서 내려가 **말단**(string)까지 도달해야

--- a/apps/web/scripts/verify-i18n-namespace-referenced.test.ts
+++ b/apps/web/scripts/verify-i18n-namespace-referenced.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  collectTableBareKeys, isNamespaceReferenced, loadOverlayAllowlist, runScan,
+  type NamespaceReferenceInputs,
+} from './verify-i18n-namespace-referenced';
+
+function baseInputs(overrides: Partial<NamespaceReferenceInputs> = {}): NamespaceReferenceInputs {
+  return {
+    topLevelNamespaces: new Set(['nav']),
+    literalRefFullKeys: new Set(),
+    dynamicNamespaces: new Set(),
+    unknownNsLiteralWords: new Set(),
+    tableBareKeys: new Set(),
+    overlayNamespaces: new Set(),
+    leafKeysByNamespace: new Map([['nav', new Set(['dashboard'])]]),
+    ...overrides,
+  };
+}
+
+describe('isNamespaceReferenced — story #3757', () => {
+  it('A: 전체경로 리터럴 참조가 있으면 참조됨', () => {
+    const inputs = baseInputs({ literalRefFullKeys: new Set(['nav.dashboard']) });
+    expect(isNamespaceReferenced('nav', inputs)).toBe(true);
+  });
+
+  it('B: 동적 호출이 있는 ns는 참조됨(모름≠안 됨)', () => {
+    const inputs = baseInputs({ dynamicNamespaces: new Set(['nav']) });
+    expect(isNamespaceReferenced('nav', inputs)).toBe(true);
+  });
+
+  it("A′: unknown-ns 낱말이 이 ns의 leaf bare와 일치하면 참조됨", () => {
+    const inputs = baseInputs({ unknownNsLiteralWords: new Set(['dashboard']) });
+    expect(isNamespaceReferenced('nav', inputs)).toBe(true);
+  });
+
+  it('C: 데이터 카탈로그 낱말이 이 ns의 leaf bare와 일치하면 참조됨', () => {
+    const inputs = baseInputs({ tableBareKeys: new Set(['dashboard']) });
+    expect(isNamespaceReferenced('nav', inputs)).toBe(true);
+  });
+
+  it('D: SaaS 오버레이가 이 ns를 열면 참조됨', () => {
+    const inputs = baseInputs({ overlayNamespaces: new Set(['nav']) });
+    expect(isNamespaceReferenced('nav', inputs)).toBe(true);
+  });
+
+  it('⭐음성대조 — 네 신호가 전부 없으면 참조 안 됨(RED 대상)', () => {
+    const inputs = baseInputs();
+    expect(isNamespaceReferenced('nav', inputs)).toBe(false);
+  });
+
+  it('다른 ns의 신호는 이 ns를 못 살린다(namespace 경계 존중)', () => {
+    const inputs = baseInputs({
+      literalRefFullKeys: new Set(['other.dashboard']),
+      unknownNsLiteralWords: new Set(),
+    });
+    expect(isNamespaceReferenced('nav', inputs)).toBe(false);
+  });
+});
+
+describe('collectTableBareKeys — story #3757', () => {
+  it('descriptionKey/labelKey 등 등재된 필드의 리터럴 값을 모은다', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'table-bare-keys-'));
+    try {
+      writeFileSync(
+        path.join(dir, 'nav-config.ts'),
+        `export const items = [{ labelKey: 'board', descriptionKey: 'descBoard' }];`,
+      );
+      const keys = collectTableBareKeys(dir);
+      expect(keys).toEqual(new Set(['board', 'descBoard']));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('등재 안 된 *Key 필드(예: apiKey)는 안 잡는다(오탐 방지)', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'table-bare-keys-neg-'));
+    try {
+      writeFileSync(path.join(dir, 'auth.ts'), `const cfg = { apiKey: 'sk_live_xxx' };`);
+      const keys = collectTableBareKeys(dir);
+      expect(keys).toEqual(new Set());
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadOverlayAllowlist — story #3757', () => {
+  it('sha·date·namespaces를 읽는다', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'overlay-allowlist-'));
+    try {
+      const file = path.join(dir, 'overlay.json');
+      writeFileSync(file, JSON.stringify({
+        overlay_commit_sha: 'abc123', overlay_commit_date: '2026-01-01', namespaces: ['billing'],
+      }));
+      const loaded = loadOverlayAllowlist(file);
+      expect(loaded.namespaces).toEqual(['billing']);
+      expect(loaded.overlay_commit_sha).toBe('abc123');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// story #3757(카디르 qa:changes on #4107 동형 재발 방지) — runScan()이 실제로 4개 신호를
+// 전부 파이프라인에 연결하는지 임시 픽스처로 끝까지 돌려 확인. 순수 함수(isNamespaceReferenced)
+// 유닛 테스트만으론 이 배선 자체는 안 잰다.
+describe('runScan — 파이프라인 통합(story #3757)', () => {
+  function makeFixture(): { dir: string; srcRoot: string; koPath: string; enPath: string; overlayAllowlistPath: string } {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'i18n-ns-fixture-'));
+    const srcRoot = path.join(dir, 'src', 'components');
+    mkdirSync(srcRoot, { recursive: true });
+
+    // A: 리터럴 참조 ns.
+    writeFileSync(
+      path.join(srcRoot, 'a-widget.tsx'),
+      `
+        import { useTranslations } from 'next-intl';
+        export function AWidget() {
+          const t = useTranslations('nsA');
+          return <div>{t('label')}</div>;
+        }
+      `,
+    );
+    // B: 동적 호출 ns.
+    writeFileSync(
+      path.join(srcRoot, 'b-widget.tsx'),
+      `
+        import { useTranslations } from 'next-intl';
+        export function BWidget(status: string) {
+          const t = useTranslations('nsB');
+          return <div>{t(\`status_\${status}\`)}</div>;
+        }
+      `,
+    );
+    // A′: 번역자 파라미터를 통한 리터럴 — nsD의 bare 세그먼트('unnamedLabel')와 일치시킴.
+    writeFileSync(
+      path.join(srcRoot, 'helper.ts'),
+      `
+        export function label(t: (key: string) => string): string {
+          return t('unnamedLabel');
+        }
+      `,
+    );
+    // C: 데이터 카탈로그 리터럴 — nsE의 bare 세그먼트('descFoo')와 일치시킴.
+    writeFileSync(
+      path.join(srcRoot, 'nav-config.ts'),
+      `export const items = [{ descriptionKey: 'descFoo' }];`,
+    );
+
+    const koPath = path.join(dir, 'ko.json');
+    const enPath = path.join(dir, 'en.json');
+    const messages = {
+      nsA: { label: '라벨' },
+      nsB: { status_active: '활성' },
+      nsC: { onlyOverlay: '오버레이 전용' }, // D로만 살아남아야 함.
+      nsD: { unnamedLabel: '이름 없음' }, // A′로 살아남아야 함.
+      nsE: { descFoo: '설명' }, // C로 살아남아야 함.
+      nsDead: { orphanKey: '아무도 안 씀' }, // 넷 다 없음 — RED 대상.
+    };
+    writeFileSync(koPath, JSON.stringify(messages));
+    writeFileSync(enPath, JSON.stringify(messages));
+
+    const overlayAllowlistPath = path.join(dir, 'overlay.json');
+    writeFileSync(overlayAllowlistPath, JSON.stringify({
+      overlay_commit_sha: 'fixture', overlay_commit_date: '2026-01-01', namespaces: ['nsC'],
+    }));
+
+    return { dir, srcRoot, koPath, enPath, overlayAllowlistPath };
+  }
+
+  it('⭐임시 픽스처를 runScan()으로 끝까지 돌리면 A/A′/B/C/D 넷 다 각자 살리고 신호 0인 ns만 dead로 잡는다', () => {
+    const f = makeFixture();
+    try {
+      const { deadNamespaces, topLevelNamespaces } = runScan({
+        srcRoot: f.srcRoot, koPath: f.koPath, enPath: f.enPath, overlayAllowlistPath: f.overlayAllowlistPath, minExpectedFiles: 1,
+      });
+      expect(topLevelNamespaces).toEqual(new Set(['nsA', 'nsB', 'nsC', 'nsD', 'nsE', 'nsDead']));
+      expect(deadNamespaces).toEqual(['nsDead']);
+    } finally {
+      rmSync(f.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('⭐양성대조 — 죽은 ns 하나를 심으면(nsDead) RED 목록에 그 ns가 실제로 나온다', () => {
+    // 위 테스트가 이미 이걸 확인하지만(nsDead 존재), 여기서는 "심으면 RED가 된다"를
+    // 페드루 지시 문구 그대로 별도 표본으로 고정 — nsDead를 지워 GREEN으로 되돌아가는지까지.
+    const f = makeFixture();
+    try {
+      const before = runScan({
+        srcRoot: f.srcRoot, koPath: f.koPath, enPath: f.enPath, overlayAllowlistPath: f.overlayAllowlistPath, minExpectedFiles: 1,
+      });
+      expect(before.deadNamespaces).toContain('nsDead');
+
+      // nsDead를 제거한 메시지로 다시 쓰고 재실행 — 이제 dead 후보가 0이어야 한다.
+      const messagesWithoutDead = {
+        nsA: { label: '라벨' }, nsB: { status_active: '활성' }, nsC: { onlyOverlay: 'x' },
+        nsD: { unnamedLabel: 'x' }, nsE: { descFoo: 'x' },
+      };
+      writeFileSync(f.koPath, JSON.stringify(messagesWithoutDead));
+      writeFileSync(f.enPath, JSON.stringify(messagesWithoutDead));
+      const after = runScan({
+        srcRoot: f.srcRoot, koPath: f.koPath, enPath: f.enPath, overlayAllowlistPath: f.overlayAllowlistPath, minExpectedFiles: 1,
+      });
+      expect(after.deadNamespaces).toEqual([]);
+    } finally {
+      rmSync(f.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('⭐양성대조 — 살아 있는 ns의 유일한 참조를 지우면 그 ns가 RED로 넘어간다', () => {
+    const f = makeFixture();
+    try {
+      const before = runScan({
+        srcRoot: f.srcRoot, koPath: f.koPath, enPath: f.enPath, overlayAllowlistPath: f.overlayAllowlistPath, minExpectedFiles: 1,
+      });
+      expect(before.deadNamespaces).not.toContain('nsA');
+
+      // nsA를 참조하던 유일한 파일을 지운다(A층 신호 제거).
+      rmSync(path.join(f.srcRoot, 'a-widget.tsx'));
+      const after = runScan({
+        srcRoot: f.srcRoot, koPath: f.koPath, enPath: f.enPath, overlayAllowlistPath: f.overlayAllowlistPath, minExpectedFiles: 1,
+      });
+      expect(after.deadNamespaces).toContain('nsA');
+    } finally {
+      rmSync(f.dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/web/scripts/verify-i18n-namespace-referenced.ts
+++ b/apps/web/scripts/verify-i18n-namespace-referenced.ts
@@ -1,0 +1,200 @@
+/**
+ * story #3757(별건 ⑤) — i18n 「죽은 키」 messages→코드 역방향 최상위 ns 단위 가드.
+ *
+ * 기존 `check-i18n-keys.js`(#2371, 루트 스크립트, 정규식 기반)가 이미 이 방향(②)을
+ * 시도했으나, 그 파서의 훅-바인딩 인식이 직접 `useTranslations()` 호출만 알고 유나
+ * 표(v2/v3, `b8695901-8134-4767-ab35-db59071ab607`)가 "여섯 표기"로 부른 나머지 넷
+ * (번역자 파라미터·call-signature 인터페이스·프로퍼티 접근·훅 반환 구조분해)을 몰라
+ * `common.memberUnnamed`류를 대량으로 거짓 사망 처리했다(실측 2026-09-10: 정규식
+ * 스캔 1174건 vs 이 파일이 재사용하는 TS AST 워커 159건). **`check-i18n-keys.js`는
+ * 이 결함 클래스로 인해 폐기 대상**(이 스토리는 그 스크립트를 고치지 않는다 — PO 決
+ * 2026-09-09, 카드에만 적고 별도 폐기 스토리로) — 이 파일이 대신 `verify-i18n-keys-exist.ts`
+ * (#3754/#5ead8723, 여섯 표기 전부 검증된 TS AST 워커)를 새 기전 없이 재사용한다.
+ *
+ * ## 판정 — 최상위 네임스페이스 단위(키 단위 아님)
+ * 아래 네 신호 중 하나라도 있으면 그 네임스페이스는 "참조됨"(GREEN):
+ *   A/A′ — `scanRepo()`의 literalRefs 또는 unknownNsLiteralWords가 그 ns의 리프 키
+ *          중 하나라도 가리킴(전체경로 또는 낱말 매치).
+ *   B    — `scanRepo()`의 dynamicNamespaces에 그 ns가 있음(동적 호출 — 「참조됐는지
+ *          알 수 없음」이지 「참조 안 됨」이 아니다, 유나 정의).
+ *   C    — `KEY_FIELD_NAMES` 데이터 카탈로그 리터럴(`descriptionKey: 'x'`류)이 그 ns
+ *          어딘가의 bare 세그먼트와 일치.
+ *   D    — `i18n-overlay-consumed-namespaces.json`(비공개 SaaS 오버레이 정적 등재,
+ *          아래 파일 참고 — CI가 그 저장소에 못 붙어 정적 스냅샷으로 대신한다)에 그
+ *          ns 이름이 있음.
+ * 넷 다 없으면 그 네임스페이스 전체가 죽었다 — RED. 허용목록 0건(fail-closed).
+ *
+ * ⚠️이 가드가 «키 단위» dead 판정은 아니다 — ns 전체가 완전히 안 열리는 극단만 잡는다.
+ * 개별 키 단위 삭제 판정(A/B/C/D 신호가 하나라도 있는 ns 안에서 "이 특정 키"는 아직도
+ * 안 쓰일 수 있음)은 사람이 스토리 본문에서 직접 읽는다(#3757 AC2, ⛔이 가드는 그 축을
+ * 대신하지 않는다).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { collectLeafKeys, scanRepo } from './verify-i18n-keys-exist';
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const KO_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/ko.json');
+const EN_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/en.json');
+const OVERLAY_ALLOWLIST_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)), './i18n-overlay-consumed-namespaces.json',
+);
+
+// story #3420(check-i18n-keys.js)와 같은 근거로 확인된 실 i18n-key-holding 필드 이름만
+// 등재한다(grep 전수, 2026-09-10 — apiKey/authKey/storageKey류처럼 이름은 비슷해도
+// `t(x.field)`로 소비되지 않는 필드는 제외했다). 새 필드가 생기면 여기 등재해야 이
+// 층(C)이 잡는다 — 등재 없이는 그 필드를 쓰는 ns가 거짓 dead로 뜬다.
+const KEY_FIELD_NAMES = ['labelKey', 'descriptionKey', 'descKey', 'statusKey', 'helpKey', 'argHintKey'];
+const KEY_FIELD_RE = new RegExp(`\\b(?:${KEY_FIELD_NAMES.join('|')}):\\s*['"]([^'"]*)['"]`, 'g');
+
+type MessageNode = string | { [key: string]: MessageNode };
+
+const EXT_RE = /\.tsx?$/;
+const TEST_RE = /\.test\.tsx?$/;
+
+function walkDir(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) walkDir(full, out);
+    else if (EXT_RE.test(entry) && !TEST_RE.test(entry)) out.push(full);
+  }
+}
+
+export function collectTableBareKeys(srcRoot: string): Set<string> {
+  const files: string[] = [];
+  walkDir(srcRoot, files);
+  const out = new Set<string>();
+  for (const abs of files) {
+    const content = readFileSync(abs, 'utf8');
+    for (const m of content.matchAll(KEY_FIELD_RE)) {
+      if (m[1] !== '') out.add(m[1]);
+    }
+  }
+  return out;
+}
+
+export interface OverlayAllowlist {
+  overlay_commit_sha: string;
+  overlay_commit_date: string;
+  namespaces: string[];
+}
+
+export function loadOverlayAllowlist(filePath: string): OverlayAllowlist {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as OverlayAllowlist;
+}
+
+export interface NamespaceReferenceInputs {
+  topLevelNamespaces: Set<string>;
+  literalRefFullKeys: Set<string>;
+  dynamicNamespaces: Set<string>;
+  unknownNsLiteralWords: Set<string>;
+  tableBareKeys: Set<string>;
+  overlayNamespaces: Set<string>;
+  // 각 ns의 leaf 키(bare 세그먼트 포함) — unknownNsLiteralWords/tableBareKeys를 그 ns
+  // 안에서 실제로 갖고 있는지 볼 때 필요.
+  leafKeysByNamespace: Map<string, Set<string>>;
+}
+
+/** 네임스페이스 하나가 "참조됨"인지(A/A′/B/C/D 어느 신호든) 순수 판정 — self-test·main() 공용. */
+export function isNamespaceReferenced(ns: string, inputs: NamespaceReferenceInputs): boolean {
+  // A — 전체경로 리터럴 참조.
+  const leaves = inputs.leafKeysByNamespace.get(ns) ?? new Set();
+  for (const bare of leaves) {
+    if (inputs.literalRefFullKeys.has(`${ns}.${bare}`)) return true;
+  }
+  // B — 동적 호출이 하나라도 있는 ns 전체 보류(참조 안 됨이 아니라 모름).
+  if (inputs.dynamicNamespaces.has(ns)) return true;
+  // A′ — unknown-ns 리터럴 낱말이 이 ns의 leaf bare 세그먼트와 일치.
+  for (const bare of leaves) {
+    if (inputs.unknownNsLiteralWords.has(bare)) return true;
+  }
+  // C — 데이터 카탈로그 리터럴이 이 ns의 leaf bare 세그먼트와 일치.
+  for (const bare of leaves) {
+    if (inputs.tableBareKeys.has(bare)) return true;
+  }
+  // D — SaaS 오버레이가 이 ns를 연다(정적 등재, 키 단위 아님 — ns 단위 가드의 스코프).
+  if (inputs.overlayNamespaces.has(ns)) return true;
+  return false;
+}
+
+// story #3757(카디르 qa:changes on #4107 동형 재발 방지) — 순수 판정 함수(isNamespaceReferenced)
+// 유닛 테스트만으론 「main()이 그 함수를 실제로 이 파이프라인 안에서 부르는지」를 못 잰다
+// (verify-no-i18n-phrase-collision.ts에서 실제로 겪은 결함 클래스 — 호출부를 지워도 유닛
+// 테스트가 그대로 초록이었다). runScan에 경로 오버라이드를 열어 임시 픽스처 디렉터리로
+// 이 함수 전체를 끝까지 돌리는 통합 테스트를 가능하게 한다(scanRepoCounts(dir) 동형 관례).
+export function runScan(overrides: {
+  srcRoot?: string; koPath?: string; enPath?: string; overlayAllowlistPath?: string;
+  minExpectedFiles?: number;
+} = {}): { deadNamespaces: string[]; topLevelNamespaces: Set<string> } {
+  const srcRoot = overrides.srcRoot ?? SRC_ROOT;
+  const koPath = overrides.koPath ?? KO_PATH;
+  const enPath = overrides.enPath ?? EN_PATH;
+  const overlayAllowlistPath = overrides.overlayAllowlistPath ?? OVERLAY_ALLOWLIST_PATH;
+
+  const koMessages = JSON.parse(readFileSync(koPath, 'utf8')) as MessageNode;
+  const enMessages = JSON.parse(readFileSync(enPath, 'utf8')) as MessageNode;
+  const enLeaves = collectLeafKeys(enMessages);
+  const koLeaves = collectLeafKeys(koMessages);
+
+  const topLevelNamespaces = new Set<string>();
+  const leafKeysByNamespace = new Map<string, Set<string>>();
+  for (const leaf of new Set([...enLeaves, ...koLeaves])) {
+    const dotIdx = leaf.indexOf('.');
+    const ns = dotIdx === -1 ? leaf : leaf.slice(0, dotIdx);
+    const bare = leaf.slice(leaf.lastIndexOf('.') + 1);
+    topLevelNamespaces.add(ns);
+    if (!leafKeysByNamespace.has(ns)) leafKeysByNamespace.set(ns, new Set());
+    leafKeysByNamespace.get(ns)!.add(bare);
+  }
+
+  const scan = overrides.minExpectedFiles !== undefined
+    ? scanRepo(srcRoot, overrides.minExpectedFiles)
+    : scanRepo(srcRoot);
+  const literalRefFullKeys = new Set(scan.literalRefs.map((r) => r.fullKey));
+  const tableBareKeys = collectTableBareKeys(srcRoot);
+  const overlay = loadOverlayAllowlist(overlayAllowlistPath);
+  const overlayNamespaces = new Set(overlay.namespaces);
+
+  const inputs: NamespaceReferenceInputs = {
+    topLevelNamespaces,
+    literalRefFullKeys,
+    dynamicNamespaces: scan.dynamicNamespaces,
+    unknownNsLiteralWords: scan.unknownNsLiteralWords,
+    tableBareKeys,
+    overlayNamespaces,
+    leafKeysByNamespace,
+  };
+
+  const deadNamespaces = [...topLevelNamespaces].filter((ns) => !isNamespaceReferenced(ns, inputs));
+  return { deadNamespaces, topLevelNamespaces };
+}
+
+function main(): number {
+  const { deadNamespaces, topLevelNamespaces } = runScan();
+
+  console.log(
+    `[가드] i18n 네임스페이스 참조 스캔 — 네임스페이스 ${topLevelNamespaces.size}개 ` +
+      `(SaaS 오버레이 스냅샷 — 잠정치, i18n-overlay-consumed-namespaces.json 만료조건 참고)`,
+  );
+
+  if (deadNamespaces.length > 0) {
+    console.error(`\nFAIL: 참조 신호가 A/A′/B/C/D 어디에도 없는 네임스페이스 ${deadNamespaces.length}개:`);
+    for (const ns of deadNamespaces.sort()) console.error(`  ${ns}`);
+    console.error(
+      '\n→ 이 네임스페이스는 OSS 코드·SaaS 오버레이(정적 스냅샷) 어디서도 안 열린다 — 죽은 ' +
+        'ns 후보(키 단위 삭제 판정은 별도, story #3757 AC2). 허용목록 0건(fail-closed) — ' +
+        '정말 살아 있다면 위 네 신호 중 하나가 이 ns를 잡게 만들 것(overlay라면 ' +
+        'i18n-overlay-consumed-namespaces.json 재측정 후 등재).',
+    );
+    return 1;
+  }
+
+  console.log('\nOK: 모든 최상위 네임스페이스가 A/A′/B/C/D 중 하나 이상의 신호로 참조됨.');
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary
- `check-i18n-keys.js`(#2371, 루트 정규식 스캐너)로 재측정하면 dead 후보 1174건 — 유나 표(v2/v3, `b8695901-8134-4767-ab35-db59071ab607`)의 143건과 큰 격차. 원인: 이 스캐너가 "여섯 표기" 중 직접 `useTranslations()` 외 나머지 넷을 몰라 `common.memberUnnamed`류를 대량 거짓 사망 처리한다. **PO 決(2026-09-09) — `check-i18n-keys.js`는 이 결함 클래스로 폐기 대상, 이 스토리는 고치지 않는다(별도 폐기 스토리로).**
- 새 스캐너를 만들지 않고 `verify-i18n-keys-exist.ts`(#3754/#5ead8723)를 재사용 — `scanFileContent`/`scanRepo`에 `dynamicNamespaces`(층 B)·`unknownNsLiteralWords`(층 A′) 두 필드 추가.
- 신규 `verify-i18n-namespace-referenced.ts` — 최상위 네임스페이스가 A/A′/B/C(데이터 카탈로그 `*Key` 필드)/D(비공개 SaaS 오버레이, 정적 스냅샷) 넷 중 하나도 없으면 fail-closed. **현재 65개 네임스페이스 전부 GREEN.**
- 순수 판정 함수 유닛 테스트 + 카디르가 #4107 리뷰에서 발견한 "함수는 있는데 파이프라인 호출부가 없어도 유닛 테스트가 초록" 클래스 재발 방지용 임시 픽스처 통합 테스트. `ci.yml` + `package.json` 배선 완료.

## 삭제(후속 커밋) — 124건, 교집합만
- 디디 재계산(HEAD `5c55c8d10`, A+A′+B+C+D) 159건 ∩ 유나 재현(같은 HEAD, 153건, artifact `87733a68-6378-4faf-a776-0f405f06c48a`) 138건.
- ⚠️**교집합 138건 중에서도 14건을 최종 삭제 直前 수작업으로 되살렸다** — 두 자 모두가 공유하는 구조적 blind spot(`Record<string,string>` 조회 테이블의 값을 변수로 들고 `t(변수)`로 호출하는 간접 호출, 리터럴/데이터-카탈로그 필드명 검사 둘 다 원리적으로 못 봄):
  - `invite.acceptFailed`(1건) — `lib/invite-error-message.ts`의 fallbackKey 간접 호출. 삭제 시도 중 `invite-accept-client.test.tsx`가 tsc 타입에러로 실제로 잡아냄.
  - `dashboard.ccGateType*`(13건 전량) — `lib/gate-type-label.ts`의 `GATE_TYPE_LABEL_KEYS` 간접 호출(Command Center·게이트 상세·결재함 카드 3화면 공용).
  - 발견 방법: 138건 전체를 "이미 센 직접 t()/.rich()/.raw()/.has() 호출 밖의 다른 문자열 리터럴로 코드 어딘가에 나타나는가" 정규식 전수 스윕 → 23건 후보 → 9건은 무관 동음이의로 기각, 14건 확定.
- **최종 삭제 124건**, ko/en 대칭 유지.

FE tsc 무오류·vitest 7308 passed(gate-type 라벨·invite 폴백 메시지 실 렌더 포함).

## Test plan
- [x] FE `tsc --noEmit` 무오류
- [x] FE `vitest` 7308 passed
- [x] `pnpm --filter web verify:i18n-keys-exist` — 5120 말단(5244-124), missing 0건
- [x] `pnpm --filter web verify:i18n-namespace-referenced` — 65개 ns 전부 GREEN
- [x] `pnpm --filter web verify:no-duplicate-i18n-keys` / `verify:no-hanja-in-i18n` / `verify:no-i18n-phrase-collision` 전부 GREEN
- [x] `pnpm --filter web verify:ci-wires-all-verify-scripts` — 배선 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)