### PR TITLE
[SID:3769] feat(MCP): sprintable_get_content_rules — 조직 콘텐츠 규칙 읽기 도구

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -74,7 +74,11 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     # "withdraw"는 의도적으로 뺐다 — 이 하나의 동사만으로 미래의 무관한 도구(예: 보상/지갑
     # 인출류)까지 이 그룹으로 잘못 끌어올 위험이 "channel_post" 등 구체 키워드보다 크다.
     # 지금 유일한 실 도구(withdraw_channel_post_draft)는 "channel_post" 키워드로 이미 잡힌다.
-    ("content", ("channel_post", "site_post", "channel_connection", "post_comment", "insight")),
+    # story #3769(2026-09-10): "content_rule" — sprintable_get_content_rules(신설, 콘텐츠
+    # 규칙 읽기)도 같은 콘텐츠 파이프라인 도구다. "channel_post"/"site_post" 등과 겹치지
+    # 않는 독립 키워드(순서 의존 없음).
+    ("content", ("channel_post", "site_post", "channel_connection", "post_comment", "insight",
+                 "content_rule")),
 ]
 
 _CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
@@ -320,6 +324,9 @@ _ORG_SCOPED_PATH_GROUP_SEGMENTS: tuple[tuple[str, str], ...] = (
     ("insights", "content"),
     ("insights-board", "content"),
     ("publishing-metrics", "content"),
+    # story #3769(2026-09-10): sprintable_get_content_rules 신설로 "MCP 도구/키워드 0건"
+    # 사유가 더 이상 사실이 아니게 됐다 — 예외 목록(아래)에서 이리로 이관.
+    ("content-rules", "content"),
 )
 
 # story #3654(정적 가드) — `test_3654_org_scoped_content_rest_group.py`의 가드 테스트가
