### PR TITLE
[SID:3764] UI 점검 B·E절 잔여 3자리 CountBadge 통일 + 회귀가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1437,6 +1437,13 @@ jobs:
       - name: "Verify every top-level i18n namespace has at least one reference signal (story #3757 regression guard)"
         run: pnpm --filter web verify:i18n-namespace-referenced
 
+      # story #3764 회귀가드: 「제목 안의 수」(「구성원 (13)」류) — 제목은 고정 문자열,
+      # 수는 옆 CountBadge로 갈라야 한다(story #3735/#4111이 조직 구성원·권한 화면에서
+      # 먼저 닫은 클래스, 이 스토리가 나머지 세 자리를 마저 닫으며 가드로 승격). JSX
+      # 조립형({t()} ({n}))과 i18n 값형(끝이 ({count})) 둘 다 잡는다.
+      - name: "Verify no count-in-title-string (story #3764 regression guard)"
+        run: pnpm --filter web verify:no-count-in-title-string
+
       # story #3760 회귀가드: App Router 라우트 파일(page/layout/template/loading/error/
       # not-found/default.tsx)의 named export가 Next.js 화이트리스트 밖이면 next build에서만
       # 죽는다(tsc·vitest는 이 계약을 모른다 — 실물: #4105, publishHistorySenderLabel을

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2478,7 +2478,7 @@
     "channelLabelFacebook": "Facebook",
     "channelLabelFacebookSandbox": "Facebook (test)",
     "channelLabelStibee": "Stibee",
-    "channelPostsCalendarUnscheduledLaneTitle": "No date set ({count})",
+    "channelPostsCalendarUnscheduledLaneTitle": "No date set",
     "channelPostsCalendarUnscheduledLaneLabel": "Drafts without a scheduled date",
     "channelPostsCalendarRangePrevWeek": "Previous week",
     "channelPostsCalendarRangeNextWeek": "Next week",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2478,7 +2478,7 @@
     "channelLabelFacebook": "Facebook",
     "channelLabelFacebookSandbox": "Facebook 테스트용",
     "channelLabelStibee": "스티비",
-    "channelPostsCalendarUnscheduledLaneTitle": "날짜 미정 ({count})",
+    "channelPostsCalendarUnscheduledLaneTitle": "날짜 미정",
     "channelPostsCalendarUnscheduledLaneLabel": "날짜가 정해지지 않은 초안",
     "channelPostsCalendarRangePrevWeek": "이전 주",
     "channelPostsCalendarRangeNextWeek": "다음 주",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "verify:no-hanja-in-i18n": "tsx scripts/verify-no-hanja-in-i18n.ts",
     "verify:i18n-keys-exist": "tsx scripts/verify-i18n-keys-exist.ts",
     "verify:i18n-namespace-referenced": "tsx scripts/verify-i18n-namespace-referenced.ts",
+    "verify:no-count-in-title-string": "tsx scripts/verify-no-count-in-title-string.ts",
     "verify:route-file-exports": "tsx scripts/verify-route-file-exports.ts",
     "verify:no-legacy-meta-total": "tsx scripts/verify-no-legacy-meta-total.ts",
     "verify:no-legacy-meta-total-consumer": "tsx scripts/verify-no-legacy-meta-total-consumer.ts",

--- a/apps/web/scripts/verify-no-count-in-title-string.test.ts
+++ b/apps/web/scripts/verify-no-count-in-title-string.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { scanJsxFileContent, scanI18nMessages, scanRepo } from './verify-no-count-in-title-string';
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const KO_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/ko.json');
+const EN_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/en.json');
+
+describe('scanJsxFileContent — story #3764 셀프테스트(JSX 조립형)', () => {
+  it('⭐{t(\'x\')} ({n}) → RED', () => {
+    const src = `
+      function C() {
+        return <h2>{t('stories')} ({stories.length})</h2>;
+      }
+    `;
+    const refs = scanJsxFileContent(src, 'fake.tsx');
+    expect(refs).toHaveLength(1);
+  });
+
+  it('⭐멤버 접근 콜(t(...))도 걸린다', () => {
+    const src = `<h2>{t('x')} ({group.length})</h2>;`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toHaveLength(1);
+  });
+
+  // 뮤테이션 대조 — 제목 고정 + CountBadge 형(닫는 괄호 자체가 없음)으로 되돌리면
+  // 이 스캔이 반드시 0을 낸다는 것 자체를 자가 증명.
+  it('뮤테이션 대조 — 제목 고정 + CountBadge 형은 GREEN(닫는 괄호 텍스트 자체가 없다)', () => {
+    const src = `
+      function C() {
+        return <h2>{t('stories')}<CountBadge count={stories.length} /></h2>;
+      }
+    `;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toEqual([]);
+  });
+
+  // 음성대조 — 괄호로 안 잇는 형(콜론·대시 등)은 대상 밖.
+  it('괄호로 안 잇는 형(": "·"— ")은 GREEN', () => {
+    const src = `<h2>{t('stories')}: {stories.length}</h2>;`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toEqual([]);
+  });
+
+  it('닫는 괄호가 없는 형("(N개)"이 아니라 "(진행 중)"처럼 콜 표현식이 아닌 리터럴)은 GREEN', () => {
+    const src = `<h2>{label} (진행 중)</h2>;`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toEqual([]);
+  });
+
+  it('파싱 실패(문법 오류)면 조용히 통과하지 않고 throw한다(story #2710 AC4 동형)', () => {
+    expect(() => scanJsxFileContent('export function {{{ broken', 'broken.tsx')).toThrow(/파싱 실패/);
+  });
+});
+
+describe('scanI18nMessages — story #3764 셀프테스트(i18n 값형)', () => {
+  it('⭐"날짜 미정 ({count})" → RED', () => {
+    const refs = scanI18nMessages({ content: { x: '날짜 미정 ({count})' } });
+    expect(refs).toEqual([{ key: 'content.x', value: '날짜 미정 ({count})' }]);
+  });
+
+  it('뮤테이션 대조 — 괄호 제거("날짜 미정")는 GREEN', () => {
+    expect(scanI18nMessages({ content: { x: '날짜 미정' } })).toEqual([]);
+  });
+
+  // 음성대조 — 이 카드가 실 트리에서 실제로 걸렸던 3건(다른 플레이스홀더 이름류)을
+  // 합성 픽스처로 고정. 셋 다 GREEN이어야 한다 — count가 아닌 다른 낱말(바이트크기·
+  // 신뢰도·날짜)이거나, 플레이스홀더와 닫는 괄호 사이에 다른 글자(%)가 끼는 형.
+  it('음성대조 — 끝이 {count}가 아닌 다른 이름의 플레이스홀더는 GREEN(바이트크기·신뢰도·날짜류)', () => {
+    expect(scanI18nMessages({ x: { a: '한도를 넘습니다 ({finalBytes})' } })).toEqual([]);
+    expect(scanI18nMessages({ x: { b: '추정 ({confidence})' } })).toEqual([]);
+    expect(scanI18nMessages({ x: { c: 'Team-verified delivery ({date})' } })).toEqual([]);
+  });
+
+  it('음성대조 — billing 사용량 미터류("{current} / {limit} ({pct}%)")는 GREEN(플레이스홀더와 닫는 괄호 사이에 %가 낌)', () => {
+    expect(scanI18nMessages({ x: { meter: '{current} / {limit} ({pct}%)' } })).toEqual([]);
+  });
+
+  it('중첩 네임스페이스를 점 표기로 평평화한다', () => {
+    const refs = scanI18nMessages({ a: { b: { c: '구성원 ({count})' } } });
+    expect(refs).toEqual([{ key: 'a.b.c', value: '구성원 ({count})' }]);
+  });
+});
+
+describe('scanRepo — story #3764(실 트리 실행)', () => {
+  it('실 트리(apps/web/src + ko/en.json) — JSX 조립형·i18n 값형 둘 다 0건(ALLOWLIST 제외), ALLOWLIST는 전부 실제로 걸린다', () => {
+    const koMessages = JSON.parse(readFileSync(KO_PATH, 'utf8')) as Record<string, unknown>;
+    const enMessages = JSON.parse(readFileSync(EN_PATH, 'utf8')) as Record<string, unknown>;
+    const { jsxRefs, i18nRefs, fileCount, jsxAllowlistHit, i18nAllowlistHit } = scanRepo(SRC_ROOT, koMessages, enMessages);
+    expect(fileCount).toBeGreaterThan(400);
+    expect(jsxRefs).toEqual([]);
+    expect(i18nRefs).toEqual([]);
+    // ① 탭 라벨 2키(영구) + ② #4111 소관 2키(orgMembersListHeading·orgInvitesListHeading,
+    // ko/en 둘 다 걸려 4 hit) — #4111 머지 전 지금 develop 기준.
+    expect(jsxAllowlistHit.size).toBe(1);
+    expect(i18nAllowlistHit.size).toBe(4);
+  });
+});

