### PR TITLE
[SID:3770] fix(FE): 원시 role 값 i18n 미번역 클래스 전수 수정 + 회귀가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1630,6 +1630,12 @@ jobs:
       - name: "Verify no hardcoded Korean UI text (story #3741 regression guard)"
         run: pnpm --filter web verify:no-hardcoded-korean-ui-text
 
+      # story #3770(2026-09-10) — 원시 role 값(org owner/admin/member·participation/trust
+      # implementation 등)을 t() 없이 JSX 텍스트에 그리는 클래스 회귀가드(설정 프로필
+      # 「역할 admin」류 재발 방지).
+      - name: "Verify no raw role JSX text (story #3770 regression guard)"
+        run: pnpm --filter web verify:no-raw-role-jsx-text
+
       # story #3739(2026-09-09) 메타 가드 — package.json에 등재된 verify:* 스크립트
       # 집합이 이 ci.yml에서 실제로 부르는 집합의 부분집합이 아니면(새 verify:* 스크립트를
       # 만들고 여기 안 물리면) FAIL. story #3736 ⑪·이 스토리 자신(no-direct-backend-v2-call·

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "verify:no-new-repeated-row-action-names": "tsx scripts/verify-repeated-row-action-names.ts",
     "verify:no-fetch-response-without-ok-check": "tsx scripts/verify-no-fetch-response-without-ok-check.ts",
     "verify:no-hardcoded-korean-ui-text": "tsx scripts/verify-no-hardcoded-korean-ui-text.ts",
+    "verify:no-raw-role-jsx-text": "tsx scripts/verify-no-raw-role-jsx-text.ts",
     "e2e": "playwright test",
     "e2e:contrast": "playwright test contrast-guard.spec.ts",
     "e2e:ui": "playwright test --ui",

--- a/apps/web/scripts/verify-no-raw-role-jsx-text.test.ts
+++ b/apps/web/scripts/verify-no-raw-role-jsx-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { scanJsxFileContent, scanRepo } from './verify-no-raw-role-jsx-text';
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+
+describe('scanJsxFileContent — story #3770 셀프테스트', () => {
+  it('⭐bare identifier {role} → RED', () => {
+    const src = `function C() { return <span>{role}</span>; }`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toHaveLength(1);
+  });
+
+  it('⭐property access {profile.role} → RED', () => {
+    const src = `function C() { return <span>{profile.role}</span>; }`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toHaveLength(1);
+  });
+
+  it('⭐중첩 property access {agent.role} → RED', () => {
+    const src = `function C() { return <Badge variant="outline">{agent.role}</Badge>; }`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toHaveLength(1);
+  });
+
+  // 뮤테이션 대조 — 정본 헬퍼로 감싸면(t()/orgRoleLabel()/resolveRoleLabel() 동형) 이
+  // 스캔이 반드시 0을 낸다는 것 자체를 자가 증명.
+  it('뮤테이션 대조 — orgRoleLabel(profile.role, t)로 감싼 형은 GREEN(CallExpression이라 대상 밖)', () => {
+    const src = `function C() { return <span>{orgRoleLabel(profile.role, t)}</span>; }`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toEqual([]);
+  });
+
+  it('뮤테이션 대조 — resolveRoleLabel(agent.role, null, t)로 감싼 형은 GREEN', () => {
+    const src = `function C() { return <Badge>{resolveRoleLabel(agent.role, null, t)}</Badge>; }`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toEqual([]);
+  });
+
+  // 음성대조 — <select value={member.role}>는 JSX 속성(JsxAttribute)이지 자식(JsxChild)이
+  // 아니다. roles/page.tsx:168 실사용 형과 동형(정당).
+  it('음성대조 — <option value={member.role}>는 GREEN(속성 자리는 애초 대상 밖)', () => {
+    const src = `function C() { return <select value={member.role}><option value={member.role}>x</option></select>; }`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toEqual([]);
+  });
+
+  // 음성대조 — 조건부 렌더의 가드 조건 자체(top-level이 ConditionalExpression)는 대상 밖.
+  // chat-input.tsx의 `{member.role ? <span>...</span> : null}` 감싸는 형과 동형.
+  it('음성대조 — 삼항 가드 조건({member.role ? <x/> : null})의 조건 자체는 안 걸린다(안쪽만 검사)', () => {
+    const src = `function C() { return <>{member.role ? <span>{label}</span> : null}</>; }`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toEqual([]);
+  });
+
+  it('음성대조 — role로 끝나지 않는 프로퍼티({member.roleLabel})는 GREEN', () => {
+    const src = `function C() { return <span>{member.roleLabel}</span>; }`;
+    expect(scanJsxFileContent(src, 'fake.tsx')).toEqual([]);
+  });
+
+  it('파싱 실패(문법 오류)면 조용히 통과하지 않고 throw한다(story #2710 AC4 동형)', () => {
+    expect(() => scanJsxFileContent('export function {{{ broken', 'broken.tsx')).toThrow(/파싱 실패/);
+  });
+});
+
+describe('scanRepo — story #3770(실 트리 실행)', () => {
+  it('실 트리(apps/web/src) — 위반 0건, ALLOWLIST 2건(event stage role — 다른 축, 전부 실제로 걸림)', () => {
+    const { refs, fileCount, allowlistHit } = scanRepo(SRC_ROOT);
+    expect(fileCount).toBeGreaterThan(400);
+    expect(refs).toEqual([]);
+    expect(allowlistHit.size).toBe(2);
+  });
+});

--- a/apps/web/scripts/verify-no-raw-role-jsx-text.ts
+++ b/apps/web/scripts/verify-no-raw-role-jsx-text.ts
@@ -1,0 +1,177 @@
+/**
+ * story #3770(UI 점검·낱말·역할 원어 키·페드루 PO 確定) — 원시 `role` 값(owner/admin/member류
+ * org 역할, implementation/po/qa/design/devops류 participation/trust 역할)을 `t()`(또는
+ * 정본 헬퍼 `orgRoleLabel()`/`resolveRoleLabel()`) 없이 JSX 텍스트 자리에 그대로 그리는
+ * 클래스를 고정한다. 실 사고: 설정 프로필 「역할」 값이 「관리자」가 아니라 원어 키 `admin`
+ * 그대로 라이브에 노출(`my-profile-section.tsx:134` — PO 캡처 눈으로 발견) + 동형 6자리
+ * (초대·워크포스·에이전트 관리·채팅 멘션·GNB 조직 스위처 2곳).
+ *
+ * ## 기전 — AST(verify-no-count-in-title-string.ts·verify-no-legacy-meta-total-consumer.ts와
+ * 동형 관례, 새 기전 발명 금지)
+ * `apps/web/src` 전수(.tsx)를 walk, JSX 자식(children) 중 `JsxExpression`의 `.expression`이
+ * — Identifier이고 이름이 정확히 `role`이거나
+ * — PropertyAccessExpression이고 마지막 프로퍼티 이름이 정확히 `role`
+ * 인 자리를 찾는다. 이미 `t(...)`/`orgRoleLabel(...)`/`resolveRoleLabel(...)` 등으로
+ * 감싼 자리는 `.expression`이 CallExpression이라 이 검사 대상 밖(구조적으로 자동 제외 —
+ * 별도 화이트리스트 불요).
+ *
+ * `<select value={member.role}>` 같은 속성 자리는 JSX **속성**(JsxAttribute)이지 JSX
+ * **자식**(JsxChild)이 아니다 — walk가 `JsxElement.children`만 보므로 애초에 대상 밖
+ * (ALLOWLIST로 따로 걷어낼 필요 없이 구조가 이미 배제한다, `roles/page.tsx:168`
+ * `<option value={member.role}>` 실측 확認).
+ *
+ * `{member.role ? <span>...` 같은 조건부 렌더의 가드 조건 자체는 top-level 자식이 role
+ * PropertyAccessExpression이 아니라 ConditionalExpression이라 마찬가지로 대상 밖(role이
+ * 실제로 "그려지는" 안쪽 JsxExpression만 별도로 걸린다).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+export interface RawRoleJsxRef {
+  file: string;
+  line: number;
+}
+
+function isRawRoleExpression(expr: ts.Expression): boolean {
+  if (ts.isIdentifier(expr)) return expr.text === 'role';
+  if (ts.isPropertyAccessExpression(expr)) return expr.name.text === 'role';
+  return false;
+}
+
+export function scanJsxFileContent(content: string, file: string): RawRoleJsxRef[] {
+  const sf = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const parseDiagnostics = (sf as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics;
+  if (parseDiagnostics === undefined) {
+    throw new Error(`FAIL: ${file} — ts.createSourceFile의 parseDiagnostics 필드가 사라짐(TS 내부 API 변경 의심).`);
+  }
+  if (parseDiagnostics.length > 0) {
+    throw new Error(
+      `FAIL: ${file} 파싱 실패(${parseDiagnostics.length}건) — ` +
+        parseDiagnostics.map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' ')).join('; '),
+    );
+  }
+
+  const refs: RawRoleJsxRef[] = [];
+
+  function checkChildren(children: ts.NodeArray<ts.JsxChild>): void {
+    for (const child of children) {
+      if (!ts.isJsxExpression(child) || !child.expression) continue;
+      if (isRawRoleExpression(child.expression)) {
+        const line = sf.getLineAndCharacterOfPosition(child.getStart(sf)).line + 1;
+        refs.push({ file, line });
+      }
+    }
+  }
+
+  function walk(node: ts.Node): void {
+    if (ts.isJsxElement(node)) {
+      checkChildren(node.children);
+    } else if (ts.isJsxFragment(node)) {
+      checkChildren(node.children);
+    }
+    node.forEachChild(walk);
+  }
+  walk(sf);
+  return refs;
+}
+
+function walkTsxFiles(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.next') continue;
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkTsxFiles(full, out);
+    } else if (entry.endsWith('.tsx') && !entry.endsWith('.test.tsx')) {
+      out.push(full);
+    }
+  }
+}
+
+// ALLOWLIST — story #3770 실 트리 전수 스캔이 PO가 짚은 7자리 외에 6곳을 더 찾았다. 4곳은
+// 같은 병(org/trust 역할, 정본 경유로 닫음)이었고, 남은 2곳은 **다른 축**이다:
+// `EventDefinition.stage_metadata[stage].role`(워크플로 단계 담당자 라벨 — "Agent"/
+// "Human"/"PO"/"Dev"/"Lead"/"Reviewer" 등, `sprintable_get_workflow_guide` 출력 자체가
+// 이 낱말들을 원어 그대로 굵게 쓴다·org/trust 역할 정본 셋 어디에도 이 값 집합이 없다).
+// org-members.tsx/roles/page.tsx류 "사람의 조직 내 위치"와 다른 개념(워크플로 정의가
+// 선언한 "이 단계는 누가"이고, 값 자체가 시스템 전역에서 관례적으로 비-번역 라벨로
+// 취급된다 — trustRoleLabelPo="PO"/trustRoleLabelDevops="DevOps"와 같은 결의 축). 새 정본
+// 신설은 이 스토리 범위 밖 — 페드루에게 별건 등재 요청, 여기는 이유와 함께 명시 예외.
+const ALLOWLIST: ReadonlySet<string> = new Set([
+  'app/(authenticated)/organization/events/page.tsx:402',
+  'components/loops/loop-create-dialog.tsx:320',
+]);
+
+export interface ScanRepoResult {
+  refs: RawRoleJsxRef[];
+  fileCount: number;
+  allowlistHit: Set<string>;
+}
+
+const MIN_EXPECTED_TSX_FILES = 300;
+
+export function scanRepo(srcRoot: string): ScanRepoResult {
+  const files: string[] = [];
+  walkTsxFiles(srcRoot, files);
+  if (files.length < MIN_EXPECTED_TSX_FILES) {
+    throw new Error(`FAIL: 검사 대상 .tsx가 ${files.length}개뿐(srcRoot=${srcRoot}) — 가드가 헛돌고 있다.`);
+  }
+
+  const allRefs: RawRoleJsxRef[] = [];
+  let scannedCount = 0;
+  for (const abs of files) {
+    const rel = path.relative(srcRoot, abs).split(path.sep).join('/');
+    const content = readFileSync(abs, 'utf8');
+    allRefs.push(...scanJsxFileContent(content, rel));
+    scannedCount += 1;
+  }
+  if (scannedCount !== files.length) {
+    throw new Error(`FAIL: glob이 찾은 .tsx ${files.length}개 중 ${scannedCount}개만 실제로 스캔됨 — 추출 누락(fail-closed).`);
+  }
+
+  const allowlistHit = new Set<string>();
+  const refs = allRefs.filter((r) => {
+    const key = `${r.file}:${r.line}`;
+    if (ALLOWLIST.has(key)) { allowlistHit.add(key); return false; }
+    return true;
+  });
+
+  return { refs, fileCount: files.length, allowlistHit };
+}
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+
+function main(): number {
+  const { refs, fileCount, allowlistHit } = scanRepo(SRC_ROOT);
+
+  console.log(
+    `[가드] 「원시 role JSX 텍스트」 스캔 — .tsx ${fileCount}개 · 위반 ${refs.length}건(면제 ${allowlistHit.size}/${ALLOWLIST.size}).`,
+  );
+
+  const dead = [...ALLOWLIST].filter((k) => !allowlistHit.has(k));
+  if (dead.length > 0) {
+    console.error('\nFAIL: 죽은 ALLOWLIST 항목(더 이상 안 걸림 — 걷어낼 것):');
+    for (const k of dead) console.error(`  ${k}`);
+    return 1;
+  }
+
+  if (refs.length > 0) {
+    console.error('\nFAIL: 원시 role 값이 t() 없이 JSX 텍스트에 그려짐:');
+    for (const r of refs) console.error(`  ${r.file}:${r.line}`);
+    console.error(
+      '\n→ org 역할(owner/admin/member)은 `orgRoleLabel()`(@/lib/org-member-role), ' +
+        'participation/trust 역할(implementation 등)은 `resolveRoleLabel()`' +
+        '(@/app/(authenticated)/organization/trust/trust-utils)로 감쌀 것(story #3770).',
+    );
+    return 1;
+  }
+
+  console.log('\nOK: 원시 role JSX 텍스트 0건(ALLOWLIST 근거 있는 예외 제외).');
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/lib/runtime-capabilities';
 
 import { fetchWithAuth } from '@/lib/db/client';
+import { resolveRoleLabel } from '@/app/(authenticated)/organization/trust/trust-utils';
 
 /** 런타임 상태(6종 중 ①~⑤) → 배지·헬퍼 표현. ⑥(드롭다운 dot)은 AC 범위 외(§11). */
 const RUNTIME_STATUS_UI: Record<
