### PR TITLE
[SID:3766] 성과 보드 행에 「사람 차례」 발행 명령 상태 배지

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/insights-board/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/insights-board/page.test.tsx
@@ -677,6 +677,97 @@ describe('InsightsBoardPage — 원본과 대조 행 액션(story #3620)', () =>
   });
 });
 
+// story #3766(별건 ⑩, 3746 §3 유나 定) — 「사람 차례」 발행 명령 축은 필터가 아니라
+// 행 배지(FailureActionBadge, compact)로만 선다. 자리는 유나 정(issuecomment
+// 2026-09-10 02:11Z 갈음): 행동칸(후속 조치·원본과 대조 버튼) «위» 별도 줄, 배지
+// 없으면 그 줄 노드 자체가 없고(①), 버튼 div도 canCreateFollowUp||canReconcile일
+// 때만 렌더한다(②).
+describe('InsightsBoardPage — 「사람 차례」 행 배지(story #3766)', () => {
+  const ROW_DEAD_LETTER = {
+    publication_id: 'pub-dl', kind: 'channel_publication', channel: 'threads', work_item_id: 'wi-dl',
+    title: '글 DL', published_at: '2026-09-01T00:00:00Z', external_url: null, connection_id: 'conn-1',
+    d1: null, d7: null, command_status: 'dead_letter',
+  };
+  const ROW_BLOCKED = {
+    publication_id: 'pub-bl', kind: 'channel_publication', channel: 'threads', work_item_id: 'wi-bl',
+    title: '글 BL', published_at: '2026-09-01T00:00:00Z', external_url: null, connection_id: 'conn-2',
+    d1: null, d7: null, command_status: 'blocked',
+  };
+  // 뮤테이션 대조 — dead_letter/blocked가 아닌 다른 command_status는(자동으로 풀리는
+  // 갈래거나 이 화면엔 안 실리는 failure_kind가 필요한 갈래라) 배지가 안 떠야 한다.
+  const ROW_PENDING = {
+    publication_id: 'pub-pd', kind: 'channel_publication', channel: 'threads', work_item_id: 'wi-pd',
+    title: '글 PD', published_at: '2026-09-01T00:00:00Z', external_url: null, connection_id: 'conn-3',
+    d1: null, d7: null, command_status: 'pending',
+  };
+  const ROW_VOIDED = {
+    publication_id: 'pub-vd', kind: 'channel_publication', channel: 'threads', work_item_id: 'wi-vd',
+    title: '글 VD', published_at: '2026-09-01T00:00:00Z', external_url: null, connection_id: 'conn-4',
+    d1: null, d7: null, command_status: 'voided',
+  };
+
+  it('⭐dead_letter 행엔 배지("발행 실패" 계열 문구)가 뜬다', async () => {
+    stubFetch({ page1: [ROW_DEAD_LETTER] });
+    await mount();
+    const row = container.querySelector('[data-testid="insights-board-row"]')!;
+    const badge = row.querySelector('[data-testid="channel-post-failure-badge"]');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe(koMessages.content.channelPostsFailureDeadLetter);
+  });
+
+  it('⭐blocked 행엔 배지가 뜬다', async () => {
+    stubFetch({ page1: [ROW_BLOCKED] });
+    await mount();
+    const row = container.querySelector('[data-testid="insights-board-row"]')!;
+    const badge = row.querySelector('[data-testid="channel-post-failure-badge"]');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe(koMessages.content.channelPostsFailureBlocked);
+  });
+
+  // 뮤테이션 대조 — BE 필드(command_status)가 응답에서 빠지면(undefined) 배지도 0.
+  it('뮤테이션 대조 — command_status 자체가 없으면(BE 필드 누락 시뮬) 배지가 안 뜬다', async () => {
+    const { command_status: _omit, ...rowWithoutField } = ROW_DEAD_LETTER;
+    void _omit;
+    stubFetch({ page1: [rowWithoutField] });
+    await mount();
+    const row = container.querySelector('[data-testid="insights-board-row"]')!;
+    expect(row.querySelector('[data-testid="channel-post-failure-badge"]')).toBeNull();
+  });
+
+  it('pending·voided는 배지가 안 뜬다(이 보드엔 failure_kind/reasonCode가 없어 그 갈래는 애초에 판정 불가)', async () => {
+    stubFetch({ page1: [ROW_PENDING, ROW_VOIDED] });
+    await mount();
+    const rows = [...container.querySelectorAll('[data-testid="insights-board-row"]')];
+    expect(rows[0]!.querySelector('[data-testid="channel-post-failure-badge"]')).toBeNull();
+    expect(rows[1]!.querySelector('[data-testid="channel-post-failure-badge"]')).toBeNull();
+  });
+
+  it('배지가 뜬 행에서도 행동 버튼(후속 조치·원본과 대조)은 그대로 같이 선다(자리만 갈림, 행동 자체는 무변)', async () => {
+    stubFetch({ page1: [ROW_DEAD_LETTER] });
+    await mount();
+    const row = container.querySelector('[data-testid="insights-board-row"]')!;
+    expect(row.querySelector('[data-testid="insights-board-reconcile-button"]')).not.toBeNull();
+  });
+
+  // ①② — 배지도 버튼도 없을 때 그 자리 자체가 남지 않는다(빈 flex div가 gap만
+  // 먹는 회귀 방지). site_post 행(canReconcile=false)이면서 command_status가 없는
+  // 행으로 재는다 — canCreateFollowUp은 useDashboardContext mock의
+  // currentMemberType='human'이라 기본 true인 만큼, agent로 바꿔 버튼 축까지 끈다.
+  it('①② 배지도 행동 버튼도 없으면 그 td가 완전히 빈다(빈 wrapper 노드 0)', async () => {
+    useDashboardContextMock.mockReturnValue({ orgId: ORG_ID, currentMemberType: 'agent' });
+    const rowNoActionsNoBadge = {
+      publication_id: 'pub-none', kind: 'site_post', channel: 'hosted_site', work_item_id: 'wi-none',
+      title: '글 없음', published_at: '2026-09-01T00:00:00Z', external_url: null, connection_id: null,
+      d1: null, d7: null, command_status: null,
+    };
+    stubFetch({ page1: [rowNoActionsNoBadge] });
+    await mount();
+    const row = container.querySelector('[data-testid="insights-board-row"]')!;
+    const actionCell = row.querySelectorAll('td')[6] as HTMLElement;
+    expect(actionCell.children.length).toBe(0);
+  });
+});
+
 // story #3656(Phase2·FE+BE, 페드루 PO 確定 2026-09-07) — 소재/훅 묶음 토글. BE(#3656
 // 절반)가 아직 안 착지해 asset_sha256s/hook_key가 실린 목 행으로 먼저 짓는다(PO
 // 지시 — FE 절반 지금, BE는 #4002 착지 뒤 같은 브랜치에).