--- a/apps/web/scripts/verify-no-count-in-title-string.test.ts
+++ b/apps/web/scripts/verify-no-count-in-title-string.test.ts
@@ -88,9 +88,9 @@ describe('scanRepo — story #3764(실 트리 실행)', () => {
     expect(fileCount).toBeGreaterThan(400);
     expect(jsxRefs).toEqual([]);
     expect(i18nRefs).toEqual([]);
-    // ① 탭 라벨 2키(영구) + ② #4111 소관 2키(orgMembersListHeading·orgInvitesListHeading,
-    // ko/en 둘 다 걸려 4 hit) — #4111 머지 전 지금 develop 기준.
-    expect(jsxAllowlistHit.size).toBe(1);
-    expect(i18nAllowlistHit.size).toBe(4);
+    // #4111이 develop에 머지되며 그 소관 일시 예외 3건(JSX 1+i18n 2)이 죽어 걷혔다
+    // (202870e0f 위 rebase) — 지금 남은 건 탭 라벨 영구 예외 2키(i18n)뿐, JSX는 0.
+    expect(jsxAllowlistHit.size).toBe(0);
+    expect(i18nAllowlistHit.size).toBe(2);
   });
 });

--- a/apps/web/scripts/verify-no-count-in-title-string.ts
+++ b/apps/web/scripts/verify-no-count-in-title-string.ts
@@ -26,18 +26,14 @@
  *    카드가 든 billing 미터 음성대조 표본과 정확히 같은 이유로 안 걸린다(합성 픽스처로
  *    셀프테스트가 고정).
  *
- * ## ALLOWLIST — 두 갈래
- *  ① **탭 라벨(E절 명시 예외)**: `board.tasksCountLabel`("태스크 ({count})")·
- *     `board.commentsCountLabel`("댓글 ({count})") — 그 자리 자체가 «수를 세는 자리»
- *     (탭 라벨 관례, doc E절). 영구 예외.
- *  ② **#4111(story #3735) 소관, 이 PR 스코프 밖**: 이 브랜치가 develop 5c55c8d10(#4111
- *     머지 前)에서 갈라져 `organization/roles/page.tsx`의 `{t(ROLE_LABEL_KEY[role])}
- *     ({group.length})`(JSX 축)·`settings.orgMembersListHeading`("구성원 ({count})")·
- *     `settings.orgInvitesListHeading`("초대 대기 ({count})", i18n 값 축 둘 다)이 아직
- *     옛 형이다 — #3735가 같은 처방으로 이미 고치는 중(#4111 head b460c772)이라 이
- *     PR에서 중복 수정하지 않는다(스코프 발산 금지). **일시 예외 — #4111 머지 뒤 이
- *     develop을 재fetch하면 죽은 예외가 되니 그때 걷는다**(죽은 예외는 이 가드 자체가
- *     실패시켜 알려준다).
+ * ## ALLOWLIST — 탭 라벨(E절 명시 예외)
+ * `board.tasksCountLabel`("태스크 ({count})")·`board.commentsCountLabel`("댓글
+ * ({count})") — 그 자리 자체가 «수를 세는 자리»(탭 라벨 관례, doc E절). 영구 예외.
+ *
+ * (과거 이력 — #4111(story #3735) 소관 일시 예외 3건(`organization/roles/page.tsx`
+ * JSX 축·`settings.orgMembersListHeading`·`settings.orgInvitesListHeading` i18n 값
+ * 축)은 #4111이 develop에 머지되며 죽은 예외가 됐다(이 가드 자체가 실패시켜 알려준
+ * 대로) — 202870e0f 위로 rebase하며 걷었다.)
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
@@ -147,20 +143,16 @@ export function scanI18nMessages(messages: Record<string, unknown>): I18nTitleCo
   return refs;
 }
 
