### PR TITLE
[SID:3774] fix(FE): 회고 「내보내기」 BFF가 마크다운 텍스트를 JSON으로 잘못 파싱하던 결함

### DIFF
--- a/apps/web/src/app/api/retro-sessions/[id]/export/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/export/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
+  proxyToFastapiWithParams: vi.fn(),
+}));
+
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { GET } from './route';
+
+function makeAgent() {
+  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
+}
+
+// story #3774 — BE `retros.py::export_session`은 JSON 봉투가 아니라 마크다운 텍스트를
+// `Response(media_type="text/markdown")`로 그대로 준다. 이전엔 이 라우트가 그 응답을
+// `.json()`으로 파싱하다 `SyntaxError`(마크다운 첫 글자 `#`)로 죽어 「내보내기」가
+// 라이브에서 한 번도 성공한 적 없었다 — 이 스위트가 그 계약을 고정한다.
+describe('GET /api/retro-sessions/[id]/export', () => {
+  beforeEach(() => {
+    getOrgProjectAuthContext.mockReset();
+    proxyToFastapiWithParams.mockReset();
+    getOrgProjectAuthContext.mockResolvedValue(makeAgent());
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    getOrgProjectAuthContext.mockResolvedValue(null);
+
+    const response = await GET(
+      new Request('http://localhost/api/retro-sessions/session-1/export?project_id=project-1'),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  // ⭐되돌리면 RED — BE의 실제 응답 형(text/markdown 원문)을 그대로 재현한다. `.json()`으로
+  // 파싱하는 이전 코드로 되돌리면 이 텍스트("# 회고 제목"으로 시작)가 JSON 파싱에 실패해
+  // 500/400으로 죽는다(라이브에서 관측된 정확한 그 실패).
+  it('⭐BE가 text/markdown 원문을 주면 200 + { data: { markdown } } 봉투로 감싼다', async () => {
+    const markdown = '# 픽셀 로딩 시드\n**Phase:** action\n\n## 잘된 점 (Good)\n- 빨랐다 (3 votes)';
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(markdown, { status: 200, headers: { 'Content-Type': 'text/markdown; charset=utf-8' } }),
+    );
+
+    const response = await GET(
+      new Request('http://localhost/api/retro-sessions/session-1/export?project_id=project-1'),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { markdown: string } };
+    expect(body.data.markdown).toBe(markdown);
+    expect(body.data.markdown.startsWith('#')).toBe(true);
+  });
+
+  it('BE가 이미 JSON 봉투를 주면 그대로 통과한다(회귀 대비 — 미래에 BE가 JSON으로 바뀌어도 무변)', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ markdown: '# from json' }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const response = await GET(
+      new Request('http://localhost/api/retro-sessions/session-1/export?project_id=project-1'),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { markdown: string } };
+    expect(body.data.markdown).toBe('# from json');
+  });
+
+  it('BE 4xx/5xx는 그대로 전달한다(봉투 변환 없음)', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'FORBIDDEN', message: 'no access' } }), { status: 403, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const response = await GET(
+      new Request('http://localhost/api/retro-sessions/session-1/export?project_id=project-1'),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
@@ -16,6 +16,18 @@ export async function GET(request: Request, { params }: RouteParams) {
     const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/export', { id });
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
+    // story #3774 — BE(`retros.py::export_session`)는 JSON 봉투가 아니라 마크다운
+    // «텍스트»를 `Response(media_type="text/markdown")`로 그대로 준다(FE가 클립보드에
+    // 그대로 복사할 원문이라 JSON 왕복이 필요 없는 자리). 이전엔 여기서 `.json()`으로
+    // 파싱하다 `SyntaxError`(마크다운 첫 글자 `#`가 JSON으로 안 읽힘)가 나 매번 500으로
+    // 죽었다 — 실 성공 경로가 한 번도 없었다. Content-Type으로 분기: JSON이 아니면
+    // 텍스트로 읽어 FE가 기대하는 `{ data: { markdown } }` 봉투로 감싼다(FE
+    // `retro/[id]/page.tsx::exportSession` 무변 — 그 계약이 이미 유일한 소비처).
+    const contentType = _r.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      const markdown = await _r.text();
+      return apiSuccess({ markdown });
+    }
     return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);


### PR DESCRIPTION
## 배경(PO 3759 라이브 실측 03:24Z 발견 → 프로브 03:57Z)
BE `retros.py::export_session`은 JSON 봉투가 아니라 마크다운 텍스트를 `Response(media_type="text/markdown")`로 그대로 줍니다(클립보드에 그대로 복사할 원문이라 JSON 왕복이 원래 불필요한 자리). BFF `/api/retro-sessions/[id]/export` 라우트가 그 응답을 `.json()`으로 파싱하다 `SyntaxError`(마크다운 첫 글자 `#`)로 죽어 400 `INTERNAL_ERROR "Unexpected token '#'..."`를 냈습니다 — FE는 `json.data.markdown`을 기대하는데 세 층(BE 텍스트·BFF JSON 파싱·FE JSON 봉투)의 계약이 서로 달라 **「내보내기」가 라이브에서 한 번도 성공한 적 없었습니다**.

## 처방
그라운딩 뒤 가장 작은 쪽(BFF만)으로 계약을 하나로 합쳤습니다. Content-Type으로 분기: JSON이 아니면(BE의 실제 응답) 텍스트로 읽어 FE가 이미 기대하는 `{ data: { markdown } }` 봉투로 감쌉니다. JSON이면(미래 BE 변경 대비) 그대로 통과 — **FE·BE 둘 다 무변**.

## 검증
- 신규 라우트 테스트 4건: 401 · text/markdown 원문→200+봉투(라이브 관측 그대로 재현) · 이미 JSON이면 통과(회귀 대비) · 4xx/5xx는 봉투 변환 없이 그대로 전달.
- **뮤테이션**(`.json()` 파싱으로 되돌려 정확히 관측된 400을 재현 확認 후 복구).
- FE tsc 무오류 · vitest 7370 passed.

## Test plan
- [x] tsc --noEmit 무오류
- [x] vitest 7370 passed(신규 4건, 뮤테이션 확認 포함)
- [ ] **라이브**: 배포 뒤 dev 회고 「내보내기」 1회 → 성공 토스트·클립보드에 `# ...`(PO 실측)로 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)