### PR TITLE
[SID:3763] promote(main): Cloudbuild Secret Manifest Guard union 대조 승격(#3272·#3552)

### DIFF
--- a/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
+++ b/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
@@ -277,3 +277,56 @@ def test_sync_against_real_manifest_and_real_gcp_if_available():
     manifest = pr_gate.load_manifest()
     ok, lines = sync_gate.check(manifest, live)
     assert ok, f"manifest가 GCP 실물과 어긋남(정기 갱신 필요) — {lines}"
+
+
+# ── story #3272 — main+develop manifest 합집합(스케줄 가드 배경음화 방지) ────────────────
+
+
+def test_parse_manifest_text_strips_blank_lines_and_comments():
+    text = "A\n# comment\n\nB\n  C  \n"
+    assert sync_gate.parse_manifest_text(text) == {"A", "B", "C"}
+
+
+def test_load_manifest_union_adds_develop_only_names():
+    """⭐핵심 pin — main 매니페스트엔 없고 develop에만 있는(=아직 승격 전) 이름이 union에
+    들어가면, 그 이름이 GCP에 있어도 더 이상 "GCP엔 있는데 manifest에 없음" 드리프트로
+    안 잡힌다(story #3272 실사고: SUPPORT_GATEWAY_*_dev 3종, run 33458117504)."""
+    with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
+         patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\nSUPPORT_GATEWAY_TOKEN_SECRET_dev\n"):
+        union = sync_gate.load_manifest_union()
+    assert union == {"A", "SUPPORT_GATEWAY_TOKEN_SECRET_dev"}
+
+    ok, lines = sync_gate.check(manifest=union, live={"A", "SUPPORT_GATEWAY_TOKEN_SECRET_dev"})
+    assert ok is True  # union 적용 전이었다면 main={"A"} 단독 대조로 이 케이스가 FAIL이었다.
+
+
+def test_load_manifest_union_falls_back_to_main_only_when_develop_fetch_fails():
+    """develop을 못 읽으면(네트워크 실패 등) 조용히 main 단독으로 폴백 — 완화가 안 걸릴
+    뿐, 이 스크립트 자체가 죽거나 예외를 삼켜 원인불명 성공을 내지는 않는다."""
+    with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
+         patch.object(sync_gate, "fetch_develop_manifest_text", return_value=None):
+        union = sync_gate.load_manifest_union()
+    assert union == {"A"}
+
+
+def test_load_manifest_union_still_catches_true_orphan_secret():
+    """⭐선언 검증 — main·develop 어느 쪽 manifest에도 없는 이름(진짜 고아)은 union
+    적용 후에도 여전히 "GCP엔 있는데 manifest에 없음"으로 잡힌다(이 처방이 넓히는 "정상"
+    범위는 develop이 아는 이름으로 한정된다는 모듈 docstring의 선언 그대로)."""
+    with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
+         patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\n"):
+        union = sync_gate.load_manifest_union()
+    ok, lines = sync_gate.check(manifest=union, live={"A", "TRULY_ORPHANED_SECRET"})
+    assert ok is False
+    assert any("TRULY_ORPHANED_SECRET" in line for line in lines)
+
+
+def test_load_manifest_union_still_catches_dangerous_axis_deleted_from_gcp():
+    """위험 축(manifest엔 있는데 GCP엔 없음)은 union 적용 후에도 그대로 잡힌다 — 이
+    처방이 손대는 건 저위험 축(GCP엔 있는데 manifest에 없음)뿐이다."""
+    with patch.object(sync_gate, "load_manifest", return_value={"A", "GHOST"}), \
+         patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\n"):
+        union = sync_gate.load_manifest_union()
+    ok, lines = sync_gate.check(manifest=union, live={"A"})
+    assert ok is False
+    assert any("GHOST" in line for line in lines)

--- a/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
+++ b/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
@@ -10,6 +10,7 @@
 AC2(양성대조) — 오탈자 뮤테이션 주입 시 ①이 실제로 red가 되는지가 이 스위트의 핵심 표본."""
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -293,8 +294,9 @@ def test_load_manifest_union_adds_develop_only_names():
     안 잡힌다(story #3272 실사고: SUPPORT_GATEWAY_*_dev 3종, run 33458117504)."""
     with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
          patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\nSUPPORT_GATEWAY_TOKEN_SECRET_dev\n"):
-        union = sync_gate.load_manifest_union()
+        union, fell_back = sync_gate.load_manifest_union()
     assert union == {"A", "SUPPORT_GATEWAY_TOKEN_SECRET_dev"}
+    assert fell_back is False
 
     ok, lines = sync_gate.check(manifest=union, live={"A", "SUPPORT_GATEWAY_TOKEN_SECRET_dev"})
     assert ok is True  # union 적용 전이었다면 main={"A"} 단독 대조로 이 케이스가 FAIL이었다.
@@ -302,11 +304,13 @@ def test_load_manifest_union_adds_develop_only_names():
 
 def test_load_manifest_union_falls_back_to_main_only_when_develop_fetch_fails():
     """develop을 못 읽으면(네트워크 실패 등) 조용히 main 단독으로 폴백 — 완화가 안 걸릴
-    뿐, 이 스크립트 자체가 죽거나 예외를 삼켜 원인불명 성공을 내지는 않는다."""
+    뿐, 이 스크립트 자체가 죽거나 예외를 삼켜 원인불명 성공을 내지는 않는다. story #3552
+    — 폴백 여부(두 번째 반환값)를 호출부가 알 수 있어야 한다."""
     with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
          patch.object(sync_gate, "fetch_develop_manifest_text", return_value=None):
-        union = sync_gate.load_manifest_union()
+        union, fell_back = sync_gate.load_manifest_union()
     assert union == {"A"}
+    assert fell_back is True
 
 
 def test_load_manifest_union_still_catches_true_orphan_secret():
@@ -315,7 +319,7 @@ def test_load_manifest_union_still_catches_true_orphan_secret():
     범위는 develop이 아는 이름으로 한정된다는 모듈 docstring의 선언 그대로)."""
     with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
          patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\n"):
-        union = sync_gate.load_manifest_union()
+        union, _fell_back = sync_gate.load_manifest_union()
     ok, lines = sync_gate.check(manifest=union, live={"A", "TRULY_ORPHANED_SECRET"})
     assert ok is False
     assert any("TRULY_ORPHANED_SECRET" in line for line in lines)
@@ -326,7 +330,81 @@ def test_load_manifest_union_still_catches_dangerous_axis_deleted_from_gcp():
     처방이 손대는 건 저위험 축(GCP엔 있는데 manifest에 없음)뿐이다."""
     with patch.object(sync_gate, "load_manifest", return_value={"A", "GHOST"}), \
          patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\n"):
-        union = sync_gate.load_manifest_union()
+        union, _fell_back = sync_gate.load_manifest_union()
     ok, lines = sync_gate.check(manifest=union, live={"A"})
     assert ok is False
     assert any("GHOST" in line for line in lines)
+
+
+# ── story #3552 — narrow(단일 브랜치 shallow) checkout에서 develop fetch가 실제로 되는지 ──
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_local_remote_with_main_and_develop(tmp_path: Path) -> Path:
+    """로컬 bare repo(파일시스템 경로 — GitHub 네트워크 0)에 main·develop 두 브랜치를
+    만들고 서로 다른 manifest 내용을 심는다. `actions/checkout@v4`의 narrow fetch
+    refspec 문제는 원격 프로토콜과 무관한 순수 git ref 메커니즘 문제라 로컬 경로로도
+    똑같이 재현된다."""
+    bare = tmp_path / "origin.git"
+    _git("init", "--bare", str(bare), cwd=tmp_path)
+
+    seed = tmp_path / "seed"
+    _git("clone", str(bare), str(seed), cwd=tmp_path)
+    _git("config", "user.email", "t@t.dev", cwd=seed)
+    _git("config", "user.name", "t", cwd=seed)
+
+    manifest_dir = seed / "infra"
+    manifest_dir.mkdir()
+    (manifest_dir / "cloudbuild-secret-manifest.txt").write_text("A\n")
+    _git("add", ".", cwd=seed)
+    _git("commit", "-m", "main", cwd=seed)
+    _git("branch", "-M", "main", cwd=seed)
+    _git("push", "origin", "main", cwd=seed)
+
+    _git("checkout", "-b", "develop", cwd=seed)
+    (manifest_dir / "cloudbuild-secret-manifest.txt").write_text("A\nDEVELOP_ONLY_SECRET\n")
+    _git("commit", "-am", "develop", cwd=seed)
+    _git("push", "origin", "develop", cwd=seed)
+
+    return bare
+
+
+def _narrow_clone_like_actions_checkout(bare_repo: Path, dest: Path) -> None:
+    """`actions/checkout@v4` 기본 동작 재현 — 단일 브랜치 shallow(narrow fetch refspec,
+    `remote.origin.fetch`가 checkout한 브랜치 하나로 좁혀짐)."""
+    subprocess.run(
+        ["git", "clone", "--depth=1", "--single-branch", "--branch", "main", str(bare_repo), str(dest)],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def test_fetch_develop_manifest_text_works_against_narrow_checkout_clone(tmp_path, monkeypatch):
+    """페드루 PO 판별축①(2026-09-06) 실물 재현 — `actions/checkout@v4` 기본(단일 브랜치
+    shallow)과 정확히 같은 조건에서도 `fetch_develop_manifest_text()`가 develop 텍스트를
+    정상 읽어야 한다. destination refspec(`origin develop:refs/remotes/origin/develop`)
+    없이는(뮤테이션 자가검증 대상) `origin/develop` ref가 안 만들어져 None(폴백)만 나온다
+    — 실 스케줄 run이 2026-09-03부터 매일 이 상태였다."""
+    bare = _init_local_remote_with_main_and_develop(tmp_path)
+    narrow = tmp_path / "narrow"
+    _narrow_clone_like_actions_checkout(bare, narrow)
+
+    monkeypatch.setattr(sync_gate, "_REPO_ROOT", narrow)
+    text = sync_gate.fetch_develop_manifest_text()
+    assert text is not None, "narrow checkout 환경에서 develop manifest를 못 읽었다(원래 결함 재현)"
+    assert "DEVELOP_ONLY_SECRET" in sync_gate.parse_manifest_text(text)
+
+
+def test_fetch_develop_manifest_text_prints_failure_reason_on_fallback(tmp_path, monkeypatch, capsys):
+    """페드루 PO 판별축②(2026-09-06) — 폴백 시 조용히 삼키지 않고 stderr에 실패 사유를
+    찍는다(원래 있던 침묵 폴백이 재발을 아무도 못 보게 했다)."""
+    not_a_repo = tmp_path / "not-a-repo"
+    not_a_repo.mkdir()
+    monkeypatch.setattr(sync_gate, "_REPO_ROOT", not_a_repo)
+
+    text = sync_gate.fetch_develop_manifest_text()
+    assert text is None
+    captured = capsys.readouterr()
+    assert "develop manifest fetch 실패" in captured.err

--- a/infra/sync_cloudbuild_secret_manifest.py
+++ b/infra/sync_cloudbuild_secret_manifest.py
@@ -11,6 +11,22 @@
 - manifest에 있는데 GCP에 없음 = **위험** — 시크릿이 실제로 삭제/이름변경됐는데 manifest는
   그걸 여전히 "존재"로 승인하고 있어 PR 게이트가 그 이름에 대해 거짓 안전(false green)을 낸다.
 
+story #3272(2026-09-01) — 스케줄 워크플로우(cloudbuild-secret-manifest-guard.yml)는 schedule
+트리거라 기본적으로 **main**을 checkout한다. dev 전용 시크릿(SUPPORT_GATEWAY_*_dev 3종 등,
+story #3140 후속 추가분)은 develop 매니페스트가 정본이고 main엔 승격 시점에야 도착한다 —
+그 사이 이 스크립트가 main만 보면 매번 "GCP엔 있는데 manifest에 없음"으로 FAIL을 쏘는
+«빨강=배경음» 클래스가 된다(실측: run 33458117504, develop 매니페스트엔 3/3 존재·main엔
+0/3). 처방: **main+develop 매니페스트의 합집합**을 GCP 실물과 대조한다 — `check()` 자체의
+2방향 판정(위험 축/저위험 축)은 그대로 유지하면서, "아직 승격 전"이라는 정상 상태를 더 이상
+드리프트로 오판하지 않는다.
+
+**이 처방이 새로 못 잡게 되는 것**(선언): main엔 아예 없고 develop 매니페스트에만 적힌
+이름이 GCP에도 존재하면(예: 실험 브랜치가 등록했지만 결국 main에 승격 안 시킨 시크릿), 이
+가드는 이제 그걸 "정상"(승격 대기 중)으로 봐준다 — 실제로는 그냥 만들어두고 잊은 고아
+시크릿일 수 있다. main·GCP 어느 쪽에도 없는 이름(진짜 고아)은 여전히 잡는다(develop에도
+없으면 union에서 빠지므로 `only_in_gcp`로 그대로 걸린다) — 이 처방이 넓히는 "정상" 범위는
+정확히 "develop 매니페스트가 이미 알고 있는 이름"으로 제한된다.
+
 **이 스크립트가 못 잡는 것**(선언, AC3): 이름이 존재하고 manifest·GCP 둘 다 일치해도 그
 시크릿의 **내용**(값)이 낡았는지는 안 본다(예: 로테이션 기한이 지난 API 키) — 이름 존재 축과
 내용 신선도 축은 별개 문제.
@@ -29,6 +45,47 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from check_cloudbuild_secret_manifest import _MANIFEST_PATH, load_manifest  # noqa: E402
 from cloudbuild_secret_refs import _REPO_ROOT  # noqa: E402
+
+_MANIFEST_RELATIVE_PATH = "infra/cloudbuild-secret-manifest.txt"
+
+
+def parse_manifest_text(text: str) -> set[str]:
+    """load_manifest()와 동일한 파싱 규칙(빈 줄·주석 제외) — git show로 얻은 develop 쪽
+    텍스트에 재사용하는 순수 함수(테스트가 git/subprocess 없이 검증)."""
+    return {
+        line.strip() for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+
+
+def fetch_develop_manifest_text() -> str | None:
+    """origin/develop의 manifest 파일 내용을 로컬 clone 안에서 직접 읽는다(git show — 추가
+    GCP 권한 불요, 이미 checkout된 로컬 저장소만 씀). 실패(fetch 안 됨·develop에 파일이
+    없음 등)하면 조용히 None — 그 경우 main 단독으로 대조(구 동작으로 안전측 폴백, 회귀는
+    아니고 "완화가 적용 안 됨"일 뿐)."""
+    try:
+        subprocess.run(
+            ["git", "fetch", "--depth=1", "origin", "develop"],
+            cwd=_REPO_ROOT, capture_output=True, text=True, check=True, timeout=30,
+        )
+        proc = subprocess.run(
+            ["git", "show", f"origin/develop:{_MANIFEST_RELATIVE_PATH}"],
+            cwd=_REPO_ROOT, capture_output=True, text=True, check=True, timeout=30,
+        )
+        return proc.stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def load_manifest_union() -> set[str]:
+    """story #3272 — 현재 checkout(스케줄 워크플로우=main)의 manifest + develop 브랜치의
+    manifest 합집합. develop 텍스트를 못 읽으면(위 fetch_develop_manifest_text 참고)
+    main 단독으로 폴백한다."""
+    manifest = load_manifest()
+    develop_text = fetch_develop_manifest_text()
+    if develop_text is not None:
+        manifest |= parse_manifest_text(develop_text)
+    return manifest
 
 
 def _live_gcp_secret_names() -> set[str]:
@@ -65,13 +122,13 @@ def check(manifest: set[str], live: set[str]) -> tuple[bool, list[str]]:
 
 
 def main() -> int:
-    manifest = load_manifest()
+    manifest = load_manifest_union()
     live = _live_gcp_secret_names()
     ok, lines = check(manifest, live)
     for line in lines:
         print(line)
     if ok:
-        print(f"OK — manifest({len(manifest)}건)가 GCP 실물과 정확히 일치.")
+        print(f"OK — manifest(main+develop 합집합 {len(manifest)}건)가 GCP 실물과 정확히 일치.")
     return 0 if ok else 1
 
 

--- a/infra/sync_cloudbuild_secret_manifest.py
+++ b/infra/sync_cloudbuild_secret_manifest.py
@@ -20,6 +20,20 @@ story #3140 후속 추가분)은 develop 매니페스트가 정본이고 main엔
 2방향 판정(위험 축/저위험 축)은 그대로 유지하면서, "아직 승격 전"이라는 정상 상태를 더 이상
 드리프트로 오판하지 않는다.
 
+story #3552(2026-09-06, 페드루 PO 확定·디디 로컬 재현) — 위 처방이 실 스케줄 run에서
+**무력했다**(2026-09-03~09-06 매일 실패, develop엔 이미 등재된 5개를 여전히 "manifest에
+없음"으로 잡음). 근본 원인은 `actions/checkout@v4` 기본(단일 브랜치 shallow)이
+`remote.origin.fetch`를 `+refs/heads/main:refs/remotes/origin/main` 하나로 좁혀두는
+것 — 그 뒤 `git fetch --depth=1 origin develop`(목적지 refspec 없음)은 **성공은 하지만**
+(exit 0, FETCH_HEAD만 갱신) `refs/remotes/origin/develop` 자체를 안 만든다(narrow
+refspec이라 자동 매핑도 없음). 다음 줄 `git show origin/develop:...`이 "invalid object
+name" exit 128로 죽고, 그게 `CalledProcessError`로 조용히 삼켜져 매번 폴백만 탔다(로컬
+git clone --depth=1 --single-branch --branch main 재현으로 100% 재확認, GCP 인증 불요).
+처방: fetch에 목적지 refspec을 명시(`origin develop:refs/remotes/origin/develop`)해
+narrow refspec과 무관하게 그 ref를 강제로 만든다 + 폴백 시 실패 사유를 stderr에 찍고
+최종 출력에도 "main 단독(develop 미반영)"임을 명시(침묵 폴백 재발 방지, 페드루 PO
+판별축②).
+
 **이 처방이 새로 못 잡게 되는 것**(선언): main엔 아예 없고 develop 매니페스트에만 적힌
 이름이 GCP에도 존재하면(예: 실험 브랜치가 등록했지만 결국 main에 승격 안 시킨 시크릿), 이
 가드는 이제 그걸 "정상"(승격 대기 중)으로 봐준다 — 실제로는 그냥 만들어두고 잊은 고아
@@ -61,11 +75,18 @@ def parse_manifest_text(text: str) -> set[str]:
 def fetch_develop_manifest_text() -> str | None:
     """origin/develop의 manifest 파일 내용을 로컬 clone 안에서 직접 읽는다(git show — 추가
     GCP 권한 불요, 이미 checkout된 로컬 저장소만 씀). 실패(fetch 안 됨·develop에 파일이
-    없음 등)하면 조용히 None — 그 경우 main 단독으로 대조(구 동작으로 안전측 폴백, 회귀는
-    아니고 "완화가 적용 안 됨"일 뿐)."""
+    없음 등)하면 None — 그 경우 main 단독으로 대조(구 동작으로 안전측 폴백)하되, 실패
+    사유는 stderr에 찍는다(story #3552 — 조용히 삼키면 재발을 아무도 못 본다).
+
+    story #3552 — fetch 목적지에 `:refs/remotes/origin/develop`를 명시한다. 이게 없으면
+    `actions/checkout@v4` 기본(단일 브랜치 shallow, `remote.origin.fetch`가 checkout한
+    브랜치 하나로 좁혀짐)인 환경에서 이 fetch 자체는 성공해도(exit 0, FETCH_HEAD만 갱신)
+    `origin/develop` ref가 실제로 안 만들어져 다음 줄 `git show origin/develop:...`이
+    매번 "invalid object name"으로 죽는다 — 실 스케줄 run이 2026-09-03부터 이 상태였다
+    (로컬 narrow-clone 재현으로 확認, GCP 인증 불요)."""
     try:
         subprocess.run(
-            ["git", "fetch", "--depth=1", "origin", "develop"],
+            ["git", "fetch", "--depth=1", "origin", "develop:refs/remotes/origin/develop"],
             cwd=_REPO_ROOT, capture_output=True, text=True, check=True, timeout=30,
         )
         proc = subprocess.run(
@@ -73,19 +94,23 @@ def fetch_develop_manifest_text() -> str | None:
             cwd=_REPO_ROOT, capture_output=True, text=True, check=True, timeout=30,
         )
         return proc.stdout
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        reason = exc.stderr.strip() if isinstance(exc, subprocess.CalledProcessError) and exc.stderr else str(exc)
+        print(f"⚠️ develop manifest fetch 실패(main 단독 폴백) — {reason}", file=sys.stderr)
         return None
 
 
-def load_manifest_union() -> set[str]:
+def load_manifest_union() -> tuple[set[str], bool]:
     """story #3272 — 현재 checkout(스케줄 워크플로우=main)의 manifest + develop 브랜치의
     manifest 합집합. develop 텍스트를 못 읽으면(위 fetch_develop_manifest_text 참고)
-    main 단독으로 폴백한다."""
+    main 단독으로 폴백한다. 반환의 두 번째 값(story #3552)=폴백이 실제로 일어났는지 —
+    호출부가 결과 범위(main+develop vs main 단독)를 요약에 반영할 수 있게."""
     manifest = load_manifest()
     develop_text = fetch_develop_manifest_text()
+    fell_back = develop_text is None
     if develop_text is not None:
         manifest |= parse_manifest_text(develop_text)
-    return manifest
+    return manifest, fell_back
 
 
 def _live_gcp_secret_names() -> set[str]:
@@ -122,13 +147,18 @@ def check(manifest: set[str], live: set[str]) -> tuple[bool, list[str]]:
 
 
 def main() -> int:
-    manifest = load_manifest_union()
+    manifest, fell_back = load_manifest_union()
     live = _live_gcp_secret_names()
     ok, lines = check(manifest, live)
     for line in lines:
         print(line)
+    scope = "main 단독(develop 미반영)" if fell_back else "main+develop 합집합"
+    if fell_back:
+        # story #3552 — 폴백이 조용히 결과 범위를 좁혔다는 사실을 요약에도 남긴다(위
+        # fetch_develop_manifest_text가 이미 stderr에 실패 사유를 찍었다).
+        print(f"⚠️ {scope}으로만 대조했습니다 — 위 develop fetch 실패 사유를 확인하세요.")
     if ok:
-        print(f"OK — manifest(main+develop 합집합 {len(manifest)}건)가 GCP 실물과 정확히 일치.")
+        print(f"OK — manifest({scope} {len(manifest)}건)가 GCP 실물과 정확히 일치.")
     return 0 if ok else 1
 
 


### PR DESCRIPTION
## ⚠️ 머지 금지 — 열기만
**main push = prod 배포 트리거**입니다. 이 PR의 머지는 선생님 명시 허가 뒤 페드루가 진행합니다(#3750/#4008과 같은 축). 이 PR은 「원인 확定 + 처방 실측」 산출물로 열려 있으며, 셀프머지하지 않습니다.

## 배경(story #3763)
`Cloudbuild Secret Manifest Guard`(schedule·main)가 2026-09-07~09-10 4일 연속 failure — GCP엔 있는데 manifest에 없다고 보고된 5개 시크릿(`CHANNEL_CREDENTIAL_ENCRYPTION_KEY_DEV`·`CHANNEL_OAUTH_STATE_SECRET_DEV`·`SUPPORT_GATEWAY_ADMIN_TOKEN_dev`·`SUPPORT_GATEWAY_DATABASE_URL_dev`·`SUPPORT_GATEWAY_TOKEN_SECRET_dev`)는 **develop의 `infra/cloudbuild-secret-manifest.txt`엔 이미 전부 등재**되어 있습니다(#3644/#3659/#3736). manifest 자체는 정상 — main이 그걸 못 받고 있을 뿐입니다.

`git merge-base --is-ancestor 840fbb10e origin/main` → NOT ancestor로 확認: main은 아직 **#3272**(main+develop 매니페스트 union 대조 도입)와 **#3552**(narrow-fetch refspec 버그 수정 — union 완화가 스케줄 워크플로우에서 실제로는 무력했던 근본원인 수정)를 받지 못했습니다. 최근 부분 승격(#4019, 09-08 "promote/main-20260907-3629-3635")이 스토리 단위로 골라 올린 승격이라 이 인프라 가드 fix 두 건이 거기 빠졌습니다.

## 이 PR의 내용
- `d4eacf80b`(#3272) cherry-pick -x — main+develop manifest union 대조.
- `840fbb10e`(#3552) cherry-pick -x — narrow shallow-clone fetch refspec 버그 수정(`origin develop:refs/remotes/origin/develop` 명시 + 폴백 시 실패 사유 출력).
- `infra/cloudbuild-secret-manifest.txt` 텍스트 변경 **0줄** — 아래 실측대로 두 커밋만으로 충분했습니다(develop이 이미 정본).

## 실측(읽지 않고 돌려서 판정 — 페드루 PO 지시)
로컬 `gcloud` 인증(WIF와 별개, 개인 계정)으로 스케줄 워크플로우와 동일한 명령을 그대로 실행:

**양성대조 — main 그대로(cherry-pick 前)**:
```
$ python3 infra/sync_cloudbuild_secret_manifest.py
GCP엔 있는데 manifest에 없음(신규, manifest 갱신 필요) 5건: [...5개 전부]
EXIT CODE: 1
```
→ 관측된 4일 연속 failure 100% 재현.

**이 브랜치(cherry-pick 後)**:
```
$ python3 infra/sync_cloudbuild_secret_manifest.py
OK — manifest(main+develop 합집합 53건)가 GCP 실물과 정확히 일치.
EXIT CODE: 0
```
→ manifest 텍스트 변경 없이 GREEN. develop이 정본이라는 그라운딩이 실측으로 확認됨.

**backend pytest**(`backend/tests/test_3140_cloudbuild_secret_manifest_guard.py`): 32건 중 31 passed·1 failed — 실패한 `test_sync_against_real_manifest_and_real_gcp_if_available`는 **PR 게이트**(`check_cloudbuild_secret_manifest.py`)의 `load_manifest()`(main 단독, union 아님)를 실 GCP와 직접 대조하는 별도 축이라 이 두 커밋과 무관 — main의 manifest.txt가 5줄을 못 받은 상태에서는(승격 前) 로컬 gcloud 인증 환경에서 항상 이렇게 나오는 사전 존재 갭입니다(CI는 보통 gcloud 미인증이라 skip). 회귀 아님.

## Test plan
- [x] 양성대조: main 그대로 RED(위 출력)
- [x] 이 브랜치: 스케줄과 동일 명령 GREEN(위 출력)
- [x] backend pytest 31/32 passed(1건은 무관 사전 갭, 본문 설명)
- [ ] **머지는 선생님 허가 뒤 페드루가 진행**

🤖 Generated with [Claude Code](https://claude.com/claude-code)