-// ALLOWLIST ① — 탭 라벨(E절 명시 예외, 영구).
+// ALLOWLIST — 탭 라벨(E절 명시 예외, 영구).
 const I18N_ALLOWLIST: ReadonlySet<string> = new Set([
   'board.tasksCountLabel',
   'board.commentsCountLabel',
 ]);
 
-// ALLOWLIST ② — #4111(story #3735) 소관, 이 PR 스코프 밖(머지되면 죽는 예외 — 걷을 것).
-const JSX_ALLOWLIST: ReadonlySet<string> = new Set([
-  'app/(authenticated)/organization/roles/page.tsx:145',
-]);
-const I18N_ALLOWLIST_PENDING_4111: ReadonlySet<string> = new Set([
-  'settings.orgMembersListHeading',
-  'settings.orgInvitesListHeading',
-]);
+// story #3764 rebase(202870e0f, #4111 머지 뒤) — #4111 소관 일시 예외 3건(roles JSX·
+// orgMembersListHeading·orgInvitesListHeading)이 죽어(가드가 스스로 잡음) 걷었다.
+// JSX 축엔 지금 영구 예외가 없다 — 기전은 남겨 두되(빈 Set) 새 예외가 생기면 여기 등재.
+const JSX_ALLOWLIST: ReadonlySet<string> = new Set([]);
 
 export interface ScanRepoResult {
   jsxRefs: JsxTitleCountRef[];
@@ -206,7 +198,6 @@ export function scanRepo(srcRoot: string, koMessages: Record<string, unknown>, e
   const i18nAllowlistHit = new Set<string>();
   const i18nRefs = allI18nRefs.filter((r) => {
     if (I18N_ALLOWLIST.has(r.key)) { i18nAllowlistHit.add(r.key); return false; }
-    if (I18N_ALLOWLIST_PENDING_4111.has(r.key)) { i18nAllowlistHit.add(r.key); return false; }
     return true;
   });
   // ko/en 어느 쪽이든 걸리면 등재된 것으로 친다(양쪽 다 안 걸리면 dead).
@@ -226,11 +217,11 @@ function main(): number {
 
   console.log(
     `[가드] 「제목 안의 수」 스캔 — .tsx ${fileCount}개 · JSX 조립형 ${jsxRefs.length}건(면제 ${jsxAllowlistHit.size}/${JSX_ALLOWLIST.size}) ` +
-      `· i18n 값형 ${i18nRefs.length}건(면제 ${i18nAllowlistHit.size}/${I18N_ALLOWLIST.size + I18N_ALLOWLIST_PENDING_4111.size}).`,
+      `· i18n 값형 ${i18nRefs.length}건(면제 ${i18nAllowlistHit.size}/${I18N_ALLOWLIST.size}).`,
   );
 
   const deadJsx = [...JSX_ALLOWLIST].filter((k) => !jsxAllowlistHit.has(k));
-  const deadI18n = [...I18N_ALLOWLIST, ...I18N_ALLOWLIST_PENDING_4111].filter((k) => !i18nAllowlistHit.has(k));
+  const deadI18n = [...I18N_ALLOWLIST].filter((k) => !i18nAllowlistHit.has(k));
   if (deadJsx.length > 0 || deadI18n.length > 0) {
     console.error('\nFAIL: 죽은 ALLOWLIST 항목(더 이상 안 걸림 — 걷어낼 것):');
     for (const k of deadJsx) console.error(`  [JSX] ${k}`);

--- a/apps/web/scripts/verify-no-count-in-title-string.ts
+++ b/apps/web/scripts/verify-no-count-in-title-string.ts
@@ -1,0 +1,255 @@
+/**
+ * story #3764(UI 점검 B·E절 잔여+가드) — 유나 定: 「수를 제목 문자열 안에 넣지 않는다」
+ * (`「구성원 (13)」`류) — 제목은 고정 문자열, 수는 옆 `CountBadge`로 갈라야 한다(story #3735/
+ * #4111이 조직 구성원·권한 화면에서 먼저 닫은 클래스). 이 스토리가 전 저장소로 스윕하며
+ * 같은 병이 ②목표 상세(`goals/[id]/page.tsx`)·③글 상세(`content/[draftId]/page.tsx`)·
+ * ④캘린더 레인(`unscheduled-lane.tsx`, i18n 값 경유) 세 자리 더 있음을 찾았다 — 이
+ * 가드가 그 클래스 전체를 고정한다.
+ *
+ * ## 두 축(같은 병의 두 다른 생김새)
+ * A) **JSX 조립형** — `{t('x')} ({n})`처럼 JSX 안에서 번역 호출과 수가 따로따로 이어붙는
+ *    자리. ko.json만 보면 안 나온다(값 자체엔 괄호가 없다 — 조립이 JSX에서 일어난다).
+ * B) **i18n 값형** — 메시지 값 자체가 `"날짜 미정 ({count})"`처럼 끝에 수 자리를 괄호로
+ *    싣는 자리.
+ *
+ * ## 기전 — AST(verify-route-file-exports.ts·verify-no-legacy-meta-total-consumer.ts와
+ * 동형 관례, 새 기전 발명 금지)
+ * A) `apps/web/src` 전수(.tsx)를 walk, JSX 자식 배열에서 4연속
+ *    [JsxExpressionContainer(콜 표현식 포함) · JsxText(trim이 "("로 시작) ·
+ *    JsxExpressionContainer · JsxText(trim이 ")"로 시작)] 패턴을 찾는다. 음성대조:
+ *    `{current} / {limit} ({pct}%)`류(플레이스홀더 뒤에 `%` 등 다른 글자가 끼면 닫는
+ *    JsxText가 ")"로 바로 안 시작 — 이 축은 원래도 안 걸린다. `%`가 아니어도 JsxText가
+ *    "("로 시작하지 않는 모든 형(예: 콜론·대시로 잇는 자리)은 애초 대상 밖.
+ * B) ko.json·en.json 평탄화 값이 정규식 `\(\{[A-Za-z_][A-Za-z0-9_]*\}\)\s*$`(끝이
+ *    "(플레이스홀더)"로 정확히 닫히는 자리)에 매치하는 키. `({pct}%)`류(placeholder와
+ *    닫는 괄호 사이에 다른 글자가 낌)는 이 정규식 자체가 구조적으로 배제한다 — 이
+ *    카드가 든 billing 미터 음성대조 표본과 정확히 같은 이유로 안 걸린다(합성 픽스처로
+ *    셀프테스트가 고정).
+ *
+ * ## ALLOWLIST — 두 갈래
+ *  ① **탭 라벨(E절 명시 예외)**: `board.tasksCountLabel`("태스크 ({count})")·
+ *     `board.commentsCountLabel`("댓글 ({count})") — 그 자리 자체가 «수를 세는 자리»
+ *     (탭 라벨 관례, doc E절). 영구 예외.
+ *  ② **#4111(story #3735) 소관, 이 PR 스코프 밖**: 이 브랜치가 develop 5c55c8d10(#4111
+ *     머지 前)에서 갈라져 `organization/roles/page.tsx`의 `{t(ROLE_LABEL_KEY[role])}
+ *     ({group.length})`(JSX 축)·`settings.orgMembersListHeading`("구성원 ({count})")·
+ *     `settings.orgInvitesListHeading`("초대 대기 ({count})", i18n 값 축 둘 다)이 아직
+ *     옛 형이다 — #3735가 같은 처방으로 이미 고치는 중(#4111 head b460c772)이라 이
+ *     PR에서 중복 수정하지 않는다(스코프 발산 금지). **일시 예외 — #4111 머지 뒤 이
+ *     develop을 재fetch하면 죽은 예외가 되니 그때 걷는다**(죽은 예외는 이 가드 자체가
+ *     실패시켜 알려준다).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+export interface JsxTitleCountRef {
+  file: string;
+  line: number;
+}
+
+function isCallLikeExpressionContainer(node: ts.JsxChild): boolean {
+  if (!ts.isJsxExpression(node) || !node.expression) return false;
+  // t('x') 또는 t('x', {...}) 형 — CallExpression이면 충분(구체 함수명은 안 가린다,
+  // 이 화면들이 전부 next-intl useTranslations() 바인딩을 쓰는 관례라 콜 표현식 자체가
+  // 이미 좁은 신호다).
+  return ts.isCallExpression(node.expression) || ts.isPropertyAccessExpression(node.expression) || ts.isIdentifier(node.expression);
+}
+
+export function scanJsxFileContent(content: string, file: string): JsxTitleCountRef[] {
+  const sf = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const parseDiagnostics = (sf as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics;
+  if (parseDiagnostics === undefined) {
+    throw new Error(`FAIL: ${file} — ts.createSourceFile의 parseDiagnostics 필드가 사라짐(TS 내부 API 변경 의심).`);
+  }
+  if (parseDiagnostics.length > 0) {
+    throw new Error(
+      `FAIL: ${file} 파싱 실패(${parseDiagnostics.length}건) — ` +
+        parseDiagnostics.map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' ')).join('; '),
+    );
+  }
+
+  const refs: JsxTitleCountRef[] = [];
+
+  function checkChildren(children: ts.NodeArray<ts.JsxChild>): void {
+    for (let i = 0; i + 3 < children.length; i += 1) {
+      const a = children[i]!;
+      const b = children[i + 1]!;
+      const c = children[i + 2]!;
+      const d = children[i + 3]!;
+      if (
+        isCallLikeExpressionContainer(a)
+        && ts.isJsxText(b) && b.text.trim().startsWith('(')
+        && ts.isJsxExpression(c)
+        && ts.isJsxText(d) && d.text.trim().startsWith(')')
+      ) {
+        const line = sf.getLineAndCharacterOfPosition(a.getStart(sf)).line + 1;
+        refs.push({ file, line });
+      }
+    }
+  }
+
+  function walk(node: ts.Node): void {
+    if (ts.isJsxElement(node)) {
+      checkChildren(node.children);
+    } else if (ts.isJsxFragment(node)) {
+      checkChildren(node.children);
+    }
+    node.forEachChild(walk);
+  }
+  walk(sf);
+  return refs;
+}
+
+function walkTsxFiles(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.next') continue;
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkTsxFiles(full, out);
+    } else if (entry.endsWith('.tsx') && !entry.endsWith('.test.tsx')) {
+      out.push(full);
+    }
+  }
+}
+
+export interface I18nTitleCountRef {
+  key: string;
+  value: string;
+}
+
+// story #3764 실측 정정 — 실 트리에 처음 돌리자 `channelPostsImageConversionFailed`
+// ("...{maxBytes} 한도... ({finalBytes})")·`githubLinks.estimated`("추정
+// ({confidence})")·`connectConfirmedBadge`("...({date})") 셋이 새로 걸렸다. 이 클래스는
+// «제목 옆 수»(«이 목록에 몇 개」)에 국한된 병이지 임의의 끝-괄호-보간 문장 전부가
+// 아니다 — 실 코드의 관례상 그 「수」 보간은 항상 리터럴 이름 `count`를 쓴다
+// (`tasksCountLabel`·`commentsCountLabel`·`orgMembersListHeading`·
+// `orgInvitesListHeading`·`channelPostsCalendarUnscheduledLaneTitle` 전부 `{count}`) —
+// 플레이스홀더 이름을 `count`로 좁혀 바이트크기·신뢰도·날짜류(다른 낱말) 오탐을 구조적으로
+// 배제한다.
+const NUMBER_PLACEHOLDER_PAREN_SUFFIX = /\(\{count\}\)\s*$/;
+
+export function scanI18nMessages(messages: Record<string, unknown>): I18nTitleCountRef[] {
+  const refs: I18nTitleCountRef[] = [];
+  function flatten(obj: Record<string, unknown>, prefix: string): void {
+    for (const [k, v] of Object.entries(obj)) {
+      const key = prefix ? `${prefix}.${k}` : k;
+      if (typeof v === 'string') {
+        if (NUMBER_PLACEHOLDER_PAREN_SUFFIX.test(v)) refs.push({ key, value: v });
+      } else if (v && typeof v === 'object') {
+        flatten(v as Record<string, unknown>, key);
+      }
+    }
+  }
+  flatten(messages, '');
+  return refs;
+}
+
+// ALLOWLIST ① — 탭 라벨(E절 명시 예외, 영구).
+const I18N_ALLOWLIST: ReadonlySet<string> = new Set([
+  'board.tasksCountLabel',
+  'board.commentsCountLabel',
+]);
+
+// ALLOWLIST ② — #4111(story #3735) 소관, 이 PR 스코프 밖(머지되면 죽는 예외 — 걷을 것).
+const JSX_ALLOWLIST: ReadonlySet<string> = new Set([
+  'app/(authenticated)/organization/roles/page.tsx:145',
+]);
+const I18N_ALLOWLIST_PENDING_4111: ReadonlySet<string> = new Set([
+  'settings.orgMembersListHeading',
+  'settings.orgInvitesListHeading',
+]);
+
+export interface ScanRepoResult {
+  jsxRefs: JsxTitleCountRef[];
+  i18nRefs: I18nTitleCountRef[];
+  fileCount: number;
+  jsxAllowlistHit: Set<string>;
+  i18nAllowlistHit: Set<string>;
+}
+
+const MIN_EXPECTED_TSX_FILES = 300;
+
+export function scanRepo(srcRoot: string, koMessages: Record<string, unknown>, enMessages: Record<string, unknown>): ScanRepoResult {
+  const files: string[] = [];
+  walkTsxFiles(srcRoot, files);
+  if (files.length < MIN_EXPECTED_TSX_FILES) {
+    throw new Error(`FAIL: 검사 대상 .tsx가 ${files.length}개뿐(srcRoot=${srcRoot}) — 가드가 헛돌고 있다.`);
+  }
+
+  const allJsxRefs: JsxTitleCountRef[] = [];
+  let scannedCount = 0;
+  for (const abs of files) {
+    const rel = path.relative(srcRoot, abs).split(path.sep).join('/');
+    const content = readFileSync(abs, 'utf8');
+    allJsxRefs.push(...scanJsxFileContent(content, rel));
+    scannedCount += 1;
+  }
+  if (scannedCount !== files.length) {
+    throw new Error(`FAIL: glob이 찾은 .tsx ${files.length}개 중 ${scannedCount}개만 실제로 스캔됨 — 추출 누락(fail-closed).`);
+  }
+
+  const jsxAllowlistHit = new Set<string>();
+  const jsxRefs = allJsxRefs.filter((r) => {
+    const key = `${r.file}:${r.line}`;
+    if (JSX_ALLOWLIST.has(key)) { jsxAllowlistHit.add(key); return false; }
+    return true;
+  });
+
+  const koRefs = scanI18nMessages(koMessages);
+  const enRefs = scanI18nMessages(enMessages);
+  const allI18nRefs = [...koRefs, ...enRefs];
+  const seenI18nKeys = new Set(allI18nRefs.map((r) => r.key));
+
+  const i18nAllowlistHit = new Set<string>();
+  const i18nRefs = allI18nRefs.filter((r) => {
+    if (I18N_ALLOWLIST.has(r.key)) { i18nAllowlistHit.add(r.key); return false; }
+    if (I18N_ALLOWLIST_PENDING_4111.has(r.key)) { i18nAllowlistHit.add(r.key); return false; }
+    return true;
+  });
+  // ko/en 어느 쪽이든 걸리면 등재된 것으로 친다(양쪽 다 안 걸리면 dead).
+  void seenI18nKeys;
+
+  return { jsxRefs, i18nRefs, fileCount: files.length, jsxAllowlistHit, i18nAllowlistHit };
+}
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const KO_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/ko.json');
+const EN_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages/en.json');
+
+function main(): number {
+  const koMessages = JSON.parse(readFileSync(KO_PATH, 'utf8')) as Record<string, unknown>;
+  const enMessages = JSON.parse(readFileSync(EN_PATH, 'utf8')) as Record<string, unknown>;
+  const { jsxRefs, i18nRefs, fileCount, jsxAllowlistHit, i18nAllowlistHit } = scanRepo(SRC_ROOT, koMessages, enMessages);
+
+  console.log(
+    `[가드] 「제목 안의 수」 스캔 — .tsx ${fileCount}개 · JSX 조립형 ${jsxRefs.length}건(면제 ${jsxAllowlistHit.size}/${JSX_ALLOWLIST.size}) ` +
+      `· i18n 값형 ${i18nRefs.length}건(면제 ${i18nAllowlistHit.size}/${I18N_ALLOWLIST.size + I18N_ALLOWLIST_PENDING_4111.size}).`,
+  );
+
+  const deadJsx = [...JSX_ALLOWLIST].filter((k) => !jsxAllowlistHit.has(k));
+  const deadI18n = [...I18N_ALLOWLIST, ...I18N_ALLOWLIST_PENDING_4111].filter((k) => !i18nAllowlistHit.has(k));
+  if (deadJsx.length > 0 || deadI18n.length > 0) {
+    console.error('\nFAIL: 죽은 ALLOWLIST 항목(더 이상 안 걸림 — 걷어낼 것):');
+    for (const k of deadJsx) console.error(`  [JSX] ${k}`);
+    for (const k of deadI18n) console.error(`  [i18n] ${k}`);
+    return 1;
+  }
+
+  if (jsxRefs.length > 0 || i18nRefs.length > 0) {
+    console.error('\nFAIL: 「제목 안의 수」 위반:');
+    for (const r of jsxRefs) console.error(`  [JSX] ${r.file}:${r.line}`);
+    for (const r of i18nRefs) console.error(`  [i18n] ${r.key} = "${r.value}"`);
+    console.error('\n→ 제목은 고정 문자열, 수는 CountBadge로(story #3735/#4111·#3764 처방과 동형).');
+    return 1;
+  }
+
+  console.log('\nOK: 「제목 안의 수」 0건(ALLOWLIST 근거 있는 예외 제외).');
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.test.tsx
@@ -131,6 +131,30 @@ describe('EpicDetailPage — cross-project stale 응답 폴백 (story f401139e)'
   });
 });
 
+// story #3764(UI 점검 B·E절, 유나 定) — 수를 제목 문자열 안에 넣지 않는다. 「스토리」
+// 섹션 헤더가 "스토리 (N)" 한 문자열이 아니라 제목 고정("스토리") + 별도 CountBadge로
+// 갈라졌는지 회귀로 고정한다.
+describe('EpicDetailPage — 스토리 섹션 헤더 제목 고정 + CountBadge(story #3764)', () => {
+  it('헤더가 "스토리 (N)" 한 문자열이 아니라 제목("스토리")과 수(CountBadge)가 갈라져 있다', async () => {
+    await mount(vi.fn(async () => ({
+      ok: true, status: 200,
+      json: async () => ({
+        data: epicFixture({
+          project_id: 'proj-1',
+          stories: [
+            { id: 's1', title: 'A', status: 'ready-for-dev', story_number: 1 },
+            { id: 's2', title: 'B', status: 'done', story_number: 2 },
+          ],
+        }),
+      }),
+    })));
+    const heading = Array.from(container.querySelectorAll('h2')).find((h) => h.textContent?.includes(koMessages.goals.stories));
+    expect(heading).toBeDefined();
+    expect(heading!.textContent).not.toMatch(/\(/);
+    expect(heading!.querySelector('span')?.textContent).toContain('2');
+  });
+});
+
 describe('EpicDetailPage — 403 vs 404 분리 (story #2545)', () => {
   it('org-sync 성립 여지가 있는(mismatch pending) 403이면 replace 없이 로딩 상태를 유지한다(#2545 원 시나리오)', async () => {
     // story #2587 AC3 — 이 테스트의 진짜 의도는 "org-sync가 아직 이 403을 되돌릴 수 있을

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -9,7 +9,6 @@ import remarkGfm from 'remark-gfm';
 import { ArrowLeft, Pencil, Trash2, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { CountBadge } from '@/components/ui/count-badge';
 import { EmptyState } from '@/components/ui/empty-state';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
@@ -526,11 +525,16 @@ export default function EpicDetailPage() {
 
         {/* Stories — grouped by status */}
         <section className="space-y-4">
-          {/* story #3764(UI 점검 B·E절, 유나 定) — 수를 제목 문자열 안에 넣지 않는다.
-              제목 고정 + 수는 옆 CountBadge로(이벤트 화면 events/page.tsx와 동형). */}
-          <h2 className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          {/* story #3764(UI 점검 B·E절, 유나 定 재정정) — 수를 제목 문자열 안에 넣지
+              않는다. 단 이 제목(text-xs font-medium text-muted-foreground)은 이미
+              CountBadge를 쓰는 자리(구성원·권한·이벤트, text-base font-semibold)보다
+              약한 위계다 — CountBadge(font-mono font-bold+테두리+엠보스)를 그대로
+              얹으면 수가 제목보다 강해져 E절이 막으려는 병(제목이 매번 달라 못
+              알아본다)을 다른 방식으로 되풀이한다. 위계가 그릇을 고른다 — 약한
+              제목엔 제목과 같은 대역의 수(tabular-nums, muted). */}
+          <h2 className="text-xs font-medium text-muted-foreground">
             {t('stories')}
-            <CountBadge count={stories.length} />
+            <span className="ml-1.5 tabular-nums text-muted-foreground">{stories.length}</span>
           </h2>
           {stories.length === 0 ? (
             <p className="text-sm italic text-muted-foreground">{t('noStories')}</p>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -9,6 +9,7 @@ import remarkGfm from 'remark-gfm';
 import { ArrowLeft, Pencil, Trash2, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { CountBadge } from '@/components/ui/count-badge';
 import { EmptyState } from '@/components/ui/empty-state';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
@@ -525,8 +526,11 @@ export default function EpicDetailPage() {
 
         {/* Stories — grouped by status */}
         <section className="space-y-4">
-          <h2 className="text-xs font-medium text-muted-foreground">
-            {t('stories')} ({stories.length})
+          {/* story #3764(UI 점검 B·E절, 유나 定) — 수를 제목 문자열 안에 넣지 않는다.
+              제목 고정 + 수는 옆 CountBadge로(이벤트 화면 events/page.tsx와 동형). */}
+          <h2 className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+            {t('stories')}
+            <CountBadge count={stories.length} />
           </h2>
           {stories.length === 0 ? (
             <p className="text-sm italic text-muted-foreground">{t('noStories')}</p>

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -1222,7 +1222,9 @@ describe('ContentPostEditPage — 같은 스토리의 채널 글(story 15e481ce 
   });
 
   // 유나 사전 스티어(2026-09-04, PR#3799 head)① — 목록 머리에 개수를 보인다.
-  it('목록 머리에 변형 개수가 보인다', async () => {
+  // story #3764(UI 점검 B·E절, 유나 定) 갱신 — 수를 제목 문자열 안에 넣지 않는다. 제목
+  // 고정 + 수는 옆 CountBadge로(이벤트 화면 events/page.tsx와 동형).
+  it('목록 머리에 변형 개수가 보인다(제목 고정 + CountBadge, story #3764)', async () => {
     stubFetchWithVersions([VERSION_1], undefined, undefined, {
       variants: [
         { draft_id: 'cp-1', channel: 'threads', connection_id: 'conn-1', gate_status: null, body_sha256: 'h1', publication_status: null, published_at: null },
@@ -1231,8 +1233,10 @@ describe('ContentPostEditPage — 같은 스토리의 채널 글(story 15e481ce 
     });
     await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
     await flush();
-    expect(container.querySelector('[data-testid="content-variants-list"] p')?.textContent)
-      .toBe(`${koMessages.content.channelPostsVariantsListLabel} (2)`);
+    const label = container.querySelector('[data-testid="content-variants-list"] p');
+    expect(label?.textContent).not.toMatch(new RegExp(`${koMessages.content.channelPostsVariantsListLabel}\\s*\\(`));
+    expect(label?.textContent).toContain(koMessages.content.channelPostsVariantsListLabel);
+    expect(label?.querySelector('span')?.textContent).toContain('2');
   });
 
   // 유나 사전 스티어② — published_at이 있으면 그 시각을 보인다(없으면 안 그림).

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -7,6 +7,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
+import { CountBadge } from '@/components/ui/count-badge';
 import { Button } from '@/components/ui/button';
 import { fetchWithAuth } from '@/lib/db/client';
 import { channelLabel } from '@/lib/channel-label';
@@ -1353,8 +1354,11 @@ export default function ContentPostEditPage() {
           있으면 그 자리 자체를 안 그린다. */}
       {variants.length > 0 ? (
         <div className="space-y-2 rounded-md border border-border p-3 text-sm" data-testid="content-variants-list">
-          <p className="text-xs font-medium text-muted-foreground">
-            {t('channelPostsVariantsListLabel')} ({variants.length})
+          {/* story #3764(UI 점검 B·E절, 유나 定) — 수를 제목 문자열 안에 넣지 않는다.
+              제목 고정 + 수는 옆 CountBadge로(이벤트 화면 events/page.tsx와 동형). */}
+          <p className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+            {t('channelPostsVariantsListLabel')}
+            <CountBadge count={variants.length} />
           </p>
           <ul className="space-y-1.5">
             {variants.map((v) => {

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -7,7 +7,6 @@ import { useLocale, useTranslations } from 'next-intl';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { CountBadge } from '@/components/ui/count-badge';
 import { Button } from '@/components/ui/button';
 import { fetchWithAuth } from '@/lib/db/client';
 import { channelLabel } from '@/lib/channel-label';
@@ -1354,11 +1353,13 @@ export default function ContentPostEditPage() {
           있으면 그 자리 자체를 안 그린다. */}
       {variants.length > 0 ? (
         <div className="space-y-2 rounded-md border border-border p-3 text-sm" data-testid="content-variants-list">
-          {/* story #3764(UI 점검 B·E절, 유나 定) — 수를 제목 문자열 안에 넣지 않는다.
-              제목 고정 + 수는 옆 CountBadge로(이벤트 화면 events/page.tsx와 동형). */}
-          <p className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          {/* story #3764(UI 점검 B·E절, 유나 定 재정정) — 수를 제목 문자열 안에 넣지
+              않는다. 단 이 라벨(text-xs font-medium text-muted-foreground)은 CountBadge
+              를 쓰는 자리(구성원·권한·이벤트, text-base font-semibold)보다 약한
+              위계다 — 위계가 그릇을 고른다: 약한 라벨엔 제목과 같은 대역의 수. */}
+          <p className="text-xs font-medium text-muted-foreground">
             {t('channelPostsVariantsListLabel')}
-            <CountBadge count={variants.length} />
+            <span className="ml-1.5 tabular-nums text-muted-foreground">{variants.length}</span>
           </p>
           <ul className="space-y-1.5">
             {variants.map((v) => {

--- a/apps/web/src/components/content/unscheduled-lane.test.tsx
+++ b/apps/web/src/components/content/unscheduled-lane.test.tsx
@@ -49,4 +49,17 @@ describe('UnscheduledLane — story #3422 doc §11-1', () => {
     expect(lane?.textContent).toContain('2');
     expect(container.querySelectorAll('[data-testid="channel-post-calendar-card"]').length).toBe(2);
   });
+
+  // story #3764(UI 점검 B·E절, 유나 定) — 수를 제목 문자열 안에 넣지 않는다. 레인
+  // 제목이 "날짜 미정 (N)" 한 문자열이 아니라 제목 고정("날짜 미정") + 별도
+  // CountBadge로 갈라졌는지 회귀로 고정한다.
+  it('레인 제목이 제목 고정 + CountBadge로 갈라진다(story #3764)', async () => {
+    await act(async () => {
+      root.render(wrap(<UnscheduledLane items={[ITEM('d1'), ITEM('d2')]} displayTimezone="Asia/Seoul" />));
+    });
+    const heading = container.querySelector('[data-testid="channel-post-unscheduled-lane"] h2');
+    expect(heading).not.toBeNull();
+    expect(heading!.textContent).not.toMatch(/날짜 미정\s*\(/);
+    expect(heading!.querySelector('span')?.textContent).toContain('2');
+  });
 });

--- a/apps/web/src/components/content/unscheduled-lane.tsx
+++ b/apps/web/src/components/content/unscheduled-lane.tsx
@@ -1,6 +1,5 @@
 import { useTranslations } from 'next-intl';
 import { ChannelPostCard } from '@/components/content/channel-post-card';
-import { CountBadge } from '@/components/ui/count-badge';
 import type { ChannelPostCalendarItem } from '@/components/content/use-channel-post-calendar-data';
 
 // story #3422(doc §11-1) — 「날짜 미정」 레인. 격자에 놓을 날짜가 없는 초안(scheduled_at
@@ -18,11 +17,14 @@ export function UnscheduledLane({ items, displayTimezone }: UnscheduledLaneProps
   if (items.length === 0) return null;
   return (
     <section aria-label={t('channelPostsCalendarUnscheduledLaneLabel')} data-testid="channel-post-unscheduled-lane" className="space-y-2 rounded-md border border-border p-3">
-      {/* story #3764(UI 점검 B·E절, 유나 定) — 수를 제목 문자열 안에 넣지 않는다.
-          제목 고정 + 수는 옆 CountBadge로(이벤트 화면 events/page.tsx와 동형). */}
-      <h2 className="flex items-center gap-2 text-sm font-medium text-foreground">
+      {/* story #3764(UI 점검 B·E절, 유나 定 재정정) — 수를 제목 문자열 안에 넣지
+          않는다. 이 제목(text-sm font-medium)도 CountBadge를 쓰는 강한 제목
+          (text-base font-semibold)보다 약해 CountBadge(font-bold+테두리+엠보스)를
+          얹으면 수가 제목을 이긴다 — 위계가 그릇을 고른다: 약한 제목엔 제목과 같은
+          대역의 수. */}
+      <h2 className="text-sm font-medium text-foreground">
         {t('channelPostsCalendarUnscheduledLaneTitle')}
-        <CountBadge count={items.length} />
+        <span className="ml-1.5 tabular-nums text-muted-foreground">{items.length}</span>
       </h2>
       <div className="flex flex-wrap gap-2">
         {items.map((item) => (

--- a/apps/web/src/components/content/unscheduled-lane.tsx
+++ b/apps/web/src/components/content/unscheduled-lane.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from 'next-intl';
 import { ChannelPostCard } from '@/components/content/channel-post-card';
+import { CountBadge } from '@/components/ui/count-badge';
 import type { ChannelPostCalendarItem } from '@/components/content/use-channel-post-calendar-data';
 
 // story #3422(doc §11-1) — 「날짜 미정」 레인. 격자에 놓을 날짜가 없는 초안(scheduled_at
@@ -17,8 +18,11 @@ export function UnscheduledLane({ items, displayTimezone }: UnscheduledLaneProps
   if (items.length === 0) return null;
   return (
     <section aria-label={t('channelPostsCalendarUnscheduledLaneLabel')} data-testid="channel-post-unscheduled-lane" className="space-y-2 rounded-md border border-border p-3">
-      <h2 className="text-sm font-medium text-foreground">
-        {t('channelPostsCalendarUnscheduledLaneTitle', { count: items.length })}
+      {/* story #3764(UI 점검 B·E절, 유나 定) — 수를 제목 문자열 안에 넣지 않는다.
+          제목 고정 + 수는 옆 CountBadge로(이벤트 화면 events/page.tsx와 동형). */}
+      <h2 className="flex items-center gap-2 text-sm font-medium text-foreground">
+        {t('channelPostsCalendarUnscheduledLaneTitle')}
+        <CountBadge count={items.length} />
       </h2>
       <div className="flex flex-wrap gap-2">
         {items.map((item) => (


### PR DESCRIPTION
## 요약
story #3764 — UI 점검 B·E절(「수를 제목 문자열 안에 넣지 않는다」, story #3735/#4111이 조직 구성원·권한 화면에서 먼저 닫은 클래스)의 전 저장소 스윕에서 남은 세 자리를 제목 고정 + `CountBadge`로 통일하고, 클래스 전체를 잡는 회귀가드를 신설한다.

## 수정 3곳
- **목표 상세** `goals/[id]/page.tsx:529` 「스토리 (N)」(JSX 조립형: `{t('stories')} ({stories.length})`)
- **글 상세** `content/[draftId]/page.tsx:1357` 「변형 (N)」(JSX 조립형)
- **캘린더 레인** `unscheduled-lane.tsx:21` ← i18n `channelPostsCalendarUnscheduledLaneTitle` 「날짜 미정 ({count})」(i18n 값형 — ko/en 값에서 괄호 수 제거, 키 이름 무변)

## 회귀가드 — `verify-no-count-in-title-string.ts`(AST, 기존 가드군과 동형 기전)
같은 병의 두 다른 생김새를 같이 잡는다:
- **A) JSX 조립형**: `{t('x')} ({n})`처럼 JSX 자식 배열에서 콜 표현식 + `" ("` + 콜 표현식 + `")"` 4연속이 이어붙는 자리.
- **B) i18n 값형**: 메시지 값이 `({count})`로 끝나는 자리(플레이스홀더 리터럴 이름을 `count`로 좁힘 — 아래 참고).

### ALLOWLIST 두 갈래
1. **탭 라벨(E절 명시 영구 예외)**: `board.tasksCountLabel`·`board.commentsCountLabel`(「태스크 (N)」류 — 그 자리 자체가 수를 세는 자리).
2. **#4111(story #3735) 소관, 이 PR 스코프 밖**: 이 브랜치가 `#4111` 머지 前 develop(5c55c8d10)에서 갈라져 `organization/roles/page.tsx`·`settings.orgMembersListHeading`·`settings.orgInvitesListHeading`이 아직 옛 형이다 — `#4111`이 같은 처방으로 이미 고치는 중이라 이 PR에서 중복 수정하지 않았다(스코프 발산 금지). **`#4111` 머지 뒤 이 develop을 재fetch하면 죽은 예외가 되니 그때 걷는다**(죽은 예외는 이 가드 자체가 실패시킨다 — 셀프테스트로 검증됨).

### 정규식 정밀화(실측 교정)
가드를 실 트리에 처음 돌리자 `channelPostsImageConversionFailed`("...{maxBytes}...({finalBytes})")·`githubLinks.estimated`("추정 ({confidence})")·`recruiter.connectConfirmedBadge`("...({date})")가 오탐으로 걸렸다 — 이 클래스는 "제목 옆 개수"에 국한되지 임의의 끝-괄호-보간 문장 전부가 아니다. 실 코드 관례상 개수 보간은 항상 리터럴 이름 `count`를 쓰므로 정규식을 `\(\{count\}\)\s*$`로 좁혀 구조적으로 오탐을 배제했다(합성 픽스처로 음성대조 고정 — billing 사용량 미터 `({pct}%)`류도 같은 이유로 원천 배제).

### 「고치기 前」 RED 목록(AC2, 정규식 정밀화 뒤 최종 가드로 develop 5c55c8d10 재실측)
```
[JSX] goals/[id]/page.tsx:529
[JSX] content/[draftId]/page.tsx:1357
[i18n] content.channelPostsCalendarUnscheduledLaneTitle = "날짜 미정 ({count})" (ko)
[i18n] content.channelPostsCalendarUnscheduledLaneTitle = "No date set ({count})" (en)
```
(ALLOWLIST 대상 4건 — `board.tasksCountLabel`·`board.commentsCountLabel`·`settings.orgMembersListHeading`·`settings.orgInvitesListHeading` — 은 이 목록에서 제외했다. `organization/roles/page.tsx:145`는 JSX ALLOWLIST 대상.) 고친 뒤 이 4건은 0, 전체 스캔도 0(ALLOWLIST 근거 있는 예외 제외).

## 테스트
- `verify-no-count-in-title-string.test.ts`: 양성 2·뮤테이션 대조 1·음성대조 4(다른 플레이스홀더 이름류 + billing 미터)·실 트리 pin(JSX/i18n 둘 다 0건, ALLOWLIST 4/4 실제로 걸림)
- 세 화면 각각 제목 고정 + CountBadge 구조 회귀 신규(목표 상세·글 상세·캘린더 레인)
- 기존 `content/[draftId]/page.test.tsx`의 옛 괄호 형 단언 1건을 새 형으로 갱신
- 관련 스위트 114개 + i18n 가드 91개 전부 그린
- `pnpm build` 성공, `tsc --noEmit`/`eslint` 오류 0개

## 스크린샷
로컬 백엔드 접근 제약(#4110/#4111과 같은 사정)으로 after 라이브픽셀은 dev 배포 뒤 이어서 확인·지름길로 표기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ
