### PR TITLE
[SID:3768] fix(BE+FE): 설정 화면 마운트가 매번 새 TOTP 시크릿을 쓰던 결함 제거

### DIFF
--- a/apps/web/src/components/settings/two-factor-section.test.tsx
+++ b/apps/web/src/components/settings/two-factor-section.test.tsx
@@ -103,6 +103,21 @@ describe('TwoFactorSection — 마운트 읽기 계약(story #3768)', () => {
     expect(container.textContent).toBe('');
     expect(enableButton()).toBeFalsy();
   });
+
+  // ⭐되돌리면 RED — 카디르 QA(2026-09-10): BE MeResponse.totp_enabled는 `bool | None`이라
+  // null이 오는 실 분기가 있다(user 없는 org_member 폴백 등). `=== undefined`만 보면 null이
+  // 「꺼짐」으로 단정돼 이 스토리가 막으려던 「모름≠꺼짐」 결함이 그대로 재발한다.
+  it('⭐/api/me가 totp_enabled: null을 주면(BE 계약상 실제 분기) 「모름」 — 「꺼짐」으로 단정 안 함', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { totp_enabled: null } }) };
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<TwoFactorSection />)); });
+    await flush();
+
+    expect(container.textContent).toBe('');
+    expect(enableButton()).toBeFalsy();
+  });
 });
 
 describe('TwoFactorSection — error.code 분기 (story #2485)', () => {

--- a/apps/web/src/components/settings/two-factor-section.test.tsx
+++ b/apps/web/src/components/settings/two-factor-section.test.tsx
@@ -3,6 +3,10 @@
 // story #2485 — error.code 분기(backend auth.py _err() 발급 안정 값): setup(USER_NOT_FOUND/
 // TOTP_ALREADY_ENABLED), verify(USER_NOT_FOUND/TOTP_NOT_SETUP). disable은 그라운딩 결과
 // backend에 라우트 자체가 없어(#2485 별도 보고) 항상 404 — code 분기 불가, raw 노출만 제거.
+//
+// story #3768 — 마운트가 상태를 알려고 POST /api/auth/2fa/setup을 부르던 것(매번 새 시크릿을
+// DB에 쓰는 클래스)을 GET /api/me의 totp_enabled 읽기로 교체 — 아래 전체가 그 계약으로
+// 갱신됐다. setup POST는 이제 handleSetup(「켜기」 클릭)에서만 나간다.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
@@ -40,16 +44,72 @@ async function flush() {
   await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
 }
 
+function enableButton() {
+  return Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.settings.twoFactorEnable);
+}
+
+describe('TwoFactorSection — 마운트 읽기 계약(story #3768)', () => {
+  // ⭐되돌리면 RED — 뮤테이션: 마운트 useEffect가 다시 POST /api/auth/2fa/setup을 부르면
+  // 이 테스트가 그 호출을 "unexpected fetch"로 잡아 throw한다.
+  it('⭐마운트 시 setup POST가 0회 — /api/me만 읽는다', async () => {
+    let setupCalls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { totp_enabled: false } }) };
+      if (url === '/api/auth/2fa/setup') { setupCalls += 1; throw new Error('unexpected setup POST on mount'); }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<TwoFactorSection />)); });
+    await flush();
+
+    expect(setupCalls).toBe(0);
+    expect(enableButton()).toBeTruthy(); // totp_enabled:false → disabled 상태(켜기 버튼 보임).
+  });
+
+  it('totp_enabled:true → enabled 상태(해제 UI, 켜기 버튼 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { totp_enabled: true } }) };
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<TwoFactorSection />)); });
+    await flush();
+
+    expect(enableButton()).toBeFalsy();
+    const disableBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.settings.twoFactorDisable);
+    expect(disableBtn).toBeTruthy();
+  });
+
+  // ⭐되돌리면 RED — 「모름」을 「꺼짐」으로 단정하면 이 테스트에서 켜기 버튼이 그려진다.
+  it('⭐/api/me 실패(non-ok) → 「모름」(disabled 문구·켜기 버튼 0)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') return { ok: false, status: 500, json: async () => ({ error: { code: 'INTERNAL' } }) };
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<TwoFactorSection />)); });
+    await flush();
+
+    expect(container.textContent).toBe('');
+    expect(enableButton()).toBeFalsy();
+  });
+
+  // ⭐되돌리면 RED — 네트워크 자체가 죽는(reject) 경로도 「모름」이어야 한다(disabled 아님).
+  it('⭐/api/me 네트워크 reject → 「모름」(disabled 문구·켜기 버튼 0)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') throw new Error('network down');
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<TwoFactorSection />)); });
+    await flush();
+
+    expect(container.textContent).toBe('');
+    expect(enableButton()).toBeFalsy();
+  });
+});
+
 describe('TwoFactorSection — error.code 분기 (story #2485)', () => {
   it('setup 실패(USER_NOT_FOUND) — raw 영문 대신 번역 문구', async () => {
-    let setupCall = 0;
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { totp_enabled: false } }) };
       if (url === '/api/auth/2fa/setup') {
-        setupCall += 1;
-        if (setupCall === 1) {
-          // 초기 마운트 감지 호출 — enabled/enrolling 둘 다 아니게 disabled로 안착.
-          return { ok: false, status: 400, json: async () => ({ error: { code: 'X', message: 'x' } }) };
-        }
         return { ok: false, status: 404, json: async () => ({ error: { code: 'USER_NOT_FOUND', message: 'User not found' } }) };
       }
       throw new Error('unexpected fetch: ' + url);
@@ -57,7 +117,7 @@ describe('TwoFactorSection — error.code 분기 (story #2485)', () => {
     await act(async () => { root.render(wrap(<TwoFactorSection />)); });
     await flush();
 
-    const enableBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.settings.twoFactorEnable);
+    const enableBtn = enableButton();
     await act(async () => { enableBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
@@ -65,14 +125,10 @@ describe('TwoFactorSection — error.code 분기 (story #2485)', () => {
     expect(container.textContent).toContain(koMessages.settings.twoFactorUserNotFound);
   });
 
-  it('setup 실패(TOTP_ALREADY_ENABLED, 초기감지 아닌 재시도 케이스) — raw 영문 대신 번역 문구', async () => {
-    let setupCall = 0;
+  it('setup 실패(TOTP_ALREADY_ENABLED, 클릭 시점 레이스) — raw 영문 대신 번역 문구', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { totp_enabled: false } }) };
       if (url === '/api/auth/2fa/setup') {
-        setupCall += 1;
-        if (setupCall === 1) {
-          return { ok: false, status: 400, json: async () => ({ error: { code: 'X', message: 'x' } }) };
-        }
         return { ok: false, status: 409, json: async () => ({ error: { code: 'TOTP_ALREADY_ENABLED', message: 'Already enabled' } }) };
       }
       throw new Error('unexpected fetch: ' + url);
@@ -80,7 +136,7 @@ describe('TwoFactorSection — error.code 분기 (story #2485)', () => {
     await act(async () => { root.render(wrap(<TwoFactorSection />)); });
     await flush();
 
-    const enableBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.settings.twoFactorEnable);
+    const enableBtn = enableButton();
     await act(async () => { enableBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
@@ -90,6 +146,7 @@ describe('TwoFactorSection — error.code 분기 (story #2485)', () => {
 
   it('verify 실패(TOTP_NOT_SETUP) — raw 영문 대신 번역 문구', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { totp_enabled: false } }) };
       if (url === '/api/auth/2fa/setup') {
         return { ok: true, json: async () => ({ data: { secret: 'ABCD1234', uri: 'otpauth://totp/x' } }) };
       }
@@ -99,6 +156,10 @@ describe('TwoFactorSection — error.code 분기 (story #2485)', () => {
       throw new Error('unexpected fetch: ' + url);
     }));
     await act(async () => { root.render(wrap(<TwoFactorSection />)); });
+    await flush();
+
+    const enableBtn = enableButton();
+    await act(async () => { enableBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
     const input = container.querySelector('input') as HTMLInputElement;
@@ -114,9 +175,7 @@ describe('TwoFactorSection — error.code 분기 (story #2485)', () => {
 
   it('disable 실패(죽은 엔드포인트, 항상 404) — raw 영문 대신 고정 폴백', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === '/api/auth/2fa/setup') {
-        return { ok: false, status: 409, json: async () => ({ error: { code: 'TOTP_ALREADY_ENABLED', message: 'x' } }) };
-      }
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { totp_enabled: true } }) };
       if (url === '/api/auth/2fa/disable' && init?.method === 'POST') {
         return { ok: false, status: 404, json: async () => ({ error: { code: 'NOT_FOUND', message: 'raw disable message' } }) };
       }

--- a/apps/web/src/components/settings/two-factor-section.tsx
+++ b/apps/web/src/components/settings/two-factor-section.tsx
@@ -34,8 +34,12 @@ export function TwoFactorSection() {
       let res: Response;
       try { res = await fetchWithAuth('/api/me'); } catch { setState('unknown'); return; }
       if (!res.ok) { setState('unknown'); return; }
-      const json = await res.json() as { data?: { totp_enabled?: boolean } };
-      if (json.data?.totp_enabled === undefined) { setState('unknown'); return; }
+      const json = await res.json() as { data?: { totp_enabled?: boolean | null } };
+      // 카디르 QA(2026-09-10) — BE MeResponse.totp_enabled는 `bool | None`이라 실제로
+      // null이 오는 분기가 있다(user 없는 org_member 폴백·api_key/user_id 없는 경로) —
+      // `=== undefined`만 보면 null이 «false(꺼짐)»로 단정돼 이 스토리가 막으려던
+      // 「모름≠꺼짐」 결함이 그대로 재발한다. boolean 타입 검사로 undefined/null 둘 다 잡는다.
+      if (typeof json.data?.totp_enabled !== 'boolean') { setState('unknown'); return; }
       setState(json.data.totp_enabled ? 'enabled' : 'disabled');
     })();
   }, []);

--- a/apps/web/src/components/settings/two-factor-section.tsx
+++ b/apps/web/src/components/settings/two-factor-section.tsx
@@ -5,8 +5,13 @@ import { useTranslations } from 'next-intl';
 import { ShieldCheck } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { fetchWithAuth } from '@/lib/db/client';
 
-type TwoFaState = 'loading' | 'disabled' | 'enrolling' | 'enabled';
+// story #3768 — 'unknown'은 'loading'과 렌더는 같지만(둘 다 null) 의미가 다르다: 'loading'은
+// 아직 응답을 안 받은 것, 'unknown'은 /api/me가 실패해 상태를 «모르는» 채로 끝난 것 —
+// 「모름」을 「꺼짐」으로 단정하지 않는다(set-password-section/linked-accounts-section과
+// 동형: hasPassword===null·linkedProviders===null이면 섹션을 안 그린다).
+type TwoFaState = 'loading' | 'unknown' | 'disabled' | 'enrolling' | 'enabled';
 
 export function TwoFactorSection() {
   const t = useTranslations('settings');
@@ -22,19 +27,16 @@ export function TwoFactorSection() {
   const [disablePassword, setDisablePassword] = useState('');
 
   useEffect(() => {
-    // Attempt setup to detect current 2FA state
+    // story #3768 — 상태를 알려고 setup을 «부르지» 않는다(그건 새 시크릿을 매번 DB에
+    // 쓰는 쪽이다, auth.py:1160). /api/me의 totp_enabled를 읽기만 한다 — setup POST는
+    // handleSetup(사용자의 「켜기」 클릭)에만 남는다.
     (async () => {
-      const res = await fetch('/api/auth/2fa/setup', { method: 'POST' });
-      const json = await res.json() as { data?: { secret: string; uri: string }; error?: { code: string } };
-      if (res.status === 409 && json.error?.code === 'TOTP_ALREADY_ENABLED') {
-        setState('enabled');
-      } else if (res.ok && json.data) {
-        setProvUri(json.data.uri);
-        setSecret(json.data.secret);
-        setState('enrolling');
-      } else {
-        setState('disabled');
-      }
+      let res: Response;
+      try { res = await fetchWithAuth('/api/me'); } catch { setState('unknown'); return; }
+      if (!res.ok) { setState('unknown'); return; }
+      const json = await res.json() as { data?: { totp_enabled?: boolean } };
+      if (json.data?.totp_enabled === undefined) { setState('unknown'); return; }
+      setState(json.data.totp_enabled ? 'enabled' : 'disabled');
     })();
   }, []);
 
@@ -132,7 +134,9 @@ export function TwoFactorSection() {
     }
   };
 
-  if (state === 'loading') return null;
+  // story #3768 — 'unknown'(/api/me 실패)도 'loading'과 같이 렌더 안 함 — 「모름」을
+  // 「꺼짐」으로 단정해 twoFactorEnable 버튼을 잘못 그리지 않는다.
+  if (state === 'loading' || state === 'unknown') return null;
 
   return (
     <SectionCard>

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -238,6 +238,7 @@ async def get_me(
                     is_active=True,
                     has_password=bool(user.hashed_password) if user else None,
                     linked_providers=_linked_providers(user) if user else [],
+                    totp_enabled=bool(user.totp_enabled) if user else None,
                 )
 
     if member is None:
@@ -254,6 +255,7 @@ async def get_me(
             data.has_password = bool(user.hashed_password)
             data.linked_providers = _linked_providers(user)
             data.email = user.email  # E-ONBOARDING S2: User.email 노출
+            data.totp_enabled = bool(user.totp_enabled)  # story #3768
 
     # S-MBR-03: org owner/admin → effective role 상속. /me role이 JWT role과 일치하도록.
     if not is_api_key and member.user_id:

--- a/backend/app/schemas/me.py
+++ b/backend/app/schemas/me.py
@@ -25,6 +25,10 @@ class MeResponse(BaseModel):
     # 이상 상태(가입 rail 어딘가 결함)라 unlink 가드(auth.py LAST_LOGIN_METHOD)가 막는다 —
     # 이 응답 필드는 순수 표시용, unlink 허용 판정은 서버가 매번 다시 계산한다(신뢰 안 함).
     linked_providers: list[str] = []
+    # story #3768 — 설정 화면의 TwoFactorSection이 상태를 알려고 POST /totp/setup을
+    # «마운트마다» 불러 매번 새 시크릿을 DB에 썼다(읽어야 할 자리에 쓰기). has_password와
+    # 같은 자리에 읽기 전용으로 노출 — User.totp_enabled 그대로, 새 개념 0.
+    totp_enabled: bool | None = None
 
 
 class UpdateMe(BaseModel):

--- a/backend/tests/test_auth_10_backend.py
+++ b/backend/tests/test_auth_10_backend.py
@@ -258,3 +258,130 @@ async def test_get_me_has_password_false():
         assert resp.json()["has_password"] is False
     finally:
         app.dependency_overrides.clear()
+
+
+# ─── GET /api/v2/me — totp_enabled 필드(story #3768) ─────────────────────────
+# 설정 화면(two-factor-section.tsx)이 상태를 알려고 POST /totp/setup을 마운트마다
+# 부르던 것(매번 새 시크릿을 DB에 쓰는 클래스)을 이 필드 읽기로 교체 — has_password와
+# 동일 패턴(정상 분기: MeResponse.model_validate(member) 뒤 data.totp_enabled 채움).
+
+@pytest.mark.anyio
+async def test_get_me_totp_enabled_true():
+    """TOTP 켜진 사용자 → totp_enabled: true."""
+    from app.dependencies.auth import get_current_user
+    client, session, app = await _client()
+    try:
+        uid = uuid.uuid4()
+        ctx = _make_auth_ctx(uid)
+        ctx.claims = {"app_metadata": {}}
+
+        project = MagicMock()
+        project.name = "Test Project"
+        member = MagicMock()
+        member.id = uuid.uuid4()
+        member.user_id = uid
+        member.org_id = uuid.uuid4()
+        member.project_id = uuid.uuid4()
+        member.name = "Test User"
+        member.type = "human"
+        member.role = "member"
+        member.is_active = True
+        member.email = "user@example.com"
+        member.project_name = None
+        member.has_password = None
+        member.totp_enabled = None
+        member.project = project
+
+        user_mock = MagicMock()
+        user_mock.id = uid
+        user_mock.email = "user@example.com"
+        user_mock.hashed_password = "irrelevant"
+        user_mock.totp_enabled = True
+
+        async def override_auth():
+            return ctx
+
+        app.dependency_overrides[get_current_user] = override_auth
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            if call_count == 1:
+                r.scalars.return_value.first.return_value = member
+            else:
+                r.scalar_one_or_none.return_value = user_mock
+            return r
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get("/api/v2/me")
+
+        assert resp.status_code == 200
+        assert resp.json()["totp_enabled"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_me_totp_enabled_false():
+    """TOTP 안 켠 사용자 → totp_enabled: false(«모름»으로 새지 않는다)."""
+    from app.dependencies.auth import get_current_user
+    client, session, app = await _client()
+    try:
+        uid = uuid.uuid4()
+        ctx = _make_auth_ctx(uid)
+        ctx.claims = {"app_metadata": {}}
+
+        project = MagicMock()
+        project.name = "Test Project"
+        member = MagicMock()
+        member.id = uuid.uuid4()
+        member.user_id = uid
+        member.org_id = uuid.uuid4()
+        member.project_id = uuid.uuid4()
+        member.name = "Test User"
+        member.type = "human"
+        member.role = "member"
+        member.is_active = True
+        member.email = "user@example.com"
+        member.project_name = None
+        member.has_password = None
+        member.totp_enabled = None
+        member.project = project
+
+        user_mock = MagicMock()
+        user_mock.id = uid
+        user_mock.email = "user@example.com"
+        user_mock.hashed_password = "irrelevant"
+        user_mock.totp_enabled = False
+
+        async def override_auth():
+            return ctx
+
+        app.dependency_overrides[get_current_user] = override_auth
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            if call_count == 1:
+                r.scalars.return_value.first.return_value = member
+            else:
+                r.scalar_one_or_none.return_value = user_mock
+            return r
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get("/api/v2/me")
+
+        assert resp.status_code == 200
+        assert resp.json()["totp_enabled"] is False
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 배경(story #3768, 유나 r65 예행 발견)
`two-factor-section.tsx:24`의 마운트 `useEffect`가 "상태를 알려고" `POST /api/auth/2fa/setup`을 불렀습니다. BE `auth.py:1147 totp_setup`은 `user.totp_enabled`가 false면 무조건 `generate_totp_secret()` 뒤 `UPDATE users SET totp_secret=…`(:1160)을 실행합니다 — **2FA 안 켠 사용자는 설정 화면을 열 때마다(아무것도 안 눌러도) DB에 새 시크릿이 쓰이고 등록 UI(QR)가 사용자 의도 없이 뜹니다.** 읽어야 할 자리(GET)에 쓰기(POST)를 부른 클래스 — 유나 r65 예행 인터셉터가 라이브 반영 前에 잡았습니다.

두 번째 결함: 그 POST가 실패하면(네트워크/서버 오류) `disabled`(2FA 꺼짐)로 단정했습니다 — 같은 화면의 `set-password-section`(`hasPassword===null`이면 섹션 자체를 안 그림)·`linked-accounts-section`(`linkedProviders===null`이면 마찬가지)과 정반대 처리였습니다.

## 처방
- **BE**: `MeResponse`(`/api/v2/me` → BFF `/api/me`)에 `totp_enabled: bool | None` 추가 — `User.totp_enabled` 그대로 노출, 새 개념 0(`has_password`와 같은 자리·같은 패턴).
- **FE**: 마운트는 `fetchWithAuth('/api/me')`의 `totp_enabled`만 읽습니다(GET, 부작용 0). `true`→enabled·`false`→disabled(켜기 버튼)·**실패/미도달 → 새 `'unknown'` 상태**(렌더 0, 「모름」을 「꺼짐」으로 단정하지 않음 — 형제 두 섹션과 동형). `POST 2fa/setup`은 기존 `handleSetup`(사용자의 「켜기」 클릭)에만 남습니다.

## 검증
- **FE**: 마운트 시 setup POST 0회 픽스처(뮤테이션 — 마운트에 POST 되살려 RED 확認 후 원복) · totp_enabled true/false 분기 · `/api/me` non-ok/네트워크 reject 둘 다 「모름」(disabled 문구·켜기 버튼 0) — 신규 5건 + 기존 4건(새 계약으로 갱신) 전부 GREEN.
- **BE**: `totp_enabled` true/false 신규 2건(뮤테이션 — 대입 제거해 RED 확認 후 원복) + 기존 5건 GREEN.
- FE tsc 무오류 · vitest 전체 7350 passed · i18n 가드 GREEN(신규 키 0, 기존 문구 재사용).
- BE `test_3247_totp_disable.py`(16건)·`test_auth_11.py`·`test_s31.py`·`test_s_mbr_03.py`·`test_e_onboarding_s1_profile_422.py` 등 인접 스위트 무회귀.

## Test plan
- [x] FE tsc --noEmit 무오류
- [x] FE vitest 7350 passed(마운트 POST 0회 뮤테이션 포함)
- [x] BE pytest test_auth_10_backend.py 7 passed(totp_enabled 뮤테이션 포함)
- [x] BE 인접 스위트(2fa/auth/me 관련) 무회귀
- [x] i18n 가드 GREEN
- [ ] **라이브**: 배포 뒤 `/settings` 열기에 2fa/setup 요청 0(유나 인터셉터 실측)으로 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)