--- a/apps/web/src/app/(authenticated)/organization/insights-board/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/insights-board/page.tsx
@@ -27,6 +27,8 @@ import { parseInsightsBoardApiError } from '@/components/insights-board/insights
 import { ASSET_LABEL_PREFIX_LENGTH, aggregateGroupBucket, groupInsightsBoardRows, type InsightsBoardGroupBy } from '@/components/insights-board/group-rows';
 import { DEFAULT_METRIC, METRIC_KEYS, type BoardMetric, type InsightsBoardResponse, type InsightsBoardRow, type InsightsBoardWindow } from '@/components/insights-board/types';
 import { PublishingMetricsBand } from '@/components/content/publishing-metrics-band';
+import { deriveFailureAction, type CommandStatus } from '@/components/content/failure-action';
+import { FailureActionBadge } from '@/components/content/failure-action-badge';
 
 /**
  * story #3503 — 성과 보드 화면. BE #3502 의존(PR 브리프 헤더 참고, 이 파일 작성 시점
@@ -556,6 +558,17 @@ export default function InsightsBoardPage() {
                   // 를 낸다 — 버튼 자체를 그 행엔 안 보여준다(follow-up 사람전용 게이트와
                   // 동형: 실패로 알리는 대신 애초에 숨긴다).
                   const canReconcile = row.kind === 'channel_publication';
+                  // story #3766(별건 ⑩, 3746 §3 유나 定) — 「사람 차례」 발행 명령 축은
+                  // 필터가 아니라 행 배지로만 선다. deriveFailureAction(단일 판정
+                  // 출처, failure-action.ts)을 그대로 재사용하되 이 배지는 command
+                  // Status 하나만 먹인다(failure_kind/next_retry_at/reason_code는
+                  // 이 보드에 안 실려 있다 — voided/needs_check/auto_retry/processing
+                  // 은 그 필드들이 있어야 판정되므로 여기선 애초에 안 뜬다). dead_letter·
+                  // blocked 둘만 그 판정에 필요한 입력이 commandStatus 하나뿐이라
+                  // 이 좁은 조인으로도 정확히 그 둘만 걸린다.
+                  const rowFailureAction = deriveFailureAction({ commandStatus: row.command_status as CommandStatus | null });
+                  const showFailureBadge = rowFailureAction?.kind === 'dead_letter' || rowFailureAction?.kind === 'blocked';
+                  const hasRowActions = canCreateFollowUp || canReconcile;
                   return (
                     <Fragment key={row.publication_id}>
                   <tr
@@ -598,34 +611,51 @@ export default function InsightsBoardPage() {
                       <InsightsBoardCommentsCell row={row} t={t} />
                     </td>
                     <td className="px-3 py-2.5">
+                      {/* story #3766(별건 ⑩, 유나 定 — issuecomment 2026-09-10 02:11Z)
+                          — 상태 딱지(FailureActionBadge)는 행동 자리(아래 버튼 div)와
+                          다른 자리를 쓴다: 행동칸에 섞으면 「자리가 뜻을 바꾼다」(PR#4107
+                          별건 ㉓과 동형 클래스 — 소유자 배지가 제거 열에 얹혀 세로로
+                          「소유자/제거/제거」로 읽히던 결함). 물음(왜 막혔나)이 생긴
+                          자리에 답이 있도록 배지가 버튼 줄 «위». 배지 없으면 그 줄
+                          노드 자체가 없다(①, 빈 줄이 gap만 먹지 않게). */}
+                      {showFailureBadge && rowFailureAction ? (
+                        <div className="mb-1.5 leading-tight">
+                          <FailureActionBadge action={rowFailureAction} displayTimezone={displayTimezone} compact />
+                        </div>
+                      ) : null}
                       {/* story #3592(§17-20 ⑧·§22-18 동형) — 행마다 같은 「후속 조치」
-                          접근 이름이라 보조기술 버튼 목록에서 어느 행인지 못 가른다. */}
-                      <div className="flex flex-wrap gap-1.5">
-                        {canCreateFollowUp ? (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => setFollowUpRow(row)}
-                            data-testid="insights-board-follow-up-button"
-                            aria-label={t('rowActionAriaLabel', { n: index + 1, label: t('followUpAction') })}
-                          >
-                            {t('followUpAction')}
-                          </Button>
-                        ) : null}
-                        {/* story #3620 AC3 — 「원본과 대조」, 진행 中 비활성. */}
-                        {canReconcile ? (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => void handleReconcile(row)}
-                            disabled={reconcile?.status === 'loading'}
-                            data-testid="insights-board-reconcile-button"
-                            aria-label={t('rowActionAriaLabel', { n: index + 1, label: t('reconcileAction') })}
-                          >
-                            {reconcile?.status === 'loading' ? t('reconcileInProgress') : t('reconcileAction')}
-                          </Button>
-                        ) : null}
-                      </div>
+                          접근 이름이라 보조기술 버튼 목록에서 어느 행인지 못 가른다.
+                          story #3766 — 버튼 div도 조건부(②, canCreateFollowUp·
+                          canReconcile 둘 다 false면 빈 flex div 자체를 안 남긴다 —
+                          배지가 뜬 행에서 그 빈 자리가 특히 눈에 띄는 걸 막는다). */}
+                      {hasRowActions ? (
+                        <div className="flex flex-wrap gap-1.5">
+                          {canCreateFollowUp ? (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => setFollowUpRow(row)}
+                              data-testid="insights-board-follow-up-button"
+                              aria-label={t('rowActionAriaLabel', { n: index + 1, label: t('followUpAction') })}
+                            >
+                              {t('followUpAction')}
+                            </Button>
+                          ) : null}
+                          {/* story #3620 AC3 — 「원본과 대조」, 진행 中 비활성. */}
+                          {canReconcile ? (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => void handleReconcile(row)}
+                              disabled={reconcile?.status === 'loading'}
+                              data-testid="insights-board-reconcile-button"
+                              aria-label={t('rowActionAriaLabel', { n: index + 1, label: t('reconcileAction') })}
+                            >
+                              {reconcile?.status === 'loading' ? t('reconcileInProgress') : t('reconcileAction')}
+                            </Button>
+                          ) : null}
+                        </div>
+                      ) : null}
                     </td>
                   </tr>
                   {reconcile && reconcile.status !== 'loading' ? (

--- a/apps/web/src/components/insights-board/group-rows.test.ts
+++ b/apps/web/src/components/insights-board/group-rows.test.ts
@@ -8,7 +8,7 @@ function makeRow(overrides: Partial<InsightsBoardRow> & { publication_id: string
     title: '제목', published_at: '2026-09-01T00:00:00Z', external_url: null,
     connection_id: null, d1: null, d7: null, comments_count: null,
     channel_post_draft_id: null, comments_last_collected_at: null, comments_supported: false,
-    asset_sha256s: null, hook_key: null,
+    asset_sha256s: null, hook_key: null, command_status: null,
     ...overrides,
   };
 }

--- a/apps/web/src/components/insights-board/story-insights-compare-section.test.tsx
+++ b/apps/web/src/components/insights-board/story-insights-compare-section.test.tsx
@@ -70,7 +70,7 @@ function blogRow(overrides: Partial<InsightsBoardRow> = {}): InsightsBoardRow {
     title: '블로그 글', published_at: '2026-09-01T00:00:00Z', external_url: 'https://example.com/post',
     connection_id: null, d1: capturedBucket(), d7: capturedBucket(),
     comments_count: null, channel_post_draft_id: null, comments_last_collected_at: null, comments_supported: false,
-    asset_sha256s: null, hook_key: null,
+    asset_sha256s: null, hook_key: null, command_status: null,
     ...overrides,
   };
 }
@@ -81,7 +81,7 @@ function socialRow(overrides: Partial<InsightsBoardRow> = {}): InsightsBoardRow 
     title: '소셜 포스트', published_at: '2026-09-01T00:00:00Z', external_url: null,
     connection_id: 'conn-1', d1: capturedBucket(), d7: capturedBucket(),
     comments_count: 3, channel_post_draft_id: 'draft-1', comments_last_collected_at: '2026-09-02T00:00:00Z', comments_supported: true,
-    asset_sha256s: null, hook_key: null,
+    asset_sha256s: null, hook_key: null, command_status: null,
     ...overrides,
   };
 }