@@ -334,8 +341,15 @@ _ORG_SCOPED_PATH_GROUP_SEGMENTS: tuple[tuple[str, str], ...] = (
 _ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON: dict[str, str] = {
     "campaigns": "MCP 도구/키워드 0건(REST·MCP 양쪽 다 core 취급 — 이 스토리가 새로 벌리는 격차 아님)",
     "connectors": "MCP 도구/키워드 0건(connectors.py, 위와 동형)",
-    "content-rules": "MCP 도구/키워드 0건(content_rules.py, 콘텐츠 거버넌스 설정 — 산출물 자체가 아님)",
-    "generation-budget": "MCP 도구/키워드 0건(content_rules.py, 생성 한도 조회 — 산출물 자체가 아님)",
+    # story #3769(2026-09-10): "content-rules"는 sprintable_get_content_rules 신설로
+    # _ORG_SCOPED_PATH_GROUP_SEGMENTS(위)로 이관 — 여기 목록에선 제거(이중 등재 금지,
+    # test_content_group_reason_dict_has_no_overlap_with_mapped_segments 참고).
+    # "generation-budget"은 그 도구가 내부적으로 함께 읽어 응답에 병합하지만(비 1:1 REST
+    # 프록시), 이 세그먼트 자체를 독립 매핑하진 않는다 — 이유가 "0건"에서 "간접 소비"로
+    # 바뀌었을 뿐 REST 직접 호출 경로는 여전히 미매핑(permissive) 그대로 둔다(범위 밖 —
+    # 별도 필요성이 생기면 그때 매핑).
+    "generation-budget": "MCP 도구/키워드 있음(sprintable_get_content_rules가 간접 소비, 3769) — "
+                          "REST 1:1 전용 도구는 여전히 0건, 세그먼트 직접 매핑은 범위 밖으로 보류",
     "domain-labels": "MCP 도구/키워드 0건(domain_labels.py, 사이트 도메인 설정·admin류)",
     "gate-config": "MCP 도구/키워드 0건(gate_config.py, 승인 게이트 거버넌스 설정·admin류)",
     "measurement-connections": "MCP 도구/키워드 0건(measurement_connections.py, GA4 연결 설정)",
@@ -511,6 +525,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     # 발행물 인사이트(story #3651) — 이름에 "insight"가 있어 _GROUP_KEYWORDS의 "content"
     # 그룹(3631 신설)이 이미 커버한다(위 withdraw와 달리 새 갭이 아니다).
     "sprintable_get_publication_insights",
+    # 콘텐츠 규칙 읽기(story #3769) — "content_rule" 키워드로 "content" 그룹.
+    "sprintable_get_content_rules",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -47,6 +47,7 @@ from .tools.channel_posts import (
     GetPublicationInsightsInput, WithdrawChannelPostDraftInput,
     get_publication_insights, withdraw_channel_post_draft,
 )
+from .tools.content_rules import GetContentRulesInput, get_content_rules
 from .tools.decisions import RequestDecisionInput, request_decision
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.judgments import AddJudgmentInput, ListJudgmentsInput, add_judgment, list_judgments
@@ -1018,6 +1019,17 @@ _TOOL_DEFS: list[tuple] = [
      "미도래(pending)·실패(failed)면 null+사유. 한쪽이라도 미제공(null)인 지표는 델타도 "
      "null(0과 섞지 않음). 후속 스토리는 이 도구가 대신 안 만든다 — sprintable_add_story를 쓸 것.",
      GetPublicationInsightsInput, get_publication_insights),
+    # 조직 콘텐츠 규칙 읽기 — story #3769(2026-09-10). content_rules.py docstring(story
+    # #3471)이 약속한 「에이전트가 GET으로 읽는」 길의 MCP 표면. BE 신설 0(기존 GET 둘
+    # 병합). 초안 작성 전 먼저 호출하는 도구(create_channel_post_draft 계열)와 짝.
+    ("sprintable_get_content_rules",
+     "[조직] 조직 콘텐츠 규칙(참고 넷: tone·taxonomy·channel_priority·brand_kit + 기계검사 "
+     "둘: banned_terms·utm_rules/require_utm)과 생성 예산 상태(generation_budget_status)를 "
+     "함께 읽는다. 채널·사이트 글 초안을 쓰기 전에 먼저 이 도구를 불러 톤·택소노미·브랜드 "
+     "킷을 반영할 것 — 금칙어·UTM은 제출 시점에 서버가 기계로도 재검사하지만, 톤·택소노미· "
+     "채널 우선순위·브랜드 킷은 서버가 강제하지 않는 선언값이라 에이전트가 스스로 지켜야 "
+     "한다. 규칙을 한 번도 설정 안 한 조직은 rules:{}·version:0(빈 상태 그대로, 위반 아님).",
+     GetContentRulesInput, get_content_rules),
 ]
 
 for _name, _doc, _cls, _fn in _TOOL_DEFS:

--- a/backend/sprintable_mcp/tools/content_rules.py
+++ b/backend/sprintable_mcp/tools/content_rules.py
@@ -1,0 +1,42 @@
+"""story #3769(BE+MCP·소형, 페드루 PO 確定 2026-09-10) — 조직 콘텐츠 규칙 읽기 MCP 도구.
+
+`app/services/content_rules.py:4-7`의 docstring(PO 確定, story #3471)은 「톤·택소노미·채널
+우선순위·브랜드 킷은 에이전트가 GET으로 읽고 스스로 지키는 선언 슬롯」이라고 선언하지만,
+`backend/sprintable_mcp/tools/*` 전수에 그 GET을 부를 길이 0건이었다(BE는 이미 org 멤버
+자격으로 열려 있었다 — `routers/content_rules.py::get_content_rules_endpoint`, admin 게이트는
+PUT만). 이 도구가 그 갭을 메운다 — 신규 BE 엔드포인트 0(기존 GET 둘을 그대로 호출·병합).
+
+응답 낱말은 두 BE 응답의 필드명 그대로다(`ContentRulesResponse`: org_id·rules·version,
+`GenerationBudgetStatusResponse`: limit_minor 등) — rules 본문 키(tone·taxonomy·
+channel_priority·brand_kit·banned_terms·require_utm·generation_budget·utm_rules)를 이
+파일에서 재선언하지 않는다(정의가 둘이면 갈린다, PO 明示 — content_rules.py의
+`ContentRulesFields`가 유일한 형상 SSOT)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class GetContentRulesInput(SprintableInput):
+    pass
+
+
+async def get_content_rules(args: GetContentRulesInput) -> list[TextContent]:
+    """조직 콘텐츠 규칙(참고 넷+기계검사 둘)과 생성 예산 상태를 함께 읽는다. org는
+    `client.org_id`(호출자 인증 컨텍스트)로 고정 — 다른 org를 지정할 입력 자체가 없어
+    타 org 조회가 구조적으로 불가능하다(withdraw_channel_post_draft와 동형 org-scoped
+    URL 조립 패턴, channel_posts.py 참고).
+
+    규칙을 한 번도 PUT 안 한 조직은 `rules: {}`·`version: 0`(BE가 빈 상태를 그대로
+    반환 — 「없다」를 지어내지 않는다). 생성 예산도 미설정이면 전부 null(compute_
+    generation_budget_status의 None 신호 그대로, generation-budget GET과 동일 계약)."""
+    try:
+        org_id = client.org_id
+        rules_resp = await client.get(f"/api/v2/organizations/{org_id}/content-rules")
+        budget_resp = await client.get(f"/api/v2/organizations/{org_id}/generation-budget")
+        return ok({**rules_resp, "generation_budget_status": budget_resp})
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -55,7 +55,9 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     # story #3614 CHANGES가 "channel_post" 키워드로 최소 신설, story #3631이 백엔드
     # SSOT(app/services/mcp_toolset.py)와 동기화해 나머지 콘텐츠 도구 키워드로 완성.
     # "withdraw"는 의도적으로 제외(원본 주석 참고 — 미래 무관 도구 오분류 위험).
-    ("content", ("channel_post", "site_post", "channel_connection", "post_comment", "insight")),
+    # story #3769(2026-09-10): 백엔드 SSOT와 동기화 — sprintable_get_content_rules 신설.
+    ("content", ("channel_post", "site_post", "channel_connection", "post_comment", "insight",
+                 "content_rule")),
 ]
 
 _CORE = "core"

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -121,6 +121,9 @@ EXPECTED_TOOLS = {
     "sprintable_withdraw_channel_post_draft",
     # 발행물 인사이트 (1) — story #3651: 1일·7일 스냅샷 조회 + 델타. 이 도메인 둘째 도구.
     "sprintable_get_publication_insights",
+    # 콘텐츠 규칙 읽기 (1) — story #3769: content_rules.py docstring이 약속한 「에이전트가
+    # GET으로 읽는」 길의 MCP 표면(BE 신설 0, 기존 GET 둘 병합).
+    "sprintable_get_content_rules",
     # smoke
     "ping",
 }
@@ -149,8 +152,9 @@ def test_total_tool_count():
     # story #3331: sprintable_list_conversations 1종 신설(내 참여 방 목록 — 알림 미도달 백스톱) — 124→125.
     # story #3614: sprintable_withdraw_channel_post_draft 1종 신설(채널 글 초안 폐기 — 이 도메인
     # 첫 MCP 도구) — 125→126. story #3651: sprintable_get_publication_insights 1종 신설(발행물
-    # 1일·7일 인사이트 스냅샷+델타 — 이 도메인 둘째 도구) — 126→127.
-    assert len(_TOOLS) == 127  # story b6b9c52d(#2707 부수): sprintable_import_image_artifact 신설 123→124
+    # 1일·7일 인사이트 스냅샷+델타 — 이 도메인 둘째 도구) — 126→127. story #3769:
+    # sprintable_get_content_rules 1종 신설(조직 콘텐츠 규칙 읽기) — 127→128.
+    assert len(_TOOLS) == 128  # story b6b9c52d(#2707 부수): sprintable_import_image_artifact 신설 123→124
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -83,12 +83,13 @@ def test_all_registered_tools_share_the_same_lockdown():
     추가로 122→123. story b6b9c52d(#2707 부수): sprintable_import_image_artifact 추가로
     123→124. story #3331: sprintable_list_conversations 추가로 124→125. story #3614:
     sprintable_withdraw_channel_post_draft 추가로 125→126. story #3651:
-    sprintable_get_publication_insights 추가로 126→127) 전부 arg_model이
+    sprintable_get_publication_insights 추가로 126→127. story #3769:
+    sprintable_get_content_rules 추가로 127→128) 전부 arg_model이
     extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 127
+    assert len(tools) == 128
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_3769_mcp_get_content_rules.py
+++ b/backend/tests/test_3769_mcp_get_content_rules.py
@@ -1,0 +1,164 @@
+"""story #3769(2026-09-10) — sprintable_get_content_rules MCP 도구.
+
+`content_rules.py:4-7`의 docstring(story #3471)이 약속한 「에이전트가 GET으로 읽는」 길이
+`backend/sprintable_mcp/tools/*`에 0건이었다(BE는 이미 org 멤버 자격으로 열려 있었다).
+이 도구는 그 갭을 메운다 — BE 신설 0(기존 GET 둘을 그대로 호출·병합), 필드명 새로 안 짓는다
+(get_loop_context 동형 얇은 HTTP 래퍼 패턴).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _client(org_id: str = "org-1"):
+    c = MagicMock()
+    c.org_id = org_id
+    return c
+
+
+@pytest.mark.anyio
+async def test_get_content_rules_calls_both_endpoints_and_merges():
+    from sprintable_mcp.tools import content_rules as cr
+
+    rules_payload = {
+        "org_id": "org-1", "version": 3,
+        "rules": {
+            "tone": "친근하되 과장 없이", "taxonomy": ["product", "engineering"],
+            "channel_priority": ["threads", "site"], "brand_kit": {"primary_color": "#1a73e8"},
+            "banned_terms": ["spam"], "require_utm": True,
+        },
+    }
+    budget_payload = {
+        "limit_minor": 500000, "currency": "KRW", "period": "month",
+        "period_start": "2026-09-01T00:00:00Z", "period_end": "2026-10-01T00:00:00Z",
+        "spent_minor": 10000, "remaining_minor": 490000,
+    }
+
+    calls: list[str] = []
+
+    async def fake_get(path, **_kw):
+        calls.append(path)
+        if path.endswith("/content-rules"):
+            return rules_payload
+        if path.endswith("/generation-budget"):
+            return budget_payload
+        raise AssertionError(f"unexpected path {path}")
+
+    client = _client(org_id="org-1")
+    client.get = AsyncMock(side_effect=fake_get)
+    with patch.object(cr, "client", client):
+        out = await cr.get_content_rules(cr.GetContentRulesInput())
+
+    assert calls == [
+        "/api/v2/organizations/org-1/content-rules",
+        "/api/v2/organizations/org-1/generation-budget",
+    ]
+    data = json.loads(out[0].text)
+    # 필드명 그대로(재선언 0) — rules 본문이 그대로 들어있다.
+    assert data["rules"]["tone"] == "친근하되 과장 없이"
+    assert data["rules"]["taxonomy"] == ["product", "engineering"]
+    assert data["rules"]["channel_priority"] == ["threads", "site"]
+    assert data["rules"]["brand_kit"] == {"primary_color": "#1a73e8"}
+    assert data["rules"]["banned_terms"] == ["spam"]
+    assert data["rules"]["require_utm"] is True
+    assert data["version"] == 3
+    assert data["org_id"] == "org-1"
+    assert data["generation_budget_status"] == budget_payload
+
+
+@pytest.mark.anyio
+async def test_get_content_rules_empty_org_passes_through_rules_empty_dict():
+    """AC — 규칙 미설정 org는 rules:{}·version:0 그대로(「없다」를 지어내지 않는다)."""
+    from sprintable_mcp.tools import content_rules as cr
+
+    async def fake_get(path, **_kw):
+        if path.endswith("/content-rules"):
+            return {"org_id": "org-2", "rules": {}, "version": 0}
+        return {
+            "limit_minor": None, "currency": None, "period": None, "period_start": None,
+            "period_end": None, "spent_minor": None, "remaining_minor": None,
+        }
+
+    client = _client(org_id="org-2")
+    client.get = AsyncMock(side_effect=fake_get)
+    with patch.object(cr, "client", client):
+        out = await cr.get_content_rules(cr.GetContentRulesInput())
+
+    data = json.loads(out[0].text)
+    assert data["rules"] == {}
+    assert data["version"] == 0
+    assert data["generation_budget_status"]["limit_minor"] is None
+
+
+@pytest.mark.anyio
+async def test_get_content_rules_uses_caller_org_no_cross_org_param():
+    """구조적 타org 차단 — 입력 스키마에 org_id 파라미터 자체가 없다(withdraw_channel_post_draft
+    동형 org-scoped URL 조립, client.org_id만 사용)."""
+    from sprintable_mcp.tools import content_rules as cr
+
+    assert "org_id" not in cr.GetContentRulesInput.model_fields
+    with pytest.raises(Exception):
+        cr.GetContentRulesInput(org_id="other-org")
+
+
+@pytest.mark.anyio
+async def test_get_content_rules_wraps_exception_as_err():
+    from sprintable_mcp.tools import content_rules as cr
+
+    client = _client()
+    client.get = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch.object(cr, "client", client):
+        out = await cr.get_content_rules(cr.GetContentRulesInput())
+    assert out[0].text == "Error: boom"
+
+
+# ── toolset 등재(SSOT+vendored, catalog) ────────────────────────────────────────
+
+def test_get_content_rules_registered_in_all_tool_names():
+    from app.services.mcp_toolset import ALL_TOOL_NAMES
+    assert "sprintable_get_content_rules" in ALL_TOOL_NAMES
+
+
+def test_get_content_rules_grouped_as_content_ssot_and_vendored():
+    from app.services.mcp_toolset import tool_group as ssot_group
+    from sprintable_mcp.toolset import tool_group as vendored_group
+    assert ssot_group("sprintable_get_content_rules") == "content"
+    assert vendored_group("sprintable_get_content_rules") == "content"
+
+
+def test_get_content_rules_allowed_with_content_scope_blocked_without():
+    from app.services.mcp_toolset import is_tool_allowed as ssot_allowed
+    from sprintable_mcp.toolset import is_tool_allowed as vendored_allowed
+    assert ssot_allowed("sprintable_get_content_rules", ["content"])
+    assert vendored_allowed("sprintable_get_content_rules", ["content"])
+    assert not ssot_allowed("sprintable_get_content_rules", ["stories"])
+    assert not vendored_allowed("sprintable_get_content_rules", ["stories"])
+    # scope 미지정(레거시)은 비파괴 전체 허용 — get_content_rules는 파괴적이지 않다.
+    assert ssot_allowed("sprintable_get_content_rules", [])
+    assert vendored_allowed("sprintable_get_content_rules", [])
+
+
+def test_get_content_rules_registered_in_server_tool_defs():
+    """server.py `_TOOL_DEFS`(실 MCP 등록)에 실제로 얹혀 있는지 — ALL_TOOL_NAMES 등재만으론
+    tools/list 노출을 보장 못한다(story #2010/#1922와 동일 회귀 클래스)."""
+    from sprintable_mcp.server import _TOOL_DEFS
+    names = {t[0] for t in _TOOL_DEFS}
+    assert "sprintable_get_content_rules" in names
+
+
+# ── REST 직접호출 scope 게이트(story #3654 표 동기화) ────────────────────────────
+
+def test_content_rules_rest_path_now_mapped_to_content_group():
+    from app.services.mcp_toolset import path_allowed_for_scope, path_to_tool_group
+    path = "/api/v2/organizations/org-1/content-rules"
+    assert path_to_tool_group(path) == "content"
+    assert path_allowed_for_scope(path, ["stories"]) is False
+    assert path_allowed_for_scope(path, ["content"]) is True

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -84,6 +84,7 @@ def test_tool_names_and_param_models_untouched():
     story #3331: sprintable_list_conversations 1종 신설(내 참여 방 목록 — 알림 미도달
     백스톱) — 123→124. story #3614: sprintable_withdraw_channel_post_draft 1종 신설(채널 글
     초안 폐기, [일감] 축 — 콘텐츠 초안도 작업 단위 work item) — 124→125. story #3651:
