### PR TITLE
[SID:3775] fix(FE): 셸 결함 — 이름 없는(OAuth) 사용자는 설정 진입점이 통째로 막혀 있었다

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -56,6 +56,7 @@
   },
   "accountSwitcher": {
     "title": "Accounts",
+    "setName": "Set your name",
     "addAccount": "Add account",
     "signOutThis": "Sign out this account",
     "signOutAll": "Sign out all accounts",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -56,6 +56,7 @@
   },
   "accountSwitcher": {
     "title": "계정",
+    "setName": "이름 설정",
     "addAccount": "계정 추가",
     "signOutThis": "이 계정 로그아웃",
     "signOutAll": "모든 계정 로그아웃",

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -89,10 +89,10 @@ afterEach(async () => {
   vi.unstubAllGlobals();
 });
 
-async function mount() {
+async function mount(userName?: string) {
   await act(async () => {
     root.render(withProviders(
-      <AppSidebar projectMemberships={[]} chatUnreadTotal={0} />,
+      <AppSidebar projectMemberships={[]} chatUnreadTotal={0} userName={userName} />,
     ));
   });
   await act(async () => { await Promise.resolve(); await Promise.resolve(); });
@@ -474,5 +474,53 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     expandAllGroups();
     await mount();
     expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'nearest' });
+  });
+});
+
+// story #3775(카디르 QA 재발견 06:16Z) — 이전 처방(`{userName && <ProfileMenu/>}` → 항상
+// 렌더)이 실제로 맞는지 이 파일의 26개 테스트 중 어느 하나도 안 쟀다: 전부 `mount()`가
+// userName을 안 넘겨(undefined) 게이팅을 되돌려도 전부 그대로 통과했다 — 사고 재발 지점을
+// 아무도 안 잼. 이 스위트가 정확히 그 자리(AppSidebar 레벨에서 userName이 빈 값일 때
+// ProfileMenu가 실제로 마운트되는지)를 잰다(profile-menu.test.tsx는 ProfileMenu 단위
+// 테스트라 AppSidebar의 호출부 게이팅 자체는 못 잡는다 — 다른 컴포넌트, 다른 갭).
+describe('AppSidebar — story #3775 셸 결함(userName 빈 값이어도 ProfileMenu가 항상 렌더된다)', () => {
+  // ⭐되돌리면(app-sidebar.tsx가 `{userName && <ProfileMenu .../>}`로 되돌아가면) RED —
+  // userName이 undefined일 때 트리거 자체가 안 그려져야 실패한다.
+  it('⭐userName을 안 넘기면(undefined) 그래도 ProfileMenu(칩+「이름 설정」)가 렌더된다', async () => {
+    expandAllGroups();
+    await mount(undefined);
+    const trigger = container.querySelector('[data-slot="sidebar-footer"] [data-slot="dropdown-menu-trigger"]') as HTMLElement;
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain(koMessages.common.memberUnnamed);
+
+    await act(async () => { trigger.click(); });
+    const content = document.querySelector('[data-slot="dropdown-menu-content"]');
+    const setNameItem = Array.from(content!.querySelectorAll('a')).find(
+      (a) => a.textContent?.includes(koMessages.accountSwitcher.setName),
+    );
+    expect(setNameItem).toBeTruthy();
+    expect(setNameItem?.getAttribute('href')).toBe('/settings');
+  });
+
+  it('userName이 빈 문자열이어도 동형(칩+「이름 설정」)', async () => {
+    expandAllGroups();
+    await mount('');
+    const trigger = container.querySelector('[data-slot="sidebar-footer"] [data-slot="dropdown-menu-trigger"]') as HTMLElement;
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain(koMessages.common.memberUnnamed);
+  });
+
+  it('userName이 있으면(기존 회귀) 「이름 설정」 항목이 없다', async () => {
+    expandAllGroups();
+    await mount('송윤재');
+    const trigger = container.querySelector('[data-slot="sidebar-footer"] [data-slot="dropdown-menu-trigger"]') as HTMLElement;
+    expect(trigger.textContent).not.toContain(koMessages.common.memberUnnamed);
+
+    await act(async () => { trigger.click(); });
+    const content = document.querySelector('[data-slot="dropdown-menu-content"]');
+    const setNameItem = Array.from(content!.querySelectorAll('*')).find(
+      (el) => el.textContent === koMessages.accountSwitcher.setName,
+    );
+    expect(setNameItem).toBeFalsy();
   });
 });

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -444,7 +444,12 @@ export function AppSidebar({
       </SidebarContent>
 
       <SidebarFooter className="space-y-2 p-2">
-        {userName && <ProfileMenu name={userName} />}
+        {/* story #3775(유나 定 2026-09-10) — 이름 없는(OAuth 신규 가입) 사용자는 이전엔
+            이 칩 자체가 안 그려져 설정으로 가는 경로 하나가 통째로 막혀 있었다(결함,
+            유도 장치가 아니다). 이름 유무와 무관하게 항상 그린다 — 이름 없을 때의
+            표시(「이름 없는 구성원」)와 「이름 설정」 메뉴 항목은 ProfileMenu 내부에서
+            처리(공용 memberDisplayLabel 재사용, story #3755/#3758과 같은 헬퍼). */}
+        <ProfileMenu name={userName ?? null} />
         <div className="flex items-center gap-1">
           <LocaleSwitcher />
           <ThemeToggle />

--- a/apps/web/src/components/nav/profile-menu.test.tsx
+++ b/apps/web/src/components/nav/profile-menu.test.tsx
@@ -86,6 +86,48 @@ describe('ProfileMenu — 약관 및 정책 그룹 제거 회귀가드 (story #2
   });
 });
 