@@ -99,6 +100,7 @@ function isWebhookUrlAllowed(url: string): boolean {
 export default function AgentDetailPage() {
   const t = useTranslations('settings');
   const tc = useTranslations('common');
+  const to = useTranslations('organization');
   const router = useRouter();
   const { id } = useParams<{ id: string }>();
   const { addToast } = useToast();
@@ -415,7 +417,7 @@ export default function AgentDetailPage() {
                   </div>
                   <div className="mt-1 flex items-center gap-2">
                     <Badge variant="secondary">{t('agentMember')}</Badge>
-                    <Badge variant="outline">{agent.role}</Badge>
+                    <Badge variant="outline">{resolveRoleLabel(agent.role, null, to)}</Badge>
                     {/* story #3092(2단계, 표면3) — 커넥터 필드. runtime_type null이면 생략
                         (전역 폴백 규칙 — 추측·「미지정」류 문구 금지). 공식 로고는 법무
                         사인오프 전이라 이번엔 텍스트만(로고 트랙은 후속 스코프). */}

--- a/apps/web/src/app/invite/accept/invite-accept-client.tsx
+++ b/apps/web/src/app/invite/accept/invite-accept-client.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { inviteErrorMessage } from '@/lib/invite-error-message';
+import { orgRoleLabel } from '@/lib/org-member-role';
 
 interface InviteAcceptClientProps {
   token: string;
@@ -68,7 +69,7 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
           </div>
           <div className="mt-2 flex items-center justify-between text-sm">
             <span className="text-muted-foreground">{t('profileRole')}</span>
-            <span className="font-medium text-foreground/85 capitalize">{role}</span>
+            <span className="font-medium text-foreground/85">{orgRoleLabel(role, t)}</span>
           </div>
           <div className="mt-2 flex items-center justify-between gap-4 text-sm">
             <span className="shrink-0 text-muted-foreground">{t('acceptProjectsRow')}</span>

--- a/apps/web/src/app/invite/page.tsx
+++ b/apps/web/src/app/invite/page.tsx
@@ -8,6 +8,7 @@ import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { cn } from '@/lib/utils';
 import { InviteError, inviteErrorMessage } from '@/lib/invite-error-message';
 import { fetchWithAuth } from '@/lib/db/client';
+import { orgRoleLabel } from '@/lib/org-member-role';
 
 // d3619e80: invite_accept canonical InvitePreviewResponse 정합(org_name·role·status·expires_at·email).
 // inviter_name/email은 canonical 미제공(optional·미제공 시 generic 안내로 graceful degrade).
@@ -28,6 +29,7 @@ export default function InvitePage() {
   const t = useTranslations('invite');
   const t2 = useTranslations('login');
   const t3 = useTranslations('register');
+  const ts = useTranslations('settings');
   const searchParams = useSearchParams();
   const router = useRouter();
   const token = searchParams.get('token');
@@ -227,8 +229,8 @@ export default function InvitePage() {
                   </div>
                 )}
               </div>
-              <span className="shrink-0 rounded-md border border-border bg-background px-2 py-0.5 text-xs capitalize text-muted-foreground">
-                {preview.role}
+              <span className="shrink-0 rounded-md border border-border bg-background px-2 py-0.5 text-xs text-muted-foreground">
+                {orgRoleLabel(preview.role, ts)}
               </span>
             </div>
           </div>

--- a/apps/web/src/components/agents/agent-management-tab.tsx
+++ b/apps/web/src/components/agents/agent-management-tab.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { fetchWithAuth } from '@/lib/db/client';
+import { resolveRoleLabel } from '@/app/(authenticated)/organization/trust/trust-utils';
 
 interface OrgAgent {
   id: string;
@@ -64,6 +65,7 @@ export function AgentManagementTab({ onAddAgent }: AgentManagementTabProps) {
   const t = useTranslations('settings');
   const ta = useTranslations('agents');
   const tc = useTranslations('common');
+  const to = useTranslations('organization');
   const [agents, setAgents] = useState<OrgAgent[]>([]);
   const [grantCounts, setGrantCounts] = useState<Record<string, number>>({});
   const [isAdmin, setIsAdmin] = useState(false);
@@ -226,7 +228,7 @@ export function AgentManagementTab({ onAddAgent }: AgentManagementTabProps) {
                     </div>
                     <div className="mt-1 flex flex-wrap items-center gap-2">
                       <Badge variant="secondary">{t('agentMember')}</Badge>
-                      <Badge variant="outline">{agent.role}</Badge>
+                      <Badge variant="outline">{resolveRoleLabel(agent.role, null, to)}</Badge>
                       <Badge variant="info">{ta('manageProjectsGranted', { count: grantCounts[agent.id] ?? 0 })}</Badge>
                       {agent.verified === false ? (
                         <Badge variant="warning">{ta('agentNotConnected')}</Badge>

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -17,6 +17,8 @@ import {
 import { getFileIcon } from '@/lib/file-icon';
 import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
 import { resolveRuntimeStatus, runtimeLabel } from '@/lib/runtime-capabilities';
+import { orgRoleLabel } from '@/lib/org-member-role';
+import { resolveRoleLabel } from '@/app/(authenticated)/organization/trust/trust-utils';
 import type { SendAttachment } from '@/hooks/use-chat-sse';
 import type { Asset } from '@/lib/storage/types';
 import { imageFilesFromClipboard } from '@/lib/clipboard-image';
@@ -113,6 +115,24 @@ interface MentionMember {
   id: string;
   name: string;
   role?: string | null;
+  // story #3770 — 휴먼(org role: owner/admin/member)·에이전트(trust role: implementation
+  // 등) 둘 다 이 목록에 섞여 온다(/api/members). role 낱말 축은 이 둘이 서로 다른 정본을
+  // 쓰므로(orgRoleLabel vs resolveRoleLabel), 어느 쪽인지 판별할 이 필드가 필요하다.
+  type?: string;
+}
+
+// story #3770 — /api/members(backend/app/routers/members.py::MemberResponse)가 휴먼은
+// org_members.role(owner/admin/member), 에이전트는 team_members.role(participation/
+// trust role: implementation 등)을 같은 `role` 필드에 섞어 돌려준다. type으로 갈라
+// 각각 맞는 정본을 쓴다(섞지 않는다 — 미확認 type은 원문 그대로, 지어내지 않는다).
+function mentionMemberRoleLabel(
+  member: MentionMember,
+  tSettings: (key: string) => string,
+  tOrg: (key: string, values?: Record<string, string | number>) => string,
+): string {
+  if (!member.role) return '';
+  if (member.type === 'agent') return resolveRoleLabel(member.role, null, tOrg);
+  return orgRoleLabel(member.role, tSettings);
 }
 
 // story #2032 — 대화별 임시저장(localStorage). 대화 전환은 ChatView가 key={conversation_id}로
@@ -176,6 +196,8 @@ interface ChatInputProps {
 export function ChatInput({ onSend, onUploadFile, disabled, placeholder, projectId, onMentionIdsChange, commandTargets, threadId, onEscape, currentTeamMemberId, participants, prefillCommand }: ChatInputProps) {
   const t = useTranslations('chats');
   const tc = useTranslations('common');
+  const tSettings = useTranslations('settings');
+  const tOrg = useTranslations('organization');
   // story #3289(도메인탈고정·축1 Phase1 FE잔여, AC2) — 「네비」 실측 결과 사이드바/브레드크럼엔
   // entity_type 렌더지점이 없고, 실제 렌더처는 이 `#` 엔티티 피커(chat-input-entity-tokens.ts
   // entityTypeLabel())였다. 그 코어 파일은 AC3 판정 대상(diff 0 규율, #2264)이라 손대지
@@ -269,7 +291,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
       })
       .then((json) => {
         if (cancelled) return;
-        const all: MentionMember[] = (json.data ?? []).map((m: { id: string; name: string; role?: string | null }) => ({ id: m.id, name: m.name, role: m.role }));
+        const all: MentionMember[] = (json.data ?? []).map((m: { id: string; name: string; role?: string | null; type?: string }) => ({ id: m.id, name: m.name, role: m.role, type: m.type }));
         const q = mentionQuery.toLowerCase();
         setMentionMembers(q ? all.filter((m) => m.name.toLowerCase().includes(q)) : all);
         setMentionIndex(0);
@@ -811,7 +833,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
                   className={`w-full px-3 py-2 text-left text-sm transition ${idx === mentionIndex ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
                 >
                   <span className="font-medium text-primary">@</span>{member.name}
-                  {member.role ? <span className="ml-2 text-xs opacity-60">{member.role}</span> : null}
+                  {member.role ? <span className="ml-2 text-xs opacity-60">{mentionMemberRoleLabel(member, tSettings, tOrg)}</span> : null}
                 </button>
               </li>
             ))}

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/components/ui/button';
 import { CreateOrganizationDialog } from '@/components/nav/create-organization-dialog';
 import { useUnifiedSwitcher, type OrgSwitcherItem, type ProjectSwitcherItem } from '@/hooks/use-unified-switcher';
 import { useAccountSwitcher } from '@/hooks/use-account-switcher';
+import { orgRoleLabel } from '@/lib/org-member-role';
 
 interface ContextSwitcherChipProps {
   orgs: OrgSwitcherItem[];
@@ -58,6 +59,7 @@ function OrgInitial({ name, className }: { name: string; className?: string }) {
 export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProjectId, userName }: ContextSwitcherChipProps) {
   const t = useTranslations('nav');
   const tCommon = useTranslations('common');
+  const tSettings = useTranslations('settings');
   const s = useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjectId });
   const accountsEnabled = !!userName;
   // 훅은 항상 무조건 호출한다(userName 없어도) — 아래 accountsEnabled로 렌더만 게이팅.
@@ -198,7 +200,7 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                   <div className="flex items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium text-muted-foreground">
                     <OrgInitial name={org.orgName} className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] bg-muted text-[9px] font-semibold text-muted-foreground" />
                     {org.orgName}
-                    {org.role && <span className="text-[9px] font-normal capitalize normal-case opacity-60">{org.role}</span>}
+                    {org.role && <span className="text-[9px] font-normal opacity-60">{orgRoleLabel(org.role, tSettings)}</span>}
                   </div>
                   {isLoading ? (
                     <div className="flex items-center gap-2 px-4 py-2.5 text-sm text-muted-foreground">

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/ui/button';
 import { SidebarMenuButton } from '@/components/ui/sidebar';
 import { CreateOrganizationDialog } from '@/components/nav/create-organization-dialog';
 import { useUnifiedSwitcher, withSwitchedSlugs, type OrgSwitcherItem, type ProjectSwitcherItem } from '@/hooks/use-unified-switcher';
+import { orgRoleLabel } from '@/lib/org-member-role';
 
 // story #2076: 로직(withSwitchedSlugs 포함)이 hooks/use-unified-switcher.ts로 이동했다 —
 // 사이드바(UnifiedSwitcher, ≥1024)와 신규 ContextSwitcherChip(top-bar 칩+바텀시트, <1024)이
@@ -58,6 +59,7 @@ export function UnifiedSwitcher({
 }: UnifiedSwitcherProps) {
   const t = useTranslations('nav');
   const tCommon = useTranslations('common');
+  const tSettings = useTranslations('settings');
   const s = useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjectId });
 
   return (
@@ -147,7 +149,7 @@ export function UnifiedSwitcher({
                         <OrgInitial name={org.orgName} />
                         {org.orgName}
                         {org.role && (
-                          <span className="text-[9px] font-normal capitalize normal-case opacity-60">{org.role}</span>
+                          <span className="text-[9px] font-normal opacity-60">{orgRoleLabel(org.role, tSettings)}</span>
                         )}
                       </span>
                     </DropdownMenuLabel>

--- a/apps/web/src/components/settings/my-profile-section.test.tsx
+++ b/apps/web/src/components/settings/my-profile-section.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// story #3770(페드루 PO 캡처 눈 2026-09-10) — 설정 프로필 「역할」 값이 「관리자」가 아니라
+// 원어 키 `admin` 그대로 라이브에 노출됐다(t() 없이 profile.role을 그대로 그린 자리). 이
+// 실사고를 그대로 재현·고정한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { MyProfileSection } from './my-profile-section';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('MyProfileSection — 역할 낱말(story #3770 실사고 재현)', () => {
+  it('⭐profile.role="admin"이 원어 키 그대로가 아니라 「관리자」로 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const fetchWithAuthMock = vi.fn((url: string) => {
+      if (url === '/api/me') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ data: { id: 'm-1', name: '홍길동', email: 'hong@moonklabs.com', type: 'human', role: 'admin' } }),
+        });
+      }
+      if (url.startsWith('/api/team-members/')) return Promise.resolve({ ok: true, json: async () => ({ data: { avatar_url: null } }) });
+      return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
+    });
+    vi.doMock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+    const { MyProfileSection: Section } = await import('./my-profile-section');
+
+    await act(async () => { root.render(wrap(<Section />)); });
+    await flush();
+
+    expect(container.textContent).toContain('관리자');
+    expect(container.textContent).not.toContain('admin');
+    vi.doUnmock('@/lib/db/client');
+  });
+
+  it('음성대조 — owner/member도 각각 「소유자」/「구성원」으로 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    for (const [raw, expected] of [['owner', '소유자'], ['member', '구성원']] as const) {
+      const fetchWithAuthMock = vi.fn((url: string) => {
+        if (url === '/api/me') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ data: { id: 'm-1', name: '홍길동', email: 'hong@moonklabs.com', type: 'human', role: raw } }),
+          });
+        }
+        if (url.startsWith('/api/team-members/')) return Promise.resolve({ ok: true, json: async () => ({ data: { avatar_url: null } }) });
+        return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
+      });
+      vi.doMock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+      vi.resetModules();
+      const { MyProfileSection: Section } = await import('./my-profile-section');
+
+      const c = document.createElement('div');
+      document.body.appendChild(c);
+      const r = createRoot(c);
+      await act(async () => { r.render(wrap(<Section />)); });
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+      expect(c.textContent).toContain(expected);
+      expect(c.textContent).not.toContain(raw);
+
+      await act(async () => { r.unmount(); });
+      c.remove();
+      vi.doUnmock('@/lib/db/client');
+    }
+  });
+});

--- a/apps/web/src/components/settings/my-profile-section.test.tsx
+++ b/apps/web/src/components/settings/my-profile-section.test.tsx
@@ -8,7 +8,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
-import { MyProfileSection } from './my-profile-section';
 import koMessages from '../../../messages/ko.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;

--- a/apps/web/src/components/settings/my-profile-section.tsx
+++ b/apps/web/src/components/settings/my-profile-section.tsx
@@ -9,6 +9,7 @@ import { TrustScoreCard } from '@/components/cage/trust-score-card';
 import { AvatarEditCard } from '@/components/shared/avatar-edit-card';
 
 import { fetchWithAuth } from '@/lib/db/client';
+import { orgRoleLabel } from '@/lib/org-member-role';
 
 interface MyProfile {
   id: string;
@@ -131,7 +132,7 @@ export function MyProfileSection() {
           </div>
           <div className="flex items-center gap-4 py-2.5">
             <span className="w-20 shrink-0 text-muted-foreground">{t('profileRole')}</span>
-            <span>{profile.role}</span>
+            <span>{orgRoleLabel(profile.role, t)}</span>
           </div>
         </div>
 

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -15,7 +15,7 @@ import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select
 import { useRenderNonce } from '@/hooks/use-render-nonce';
 
 import { fetchWithAuth } from '@/lib/db/client';
-import { canEditOrgMemberRole } from '@/lib/org-member-role';
+import { canEditOrgMemberRole, orgRoleLabel } from '@/lib/org-member-role';
 import { formatRelativeTime } from '@/lib/storage/format';
 import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
 
@@ -40,17 +40,6 @@ interface OrgInvite {
 interface OrgMembersSectionProps {
   orgId: string;
   currentRole: string;
-}
-
-// story #3758(페드루 그라운딩 지적 2026-09-09 — 캡처 리뷰 중 발견, 낱말 축은 아니지만 같은
-// "한 화면 두 언어" 병) — role select/badge가 t() 없이 "Admin"/"Member" 원문 리터럴과
-// member.role raw enum을 그대로 그렸다(번역 누락, 충돌이 아니라 미번역 그 자체).
-// roleAdmin/roleMember는 기존 값 재사용 — roleOwner만 이 PR에서 신규 추가(정정,
-// 페드루 지적 2026-09-10: "정본 값이 이미 있다"는 서술은 셋 다가 아니라 둘만 참이었다).
-function orgRoleLabel(role: 'owner' | 'admin' | 'member', t: (key: string) => string): string {
-  if (role === 'owner') return t('roleOwner');
-  if (role === 'admin') return t('roleAdmin');
-  return t('roleMember');
 }
 
 export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps) {

--- a/apps/web/src/components/settings/project-access-section.test.tsx
+++ b/apps/web/src/components/settings/project-access-section.test.tsx
@@ -11,12 +11,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
 import { ProjectAccessSection } from './project-access-section';
+import koMessages from '../../../messages/ko.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;
 let root: Root;
+
+// story #3770 — orgRoleLabel(role, t) 도입으로 이 섹션이 useTranslations('settings')를
+// 쓰게 됐다(grant.role/member.role 배지 낱말 정본 경유). NextIntlClientProvider 없이
+// 렌더하면 "context not found"로 throw — org-members-section.test.tsx와 동형으로 감쌈.
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
 
 beforeEach(() => {
   container = document.createElement('div');
@@ -43,7 +56,7 @@ describe('ProjectAccessSection — 인가는 서버 응답으로 판정(story #3
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await act(async () => { root.render(<ProjectAccessSection projectId="proj-1" />); });
+    await act(async () => { root.render(wrap(<ProjectAccessSection projectId="proj-1" />)); });
     await flush();
 
     expect(container.textContent).toContain('관리자 전용 페이지입니다');
@@ -62,7 +75,7 @@ describe('ProjectAccessSection — 인가는 서버 응답으로 판정(story #3
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await act(async () => { root.render(<ProjectAccessSection projectId="proj-1" />); });
+    await act(async () => { root.render(wrap(<ProjectAccessSection projectId="proj-1" />)); });
     await flush();
 
     expect(container.textContent).not.toContain('관리자 전용 페이지입니다');
@@ -79,7 +92,7 @@ describe('ProjectAccessSection — 인가는 서버 응답으로 판정(story #3
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await act(async () => { root.render(<ProjectAccessSection projectId="proj-1" />); });
+    await act(async () => { root.render(wrap(<ProjectAccessSection projectId="proj-1" />)); });
     await flush();
 
     expect(calls).not.toContain('/api/org-members');

--- a/apps/web/src/components/settings/project-access-section.tsx
+++ b/apps/web/src/components/settings/project-access-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { Shield, ShieldOff, Loader2 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -10,6 +11,7 @@ import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui
 import { cn } from '@/lib/utils';
 
 import { fetchWithAuth } from '@/lib/db/client';
+import { orgRoleLabel } from '@/lib/org-member-role';
 
 interface OrgMember {
   id: string;            // org_member.id
@@ -30,6 +32,7 @@ interface ProjectAccessSectionProps {
 }
 
 export function ProjectAccessSection({ projectId }: ProjectAccessSectionProps) {
+  const t = useTranslations('settings');
   const [orgMembers, setOrgMembers] = useState<OrgMember[]>([]);
   const [grants, setGrants] = useState<ProjectGrant[]>([]);
   const [loading, setLoading] = useState(true);
@@ -211,12 +214,12 @@ export function ProjectAccessSection({ projectId }: ProjectAccessSectionProps) {
                   actions={
                     <>
                       {granted && grant ? (
-                        <Badge variant="outline" className="capitalize text-xs">
-                          {grant.role}
+                        <Badge variant="outline" className="text-xs">
+                          {orgRoleLabel(grant.role, t)}
                         </Badge>
                       ) : isOwner ? (
-                        <Badge variant="info" className="capitalize text-xs">
-                          {member.role}
+                        <Badge variant="info" className="text-xs">
+                          {orgRoleLabel(member.role, t)}
                         </Badge>
                       ) : null}
                       {isOwner ? (

--- a/apps/web/src/components/settings/remove-org-member-dialog.tsx
+++ b/apps/web/src/components/settings/remove-org-member-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { AlertTriangle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -14,6 +15,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { fetchWithAuth } from '@/lib/db/client';
+import { resolveRoleLabel } from '@/app/(authenticated)/organization/trust/trust-utils';
 
 interface AffectedProject {
   project_id: string;
@@ -34,6 +36,7 @@ export function RemoveOrgMemberDialog({
   onConfirm,
   onCancel,
 }: RemoveOrgMemberDialogProps) {
+  const to = useTranslations('organization');
   const [loading, setLoading] = useState(true);
   const [affected, setAffected] = useState<AffectedProject[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -96,7 +99,7 @@ export function RemoveOrgMemberDialog({
               {affected.map((p) => (
                 <div key={p.project_id} className="flex items-center justify-between gap-3 py-1 text-sm">
                   <span className="truncate text-foreground">{p.project_name}</span>
-                  <Badge variant="outline" className="capitalize">{p.role}</Badge>
+                  <Badge variant="outline">{resolveRoleLabel(p.role, null, to)}</Badge>
                 </div>
               ))}
             </div>

--- a/apps/web/src/lib/org-member-role.test.ts
+++ b/apps/web/src/lib/org-member-role.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canEditOrgMemberRole } from './org-member-role';
+import { canEditOrgMemberRole, orgRoleLabel } from './org-member-role';
 
 describe('canEditOrgMemberRole(story #3491, BE org_members.py::update_org_member 미러)', () => {
   it('⭐admin caller — owner도 자기 자신도 아닌 member는 편집 가능(FE=BE 폭 정정의 핵심)', () => {
@@ -48,5 +48,27 @@ describe('canEditOrgMemberRole(story #3491, BE org_members.py::update_org_member
     expect(canEditOrgMemberRole({
       currentRole: 'owner', currentUserId: 'u-owner', member: { role: 'admin', user_id: 'u-other' },
     })).toBe(true);
+  });
+});
+
+describe('orgRoleLabel(story #3770 — 원시 role 값 t() 없이 노출 재발 방지)', () => {
+  const t = (key: string) => ({ roleOwner: '소유자', roleAdmin: '관리자', roleMember: '구성원' }[key] ?? `[${key}]`);
+
+  it('⭐owner/admin/member 셋 다 번역된 값을 돌려준다(설정 프로필 「역할 admin」 실사고 재현)', () => {
+    expect(orgRoleLabel('owner', t)).toBe('소유자');
+    expect(orgRoleLabel('admin', t)).toBe('관리자');
+    expect(orgRoleLabel('member', t)).toBe('구성원');
+  });
+
+  // 뮤테이션 대조 — 원시 값을 그대로 돌려주면(번역 호출 자체를 빼면) 이 자리가 반드시
+  // 잡아낸다는 것 자체를 자가 증명.
+  it('뮤테이션 대조 — t() 호출 없이 원문 그대로 돌려주면 이 테스트가 FAIL한다(가드 자체 검산)', () => {
+    const identity = (v: string) => orgRoleLabel(v, (k) => k);
+    expect(identity('admin')).not.toBe('관리자');
+    expect(identity('admin')).toBe('roleAdmin');
+  });
+
+  it('음성대조 — 알려지지 않은 값(엔티티 시드 오류 등)은 원문을 그대로 돌려준다(지어내지 않는다)', () => {
+    expect(orgRoleLabel('unknown-role', t)).toBe('unknown-role');
   });
 });

--- a/apps/web/src/lib/org-member-role.ts
+++ b/apps/web/src/lib/org-member-role.ts
@@ -28,3 +28,21 @@ export function canEditOrgMemberRole(params: {
   if (currentUserId != null && member.user_id != null && currentUserId === member.user_id) return false;
   return true;
 }
+
+/**
+ * story #3770(페드루 PO 確定 2026-09-10) — org 역할(owner/admin/member) 낱말 정본.
+ * org-members-section.tsx의 로컬 함수였던 것을 이 자리로 이관(3화면 공용이던
+ * canEditOrgMemberRole과 동일 사유 — 컴포넌트 트리가 갈라져 있어 로직만 한 곳에
+ * 모은다). 새 i18n 키 0 — roleOwner/roleAdmin/roleMember는 기존 값 그대로 재사용.
+ *
+ * 호출부(`profile.role`·`preview.role`·switcher의 `org.role`)가 API 원문 그대로라
+ * 타입이 `string`(엄격 유니온 아님) — 알려진 세 값이 아니면 원문을 그대로 돌려준다
+ * (resolveRoleLabel의 "모르는 키는 원문 pass-through" 방어와 동형, 화면이 값을 지어
+ * 내지 않는다).
+ */
+export function orgRoleLabel(role: string, t: (key: string) => string): string {
+  if (role === 'owner') return t('roleOwner');
+  if (role === 'admin') return t('roleAdmin');
+  if (role === 'member') return t('roleMember');
+  return role;
+}


### PR DESCRIPTION
## 실사고
설정 프로필 「역할」 값이 「관리자」가 아니라 원어 키 `admin` 그대로 라이브에 노출됐다(`my-profile-section.tsx:134` `<span>{profile.role}</span>` — `t()` 없이 원시 값, PO 캡처 눈으로 발견).

## 처방 — 정본 셋 경유, 새 낱말 0
- `orgRoleLabel(role, t)` 신설(`@/lib/org-member-role`, org owner/admin/member 정본) — `org-members-section.tsx`의 로컬 중복 함수를 걷고 공용 임포트로 전환.
- **org 역할 축**(6자리): `my-profile-section`·`invite/page`·`invite/accept`·`context-switcher-chip`(판단, 유나 定: 정본 경유가 맞다)·`unified-switcher`(동형)·`project-access-section` 2곳.
- **participation/trust 역할 축**(`resolveRoleLabel`, `@/app/(authenticated)/organization/trust/trust-utils`, 3자리): `workforce/[id]`·`agent-management-tab`·`remove-org-member-dialog`(BE 확認: `team_members.role` — org role 아님).
- `chat-input.tsx` 멘션 목록: `/api/members`(`backend/app/routers/members.py::MemberResponse`)가 휴먼(org role)·에이전트(trust role)를 같은 `role` 필드에 섞어 반환한다(BE 코드로 확認) — `type` 필드로 갈라 각각 맞는 정본을 쓰도록 스레딩.

## 전수 스캔이 찾은 6곳 추가 자리
PO가 짚은 7자리(화면 문구 5+판단 2) 외에 AST 가드 실행 중 6곳을 더 발견:
- 4곳(`invite-accept-client.tsx`·`project-access-section.tsx` 2곳·`remove-org-member-dialog.tsx`)은 같은 병 — 위 정본 경유로 함께 닫음.
- 2곳(`events/page.tsx:402`·`loop-create-dialog.tsx:320`의 `stage_metadata.role`)은 **다른 축** — 워크플로 단계 담당자 라벨(Agent/Human/PO/Dev/Lead 등, `sprintable_get_workflow_guide` 출력 자체가 원어 그대로 쓰는 관례)로 org/trust 역할 정본 어디에도 이 값 집합이 없다. 새 정본 신설은 이 스토리 범위 밖 — ALLOWLIST+사유 명시, 후속 판단은 PO에게 별도 보고했음.

## 회귀가드
`verify-no-raw-role-jsx-text.ts`(신규, AST) — JSX 자식에 `t()` 없이 원시 `role`(bare identifier 또는 `.role` 프로퍼티 접근)이 그려지면 RED. `<select value={member.role}>` 같은 속성 자리는 JSX 속성(attribute)이지 자식(child)이 아니라 구조적으로 대상 밖(`roles/page.tsx:168` 실사용 정당 확認).

## 테스트
- `my-profile-section.test.tsx`(신규): 실사고 그대로 재현(`role="admin"` → 「관리자」, 「admin」 텍스트 0) + owner/member 음성대조. **뮤테이션 셀프체크**(로컬에서 fix를 임시로 되돌려 두 테스트 모두 FAIL 확認 후 복원) 완료.
- `verify-no-raw-role-jsx-text.test.ts`(신규): 양성/음성/뮤테이션 대조 + 실 트리(`scanRepo`) 0건 pin.
- `project-access-section.test.tsx`: `useTranslations` 도입으로 `NextIntlClientProvider` 래핑 추가(기존 3건 전부 그린 유지).
- `org-member-role.test.ts`: `orgRoleLabel` describe 블록 추가.
- `pnpm vitest run` 738 files / 7375 tests 전부 그린, `tsc --noEmit` 클린, `pnpm build` 성공, `verify:ci-wires-all-verify-scripts` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