--- a/apps/web/src/components/insights-board/types.ts
+++ b/apps/web/src/components/insights-board/types.ts
@@ -80,6 +80,11 @@ export interface InsightsBoardRow {
   // null — 소급 백필 없음(신규 발행부터만 채워진다).
   asset_sha256s: string[] | null;
   hook_key: string | null;
+  // story #3766(별건 ⑩, 3746 §3 유나 定) — 「사람 차례」 발행 명령 축. 채널 포스트
+  // 목록의 CommandStatus(failure-action.ts)와 같은 값 집합·같은 뜻(같은
+  // PublicationCommand 행) — 새 낱말 0. 수집 상태 축(d1/d7·comments_*)과는 다른
+  // 축이라 필터 대상이 아니라 행 배지 전용. site_post 행은 항상 null.
+  command_status: string | null;
 }
 
 export interface InsightsBoardResponse {

--- a/backend/app/routers/insights_board.py
+++ b/backend/app/routers/insights_board.py
@@ -77,6 +77,11 @@ class InsightsBoardRow(BaseModel):
     # 0건·hook_key 미기입은 각각 null.
     asset_sha256s: list[str] | None = None
     hook_key: str | None = None
+    # story #3766(별건 ⑩, 3746 §3 유나 定) — 「사람 차례」 발행 명령 축. 채널 포스트
+    # 목록 응답(ChannelPostDraftListItem.command_status)과 같은 이름·같은 뜻(같은
+    # PublicationCommand 행) — 새 낱말 0. 수집 상태 축(d1/d7·comments_*)과는 다른
+    # 축이라 섞지 않는다(필터 대상 아님 — 행 배지 전용). site_post 행은 항상 null.
+    command_status: str | None = None
 
 
 class InsightsBoardResponse(BaseModel):

--- a/backend/app/services/insights_board.py
+++ b/backend/app/services/insights_board.py
@@ -41,6 +41,7 @@ from app.models.channel_post_version import ChannelPostVersion
 from app.models.gate import Gate
 from app.models.insight_snapshot import InsightSnapshot
 from app.models.pm import Story
+from app.models.publication_command import PublicationCommand
 from app.models.site_post import SitePost
 from app.models.site_post_draft import SitePostDraft
 from app.services.insight_snapshots import (
@@ -95,6 +96,11 @@ def _build_union(*, org_id: uuid.UUID, channel: str | None, since: datetime, inc
         # story #3656 — site_post는 소재/훅 개념 자체가 없어 항상 null(channel_post_
         # draft_id와 동일 이유).
         cast(literal(None), PG_UUID(as_uuid=True)).label("version_id"),
+        # story #3766(별건 ⑩) — site_post 발행 흐름은 이 쿼리가 gate를 아예 조인하지
+        # 않는다(channel_pub_arm과 달리 site_post_arm엔 Gate 조인이 없다 — site_post
+        # 쪽 gate 경로 자체가 이 스토리 스코프 밖, comments_count·channel_post_draft_id
+        # 와 동일 이유로 null). command_status도 그래서 항상 null.
+        cast(literal(None), PG_UUID(as_uuid=True)).label("gate_id"),
     ).select_from(SitePost)
     # story #3734 AC3 후속 — SitePost에 draft로의 FK가 없다(site_posts.py 서비스와 동형
     # 관례). (org_id, work_item_id, slug)가 site_post_drafts의 unique 제약과 정확히
@@ -135,6 +141,12 @@ def _build_union(*, org_id: uuid.UUID, channel: str | None, since: datetime, inc
             # sources)의 키. 이미 조인돼 있는 ChannelPublication에서 바로 뽑는다
             # (추가 조인 0 — channel_post_draft_id와 같은 열에서 파생).
             ChannelPublication.version_id.label("version_id"),
+            # story #3766(별건 ⑩, 3746 §3 유나 定) — 「사람 차례」 발행 명령 축
+            # (command_status)은 gate_id로 PublicationCommand를 되짚는다
+            # (channel_posts.py::_channel_post_to_list_item과 동형 관례 — gate당
+            # 최신 명령 1건, "최근 생성" 기준). Gate는 위에서 이미 조인돼 있다(title
+            # 조회용) — 추가 조인 0, 열만 하나 더 뽑는다.
+            Gate.id.label("gate_id"),
         )
         .select_from(ChannelPublication)
         .join(Gate, Gate.id == ChannelPublication.gate_id)
@@ -353,6 +365,23 @@ async def list_insights_board(
     comments_last_collected_at_by_pub = await get_last_collected_at_by_publication_ids(
         db, publication_ids=channel_pub_ids,
     )
+    # story #3766(별건 ⑩, 3746 §3 유나 定) — 발행 명령 상태 배치(N+1 회피, 위 스냅샷·
+    # 댓글 배치와 동형). channel_posts.py::list_channel_post_drafts(951-959)와 정확히
+    # 같은 패턴 — gate_id로 IN 조회 후 created_at DESC로 gate당 첫 행(=최신)만
+    # dict.setdefault로 남긴다. site_post 행은 gate_id가 애초 null(위 UNION 참고)이라
+    # 이 배치엔 안 들어가고 command_status도 항상 null — 「발행 명령 축」 자체가
+    # site_post 쪽엔 없는 개념이다(이 스토리 스코프 밖, 별건).
+    gate_ids = [r.gate_id for r in page if r.gate_id is not None]
+    latest_command_by_gate: dict[uuid.UUID, PublicationCommand] = {}
+    if gate_ids:
+        cmd_rows = (await db.execute(
+            select(PublicationCommand)
+            .where(PublicationCommand.gate_id.in_(gate_ids))
+            .order_by(PublicationCommand.created_at.desc())
+        )).scalars().all()
+        for c in cmd_rows:
+            latest_command_by_gate.setdefault(c.gate_id, c)
+
     from app.services.channel_adapters import CHANNEL_ADAPTERS
 
     # story #3656(페드루 PO CHANGES, 2026-09-07) — 소재/훅 배치 조회(N+1 회피, 위
@@ -420,6 +449,13 @@ async def list_insights_board(
             # 0건·hook_key 미기입은 각각 null(소급 백필 없음 — 신규 발행부터만).
             "asset_sha256s": asset_sha256s,
             "hook_key": hook_key,
+            # story #3766(별건 ⑩) — 채널 포스트 목록 응답(ChannelPostDraftListItem.
+            # command_status)과 같은 이름·같은 뜻(같은 PublicationCommand 행) — 새
+            # 낱말 0. site_post 행은 gate_id가 null이라 latest_command_by_gate에
+            # 애초 못 들어가 이 조회도 자연히 None.
+            "command_status": (
+                latest_command_by_gate[r.gate_id].status if r.gate_id in latest_command_by_gate else None
+            ),
         })
 
     # story #3697(유나 § — 「지금 아무도 안 따라간다」가 계약을 참으로 만들지 않는다) —

--- a/backend/tests/test_3766_insights_board_command_status.py
+++ b/backend/tests/test_3766_insights_board_command_status.py
@@ -1,0 +1,232 @@
+"""story #3766(별건 ⑩·성과 보드, 3746 §3 유나 定) — 「사람 차례」 발행 명령 축.
+insights_board 행에 그 발행물(gate)의 최신 PublicationCommand.status를 조인 1필드로
+싣는다(channel_posts.py::_channel_post_to_list_item의 gate당 최신 명령 패턴과 동형 —
+gate_id IN (...) 배치 조회 후 created_at DESC로 gate당 첫 행만 남긴다).
+
+세팅 헬퍼는 test_3502_insights_board.py 재사용(중복 재발명 금지) — 이 파일 전용
+(PublicationCommand 시딩)만 새로 추가한다."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_3471_org_content_rules_lint import _seed_human, _seed_org, _seed_story, _session_factory
+from tests.test_3502_insights_board import _seed_channel_publication, _seed_gate, _seed_site_post
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_command(
+    session, *, org_id, gate_id, requested_by_member_id, status="pending",
+    created_at=None, destination=None, approved_version=None,
+):
+    from app.models.publication_command import PublicationCommand
+
+    cmd = PublicationCommand(
+        id=uuid.uuid4(), org_id=org_id, gate_id=gate_id,
+        destination=destination or uuid.uuid4(), approved_version=approved_version or uuid.uuid4(),
+        operation="publish", content_kind="channel_post", status=status,
+        attempt_count=0, requested_by_member_id=requested_by_member_id,
+    )
+    session.add(cmd)
+    await session.commit()
+    if created_at is not None:
+        # created_at은 모델 server_default(now())라 시딩 시점 순서를 뒤집을 방법이
+        # INSERT 인자로는 없다 — "gate당 최신"(created_at DESC) 판정을 테스트하려면
+        # 커밋 뒤 UPDATE로 시각을 직접 되돌린다(다른 시딩 헬퍼들과 달리 이 필드만
+        # 예외 — 서버 시각을 테스트가 통제할 유일한 길).
+        from sqlalchemy import update
+
+        await session.execute(
+            update(PublicationCommand).where(PublicationCommand.id == cmd.id).values(created_at=created_at)
+        )
+        await session.commit()
+    return cmd
+
+
+@pytest.mark.anyio
+async def test_dead_letter_command_status_joins_onto_row():
+    """AC1 — dead_letter 발행 명령이 있으면 그 행의 command_status가 "dead_letter"."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            now = datetime.now(timezone.utc)
+
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id)
+            cp = await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, channel="threads", published_at=now - timedelta(days=1),
+            )
+            await _seed_command(s, org_id=org_id, gate_id=gate.id, requested_by_member_id=human_id, status="dead_letter")
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+        row = next(r for r in result["rows"] if r["publication_id"] == cp.id)
+        assert row["command_status"] == "dead_letter"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_blocked_command_status_joins_onto_row():
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            now = datetime.now(timezone.utc)
+
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id)
+            cp = await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, channel="threads", published_at=now - timedelta(days=1),
+            )
+            await _seed_command(s, org_id=org_id, gate_id=gate.id, requested_by_member_id=human_id, status="blocked")
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+        row = next(r for r in result["rows"] if r["publication_id"] == cp.id)
+        assert row["command_status"] == "blocked"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_command_for_gate_leaves_command_status_none():
+    """뮤테이션 대조 짝 — 명령 자체가 없는(정상 발행, 재시도/차단 이력 0) 행은 None.
+    이 케이스가 없으면 "항상 뭔가 채워진다"는 거짓양성을 위 두 테스트가 못 잡는다."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            now = datetime.now(timezone.utc)
+
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id)
+            cp = await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, channel="threads", published_at=now - timedelta(days=1),
+            )
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+        row = next(r for r in result["rows"] if r["publication_id"] == cp.id)
+        assert row["command_status"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_site_post_row_command_status_always_none():
+    """site_post_arm은 Gate를 아예 조인하지 않는다(그라운딩) — gate_id가 항상 null이라
+    command_status도 구조적으로 항상 None이다(site_post는 이 스토리 스코프 밖)."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            now = datetime.now(timezone.utc)
+            sp = await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_id, slug="post-none", title="글",
+                published_at=now - timedelta(days=1),
+            )
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+        row = next(r for r in result["rows"] if r["publication_id"] == sp.id)
+        assert row["command_status"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_latest_command_by_created_at_wins_when_gate_has_multiple_commands():
+    """AC1 뮤테이션 표적 — 한 gate에 명령이 여러 번(예: 실패 뒤 수동 재시도로 새 명령)
+    쌓이면 created_at이 더 최신인 쪽 status가 이긴다(channel_posts.py 관례와 동형).
+    이 테스트가 없으면 "아무 명령이나 하나 조인"으로 구현이 퇴화해도 위 단일-명령
+    테스트들은 계속 그린이라 못 잡는다."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            now = datetime.now(timezone.utc)
+
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id)
+            cp = await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, channel="threads", published_at=now - timedelta(days=1),
+            )
+            # 옛 명령(실패로 dead_letter) → 그 뒤 사람이 재시도해 새 명령(pending)을 냄.
+            await _seed_command(
+                s, org_id=org_id, gate_id=gate.id, requested_by_member_id=human_id, status="dead_letter",
+                created_at=now - timedelta(hours=2),
+            )
+            await _seed_command(
+                s, org_id=org_id, gate_id=gate.id, requested_by_member_id=human_id, status="pending",
+                created_at=now - timedelta(minutes=1),
+            )
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+        row = next(r for r in result["rows"] if r["publication_id"] == cp.id)
+        assert row["command_status"] == "pending", "더 최신(created_at) 명령이 이겨야 하는데 옛 dead_letter가 남았다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_status_filter_axis_stays_separate_from_command_status():
+    """AC「필터에 command 값 넣으면 422/무시」 — `status` 쿼리 파라미터는 InsightSnapshot.
+    status(수집 상태 축)만 본다. command_status류 값("dead_letter")을 넣어도 그 값을
+    가진 스냅샷이 애초에 없으니(다른 테이블·다른 값 집합) 조용히 0건을 낸다 — 두 축이
+    섞여 command_status=dead_letter인 행이 엉뚱하게 걸리면(교차 오염) 이 테스트가 RED."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            now = datetime.now(timezone.utc)
+
+            gate = await _seed_gate(s, org_id=org_id, work_item_id=story_id)
+            await _seed_channel_publication(
+                s, org_id=org_id, gate_id=gate.id, channel="threads", published_at=now - timedelta(days=1),
+            )
+            await _seed_command(s, org_id=org_id, gate_id=gate.id, requested_by_member_id=human_id, status="dead_letter")
+
+            result = await list_insights_board(s, org_id=org_id, window="30d", status="dead_letter")
+        assert result["rows"] == [], (
+            "status='dead_letter'가 InsightSnapshot 축이 아니라 command_status 축에 "
+            "잘못 걸리면(교차 오염) 이 행이 여기 섞여 든다 — 두 축은 분리돼야 한다"
+        )
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1562,6 +1562,11 @@
       "file": "tests/test_3744_list_total_count.py",
       "sec": 19.6,
       "source": "story-3744-post-list-redesign(2026-09-09, PO 決 public_url 3건 추가로 재측정 — 신규 destructive_schema 파일, test_3734_post_archive.py와 동일 방법론 재사용) — 로컬 raw pytest 9건 6.79s 실측 × 같은 도메인 이웃 재측정 평균 배율(2.88, test_3734_post_archive.py source 필드 참조) = 19.6s — 실 CI 샤드 로그로 재확認 필요"
+    },
+    {
+      "file": "tests/test_3766_insights_board_command_status.py",
+      "sec": 3.3,
+      "source": "story-3766(2026-09-10) — 신규 파일 실측(로컬, sprintable/backend/.venv pytest 직접 3회 실행 average≈3.23s·최고 3.27s, 3.3s로 등재). measure_destructive_durations_local.py 전체 배치 재측정(템플릿 DB sprintable_test_tpl·role sprintable 필요)이 아니라 이 신규 파일 1건만 별도 스크래치 DB(backend_test_3766_weights)에서 3회 반복 실측한 값 — 로컬이 CI보다 ~6배 빠르다는 _snapshot_policy 전제 그대로(절대시간 아님, 상대 비중 목적) 원값 그대로 등재. 실 CI 샤드 로그로 재확認 필요(AC2 재측정 규칙)."
     }
   ]
 }


