### PR TITLE
[SID:3771] fix(FE): 구성원 목록 역할 열/액션 열 자리 고정 — 배지가 제거 버튼 자리로 안 밀림

### DIFF
--- a/apps/web/src/components/settings/org-members-section.test.tsx
+++ b/apps/web/src/components/settings/org-members-section.test.tsx
@@ -248,6 +248,41 @@ describe('OrgMembersSection — 역할 변경 게이트가 BE 인가 폭과 같�
   });
 });
 
+// story #3771(PO 별건 ㉓·유나 r65 라이브 픽셀) — 역할 변경 불가 행(소유자·자기 자신)의
+// 배지가 제거 버튼 자리로 밀려 세로 정렬이 「소유자/제거/제거」로 섞였다. 액션 열은
+// canEdit 무관하게 항상 같은 개수(2: 역할 슬롯+액션 슬롯)를 렌더해야 한다 — 액션
+// 슬롯은 canEdit=false일 때도 같은 텍스트의 Button을 invisible로 그려 폭을 지킨다.
+describe('OrgMembersSection — 역할 열/액션 열 자리 고정(story #3771)', () => {
+  it('⭐owner 행·자기 자신 행도 "제거" 버튼 엘리먼트가 DOM에 있다(자리만 invisible) — member 행은 보이는 버튼', async () => {
+    await mountAsAdmin(
+      [
+        { id: 'row-owner', user_id: 'u-owner', role: 'owner' },
+        { id: 'row-self', user_id: 'u-admin-self', role: 'admin' },
+        { id: 'row-other', user_id: 'u-member', role: 'member' },
+      ],
+      'u-admin-self',
+    );
+
+    const removeButtons = Array.from(container.querySelectorAll('button'))
+      .filter((b) => b.textContent === koMessages.settings.removeFromProject);
+    // 세 행 전부(owner·self·member) "제거" 버튼 엘리먼트 자체는 존재해야 한다(자리 고정).
+    expect(removeButtons.length).toBe(3);
+
+    const [ownerBtn, selfBtn, otherBtn] = removeButtons;
+    expect(ownerBtn.className).toContain('invisible');
+    expect(ownerBtn.getAttribute('aria-hidden')).toBe('true');
+    expect(ownerBtn.tabIndex).toBe(-1);
+
+    expect(selfBtn.className).toContain('invisible');
+    expect(selfBtn.getAttribute('aria-hidden')).toBe('true');
+
+    // member 행(변경 가능)의 버튼은 실제로 보이고 클릭 가능해야 한다 — 회귀 0.
+    expect(otherBtn.className).not.toContain('invisible');
+    expect(otherBtn.getAttribute('aria-hidden')).not.toBe('true');
+    expect(otherBtn.tabIndex).not.toBe(-1);
+  });
+});
+
 // story #3606(잔여, 페드루 PO 確定 2026-09-07) — 이 파일 전체가 t() 없는 하드코딩
 // 한글이라 en 로케일에서도 한국어가 그대로 노출됐다(초대 폼 제목·설명·성공/실패
 // 배너·멤버/초대 목록 헤딩·행 액션 버튼 등). 실 렌더(멤버 1행+대기 초대 1행 —

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -399,6 +399,13 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
                 className="border-0 rounded-none bg-transparent"
                 meta={member.joined_at ? t('orgMemberJoinedMeta', { time: formatRelativeTime(member.joined_at, locale, displayTimezone) }) : undefined}
                 actions={
+                  // story #3771(PO 별건 ㉓·유나 r65) — 역할 열/액션 열을 항상 둘 다 렌더한다
+                  // (행마다 열의 뜻이 같게). 역할 변경 불가 행(소유자·자기 자신)은 select 대신
+                  // 배지가 서지만, 그 배지가 «제거» 버튼이 있던 자리로 밀려 앉으면 세로로 읽을
+                  // 때 상태 딱지와 행동 버튼이 한 열에 섞인다(라이브 캡처로 실측된 결함) — 액션
+                  // 열은 canEdit=false일 때도 같은 Button(같은 텍스트·크기, 그래서 폭이 로케일과
+                  // 무관하게 정확히 같다)을 invisible로 그려 자리만 지킨다(클릭 불가·
+                  // aria-hidden — 보조기술 목록엔 아예 안 나온다).
                   <>
                     {canEdit ? (
                       <select
@@ -413,10 +420,17 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
                     ) : (
                       <Badge variant={isThisOwner ? 'info' : 'secondary'}>{orgRoleLabel(member.role, t)}</Badge>
                     )}
-                    {canEdit && (
+                    {canEdit ? (
                       <Button
                         size="sm" variant="glass" onClick={() => setRemoveDialogMemberId(member.id)}
                         aria-label={t('orgMemberRowActionAriaLabel', { n: index + 1, label: t('removeFromProject') })}
+                      >
+                        {t('removeFromProject')}
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm" variant="glass" tabIndex={-1} aria-hidden="true"
+                        className="invisible pointer-events-none"
                       >
                         {t('removeFromProject')}
                       </Button>

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -428,9 +428,14 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
                         {t('removeFromProject')}
                       </Button>
                     ) : (
+                      // story #3592 회귀 가드(verify-repeated-row-action-names) — aria-hidden이라
+                      // 보조기술엔 안 읽혀도 정적 스캔은 행마다 반복되는 라벨을 그대로 잡는다.
+                      // 실 버튼과 동일하게 순번을 품은 aria-label을 붙인다(무해 — aria-hidden이
+                      // 우선해 결국 안 읽힌다).
                       <Button
                         size="sm" variant="glass" tabIndex={-1} aria-hidden="true"
                         className="invisible pointer-events-none"
+                        aria-label={t('orgMemberRowActionAriaLabel', { n: index + 1, label: t('removeFromProject') })}
                       >
                         {t('removeFromProject')}
                       </Button>


### PR DESCRIPTION
## 배경(PO #4107 리뷰 별건 ㉓·유나 r65 라이브 픽셀)
`org-members-section.tsx`의 `MemberRow` `actions` 슬롯은 `canEdit=false`(소유자·자기 자신 행)일 때 배지 하나만 렌더하고 `canEdit=true` 행은 select+제거 버튼 둘을 렌더했습니다 — 행마다 슬롯 개수가 달라(1개 vs 2개) 세로로 읽으면 「소유자/제거/제거」처럼 상태 딱지와 행동 버튼이 한 열에 섞였습니다.

## 처방
액션 슬롯을 `canEdit` 무관하게 **항상** 렌더합니다 — `canEdit=false`일 때도 같은 `Button`(같은 텍스트·같은 크기, 그래서 폭이 로케일과 무관하게 정확히 같음)을 `invisible pointer-events-none` + `aria-hidden="true"` + `tabIndex={-1}`로 그려 자리만 지킵니다(클릭 불가·보조기술 목록엔 아예 안 나옴).

권한 화면(`organization/roles/page.tsx`)은 애초에 `actions` 슬롯에 역할 select/배지 하나뿐(제거 버튼이 없음)이라 이 결함 클래스가 성립하지 않음을 확認했습니다 — **무변경**.

## 검증
- 신규 테스트(owner·자기 자신·member 세 행 한 화면 — 제거 버튼 엘리먼트 개수가 항상 3, owner/self는 invisible+aria-hidden+tabIndex=-1, member는 실제로 보이고 클릭 가능) 1건.
- **뮤테이션**(액션 슬롯을 canEdit 조건부로 되돌려 버튼 개수가 3→1로 주는 RED 확認 후 복구).
- 기존 14건(#3491 역할 변경 게이트·#3606 i18n 등) 전부 GREEN — 회귀 0.
- FE tsc 무오류·vitest 7367 passed.

## Test plan
- [x] tsc --noEmit 무오류
- [x] vitest 7367 passed(신규 1건 뮤테이션 확認 포함)
- [x] roles/page.tsx 무변경 확認(무회귀)
- [ ] **판정**: 캡처 1(소유자·자기 자신·일반 행이 한 화면에) PO 눈 · 유나 픽셀 · 카디르 QA(제거 버튼 노출 규칙 무변) · 배포 뒤 라이브로 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)