### PR TITLE
[SID:3765] chore(FE): AC3 — 3757-b 잔여 中/弱 티어 후보 6건 삭제

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -305,7 +305,6 @@
   },
   "dashboard": {
     "title": "Dashboard",
-    "projects": "Projects",
     "ccZoneActions": "Your actions now",
     "ccClearTitle": "All clear",
     "ccClearBody": "Nothing needs your attention right now",
@@ -340,10 +339,6 @@
     "ccMinAgo": "{n}m ago",
     "ccHourAgo": "{n}h ago",
     "ccDayAgo": "{n}d ago",
-    "recentDocs": "Recent docs",
-    "inProgress": "In Progress",
-    "inReview": "In Review",
-    "blocked": "Blocked",
     "standup": "Standup",
     "ccGateTypeQa": "QA",
     "ccGateTypePrReview": "PR review",
@@ -1814,7 +1809,6 @@
     "runtimeTypeSaved": "Runtime type saved"
   },
   "shell": {
-    "projects": "Projects",
     "projectSelectPrompt": "Select current project",
     "projectSelectDescription": "Choose the current project from the header switcher to activate this surface."
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -305,7 +305,6 @@
   },
   "dashboard": {
     "title": "대시보드",
-    "projects": "프로젝트",
     "ccZoneActions": "지금 내 할 일",
     "ccClearTitle": "괜찮습니다",
     "ccClearBody": "지금 처리할 일이 없습니다",
@@ -340,10 +339,6 @@
     "ccMinAgo": "{n}분 전",
     "ccHourAgo": "{n}시간 전",
     "ccDayAgo": "{n}일 전",
-    "recentDocs": "최근 문서",
-    "inProgress": "진행 중",
-    "inReview": "리뷰 중",
-    "blocked": "차단됨",
     "standup": "스탠드업",
     "ccGateTypeQa": "QA",
     "ccGateTypePrReview": "PR 리뷰",
@@ -1814,7 +1809,6 @@
     "runtimeTypeSaved": "런타임 타입 저장됨"
   },
   "shell": {
-    "projects": "프로젝트",
     "projectSelectPrompt": "현재 프로젝트 선택",
     "projectSelectDescription": "헤더의 프로젝트 스위처에서 현재 프로젝트를 선택하면 이 화면이 활성화됩니다."
   },


### PR DESCRIPTION
## 배경
#4115(층 A″) 반영 후 재산출한 잔여 후보는 **6건**뿐 — 전부 유나 v3 표가 "D층(오버레이)이 살렸다"고 표시했던 바로 그 키였습니다. 유나 재실측(2026-09-10) 결과 그 판정은 자기 표 오판이었다고 정정됐습니다 — 오버레이(`eea5a6d`)는 `dashboard`·`shell` ns를 아예 안 열고, `blocked`/`projects`로 잡혔던 건 TS 유니온 리터럴(`workflow-dashboard.tsx`)·Supabase 테이블 이름(`api/projects/route.ts`)이었으며 `inProgress`/`inReview`/`recentDocs`는 오버레이에 아예 없습니다(dashboard/shell을 여는 OSS 파일 7개 전수 재확인, 양성대조 118 호출 중 6낱말 히트 0).

## 삭제 直前 재확認(develop `9f083280f`)
- 제 자로 재계산해도 정확히 같은 6건 재현.
- 수작업 grep 재스윕: `dashboard.inProgress`/`inReview`는 `board.inProgress`/`inReview`(`story-card.tsx` 직접 `t()` 호출)와, `dashboard.recentDocs`는 `docs.recentDocs`(`docs-shell-client.tsx` 직접 `t()` 호출)와 동음이의 — 둘 다 다른 ns에서 진짜 살아있고 `dashboard.*` 자체엔 어떤 호출도 안 닿습니다.
- `dashboard.blocked`/`projects`·`shell.projects` — 코드 전체에서 `t()`/`.rich()` 호출 0건(상태값 비교·유니온 타입 등 무관 동음이의만 존재).

## 삭제 목록
`dashboard.blocked` · `dashboard.inProgress` · `dashboard.inReview` · `dashboard.projects` · `dashboard.recentDocs` · `shell.projects` — ko/en 리프 집합 각 −6, 추가 0·값 변경 0.

FE tsc 무오류 · vitest 7360 passed · i18n 가드 4종 GREEN.

## Test plan
- [x] tsc --noEmit 무오류
- [x] vitest 7360 passed
- [x] verify-i18n-keys-exist/namespace-referenced/no-duplicate-i18n-keys/no-hanja-in-i18n/no-i18n-phrase-collision 전부 GREEN
- [x] ko/en 리프 집합 diff 확認(추가 0·값 변경 0, PO 재측 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)