+// story #3775(유나 定 2026-09-10) — OAuth 신규 가입(display_name 없음)이 이전엔
+// `{userName && <ProfileMenu .../>}`(호출부)로 걸러져 이 컴포넌트 자체가 안 그려졌다 —
+// 인증 셸 안에서 /settings로 가는 **유일한 상시 진입점**이 그래서 통째로 막혔었다(유나
+// 전수 확認, 4개 후보 중 나머지 셋은 상시가 아님). name=null이어도 항상 그린다.
+describe('ProfileMenu — name 없음(OAuth 신규 가입)도 항상 그린다(story #3775, 설정 진입점 복원)', () => {
+  it('⭐name=null → 칩에 「이름 없는 구성원」(common.memberUnnamed 재사용, 새 낱말 0)', async () => {
+    await mount(<ProfileMenu name={null} />);
+    const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]') as HTMLElement;
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain(koMessages.common.memberUnnamed);
+  });
+
+  it('⭐name=null → 드롭다운에 「이름 설정」 항목이 있고 /settings로 간다', async () => {
+    await mount(<ProfileMenu name={null} />);
+    await openMenu();
+    const content = document.querySelector('[data-slot="dropdown-menu-content"]');
+    const setNameItem = Array.from(content!.querySelectorAll('a')).find(
+      (a) => a.textContent?.includes(koMessages.accountSwitcher.setName),
+    );
+    expect(setNameItem).toBeTruthy();
+    expect(setNameItem?.getAttribute('href')).toBe('/settings');
+  });
+
+  // ⭐되돌리면 RED — 이름이 있으면 「이름 설정」 항목이 사라져야 한다(재노출 조건 자체가
+  // 불필요하다는 유나 定의 핵심 — 상태가 곧 표시).
+  it('⭐name이 있으면(기존 회귀) 「이름 설정」 항목이 없다', async () => {
+    await mount(<ProfileMenu name="송윤재" />);
+    await openMenu();
+    const content = document.querySelector('[data-slot="dropdown-menu-content"]');
+    const setNameItem = Array.from(content!.querySelectorAll('*')).find(
+      (el) => el.textContent === koMessages.accountSwitcher.setName,
+    );
+    expect(setNameItem).toBeFalsy();
+  });
+
+  it('빈 문자열("")도 null과 동형(메일 로컬파트 등으로 굽지 않은 빈 값) — 「이름 없는 구성원」', async () => {
+    await mount(<ProfileMenu name="" />);
+    const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]') as HTMLElement;
+    expect(trigger.textContent).toContain(koMessages.common.memberUnnamed);
+  });
+});
+
 // story #3146/#3147(모바일 스위처 통합 재설계, doc mobile-switcher-redesign-spec-4758744a)
 // — 계정 스위치 로직을 useAccountSwitcher 훅으로 추출(profile-menu.tsx 원 동작 재구현
 // 0)+데스크톱 트리거를 밝은 배경(context-switcher-chip.tsx 계정층)에도 재사용 가능하게

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { ChevronsUpDown, Settings, LogOut, Plus, Check, Loader2 } from 'lucide-react';
+import { ChevronsUpDown, Settings, LogOut, Plus, Check, Loader2, UserPen } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,9 +15,13 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { useAccountSwitcher } from '@/hooks/use-account-switcher';
+import { memberDisplayLabel } from '@/lib/member-display';
 
 interface ProfileMenuProps {
-  name: string;
+  // story #3775 — OAuth 신규 가입은 display_name을 안 채우는 게 정직한 경로(3758 確定)라
+  // null이 실제로 온다. 이전엔 호출부가 `{userName && <ProfileMenu .../>}`로 null/undefined를
+  // 아예 걸러 메뉴 자체가(그래서 설정으로 가는 경로도) 안 그려졌다 — 그 결함을 여기서 닫는다.
+  name: string | null;
   email?: string | null;
   avatarUrl?: string | null;
   /** story #3146(모바일 계정 스위치) — 기본 트리거는 `sidebar-*` 테마 토큰을 쓴다(데스크톱
@@ -59,10 +63,15 @@ function Avatar({ url, label, className }: { url?: string | null; label: string;
 
 export function ProfileMenu({ name, avatarUrl, triggerClassName }: ProfileMenuProps) {
   const tn = useTranslations('nav');
+  // story #3775 — useAccountSwitcher(아래)에 넘길 표시명을 미리 정해야 해서 그 훅이
+  // 돌려주는 tc보다 먼저 이 자리에서 한 번 더 bind한다(같은 ns, next-intl에 이중 호출
+  // 비용 없음 — 새 기전 0, 기존 memberDisplayLabel(name, t) 시그니처 그대로 재사용).
+  const tcBootstrap = useTranslations('common');
+  const hasName = Boolean(name && name.trim());
   const {
     t, tc, ordered, others, busy, error, atCap,
     triggerName, triggerAvatar, load, handleSwitch, handleAdd, handleSignOut,
-  } = useAccountSwitcher(name, avatarUrl);
+  } = useAccountSwitcher(memberDisplayLabel(name, tcBootstrap), avatarUrl);
 
   return (
     <DropdownMenu onOpenChange={(open) => { if (open) void load(); }}>
@@ -117,6 +126,15 @@ export function ProfileMenu({ name, avatarUrl, triggerClassName }: ProfileMenuPr
           {atCap && <span className="text-xs text-muted-foreground">{t('capReached')}</span>}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
+        {/* story #3775(유나 定) — 이름이 없을 때만. 채워지면 hasName이 true가 되어 이
+            항목이 사라진다(재노출 조건 자체가 불필요 — 상태가 곧 표시). 기존 「설정」
+            항목과 같은 형·같은 경로(/settings), 새 길 0. */}
+        {!hasName && (
+          <DropdownMenuItem render={<Link href="/settings" />}>
+            <UserPen className="size-4" />
+            {t('setName')}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem render={<Link href="/settings" />}>
           <Settings className="size-4" />
           {tn('settings')}


### PR DESCRIPTION
## 배경(3758 PO 決 ④·유나 定 2026-09-10)
3758이 「이메일을 이름 자리에 넣는」 클래스를 걷으며 OAuth 신규 가입은 `display_name`을 안 채우는 정직한 경로로 確定했습니다 — 그런데 `app-sidebar.tsx:447`의 `{userName && <ProfileMenu name={userName} />}`가 그 null/undefined를 그대로 걸러 프로필 메뉴 칩 자체를 안 그렸습니다.

**유나가 인증 셸 전체를 전수 확認**: `/settings`로 가는 **상시 진입점은 이 메뉴 하나뿐**(나머지 후보 3곳은 요금제 한도 모달·무인증 재설정 플로우·이미 설정 화면 안 되돌아가기라 조건부/비상시) — 즉 이름을 못 고치는 게 아니라 **테마·알림·2FA·연동 등 설정 전부에 「주소를 직접 치지 않고는」 못 닿는 셸 결함**이었습니다. 유도 장치가 아니라 결함 수정입니다.

## 처방(유나 定)
① `ProfileMenu`를 이름 유무와 무관하게 항상 그립니다. 이름이 없으면 기존 `memberDisplayLabel`+`common.memberUnnamed`(3758이 이미 세운 정본, 새 낱말 0)로 칩에 「이름 없는 구성원」을 그대로 보입니다.
② 이름이 없을 때만 메뉴에 「이름 설정」(`accountSwitcher.setName`, ko "이름 설정"/en "Set your name" — ns 관례 「{목적어} {동사}」 명사구) 항목을 추가, 기존 「설정」 항목과 같은 형·같은 `/settings` 경로(새 길 0). **재노출 조건은 만들지 않습니다** — 이름이 채워지면 그 항목이 자동으로 사라집니다(상태가 곧 표시).

## 검증
- 신규 4건(name=null → 칩 memberUnnamed·메뉴에 setName 항목+/settings 링크 · name 있으면 항목 0 · 빈 문자열도 null과 동형) — **뮤테이션**(항목 렌더 조건을 꺼 RED 확認 후 복구).
- 기존 `app-sidebar.test.tsx` 26건·`profile-menu.test.tsx` 기존 5건(약관 그룹 회귀가드·훅 추출 무회귀) 전부 GREEN.
- FE tsc 무오류 · vitest 7370 passed · i18n 가드 GREEN(신규 키 1개뿐).

## Test plan
- [x] tsc --noEmit 무오류
- [x] vitest 7370 passed(신규 4건, 뮤테이션 확認 포함)
- [x] i18n 가드 GREEN
- [ ] **캡처**: 이름 없는 픽스처 계정 — PO 눈
- [ ] **라이브**: 배포 뒤 유나 픽셀(① 칩·메뉴 존재 ② 이름 채우면 사라짐)로 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)