### PR DESCRIPTION
## 요약
story #3766(별건 ⑩) — 3746 §3(유나 定)이 정한 「발행 명령 축(command_status)은 필터가 아니라 행 배지로만 선다」를 #4093이 조인 없이 남겨둔 갭(PO 리뷰 「갭(안 지어냄)」)을 닫는다. 성과 보드 행에 그 발행물의 최신 발행 명령 상태를 1필드 조인하고, dead_letter/blocked(「사람 차례」 갈래)면 채널 포스트 목록이 이미 쓰는 `FailureActionBadge`를 재사용해 표시한다.

## BE
- `insights_board.py`의 `channel_pub_arm`에 `Gate.id.label("gate_id")` 추가(Gate는 title 조회용으로 이미 조인돼 있음 — 추가 조인 0). `site_post_arm`은 애초 Gate를 조인하지 않아 `gate_id`가 항상 null.
- `list_insights_board`에 gate당 최신 `PublicationCommand` 배치 조회 추가 — `channel_posts.py::_channel_post_to_list_item`(gate_id IN (...) 배치 + `created_at DESC`로 gate당 첫 행)과 동형 패턴, 새 기전 0.
- `InsightsBoardRow.command_status: str | None` — 채널 포스트 목록 응답(`ChannelPostDraftListItem.command_status`)과 같은 필드명·같은 뜻(같은 `PublicationCommand` 행).