-    sprintable_get_publication_insights 1종 신설(발행물 1일·7일 인사이트) — 125→126."""
-    assert len(_TOOL_DEFS) == 126
+    sprintable_get_publication_insights 1종 신설(발행물 1일·7일 인사이트) — 125→126.
+    story #3769: sprintable_get_content_rules 1종 신설(조직 콘텐츠 규칙 읽기) — 126→127."""
+    assert len(_TOOL_DEFS) == 127
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## 요약
- `content_rules.py:4-7` docstring(story #3471)이 약속한 「톤·택소노미·채널 우선순위·브랜드 킷은 에이전트가 GET으로 읽고 스스로 지키는」 길이 `backend/sprintable_mcp/tools/*` 전수에 0건이었다(그라운딩 확認). BE `GET /organizations/{org_id}/content-rules`는 이미 org 멤버(휴먼+에이전트) 자격으로 열려 있음(admin 게이트는 PUT만) — MCP 층만 비어 있던 갭.
- `sprintable_get_content_rules` 신설: content-rules GET + generation-budget GET 두 응답을 그대로 merge해 반환. BE 신설 0, 필드명 재선언 0(rules 본문은 BE 응답 그대로 pass-through).

## 그라운딩(카드에도 등재)
- 「초안 생성 도구 설명 첫 줄」 처방: `create_channel_post_draft`/`create_site_post_draft`는 별도 레포 `moonklabs/sprintable-agent-plugins`(채널 플러그인)의 `tool-definitions.ts` 소관 — 호스팅 MCP(이 레포)가 아니다. 그 레포 main(HEAD c5deae2)에도 아직 이 도구 자체가 없음(PR#45 미머지 qa-worktree에만 존재). 이번 스토리(moonklabs/sprintable) 범위 밖으로 판단, 착수 안 함 — 라우팅 필요시 PO 판단.

## 변경
- `backend/sprintable_mcp/tools/content_rules.py`(신규): `GetContentRulesInput`/`get_content_rules` — `client.org_id`로 org 자동 고정(입력에 org_id 파라미터 자체 없음 — 타 org 조회 구조적 불가).
- `backend/sprintable_mcp/server.py`: 등록(`[조직]` 축 프리픽스, content 그룹).
- `backend/app/services/mcp_toolset.py`(SSOT)·`backend/sprintable_mcp/toolset.py`(vendored): `_GROUP_KEYWORDS`의 "content" 그룹에 `content_rule` 키워드 추가.
- `backend/app/services/mcp_toolset.py`: `_ORG_SCOPED_PATH_GROUP_SEGMENTS`에 `("content-rules", "content")` 추가(REST 직접호출도 이제 content scope 필요) + `_ORG_SCOPED_UNMAPPED_SEGMENTS_WITH_REASON`에서 해당 이관·`generation-budget` 사유 갱신(간접 소비, 세그먼트 직접 매핑은 범위 밖).
- 기존 pin 카운트 가드(`test_contract.py`/`test_2412_...`/`test_mcp_axis_prefix_b_surface.py`) 갱신(126→127→128, EXPECTED_TOOLS 추가).

## 테스트
- `backend/tests/test_3769_mcp_get_content_rules.py`(신규): 응답 merge·빈 org(rules:{}·version:0)·구조적 타org차단(org_id 파라미터 없음)·에러 wrap·toolset 등재(SSOT+vendored)·scope 게이트(content 있으면 허용/없으면 차단)·REST scope-gate 매핑.
- `pytest tests/ -m "not destructive_schema"` 전체 그린(pre-existing 무관 실패 6건은 `test_2268_session_context_realdb.py` — DB env 미설정, 이 PR과 무관 확認).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