## FE
- `types.ts`에 `command_status: string | null` 추가(채널 포스트 목록 소비처와 동일 관례 — `as CommandStatus | null` 캐스트로 `deriveFailureAction` 호출).
- `insights-board/page.tsx` 행에 `deriveFailureAction({ commandStatus: row.command_status })`을 호출하고 결과가 `dead_letter`/`blocked`일 때만 배지를 그린다(voided/needs_check/auto_retry/processing은 failure_kind 등 이 보드에 없는 필드가 필요해 애초 판정 불가 — 자연히 안 뜬다).
- **배지 자리는 유나 定**(issuecomment, PR#4107 별건 ㉓ "상태 딱지가 행동 자리로 새면 자리가 뜻을 바꾼다"와 동형 클래스로 판단): 행동칸(후속 조치·원본과 대조) **위** 별도 줄.
  - ① 배지가 없으면 그 줄 노드 자체가 없다(빈 gap 방지).
  - ② 버튼 div도 `canCreateFollowUp || canReconcile`일 때만 렌더(기존엔 항상 렌더돼 둘 다 false면 빈 flex div가 남던 것도 같이 닫음).
  - ③ compact 모드는 `<p>` 텍스트만 그려 버튼과 시각적으로 안 헷갈림(구조적으로 이미 충족).
  - ④ `leading-tight`로 행 높이 증가 최소화.
- 대비 사전 검증(유나, 배포 64 라이브 주입): 라이트 5.24 · 다크 5.29 — 판정선 4.5 통과, 별도 재색칠 불요.

## 테스트
- **BE**(6개, 실 Postgres): dead_letter/blocked 조인 · 명령 0건→null · site_post 행 항상 null · **gate당 최신 명령 우선**(뮤테이션 표적 — 옛 dead_letter 위에 새 pending이 쌓이면 새 쪽이 이겨야 함) · **status 필터축 분리**(command 값을 필터에 넣어도 InsightSnapshot 축과 안 섞임, 교차 오염 검증).
- **FE**(7개): dead_letter/blocked 배지 노출 · 뮤테이션 대조(필드 누락 시 배지 0) · pending/voided 미노출 · 배지+행동버튼 공존 · **①②** 둘 다 없을 때 빈 wrapper 노드 0.
- 관련 기존 스위트(FE 64개) 전부 그린 · `pnpm build`/`tsc`/`eslint` 클린.

## 스크린샷
로컬 백엔드(FE) 접근 제약(#4110/#4111/#4114와 같은 사정)으로 라이브픽셀은 배포 뒤 이어서 확인·지름길로 표기. BE는 로컬 실 Postgres(scratch DB)로 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