### PR TITLE
[SID:3779] BE 한글 사용자 문장 재발 가드 + 화면도달 부분집합 실측

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,60 @@ jobs:
             echo "baseline growth check skipped: no comparison base ($COMPARE_LABEL에 query_sentinel_baseline.txt 없음 — 이 PR이 그 파일을 «처음 도입»하는 중이면 정상이다, story #2335 자신이 그 경우다. 다음 PR부터는 develop에 파일이 있어 실제 비교가 돈다)"
           fi
 
+  # story #3779(1층, 페드루 PO 處方 2026-09-10) — BE app/ 전수의 한글 사용자 문장이 더
+  # 늘지 않게 얼린다. grandfather 베이스라인(scripts/korean_user_strings_baseline.txt):
+  # 이 lint 도입 시점 develop에 이미 있던 1308건은 실패시키지 않는다 — 베이스라인에 없는
+  # **새** 한글 문자열만 여기서 빨개진다(story #2335 query-sentinel과 동일 계약).
+  be-korean-user-strings-lint:
+    name: BE 한글 사용자 문장 재발 가드 (guard, story #3779)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan app/ for new hardcoded Korean user-facing strings
+        working-directory: backend
+        run: python3 scripts/verify_no_new_korean_user_strings.py
+      # story #2335와 동일 계약 — 베이스라인은 «줄기만» 허용한다.
+      - name: "Verify baseline can only shrink (story #3779 — no new grandfather entries)"
+        working-directory: backend
+        run: |
+          set -e
+          PR_BASE_REF="${{ github.event.pull_request.base.ref }}"
+          PUSH_BEFORE_SHA="${{ github.event.before }}"
+          COMPARE_REF=""
+          COMPARE_LABEL=""
+          if [ -n "$PR_BASE_REF" ]; then
+            git fetch origin "$PR_BASE_REF" --depth=1 2>&1 | tail -3 || true
+            COMPARE_REF="FETCH_HEAD"
+            COMPARE_LABEL="PR base:$PR_BASE_REF"
+          elif [ -n "$PUSH_BEFORE_SHA" ] && [ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            git fetch origin "$PUSH_BEFORE_SHA" --depth=1 2>&1 | tail -3 || true
+            COMPARE_REF="FETCH_HEAD"
+            COMPARE_LABEL="push-before:$PUSH_BEFORE_SHA"
+          fi
+          if [ -n "$COMPARE_REF" ] && git show "$COMPARE_REF:backend/scripts/korean_user_strings_baseline.txt" > /tmp/base_baseline.txt 2>/dev/null; then
+            grep -vE '^#|^$' /tmp/base_baseline.txt | sort -u > /tmp/base_sorted.txt
+            grep -vE '^#|^$' scripts/korean_user_strings_baseline.txt | sort -u > /tmp/head_sorted.txt
+            new_lines=$(comm -13 /tmp/base_sorted.txt /tmp/head_sorted.txt || true)
+            base_count=$(wc -l < /tmp/base_sorted.txt | tr -d ' ')
+            head_count=$(wc -l < /tmp/head_sorted.txt | tr -d ' ')
+            echo "baseline entries: base($COMPARE_LABEL)=$base_count head=$head_count"
+            if [ -n "$new_lines" ]; then
+              echo "FAIL: 베이스라인에 «새» 항목이 추가됐다 — 이 파일은 줄기만 허용한다(story #3779)." \
+                   "새 위반은 여기 grandfather로 넣지 말고 실제로 고치는(낱말표/코드정본으로 옮기는) 것이 맞다:"
+              echo "$new_lines"
+              exit 1
+            fi
+            echo "OK: baseline은 늘지 않았다(줄었으면 환영 — 그만큼 사이트가 고쳐진 것)"
+          elif [ -z "$COMPARE_REF" ]; then
+            echo "baseline growth check skipped: no comparison base (PR context 아님 + push-before 미상 — 예: 새 브랜치 최초 push)"
+          else
+            echo "baseline growth check skipped: no comparison base ($COMPARE_LABEL에 korean_user_strings_baseline.txt 없음 — 이 PR이 그 파일을 «처음 도입»하는 중이면 정상이다, story #3779 자신이 그 경우다. 다음 PR부터는 develop에 파일이 있어 실제 비교가 돈다)"
+          fi
+
   project-access-403-lint:
     name: has_project_access 403 lint (guard, story #2342)
     runs-on: ubuntu-latest

--- a/backend/scripts/korean_user_strings_baseline.txt
+++ b/backend/scripts/korean_user_strings_baseline.txt
@@ -1,0 +1,1315 @@
+# story #3779(1층, 미르코 실측 2026-09-10) grandfather baseline — 이 가드 첫 도입
+# 시점 develop의 기존 BE 한글 사용자 문장(app/ 전수, docstring·logger.*·tests·
+# alembic 제외).
+# 마이그레이션 대상 아님 — 이 게이트는 "더 늘지 않는다"만 보장한다(freeze, 처방②
+# 코드 정본+FE 번역 전환은 별건 카드).
+# 형식: 파일::문자열(줄번호 제외, 편집마다 안 흔들리게) — story #2335 query_sentinel
+# baseline과 동일 관례.
+app/core/pagination.py::cursor 형식이 바뀌었습니다(story #2428 — 페이지 경계 동률 버그 수정). next_cursor 값을 다시 받아 처음부터 호출하세요.
+app/dependencies/auth.py::body.org_id가 auth context와 불일치인
+app/dependencies/auth.py::body.project_id가 auth context와 불일치인
+app/dependencies/auth.py::요청한 org 스코프와 다른 org 의 프로젝트에 접근할 수 없습니다
+app/dependencies/auth.py::해당 조직에 속하지 않는 프로젝트인
+app/dependencies/auth.py::해당 조직의 멤버가 아닌
+app/dependencies/auth.py::해당 프로젝트 접근권이 없는
+app/dependencies/auth.py::해당 프로젝트의 멤버가 아닌
+app/dependencies/project_scope.py::여러 프로젝트에 접근 가능한 키입니다. 요청에 project_id를 지정하거나 PATCH /api/v2/auth/me/default-project로 기본 프로젝트를 설정하세요.
+app/main.py::신뢰 — 게이트·검증·감사 로그
+app/main.py::작업 — 스토리·에픽·스프린트·워크플로우·산출물
+app/main.py::조직 — 구성원·역할·워크포스·신뢰 프로필·설정·통신
+app/main.py::지식 — 문서·스토리지·조직 학습(loop)
+app/models/reference_semantic_candidate.py::근거인용
+app/models/reference_semantic_candidate.py::낳음
+app/models/reference_semantic_candidate.py::대체
+app/models/reference_semantic_candidate.py::동종사례
+app/models/reference_semantic_candidate.py::명시적_무관
+app/models/reference_semantic_candidate.py::잇따름
+app/realtime_main.py::SSE router만 서빙 — app.main과 별개 entrypoint(#2089)
+app/realtime_main.py::Sprintable Realtime Gateway (stage2 측정용 시제품)
+app/repositories/organization.py::구현
+app/repositories/organization.py::디자인
+app/repositories/organization.py::영향도(impact) 확認 없이 삭제됨 — 조회 실패 상태에서 사용자가 명시적으로 진행을 인정
+app/repositories/standup.py::WITH roster AS (\n        -- 1) owner/admin org-wide 휴먼 (canonical = org_member.id)\n        SELECT om.id AS cid\n        FROM org_members om\n        WHERE om.org_id = :org AND om.deleted_at IS NULL AND om.role IN ('owner','admin')\n        UNION\n        -- 2) project_access grant (휴먼: canonical = org_member.id). ⚠️ 실 grant 플로우\n        --    (create_project_access)는 org_member_id만 세팅하고 member_id는 NULL로 둔다(0075 백필분만\n        --    member_id 채워짐) → member_id 키는 신규 grant-only 휴먼을 누락. org_member_id로 집계.\n        --    (에이전트 direct placement는 org_member_id NULL이라 자연 제외 — 휴먼 grant만.)\n        SELECT pa.org_member_id AS cid\n        FROM project_access pa\n        JOIN org_members om2 ON om2.id = pa.org_member_id AND om2.deleted_at IS NULL\n        WHERE pa.project_id = :proj AND pa.permission = 'granted' AND pa.org_member_id IS NOT NULL\n        UNION\n        -- 3) 레거시 휴먼 team_member → canonical(alias)\n        SELECT a.member_id AS cid\n        FROM team_members tm\n        JOIN member_identity_aliases a ON a.alias_id = tm.id\n        WHERE tm.project_id = :proj AND tm.type = 'human' AND tm.is_active = true\n    ), submitted AS (\n        -- 51447ca0: projection — 제출 여부는 entry.project_id 가 아니라 standup_entry_projects\n        -- link 로 판정(org-level 엔트리가 링크된 프로젝트서 submitted). "org 1번 제출=linked\n        -- 프로젝트 전부 not-missing". legacy 엔트리는 0099 백필 링크로 동일 커버.\n        SELECT DISTINCT COALESCE(a.member_id, se.author_id) AS cid\n        FROM standup_entries se\n        JOIN standup_entry_projects sep ON sep.entry_id = se.id\n        LEFT JOIN member_identity_aliases a ON a.alias_id = se.author_id\n        WHERE se.org_id = :org AND sep.project_id = :proj AND se.date = :date\n    )\n    SELECT r.cid FROM roster r WHERE r.cid NOT IN (SELECT cid FROM submitted)
+app/repositories/workflow_trigger_type.py::QA 검수 요청
+app/repositories/workflow_trigger_type.py::담당자 간 인계
+app/repositories/workflow_trigger_type.py::메모 답신
+app/repositories/workflow_trigger_type.py::배포 요청
+app/repositories/workflow_trigger_type.py::스토리 담당자 변경
+app/repositories/workflow_trigger_type.py::스토리 상태 전이
+app/repositories/workflow_trigger_type.py::스프린트 또는 에픽 킥오프
+app/repositories/workflow_trigger_type.py::코드 리뷰 요청
+app/routers/a2a.py::---\n[A2A] 이 task의 완료 신호는 이 메시지 스레드에 대한 답신입니다.\nreply_thread_id:
+app/routers/a2a.py::/rpc 호출은 그 에이전트의 org에 소속된 Sprintable 발급 자격증명이 필요(외부 파트너 발급 경로는 미구현 — E-A2A-EXTERNAL 후속)
+app/routers/a2a.py::Sprintable 프로젝트/AC/정책 컨텍스트를 A2A task에 첨부(opt-in, A2A-Extensions 헤더로 활성화)
+app/routers/a2a.py::— role_template 미배정(recruit 이전)
+app/routers/a2a.py::완료 시 sprintable_send_chat_message(thread_id=conversation_id, reply_thread_id=reply_thread_id, content=<결과>)로 회신하세요.
+app/routers/agent_gateway.py::SELECT\n                e.id::text            AS event_id,\n                e.event_type,\n                e.recipient_seq,\n                e.source_entity_type,\n                e.source_entity_id::text AS source_entity_id,\n                e.sender_id::text     AS sender_id,\n                e.recipient_id::text  AS recipient_id,\n                e.payload,\n                e.created_at,\n                e.project_id::text    AS project_id,\n                e.org_id::text        AS org_id,\n                c.title               AS conversation_title,\n                tm.name               AS sender_name\n            FROM events e\n            -- d0bca260: conversation_title 도출. payload.conversation_id가 uuid 형태일 때만 join\n            -- (비-대화 이벤트는 NULL → 안전). 36자 uuid 패턴 가드로 ::uuid 캐스트 에러 0.\n            LEFT JOIN conversations c\n                ON e.payload->>'conversation_id' ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'\n               AND c.id = (e.payload->>'conversation_id')::uuid\n            -- d0bca260 AC3: sender_name. events.sender_id는 team_members FK라 직접 join(canonical 무관).\n            LEFT JOIN team_members tm ON tm.id = e.sender_id\n            WHERE e.recipient_id = CAST(:agent_id AS uuid)\n              AND e.recipient_seq > :after_seq\n            ORDER BY e.recipient_seq ASC\n            LIMIT :limit
+app/routers/agent_message_policy.py::SELECT om.id, om.org_id, om.user_id, om.role,\n                   om.created_at, om.deleted_at,\n                   u.email,\n                   COALESCE(NULLIF(m.name, ''), NULLIF(u.display_name, '')) AS name  -- story #3758: email 폴백 0(name 슬롯만·email 컬럼은 그대로)\n            FROM org_members om\n            LEFT JOIN users u ON u.id = om.user_id\n            LEFT JOIN members m\n                   ON m.org_id = om.org_id AND m.user_id = om.user_id\n                  AND m.type = 'human' AND m.deleted_at IS NULL\n            WHERE om.org_id = :org_id AND om.deleted_at IS NULL\n            ORDER BY om.created_at
+app/routers/analytics.py::epic_id 또는 epic_ids 중 정확히 하나를 지정하십시오
+app/routers/analytics.py::epic_ids가 비어 있습니다
+app/routers/analytics.py::epic_ids는 콤마구분 UUID 목록이어야 합니다
+app/routers/analytics.py::콤마구분 UUID 목록 — 화면이 지금 그리는 레인 집합
+app/routers/analytics.py::콤마구분 UUID 목록(story #2679 배치)
+app/routers/assets.py::name 부분검색(ILIKE)
+app/routers/assets.py::같은 위치에 동일한 이름의 폴더가 이미 있습니다
+app/routers/assets.py::메시지
+app/routers/assets.py::업로드 URL 서명 실패
+app/routers/assets.py::업로드된 객체를 찾을 수 없습니다(PUT 미완료?)
+app/routers/assets.py::이 스코프로 발급된 업로드 경로가 아닙니다
+app/routers/assets.py::자를 초과할 수 없습니다
+app/routers/assets.py::자산 내용을 불러올 수 없습니다. 잠시 후 다시 시도하세요.
+app/routers/assets.py::폴더 이름은
+app/routers/assets.py::폴더 이름은 비워둘 수 없습니다
+app/routers/attachments.py::GCS object path (bare·스킴 없음·conv/story 전용)
+app/routers/auth.py::이 작업은 브라우저 세션에서만 가능합니다
+app/routers/auth_firebase_internal.py::인데 FIREBASE_BFF_INTERNAL_SECRET 미설정 — 내부 세션 mint/consume 엔드포인트가 인증 없이 공개된다(fail-closed·산티아고 §9 finding 4·story #2071 K_SERVICE 판정 포함).
+app/routers/billing_keys.py::) 후 삭제 가능합니다.
+app/routers/billing_keys.py::구독 종료일(
+app/routers/billing_keys.py::활성 유료 구독이 종료된 후 결제수단을 삭제할 수 있습니다.
+app/routers/bridge.py::(빈 메시지)
+app/routers/bridge.py::HITL 거부 처리한.
+app/routers/bridge.py::HITL 승인 처리한.
+app/routers/bridge.py::HITL 요청 ID가 유효하지 않는.
+app/routers/bridge.py::HITL 요청 정보를 읽지 못한.
+app/routers/bridge.py::HITL 요청을 찾지 못한.
+app/routers/bridge.py::Microsoft Teams 연동 미설정 사용자
+app/routers/bridge.py::Slack 계정이 Sprintable 팀원에 연결되지 않은.
+app/routers/bridge.py::Slack 사용자 정보를 확인하지 못한.
+app/routers/bridge.py::Slack 연동 미설정 사용자
+app/routers/bridge.py::Slack에서 승인한
+app/routers/bridge.py::가 Slack에서 거부한
+app/routers/bridge.py::이미 처리된 HITL 요청인.
+app/routers/bridge.py::지원하지 않는 HITL action인.
+app/routers/campaigns.py::campaign 생성은 휴먼 멤버만 가능합니다(에이전트는 조회만).
+app/routers/campaigns.py::campaign을 찾을 수 없습니다:
+app/routers/channel_connections.py::' 채널은 샌드박스 연결을 지원하지 않습니다.
+app/routers/channel_connections.py::15분이 지나 선택 대기 상태가 만료됐습니다. 다시 연결해주세요.
+app/routers/channel_connections.py::OAuth state가 위조되었거나 만료되었습니다.
+app/routers/channel_connections.py::OAuth state가 이 조직에 속하지 않습니다.
+app/routers/channel_connections.py::app_password가 필요합니다.
+app/routers/channel_connections.py::channel connection을 찾을 수 없습니다:
+app/routers/channel_connections.py::secret이 필요합니다.
+app/routers/channel_connections.py::site_url·username·app_password가 모두 필요합니다.
+app/routers/channel_connections.py::target_url·secret이 모두 필요합니다.
+app/routers/channel_connections.py::는 붙여넣기형 연결 대상이 아닙니다.
+app/routers/channel_connections.py::는 아직 지원하지 않습니다.
+app/routers/channel_connections.py::붙여넣기형 연결만 자격을 바꿀 수 있습니다.
+app/routers/channel_connections.py::샌드박스 채널 연결은 조직 owner 또는 admin만 가능합니다.
+app/routers/channel_connections.py::선택 대기 상태를 찾을 수 없습니다(이미 사용됐거나 존재하지 않습니다).
+app/routers/channel_connections.py::선택한 페이지가 이 선택 대기 상태의 후보 목록에 없습니다.
+app/routers/channel_connections.py::선택한 페이지를 더는 이 계정에서 관리할 수 없습니다.
+app/routers/channel_connections.py::연결에 저장된 토큰이 없습니다.
+app/routers/channel_connections.py::연결할 수 있는 페이지가 없습니다 — 이 계정이 관리하는 Facebook 페이지가 없거나, 페이지 목록 권한을 허용하지 않았습니다.
+app/routers/channel_connections.py::이 선택 대기 상태를 시작한 사람만 페이지를 고를 수 있습니다.
+app/routers/channel_connections.py::이 조직에 등록된 채널 앱 자격이 없습니다. 먼저 앱 자격을 등록해주세요.
+app/routers/channel_connections.py::이 환경에서 샌드박스 채널이 비활성화돼 있습니다(SANDBOX_CHANNEL_ENABLED).
+app/routers/channel_connections.py::재연결 대상 연결을 찾을 수 없습니다.
+app/routers/channel_connections.py::채널 연결·해제·재인증은 조직 owner만 가능합니다.
+app/routers/channel_connections.py::채널 연결은 휴먼 멤버만 가능합니다(에이전트는 토큰을 읽거나 다룰 수 없습니다).
+app/routers/channel_post_comment_replies.py::AC4 — 대상 댓글 상태를 읽는 시점에 계산(저장 안 함). null=아직 게이트가 없다(draft, 판정 대상 아님). "current"=봉인 시점과 동일. "changed"=대상 댓글 본문이 봉인 이후 바뀜(sha 불일치) — 승인은 가능하나 이 사실이 실린다. "deleted"=대상 댓글이 삭제됨 — submit·approve 모두 409로 막힌다(deleted가 changed보다 우선).
+app/routers/channel_post_comment_replies.py::PublicationCommand.status 그대로 — 다음 할 일이 갈리는 네 값(유나 §22-15): "pending"(백오프 대기 중, 기다리면 자동 재시도) · "blocked"(연결 복구 필요, 사람이 재인증해야 함) · "dead_letter"(자동 재시도 포기, 사람 판단 필요) · "voided"(전제가 바뀌어 종결, 재시도 개념 자체가 안 맞음). 그 외 "completed" 등은 성공/진행 중.
+app/routers/channel_post_comment_replies.py::transient 백오프 다음 시도 시각(ISO) — 없으면 null.
+app/routers/channel_post_comment_replies.py::voided 사유(PublicationCommand.reason_code 그대로, 새 이름 짓지 않음 — 이 컬럼은 channel_post 발행류(publication_command.py)와 공유라 열거를 닫지 않는다). 페드루 PO 대조(2026-09-06) — **현재 관측 값**: "GATE_NOT_APPROVED_OR_RESEALED"(게이트 재검증 실패) · "TARGET_COMMENT_DELETED"(승인 뒤 워커 도달 前 대상 댓글 삭제 레이스) · "CONTENT_CHANGED"(channel_posts.py 재승인 필요 전이 축, 댓글 답변 경로가 아니어도 같은 컬럼에 실린다). 이 외에도 미래 값이 더 생길 수 있다 — 화면은 아는 값만 문구로 대응하고 모르는 값은 원문 그대로/일반 문구로 안전히 처리해야 한다. voided 아니면 null.
+app/routers/channel_post_comment_replies.py::답변 단건 조회(에이전트 가능) — target_comment_state 포함
+app/routers/channel_post_comment_replies.py::답변 대상 댓글이 삭제되어 상신할 수 없습니다.
+app/routers/channel_post_comment_replies.py::답변 상신(휴먼 전용) — external_publish 게이트 생성
+app/routers/channel_post_comment_replies.py::답변 초안 생성(에이전트 가능)
+app/routers/channel_post_comment_replies.py::답변을 찾을 수 없습니다:
+app/routers/channel_post_comment_replies.py::댓글을 story로 전환
+app/routers/channel_post_comment_replies.py::댓글을 찾을 수 없습니다:
+app/routers/channel_post_comment_replies.py::안 보낸 초안이 이미 있습니다.
+app/routers/channel_post_comment_replies.py::유나 design §11-5 세 값(connection|needs_check|transient) — 실패 없었으면 null.
+app/routers/channel_post_comment_replies.py::이 액션은 휴먼 멤버만 가능합니다.
+app/routers/channel_post_comment_replies.py::이 채널은 답변 발송을 지원하지 않습니다.
+app/routers/channel_post_comment_replies.py::조각②-b(additive) — 봉인 시점(submit) 대상 댓글 원문. null=아직 게이트가 없다(draft)이거나 이 필드 추가 前에 submit된 구버전 게이트. 표시 전용 — target_comment_state 판정은 여전히 target_text_sha256(비노출)만 쓴다.
+app/routers/channel_post_comments.py::PublicationCommand.status 그대로 — 다음 할 일이 갈리는 네 값(유나 §22-15): "pending"(백오프 대기 중, 기다리면 자동 재시도) · "blocked"(연결 복구 필요, 사람이 재인증해야 함) · "dead_letter"(자동 재시도 포기, 사람 판단 필요) · "voided"(전제가 바뀌어 종결, 재시도 개념 자체가 안 맞음). 그 외 "completed" 등은 성공/진행 중.
+app/routers/channel_post_comments.py::transient 백오프 다음 시도 시각(ISO) — 없으면 null.
+app/routers/channel_post_comments.py::voided 사유(PublicationCommand.reason_code 그대로, 새 이름 짓지 않음 — 이 컬럼은 channel_post 발행류(publication_command.py)와 공유라 열거를 닫지 않는다). 페드루 PO 대조(2026-09-06) — **현재 관측 값**: "GATE_NOT_APPROVED_OR_RESEALED"(게이트 재검증 실패) · "TARGET_COMMENT_DELETED"(승인 뒤 워커 도달 前 대상 댓글 삭제 레이스) · "CONTENT_CHANGED"(channel_posts.py 재승인 필요 전이 축, 댓글 답변 경로가 아니어도 같은 컬럼에 실린다). 이 외에도 미래 값이 더 생길 수 있다 — 화면은 아는 값만 문구로 대응하고 모르는 값은 원문 그대로/일반 문구로 안전히 처리해야 한다. voided 아니면 null.
+app/routers/channel_post_comments.py::댓글 재수집은 휴먼 멤버만 가능합니다.
+app/routers/channel_post_comments.py::발행 기록을 찾을 수 없습니다:
+app/routers/channel_post_comments.py::연결이 활성 상태가 아니라 댓글을 대조/수집할 수 없습니다 — 연결 화면에서 확인해 주세요.
+app/routers/channel_post_comments.py::유나 design §11-5 세 값(connection|needs_check|transient) — 실패 없었으면 null.
+app/routers/channel_post_comments.py::이 채널은 댓글 수집을 지원하지 않습니다.
+app/routers/channel_post_comments.py::지금은 댓글을 다시 수집할 수 없습니다 — 잠시 후 다시 시도해 주세요.
+app/routers/channel_post_comments.py::채널 연결이 만료되어 댓글을 수집할 수 없습니다 — 연결 화면에서 다시 연결해 주세요.
+app/routers/channel_post_comments.py::채널 연결이 해지되어 댓글을 수집할 수 없습니다 — 연결 화면에서 다시 연결해 주세요.
+app/routers/channel_post_comments.py::채널 인증에 문제가 있어 댓글을 수집할 수 없습니다 — 연결 화면에서 확인해 주세요.
+app/routers/channel_post_comments.py::채널 쪽 호출이 많아 지금은 다시 수집할 수 없습니다 — 잠시 후 다시 시도해 주세요.
+app/routers/channel_post_comments.py::채널에서 일시적인 오류가 발생해 다시 수집하지 못했습니다 — 잠시 후 다시 시도해 주세요.
+app/routers/channel_posts.py::command를 찾을 수 없거나 재시도 대상이 아닙니다
+app/routers/channel_posts.py::draft를 찾을 수 없습니다:
+app/routers/channel_posts.py::hook_key는 64자 이하의 영문·숫자·-·_ 조합이어야 합니다
+app/routers/channel_posts.py::scheduled_at은 timezone 정보가 있어야 합니다(예: Z 또는 +09:00)
+app/routers/channel_posts.py::scheduled_at은 현재 시각 이후여야 합니다
+app/routers/channel_posts.py::scheduled_from은 scheduled_to보다 늦을 수 없습니다.
+app/routers/channel_posts.py::story #3614(AC2) — true면 폐기된(status='withdrawn') 초안도 목록에 포함한다(「폐기됨 보기」 필터). 기본은 제외 — 폐기는 결재함·목록 양쪽에서 사라진다.
+app/routers/channel_posts.py::story #3734 — true면 보관된(deleted_at not null) 초안도 목록에 포함한다(「보관됨 보기」 필터). include_withdrawn과 독립 축. 기본은 제외.
+app/routers/channel_posts.py::true면 gate.sealed_scheduled_at이 null인 draft만(캘린더 「날짜 미정」 레인). scheduled_from/scheduled_to와 상호 배타. 게이트 자체가 없는(아직 상신 안 한) 순수 초안도 포함한다 — 둘 다 「날짜 미정」이라는 점에서 같은 부류다(유나 §11-1).
+app/routers/channel_posts.py::unscheduled는 scheduled_from/scheduled_to와 함께 줄 수 없습니다.
+app/routers/channel_posts.py::«마지막 발행» publication의 id(버전 무관) — published_at/permalink/external_id와 같은 publication 행에서 온다. 발행 済 게시물에 새 버전이 생겨 재승인 대기(gate pending) 中이어도 null이 되지 않는다: 밖에 나가 있는 게시물은 새 버전과 무관하게 살아 있다(story #3525). 댓글·인사이트 조회 API(/publications/{publication_id}/comments·insights)의 path 파라미터가 이 값이다. "지금 버전 자체"의 발행 시도 상태는 publication_status/error_code가 별도로 담당(다른 축).
+app/routers/channel_posts.py::발행 취소·회수는 조직 owner 또는 admin만 가능합니다.
+app/routers/channel_posts.py::발행 취소·회수는 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지).
+app/routers/channel_posts.py::예약 시각 범위 끝(tz-aware ISO, gate.sealed_scheduled_at 기준). unscheduled와 함께 줄 수 없다.
+app/routers/channel_posts.py::예약 시각 범위 시작(tz-aware ISO, gate.sealed_scheduled_at 기준 — publication_command의 스냅샷 값이 아니다). unscheduled와 함께 줄 수 없다.
+app/routers/channel_posts.py::원문을 찾을 수 없습니다:
+app/routers/channel_posts.py::은 timezone 정보가 있어야 합니다(예: Z 또는 +09:00).
+app/routers/channel_posts.py::채널 포스트 발행은 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지).
+app/routers/content_rules.py::콘텐츠 규칙 편집은 조직 owner·admin만 가능합니다.
+app/routers/context_pack.py::임베딩 서비스를 사용할 수 없습니다. 잠시 후 다시 시도하세요.
+app/routers/context_pack.py::해당 프로젝트 접근 권한이 없습니다
+app/routers/conversations.py::님의 새 메시지
+app/routers/conversations.py::님이 회원님을 멘션했습니다
+app/routers/conversations.py::서킷브레이커 해제는 org owner/admin만 가능합니다.
+app/routers/conversations.py::폭주 감지로 이 대화의 agent 발신이 일시 차단되었습니다 — org owner/admin의 해제 또는 자동 해소를 기다려주세요.
+app/routers/conversations.py::현재 보고 있는 프로젝트(제외 대상)
+app/routers/cron.py::관찰된 참조 0건(수집범위: mention/embed, source=chat_message·doc만 — PR/커밋/증거자유텍스트는 미수집이라 이 수에 없음)
+app/routers/cron.py::인데 CRON_SECRET 미설정 — 내부 cron 엔드포인트가 인증 없이 공개된다(fail-closed·story #2072).
+app/routers/deeplink_manifest.py::entries[].app.target_promotion_pending가 true인 엔트리는 target이 가리키는 화면이 이 클라이언트 플랫폼에는 아직 전용 라우트로 존재하지 않는 잠정/폴백 상태임을 뜻한다. target 문자열 자체는 유효한 의미 식별자다(장차 승격될 실제 화면 이름) — 클라이언트는 이 값을 조건부로 해석(예: URL 조립)하지 말고, 그 화면이 아직 없으면 자신의 현재 최선의 대체 착지(상위 화면 등)로 매핑하거나 AC4 안전 폴백(`지금` 탭)을 적용해야 한다. 승격되면(전용 라우트 신설) 이 플래그가 false로 바뀌고 클라이언트는 정식 매핑을 쓴다.
+app/routers/deeplink_manifest.py::이 매니페스트를 소비하는 클라이언트는 자신이 지원하는 schema_version(MAJOR)과 이 응답의 schema_version이 다르면(특히 응답 값이 더 높으면) 이 응답을 신뢰하지 말고 클라이언트에 번들된 로컬 SSOT 사본으로 폴백해야 한다. PATCH 수준 변경(신규 엔트리 추가·설명 문구 변경)은 schema_version을 올리지 않으므로 구버전 클라이언트도 안전하게 소비 가능하다 — MAJOR bump는 Layer 1 필드(target 값 체계·parentTab enum·returnPolicy 의미) 변경 시에만 발생한다.
+app/routers/dependencies.py::사이클이 발생하는 의존성은 허용되지 않음
+app/routers/dependencies.py::의존성 대상 아이템을 찾을 수 없음
+app/routers/dependencies.py::의존성을 찾을 수 없음
+app/routers/dependencies.py::이미 존재하는 의존성
+app/routers/dependencies.py::자기참조 의존성은 허용되지 않음
+app/routers/dev_webhook_stub.py::fail-closed: prod 배포에 WEBHOOK_TEST_STUB_ENABLED가 켜져 있습니다(story e4fc29fa 조각④ AC4).
+app/routers/dev_webhook_stub.py::s 창을 벗어났습니다
+app/routers/dev_webhook_stub.py::timestamp/nonce 헤더가 없습니다
+app/routers/dev_webhook_stub.py::timestamp가
+app/routers/dev_webhook_stub.py::timestamp가 정수가 아닙니다
+app/routers/dev_webhook_stub.py::서명 헤더가 없습니다
+app/routers/dev_webhook_stub.py::서명이 일치하지 않습니다
+app/routers/dev_webhook_stub.py::이미 처리된 nonce입니다(재전송 거부)
+app/routers/dev_wordpress_stub.py::fail-closed: prod 배포에 WORDPRESS_TEST_STUB_ENABLED가 켜져 있습니다(story e4fc29fa 조각③c AC4).
+app/routers/docs.py::(sort_order,id) 복합 커서 — 이전 페이지 meta.next_cursor 값 그대로
+app/routers/docs.py::Doc 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/docs.py::comma-separated doc ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)
+app/routers/docs.py::문서가 다른 곳에서 수정됨 — 최신본을 다시 불러오세요
+app/routers/docs.py::유효하지 않은 슬러그
+app/routers/docs.py::이미 사용 중인 슬러그
+app/routers/docs.py::전문 검색 — 제목 + 본문
+app/routers/docs.py::해당 문서의 프로젝트 접근 권한이 없습니다
+app/routers/events.py::(설정 화면에서 등록하세요).
+app/routers/events.py::)는
+app/routers/events.py::)는 human 발행자만 허용합니다.
+app/routers/events.py::** 담당 —
+app/routers/events.py::- 게이트:
+app/routers/events.py::- 다음 단계:
+app/routers/events.py::- 다음 단계: 없음(마지막 stage)
+app/routers/events.py::- 다음 단계로 넘기는 발행 예시: publish_event(
+app/routers/events.py::- 다음 행동:
+app/routers/events.py::- 다음 행동: channel=
+app/routers/events.py::- 다음 행동: 산출물을 수정한 뒤, 같은 레시피 정의의 approve stage 이벤트를 다시 발행하세요(payload.previous_output_doc_id=수정본 id) — 게이트는 그 발행으로 자동 재오픈됩니다.
+app/routers/events.py::- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 확認합니다.
+app/routers/events.py::- 다음 행동: 이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 이 승인 게이트를 확인하는 발행 도구를 쓰세요).
+app/routers/events.py::- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다.
+app/routers/events.py::- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.
+app/routers/events.py::- 단계 `
+app/routers/events.py::- 대상 산출물:
+app/routers/events.py::- 사유:
+app/routers/events.py::- 할 일:
+app/routers/events.py::Cursor: ISO 8601 created_at, fetch after this time(오래된순 정렬 forward-cursor)
+app/routers/events.py::[이벤트]
+app/routers/events.py::[이벤트] preset.gate.verdict
+app/routers/events.py::extra_broadcast_member_ids에 이 org의 실존 회원이 아닌 id가 있습니다:
+app/routers/events.py::name은 key와 같을 수 없습니다(코드 키를 이름으로 쓸 수 없음)
+app/routers/events.py::name은 비울 수 없습니다(공백뿐인 값도 안 됨)
+app/routers/events.py::payload에서 project를 해소할 수 없습니다(work_item_type+work_item_id 또는 goal_id 필요).
+app/routers/events.py::role_mapping에 이 정의의 stage_metadata에 없는 stage가 있습니다:
+app/routers/events.py::role만 허용합니다.
+app/routers/events.py::미확認
+app/routers/events.py::발행 시 필수 항목:
+app/routers/events.py::발행은 성공했으나 escalation·broadcast 대상이 모두 0명입니다 — work_item이 미배정이거나 routing이 아무도 가리키지 않습니다.
+app/routers/events.py::시스템 발행
+app/routers/events.py::아래는 이 조직에서 발행 가능한 이벤트 전부입니다. 사이클형 이벤트는 각 단계마다 누가(역할) 무엇을(행동) 해야 하는지 그대로 적혀 있습니다 — 외우지 말고 그때그때 이 표를 다시 확인하세요. 한 번에 한 단계만 진행하세요. 무엇을 할지 모르겠으면 지어내지 말고 이 표에서 찾으세요.
+app/routers/events.py::앞 단계 산출물
+app/routers/events.py::에 anchor할 project가 없음 — 시스템 발신자 프로비저닝 불가
+app/routers/events.py::에 대한 커넥터 매핑이 없습니다 — 조직 설정에 channel_connector_map을 등록하세요.
+app/routers/events.py::을 지원하는 커넥터가 이 org에 등록돼 있지 않습니다 — 설정 스킬을 먼저 실행하세요.
+app/routers/events.py::의 필수 설정값이 비어 있습니다 —
+app/routers/events.py::이 이벤트(
+app/routers/events.py::이 이벤트는 다음 상황에서 발행하세요:
+app/routers/events.py::지정된 conversation_id에 escalation 대상이 참가자로 없어 발행을 거부합니다(지시가 조용히 미도달하는 것을 막기 위함).
+app/routers/events.py::커넥터가 등록돼 있지 않습니다 — 설정 스킬을 먼저 실행하세요.
+app/routers/events.py::커넥터는 등록돼 있지만 필수 설정값이 아직 비어 있습니다 — 설정 화면에서 등록하세요.
+app/routers/events.py::커넥터로 발행하세요(channel=
+app/routers/evidence.py::(gate_approval은 게이트 승인 시 시스템이 자동 생성)
+app/routers/evidence.py::)와 일치해야 합니다.
+app/routers/evidence.py::currency는 조직 정책 통화(
+app/routers/evidence.py::generation_cost evidence의 cost_minor는 0 이상의 정수여야 합니다.
+app/routers/evidence.py::story #2314 AC3② — embed 칩이 evidence의 «담긴 곳»으로 한 번에 건너뛸 자리.\n    work_item_type='story'면 work_item_id 그 자체, 'task'면 그 task의 부모 story_id(2단\n    조인) — FE가 evidence→task→story로 왕복 fetch하지 않도록 GET /{id} 응답에 얹는다.
+app/routers/evidence.py::story #2722 — NULL="버전 미상"(구 데이터 또는 아티팩트 근거 아님), 값 있으면 evidence\n    생성 시각에 서버가 고정한 그 버전.
+app/routers/evidence.py::story #2722 — artifact_version_id 하나로는 FE가 기존 ArtifactExpandDialog 왕복\n    (artifactId+versionNumber 필요, artifact-gallery-view.tsx의 handleOpenArtifact와 동일\n    계약)을 못 채운다 — evidence.artifact_version_id → artifact_versions 1-hop 조인 결과를\n    denorm으로 얹는다(둘 다 artifact_version_id가 있을 때만 채워짐, 새 컬럼 아님).
+app/routers/evidence.py::verification_sheet evidence의 items는 1건 이상의 배열이어야 합니다.
+app/routers/evidence.py::verification_sheet evidence의 각 item은 name(비어있지 않은 문자열)·verdict(
+app/routers/evidence.py::중 하나)가 필요하고, note는 있으면 문자열이어야 합니다.
+app/routers/gate_metrics.py::window 끝(이하)
+app/routers/gate_metrics.py::window 시작(이상)
+app/routers/gates.py::)는 재평가 대상이 아닙니다(pending/auto_passed만 가능).
+app/routers/gates.py::GitHub App 설치가 없어 재평가할 수 없습니다.
+app/routers/gates.py::GitHub PR head SHA를 확인할 수 없습니다.
+app/routers/gates.py::GitHub PR 정보 조회 실패 — 잠시 후 다시 시도해 주세요.
+app/routers/gates.py::GitHub 인증 토큰 발급 실패 — 잠시 후 다시 시도해 주세요.
+app/routers/gates.py::comma-separated gate ids — 배치 앵커 조회
+app/routers/gates.py::doc 결재 게이트는 doc 상신 경로로만 생성됩니다 (직접 생성 불가).
+app/routers/gates.py::doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).
+app/routers/gates.py::generic transition 은
+app/routers/gates.py::merge 게이트만 재평가를 지원합니다.
+app/routers/gates.py::게이트 대상 커밋이 승인 확인 이후 변경되었습니다. 최신 내용을 다시 확인한 뒤 승인해주세요.
+app/routers/gates.py::게이트 무효화는 org owner/admin 만 가능합니다.
+app/routers/gates.py::게이트 상태(
+app/routers/gates.py::게이트 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 승인 불가).
+app/routers/gates.py::게이트에 연결된 PR 정보가 없어 재평가할 수 없습니다.
+app/routers/gates.py::결정 요청
+app/routers/gates.py::결정 요청은 결재자를 지정해야 합니다.
+app/routers/gates.py::고위험(risk_grade=high) 게이트 승인은 근거 열람 확인(evidence_viewed=true)이 필수입니다.
+app/routers/gates.py::고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.
+app/routers/gates.py::답변 대상 댓글이 삭제되어 승인할 수 없습니다.
+app/routers/gates.py::대상 대화에 지정 결재자가 참여하고 있지 않습니다.
+app/routers/gates.py::만 허용합니다. voided/held/unhold 는 전용 엔드포인트(/void·/hold·/unhold)를 사용하세요.
+app/routers/gates.py::본인에게 위임할 수 없습니다.
+app/routers/gates.py::본인을 결재자로 지정할 수 없습니다.
+app/routers/gates.py::본인이 상신한 doc 결재는 본인이 승인/거부할 수 없습니다 (self-approval 금지·상신자 미검증 차단).
+app/routers/gates.py::상신자 또는 지정 결재자 본인만 토스할 수 있습니다.
+app/routers/gates.py::승인 뒤 내용이 바뀌었습니다. 재상신(submit)한 뒤 다시 승인해주세요.
+app/routers/gates.py::위임 대상이 이 조직의 결재 권한자(owner/admin)가 아닙니다.
+app/routers/gates.py::이 게이트 유형은 토스를 지원하지 않습니다.
+app/routers/gates.py::이 게이트를 승인/거부할 권한이 없습니다 (해당 프로젝트의 owner/admin이어야 합니다). 프로젝트 관리자에게 권한을 요청하세요.
+app/routers/gates.py::이 액션은 org owner 만 가능합니다.
+app/routers/gates.py::이 액션은 org owner/admin 만 가능합니다.
+app/routers/gates.py::이미 처리된 결재는 위임할 수 없습니다.
+app/routers/gates.py::이미 처리된 결재는 토스할 수 없습니다.
+app/routers/gates.py::이미 처리된 결재입니다. 되돌리려면 PO에게 재검토를 요청해주세요.
+app/routers/gates.py::지정 결재자 본인만 위임할 수 있습니다.
+app/routers/gates.py::지정 결재자가 없는 게이트는 토스할 수 없습니다.
+app/routers/gates.py::지정한 결재자는 결재 자격(owner/admin)이 없습니다.
+app/routers/goals.py::"glance"면 participant_ids/focal_story가 추가로 붙는다(story #2298, 옵트인).
+app/routers/goals.py::Goal 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/goals.py::comma-separated goal ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)
+app/routers/goals.py::goal status 변경은 POST /goals/{id}/transition 전용 엔드포인트를 사용하세요 (FSM·SoD·gate 우회 방지).
+app/routers/hitl.py::HITL 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/hitl.py::고위험 HITL 승인은 사유(response_text) 입력이 필수입니다.
+app/routers/hitl_config.py::merge_gate_default_approver_member_id는 이 조직의 human owner/admin 멤버여야 합니다(에이전트는 requires_human 게이트에 서명할 수 없습니다).
+app/routers/hypotheses.py::가설을 찾을 수 없습니다.
+app/routers/hypotheses.py::전이는 owner 또는 org owner/admin만 가능합니다.
+app/routers/insights_board.py::days는 7 또는 30만 허용합니다.
+app/routers/insights_board.py::publication을 찾을 수 없습니다:
+app/routers/insights_board.py::story #3734 AC3 후속(PO 라이브 판정 2026-09-09) — true면 원 초안이 보관된(deleted_at not null) 발행분도 포함한다. 목록 두 곳(site-posts·channel-posts drafts)과 같은 파라미터명·같은 뜻 — 기본은 제외.
+app/routers/insights_board.py::후속 작업 생성은 휴먼 멤버만 가능합니다(에이전트는 조회만).
+app/routers/labels.py::이미 부착된 라벨
+app/routers/loops.py::루프 결정은 휴먼 멤버만 가능합니다 (에이전트 불가).
+app/routers/loops.py::루프를 찾을 수 없습니다.
+app/routers/me.py::SELECT DISTINCT p.id::text AS project_id, p.name AS project_name\n            FROM projects p\n            WHERE p.deleted_at IS NULL\n              AND (CAST(:org_id AS uuid) IS NULL OR p.org_id = :org_id)\n              AND (\n                -- 1. TeamMember 직접 등록 (기존)\n                EXISTS (\n                    SELECT 1 FROM team_members tm\n                    WHERE tm.project_id = p.id\n                      AND (tm.id = :user_id OR tm.user_id = :user_id)\n                      AND tm.is_active = true\n                      AND tm.type = 'human'\n                )\n                -- 2. ProjectAccess grant (S-MBR-10, members.py 패턴 정합)\n                OR EXISTS (\n                    SELECT 1 FROM project_access pa\n                    JOIN org_members om ON pa.org_member_id = om.id\n                    WHERE pa.project_id = p.id\n                      AND om.user_id = :user_id\n                      AND om.deleted_at IS NULL\n                      AND pa.permission = 'granted'\n                      AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)\n                )\n                -- 3. owner/admin은 grant 없이도 org 전체 (AC2, S-MBR-03 정합)\n                OR EXISTS (\n                    SELECT 1 FROM org_members om\n                    WHERE om.user_id = :user_id\n                      AND om.deleted_at IS NULL\n                      AND om.role IN ('owner', 'admin')\n                      AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)\n                      AND p.org_id = om.org_id\n                )\n              )\n            ORDER BY project_name
+app/routers/measurement_connections.py::GA4 재인증이 필요합니다.
+app/routers/measurement_connections.py::GA4가 연결되어 있지 않습니다.
+app/routers/measurement_connections.py::이 계정에서 접근 가능한 속성이 아닙니다.
+app/routers/measurement_connections.py::이 환경에 GA4 연결이 아직 구성되지 않았습니다(google_client_id/backend_url 미설정).
+app/routers/meetings.py::Meeting 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/merge_gate.py::window 끝(이하)
+app/routers/merge_gate.py::window 시작(이상)
+app/routers/notification_preferences.py::'는 event_key를 가질 수 없습니다.
+app/routers/notification_preferences.py::scope_type='event_key'는 event_key가 필수입니다.
+app/routers/notification_preferences.py::scope_type='event_key'는 scope_id를 가질 수 없습니다.
+app/routers/notifications.py::ISO datetime cursor — 이 시각 이전 항목(내림차순 다음 페이지)
+app/routers/notifications.py::True=읽지 않은 것만, False=읽은 것만
+app/routers/notifications.py::직접 is_read 지정 (unread 우선)
+app/routers/org_members.py::org admin 또는 owner 권한 필요
+app/routers/org_members.py::owner 권한이 필요한 작업입니다.
+app/routers/org_members.py::마지막 owner는 강등할 수 없습니다.
+app/routers/org_members.py::조직 owner는 삭제할 수 없습니다
+app/routers/organizations.py::'은 유효한 IANA 타임존 이름이 아닙니다(예: Asia/Seoul).
+app/routers/organizations.py::조직 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/oss.py::SPR-1: GitHub Webhook 연동하기
+app/routers/oss.py::SPR-2: 첫 번째 스프린트 계획
+app/routers/participation.py::이미 존재하는 참여 기록
+app/routers/participation.py::참여 기록을 찾을 수 없음
+app/routers/project_access.py::SELECT om.id, om.org_id, om.user_id, om.role,\n                   om.created_at, om.deleted_at,\n                   u.email,\n                   COALESCE(NULLIF(m.name, ''), NULLIF(u.display_name, '')) AS name  -- story #3758: email 폴백 0(name 슬롯만·email 컬럼은 그대로)\n            FROM org_members om\n            LEFT JOIN users u ON u.id = om.user_id\n            LEFT JOIN members m\n                   ON m.org_id = om.org_id AND m.user_id = om.user_id\n                  AND m.type = 'human' AND m.deleted_at IS NULL\n            WHERE om.org_id = :org_id AND om.deleted_at IS NULL\n            ORDER BY om.created_at
+app/routers/projects.py::Project 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/projects.py::프로젝트 삭제는 조직 owner/admin 권한이 필요합니다
+app/routers/public_docs.py::유효하지 않은 링크
+app/routers/recipe_repeat_schedules.py::수동으로 중지되었습니다
+app/routers/recipe_repeat_schedules.py::이 스케줄은 지금 다른 회차가 처리 중입니다 — 잠시 후 다시 시도하세요.
+app/routers/retros.py::AI 종합 생성에 실패했습니다. 잠시 후 다시 시도해주세요.
+app/routers/retros.py::다음가설 채택은 사람만 할 수 있습니다.
+app/routers/retros.py::다음가설 추천 생성에 실패했습니다. 잠시 후 다시 시도해주세요.
+app/routers/retros.py::이미 채택된 추천입니다.
+app/routers/retros.py::종합을 먼저 생성해야 합니다.
+app/routers/retros.py::추천 가설을 찾을 수 없습니다.
+app/routers/retros.py::회고
+app/routers/role_templates.py::그로스
+app/routers/role_templates.py::데이터
+app/routers/role_templates.py::디자인
+app/routers/role_templates.py::마케팅
+app/routers/role_templates.py::보안
+app/routers/role_templates.py::세일즈
+app/routers/role_templates.py::엔지니어링
+app/routers/role_templates.py::오퍼레이션
+app/routers/role_templates.py::콘텐츠
+app/routers/role_templates.py::품질
+app/routers/role_templates.py::프로덕트
+app/routers/role_templates.py::플랫폼/DevOps
+app/routers/session_context.py::이 시각 이후 활동만 포함(AC4 — 생략하면 recent_activity 축 전체가 null, 빈 배열이 아니다)
+app/routers/site_posts.py::draft를 찾을 수 없습니다
+app/routers/site_posts.py::draft를 찾을 수 없습니다:
+app/routers/site_posts.py::story #3734 — true면 보관된(deleted_at not null) 초안도 목록에 포함한다(「보관됨 보기」 필터). 기본은 제외.
+app/routers/site_posts.py::글 공개는 휴먼 멤버만 가능합니다 (에이전트는 초안만 제출).
+app/routers/site_posts.py::발행 취소는 조직 owner 또는 admin만 가능합니다.
+app/routers/site_posts.py::발행 취소는 휴먼 멤버만 가능합니다.
+app/routers/sprints.py::Sprint 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/sprints.py::hypothesis_id 또는 statement/metric_definition/measure_after 전부가 필요합니다.
+app/routers/sprints.py::hypothesis_id와 신규 가설 필드를 동시에 줄 수 없습니다.
+app/routers/sprints.py::statement가 비어 있을 수 없습니다.
+app/routers/sprints.py::스프린트 종료:
+app/routers/sprints.py::스프린트를 찾을 수 없습니다.
+app/routers/stories.py::' 전이:
+app/routers/stories.py::Story 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/stories.py::comma-separated story ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관)
+app/routers/stories.py::done 전이는 merge 게이트 통과 필요:
+app/routers/stories.py::human_owner_member_id는 human member만 지정할 수 있습니다.
+app/routers/stories.py::sprint 미배정 스토리만 반환
+app/routers/stories.py::story #2328(C-11 ㉡층) — 이 story의 의미 후보(status=estimated) 대상을 결과 맨 앞으로 재정렬(필터링 아님, q 비어도 동작). 해당 항목엔 is_reference_candidate=true·matched_snippet이 실린다(유나 규격, 2026-07-29).
+app/routers/stories.py::story #2532(E-FLOW-V4 S2) — 가설·목표 둘 다 안 매달린 story만 반환. SQL WHERE 레벨 필터(epic_id IS NULL AND NOT EXISTS hypothesis_story_links)라 limit/cursor/X-Total-Count 전부 필터 後 값을 정확히 반영한다(카디르 QA REQUEST_CHANGES,\n2026-08-09 — 최초 구현이던 Python 후필터는 페이지 경계 밖 유실+헤더 거짓값 결함).
+app/routers/stories.py::story #3019 — comma-separated epic ids(IN 필터). epic_id(단일)와 별개 파라미터 — include_unassigned=true와 함께 쓰면 OR(이 에픽들 소속 «또는» 미배정) 결합.
+app/routers/stories.py::story #3019 — epic_id IS NULL(가설 링크 유무 무관, 기존 unattached와 다른 개념) 인 story도 결과에 포함. epic_ids와 단독으로도 쓸 수 있다(그 경우 미배정만).
+app/routers/stories.py::story #3019 — status=done row만 created_at이 최근 N일 이내인 것으로 제한(list_board 의 done-7일 관례를 제네릭 경로에 일반화). done 아닌 상태는 무관.
+app/routers/stories.py::story #3148 — comma-separated status 목록(IN 부정) — no_sprint(list_backlog) 분기 전용. status(단일 일치)와 별개 축, 미지정 시 무영향(무회귀).
+app/routers/stories.py::title 부분검색(ILIKE) — 기존 필터와 AND 결합
+app/routers/stories.py::단계 건너뜀
+app/routers/stories.py::새 코멘트:
+app/routers/stories.py::스토리가 다른 곳에서 수정됨 — 최신본을 다시 불러오세요
+app/routers/stories.py::에 plain 값/append/restore 중 하나만 지정하세요(동시 지정 불가).
+app/routers/stories.py::에 되돌릴 직전 값이 없습니다.
+app/routers/stories.py::워크플로우 라인 정책으로 상태 전이가 차단되었습니다.
+app/routers/stories.py::워크플로우 위반 감지
+app/routers/stories.py::이 라우트는 지금 target_type='chat_message'·form='proof' 조합만 지원합니다
+app/routers/stories.py::프로젝트 내 사람-읽는 #N(project_id와 함께 사용 — N은 project 내에서만 유일)
+app/routers/support_gateway_token.py::고객 문의 에스컬레이션 —
+app/routers/tasks.py::Task 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)
+app/routers/tasks.py::comma-separated task ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)
+app/routers/tasks.py::스토리:
+app/routers/tasks.py::이 status가 아닌 것만(예: done 제외 — 미완료 목록, get_overdue_tasks가 사용)
+app/routers/tasks.py::태스크 완료:
+app/routers/team_members.py::(에이전트)이
+app/routers/team_members.py::assignee는 별도입니다(update_story의 assignee_id/assignee_ids) — 보드 배정 표시·통지 수신자는 claim이 아니라 assignee 기준입니다.
+app/routers/team_members.py::participation 미보장 — 이 org에 기본 participation role이 없어 게이트/verdict attribution이 안 잡힘(관리자 확인 필요)
+app/routers/team_members.py::먼저 조직에 초대해야 합니다
+app/routers/team_members.py::새 에이전트 합류:
+app/routers/team_members.py::을 생성했습니다.
+app/routers/verdict_capture.py::GitHub webhook 서명 검증 실패
+app/routers/verdict_capture.py::JSON object 아님
+app/routers/verdict_capture.py::JSON 파싱 실패
+app/routers/verdict_capture.py::X-GitHub-Delivery 헤더 없음
+app/routers/verdict_capture.py::story #2327 PO 판정 2026-07-30: close-on-merge 정지 — done은 사람 확認 後
+app/routers/verdict_capture.py::처리 중 오류(재시도 가능)
+app/routers/visual_artifacts.py::HTML export 업로드 실패
+app/routers/visual_artifacts.py::HTML export가 완료됐습니다.
+app/routers/visual_artifacts.py::ISO 8601 created_at, fetch after this time — 이전 페이지 meta.next_cursor 값 그대로(오래된순 정렬이라 forward-cursor)
+app/routers/visual_artifacts.py::ISO 8601 created_at, fetch before this time — 이전 페이지 meta.next_cursor 값 그대로
+app/routers/visual_artifacts.py::PNG export가 완료됐습니다.
+app/routers/visual_artifacts.py::artifact가 새 버전으로 갱신됐습니다.
+app/routers/visual_artifacts.py::comma-separated artifact ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)
+app/routers/visual_artifacts.py::delete op에는 id가 필요합니다
+app/routers/visual_artifacts.py::latest version not found — artifact 상태 비정상
+app/routers/visual_artifacts.py::signed write URL 발급 실패
+app/routers/visual_artifacts.py::source_comment_id가 이 artifact 소속이 아닙니다
+app/routers/visual_artifacts.py::update 대상 node를 찾을 수 없습니다:
+app/routers/visual_artifacts.py::산출물 export:
+app/routers/visual_artifacts.py::산출물 수정됨:
+app/routers/visual_artifacts.py::새 산출물 생성됨:
+app/routers/visual_artifacts.py::새 시각 산출물이 생성됐습니다.
+app/routers/visual_artifacts.py::새 코멘트:
+app/routers/visual_artifacts.py::생성자만 삭제할 수 있습니다
+app/routers/visual_artifacts.py::업로드된 객체를 찾을 수 없습니다(head_object 실패)
+app/routers/webhooks.py::message_id 또는 conversation_id 중 하나 필수
+app/routers/workflow_line_config.py::반려 사유(reason)는 비어있지 않아야 합니다.
+app/schemas/a2a.py::방향서 03·에이전트 속성 — 권한 범위. 표시 SSOT=ApiKey.scope(실제 매 요청 집행되는 값, persona.config.tool_allowlist 아님 — 설계 doc agent-attributes-permission-cost-stop-2939 §1 드리프트 경고 참조). 발급된 활성 키가 없으면 None.
+app/schemas/a2a.py::방향서 03·에이전트 속성 — 사용 모델. AgentPersona.model 실물 값만 표시(no-fiction, 미배정이면 None).
+app/schemas/a2a.py::방향서 03·에이전트 속성 — 예상 비용(선언, 자유 텍스트). 미선언이면 None.
+app/schemas/a2a.py::방향서 03·에이전트 속성 — 중단 조건(선언, 자유 텍스트). 미선언이면 None.
+app/schemas/api_key.py::DEPRECATED(AC3-5 ③): canonical 식별자는 members.id. 레거시 호환용 dual 유지.
+app/schemas/deeplink_manifest.py::data payload에 반드시 있어야 하는 키 이름(event_type 제외 — 그건 항상 있다고 전제). reference_id를 요구하면 필수, target 해석에 reference_id가 필요 없는 타입(예: agent_joined처럼 항상 team_member 화면으로 가지만 특정 id 없이도 목록으로 폴백 가능한 케이스는 없음 — 이 초안에선 reference_type이 있는 모든 타입이 reference_id도 요구).
+app/schemas/deeplink_manifest.py::push data payload에 org_id가 포함되는가. story #1953(P1a-S3) 갱신: deliver_expo_push()의 _build_push_data_payload()가 org_id를 전 타입 항상 포함한다(dispatch_notification()의 org_id는 non-null 필수 파라미터라 항상 값이 있음) — 그래서 매니페스트 전 엔트리가 True. (S1 초안 당시엔 실제로 전부 False였다 — 이 갭이 이번 스토리의 존재 이유였다.)
+app/schemas/deeplink_manifest.py::push data payload에 project_id가 포함되는가. story #1953 갱신: 대부분의 알림 타입은 project-scoped 엔티티(story/epic/doc/sprint/hypothesis 등, project_id NOT NULL 컬럼)에서 발화돼 True. story #1968(P1a-S3 잔여) 갱신: `gate.pending_approval`·`gate_overridden`도 True로 승격(31/33→33/33) — create_gate() 7개 호출부 전부(routers/gates.py 제네릭 생성·workflow_line_config.py·merge_verdict_gate.py 잔여 3곳 포함)가 이제 work_item_type별로 project_id를 조회/재사용해 넘기고, override_gate()의 gate_overridden 알림도 sr(활성 step_run)=None 폴백 시 동일 로직(gate_service.resolve_work_item_project_id)으로 조회한다. 유일한 구조적 None 케이스(workflow_line_config의 org-level 'wf_line_version' — project 자체가 없는 org 전체 config)는 실패/미해결이 아니라 project-scoped가 아니라는 정직한 값이다(엔트리별 주석 참고).
+app/schemas/deeplink_manifest.py::push data.event_type 원문 리터럴
+app/schemas/deeplink_manifest.py::push data.reference_type 매치용 2차 키. None이면 이 event_type은 항상 단일 target(reference_type 무관)이라 무시된다.
+app/schemas/deeplink_manifest.py::target이 아직 전용 라우트로 승격되지 않은 잠정/폴백 상태임을 FE가 하이라이트 표시하는 데 쓰는 플래그. True인 엔트리는 target이 가리키는 화면이 실제로는 아직 없고(또는 아직 모바일 전용 라우트가 없고) 승격 시점까지 안전 폴백으로 동작한다는 뜻 — 승격 스토리는 엔트리별 주석 참고.
+app/schemas/deeplink_manifest.py::결재함(approvals) 탭 배지/큐 카운트에 이 엔트리를 포함할지. parent_tab이 approvals여도 False면 화면 자체는 그대로 결재함에 남되 배지 숫자·큐 목록 카운트에서는 제외된다(예: gate_overridden — 이미 확정된 FYI 통보라 액션 대기 큐가 아님). 긴급성/정보성 구분의 실제 등급 매핑은 #1956(채널 등급)이 담당 — 여기서는 큐 카운트 제외 여부만 스텁으로 표현.
+app/schemas/deeplink_manifest.py::논리적 화면 식별자(실제 URL 아님 — 라우트는 P1a-S3~S5/P2-S* 별도 스토리가 짓는다). FE가 이 키로 실제 컴포넌트/라우트에 매핑.
+app/schemas/hypothesis.py::source_id는 loop_goal 외 source_type에서 필수입니다.
+app/schemas/retro.py::title은 비어 있을 수 없습니다
+app/schemas/sprint.py::title은 비어 있을 수 없습니다
+app/schemas/story.py::GA4 metric_definition에 필수 키 누락:
+app/schemas/story.py::metric_definition에 필수 키 누락:
+app/schemas/validators.py::중 최소 하나는 채워야 합니다
+app/schemas/visual_artifact.py::캔버스 높이 대비 %(0~100) — ratio(0~1)·픽셀 아님
+app/schemas/visual_artifact.py::캔버스 폭 대비 %(0~100) — ratio(0~1)·픽셀 아님
+app/services/admin_billing.py::(재시도 불필요)
+app/services/admin_billing.py::)가 현재 tier(
+app/services/admin_billing.py::)보다 낮음 — grant는 강등을 하지 않는다
+app/services/admin_billing.py::미존재 — grandfather 정책은 실재 버전에만 묶는다
+app/services/admin_billing.py::예상치 못한 차단(force=True인데 발생)
+app/services/admin_billing.py::의 유효 offering_version이 없어 금액을 파생할 수 없음
+app/services/admin_billing.py::이 Idempotency-Key는 다른 조직의 요청에 이미 쓰였음 — 새 키로 재시도할 것
+app/services/admin_billing.py::이미 처리됨 — 현재 상태:
+app/services/agent_onboarding_config.py::# Hermes MCP 연결
+app/services/agent_onboarding_config.py::# Sprintable Connector 안내
+app/services/agent_onboarding_config.py::## 등록 명령
+app/services/agent_onboarding_config.py::## 사용 가능한 어댑터
+app/services/agent_onboarding_config.py::## 설정
+app/services/agent_onboarding_config.py::(선택한 런타임: {runtime})
+app/services/agent_onboarding_config.py::Claude Code/Codex/Gemini/Cursor 처럼 MCP를 네이티브 지원하지 않는 런타임은 별도 SSE
+app/services/agent_onboarding_config.py::`connectors/` 레포 경로 아래 각 폴더가 자기완결(self-contained) 어댑터입니다:
+app/services/agent_onboarding_config.py::hermes는 `.mcp.json` 파일을 자동으로 읽지 않습니다 — 자체 CLI로 MCP 서버를 등록해야\n합니다(라이브 왕복 실측 완료: story #2466, 실제 도구 110개 수신 확인).
+app/services/agent_onboarding_config.py::실행 중 인증 방식을 물으면 header를 선택하고, API key를 물으면 아래 값을 입력하세요.
+app/services/agent_onboarding_config.py::어댑터를 런타임 호스트에서 직접 실행하세요(호스팅 실행은 지원하지 않음 — 설치/실행은\n   사용자 수동).
+app/services/agent_onboarding_config.py::어댑터를 사용해 서버에 아웃바운드로 접속합니다(인바운드 도메인/웹훅 불필요).
+app/services/agent_onboarding_config.py::위 폴더 중 사용 중인 런타임에 맞는 폴더를 복사하세요(각 폴더는 sibling import 없이\n   독립 동작합니다).
+app/services/agent_onboarding_config.py::커넥터 어댑터로 연결합니다 — `.mcp.json`이 아니라 `connectors/{runtime}-sprintable/` 폴더의
+app/services/agent_onboarding_config.py::폴더의 `README.md` 안내대로 `AGENT_API_KEY`(이 에이전트의 scoped key) 등 env를 설정하세요.
+app/services/agent_recruiter.py::# {name} — Sprintable 역할 컨텍스트
+app/services/agent_recruiter.py::## Sprintable 워크플로
+app/services/agent_recruiter.py::## 런타임 노트
+app/services/agent_recruiter.py::## 발견 가능 스킬 (A2A)
+app/services/agent_recruiter.py::## 사용 가능 도구 (치트시트)
+app/services/agent_recruiter.py::## 애자일 자율 운영 룰\n\n- **claim**: 작업을 시작하기 전에 반드시 claim 하세요. 이미 누군가 진행 중인 작업을 가로채지 마세요.\n- **lock**: 같은 파일을 동시에 여러 에이전트가 건드릴 수 있는 작업이면 시작 전 잠그고, 끝나면 즉시 풉니다.\n- **status**: 작업 시작·완료·블로커 발생 시점마다 상태를 갱신하세요. 상태가 실제 진행과 어긋나면 팀 전체가 헷갈립니다.\n- **소통**: 막히거나 방향을 바꿨거나 완료했으면 침묵하지 말고 즉시 채팅으로 알리세요. 아무도 몰래 혼자 진행하지 마세요.\n- **정직**: 실제로 확인/실행하지 않은 것을 완료로 보고하지 마세요. 근거(실행 결과·재현 절차)와 함께 보고하세요.
+app/services/agent_recruiter.py::## 전달받은 에이전트에게\n\n이 문서는 당신 자신의 정체성 파일(CLAUDE.md/AGENTS.md 등)이 아니라, 이 Sprintable 조직에서\n활동하기 위한 컨텍스트 kit입니다. 다음을 스스로 판단해 당신의 메모리(또는 이미 쓰고 있는\n메모리/시스템 체계)에 반영하세요 — 이 파일 내용을 그대로 복사해 자신을 덮어쓰지 마세요:\n\n- 이 조직에서 당신이 맡은 역할(위 "역할 컨텍스트" 참고)\n- 자주 쓰게 될 `sprintable_*` 도구(위 "사용 가능 도구" 참고)\n- 워크플로는 고정 절차로 외우지 말고, 매번 `sprintable_get_workflow_guide`로 최신 확인\n\n**기존 정체성을 덮지 말고, 당신 방식대로 자기화하세요.**
+app/services/agent_recruiter.py::**{runtime} 전용 노트**:
+app/services/agent_recruiter.py::**항상 사용 가능**:
+app/services/agent_recruiter.py::<선택한 런타임>
+app/services/agent_recruiter.py::MCP 연결/스코프는 채용 시 제공된 번들이 이미 구성했습니다 — 별도 설정이 필요 없습니다.
+app/services/agent_recruiter.py::위 목록에 없는 도구 이름을 지어내지 마세요 — 확실하지 않으면 `sprintable_get_workflow_guide`로 먼저 확인하세요.
+app/services/agent_recruiter.py::이 런타임은 MCP가 아니라 SSE 커넥터 방식으로 연결합니다 — 채용 시 제공된 번들만으론 연결이 자동 구성되지 않습니다. `connectors/{adapter}-sprintable/` 폴더를 복사해 README 안내대로 `AGENT_API_KEY` 등 환경변수를 설정하고 어댑터를 직접 실행하세요.
+app/services/agent_recruiter.py::이 조직의 워크플로는 여기 고정해두지 않습니다(팀마다 커스터마이즈하므로 stale해질 수 있어서입니다) — 스스로 `sprintable_get_workflow_guide`를 불러 최신 운영법을 확인하세요.
+app/services/agent_recruiter.py::이 프로젝트에서 당신의 실행 런타임은 `{runtime}` 입니다.
+app/services/agent_recruiter.py::태그
+app/services/android_key_attestation.py::cert → True면 폐기됨. 실 HTTP 페치(https://android.googleapis.com/attestation/status)는\n호출부 책임(mock-first) — 이 모듈은 검사 시점(now)에 주어진 checker를 체인의 모든 인증서에\n적용만 한다.
+app/services/approval_delivery.py::' — 검토 요청 여부를 확인해 주세요.
+app/services/approval_delivery.py::' 결재 결과:
+app/services/approval_delivery.py::' 결재 요청
+app/services/approval_delivery.py::' 결재 요청 (토스됨)
+app/services/approval_delivery.py::' 문서 결재 — 논의 요청\n사유:
+app/services/approval_delivery.py::' 문서 결재에 대해 논의를 요청받았습니다.
+app/services/approval_delivery.py::' 문서가 채팅에서 논의됐습니다 — 이 내용이 확정본이면 검토 요청을, 아직 고칠 게 있으면 편집을 진행해 주세요.
+app/services/approval_delivery.py::'가
+app/services/approval_delivery.py::draft 문서가 채팅에서 논의됐습니다
+app/services/approval_delivery.py::gate toss 카드 삽입 실패 — tossed_by 미확인 gate=
+app/services/approval_delivery.py::gate toss 카드 삽입 실패 — 대상 conversation 미확인 gate=
+app/services/approval_delivery.py::갱신
+app/services/approval_delivery.py::결재 결과:
+app/services/approval_delivery.py::고쳐
+app/services/approval_delivery.py::고치
+app/services/approval_delivery.py::교체
+app/services/approval_delivery.py::됐습니다.
+app/services/approval_delivery.py::문서 결재 — 논의 요청
+app/services/approval_delivery.py::바꾸
+app/services/approval_delivery.py::바꿔
+app/services/approval_delivery.py::반려
+app/services/approval_delivery.py::사유:
+app/services/approval_delivery.py::수정
+app/services/approval_delivery.py::승인
+app/services/approval_delivery.py::업데이트
+app/services/approval_delivery.py::정정
+app/services/approval_delivery.py::철회
+app/services/approval_delivery.py::폐기
+app/services/attachment_context.py::--- 첨부 내용 ---
+app/services/attachment_context.py::[…첨부 컨텍스트 총량 한도 도달 — 이후 첨부 생략]
+app/services/attachment_context.py::[이미지 첨부(접근 범위 밖):
+app/services/attachment_context.py::[이미지 첨부:
+app/services/attachment_context.py::[첨부(미지원 형식):
+app/services/attachment_context.py::[첨부(접근 범위 밖):
+app/services/attachment_context.py::[첨부(추출 실패):
+app/services/attachment_context.py::[첨부:
+app/services/attachment_context.py::— URL 생성 실패]
+app/services/attachment_context.py::— 총량 한도로 생략]
+app/services/attachment_context.py::— 추출 텍스트 없음]
+app/services/attachment_context.py::…(잘림)
+app/services/attachment_context.py::첨부
+app/services/attachment_suggestion.py::[\\w가-힣]+
+app/services/attachment_suggestion.py::가
+app/services/attachment_suggestion.py::가설
+app/services/attachment_suggestion.py::가정
+app/services/attachment_suggestion.py::검증
+app/services/attachment_suggestion.py::결함
+app/services/attachment_suggestion.py::고침
+app/services/attachment_suggestion.py::과
+app/services/attachment_suggestion.py::그
+app/services/attachment_suggestion.py::는
+app/services/attachment_suggestion.py::도
+app/services/attachment_suggestion.py::를
+app/services/attachment_suggestion.py::리서치
+app/services/attachment_suggestion.py::및
+app/services/attachment_suggestion.py::버그
+app/services/attachment_suggestion.py::복구
+app/services/attachment_suggestion.py::수정
+app/services/attachment_suggestion.py::실험
+app/services/attachment_suggestion.py::안정화
+app/services/attachment_suggestion.py::에
+app/services/attachment_suggestion.py::오류
+app/services/attachment_suggestion.py::와
+app/services/attachment_suggestion.py::유지보수
+app/services/attachment_suggestion.py::은
+app/services/attachment_suggestion.py::을
+app/services/attachment_suggestion.py::의
+app/services/attachment_suggestion.py::이
+app/services/attachment_suggestion.py::인프라
+app/services/attachment_suggestion.py::장애
+app/services/attachment_suggestion.py::조사
+app/services/attachment_suggestion.py::측정
+app/services/attachment_suggestion.py::테스트
+app/services/attachment_suggestion.py::패치
+app/services/attachment_suggestion.py::핫픽스
+app/services/attachment_suggestion.py::회귀
+app/services/avatar_upload.py::(허용:
+app/services/avatar_upload.py::avatar 업로드가 이 환경에 구성되지 않음
+app/services/avatar_upload.py::bytes 초과
+app/services/avatar_upload.py::bytes가 상한
+app/services/avatar_upload.py::업로드 URL 서명 실패
+app/services/avatar_upload.py::업로드된 객체를 찾을 수 없음(PUT 미완료?)
+app/services/avatar_upload.py::이 member 소유 업로드 경로가 아님
+app/services/avatar_upload.py::허용되지 않는 content_type:
+app/services/billing_charge.py::Sprintable 정기결제
+app/services/billing_charge_amount.py::)에 offering_version_id가 바인딩되지 않음
+app/services/billing_charge_amount.py::가 included_seats를
+app/services/billing_charge_amount.py::를 찾을 수 없음
+app/services/billing_charge_amount.py::석 초과했으나 이 offering은 추가좌석을 팔지 않음(정책상 상위 티어 전환 후에만 가능한 상태 — 초과 상태로 청구를 계산하면 안 됨)
+app/services/billing_charge_amount.py::이 'monthly'/'annual' 둘 다 아님 — monthly로 조용히 폴백하지 않는다
+app/services/billing_charge_amount.py::잔여기간 계산 불가(total_seconds=
+app/services/billing_pack.py::개
+app/services/billing_pack.py::개 예약/구매,
+app/services/billing_pack.py::개 추가 요청
+app/services/billing_pack.py::는 tier=
+app/services/billing_pack.py::를 찾을 수 없음
+app/services/billing_pack.py::에 활성 유료 구독이 없음 — 팩 구매 대상 아님
+app/services/billing_pack.py::에서 판매하지 않음(판매 자원:
+app/services/billing_pack.py::의 current_period가 세팅되지 않아 max_packs 판정 불가
+app/services/billing_pack.py::초과 — 이번 주기 이미
+app/services/billing_pack.py::팩
+app/services/billing_receipt_email.py::원
+app/services/billing_scheduler.py::Sprintable 정기결제(갱신)
+app/services/billing_scheduler.py::WITH absolute_latest_grants AS (\n                    -- companion 유무와 무관하게, org별 «절대 최신» grant 정확히 1건을\n                    -- 먼저 확定(위 불변식 ⓐ 이전 단계 — superseded 판정의 유일한 축).\n                    SELECT DISTINCT ON (org_id) id, org_id, amount_minor, currency,\n                           metadata AS entry_metadata\n                    FROM billing_ledger_entries\n                    WHERE entry_type = 'credit_grant' AND metadata->>'kind' = 'tier_grant'\n                    ORDER BY org_id, ts DESC\n                )\n                SELECT lg.id, lg.org_id, lg.amount_minor, lg.currency, lg.entry_metadata\n                FROM absolute_latest_grants lg\n                WHERE NOT EXISTS (\n                    -- «그 특정 절대-최신 행 하나»에만 companion 유무를 검사(불변식 ⓐ).\n                    -- companion이 있으면 이 org는 이번 스윕에서 후보가 아예 없음(구\n                    -- grant로 되돌아가지 않는다 — superseded는 영구 제외).\n                    SELECT 1 FROM billing_ledger_entries r\n                    WHERE r.entry_type = 'adjustment'\n                      AND r.metadata->>'kind' = 'tier_grant_revert'\n                      AND r.metadata->>'reverted_entry_id' = lg.id::text\n                )
+app/services/blog_destinations.py::블로그 목적지는 아직 배선되지 않았습니다(wordpress=조각③b·webhook=조각④에서 배선 예정).
+app/services/campaigns.py::campaign을 찾을 수 없습니다:
+app/services/chain_escalation.py::)이 발생해 agent 발신이 일시 차단되었습니다. 이 알림의 «차단 해제»로 즉시 풀 수 있습니다.
+app/services/chain_escalation.py::)이 발생했습니다.
+app/services/chain_escalation.py::human 참가자가 없는 대화에서 최근
+app/services/chain_escalation.py::건(임계
+app/services/chain_escalation.py::무인간 대화 무감독 연쇄 감지
+app/services/chain_escalation.py::무인간 대화 자동 차단(서킷브레이커)
+app/services/chain_escalation.py::초간 메시지
+app/services/channel_adapters.py::Sprintable 호스팅 블로그
+app/services/channel_adapters.py::fail-closed: prod 배포에 sandbox 채널 어댑터가 등재돼 있습니다(SANDBOX_CHANNEL_ENABLED가 prod에 잘못 설정됐을 가능성 — story 5b27b32f AC5).
+app/services/channel_adapters.py::고객 웹훅(signed)
+app/services/channel_adapters.py::는 kind='blog'라 get_publish_client_module 디스패치 대상이 아닙니다(hosted_site=site_posts.py 직접 처리, wordpress/webhook=조각② 배선 예정).
+app/services/channel_adapters.py::발행 클라이언트 디스패치가 없는 채널입니다:
+app/services/channel_connection.py::channel connection을 찾을 수 없습니다:
+app/services/channel_post_comment_replies.py::(표시명 없음)
+app/services/channel_post_comment_replies.py::)에서는 상신할 수 없습니다
+app/services/channel_post_comment_replies.py::[댓글 후속 작업 — 원문:
+app/services/channel_post_comment_replies.py::기본 승인 role이 없습니다:
+app/services/channel_post_comment_replies.py::댓글 후속 작업 생성(comment
+app/services/channel_post_comment_replies.py::본문:
+app/services/channel_post_comment_replies.py::안 보낸 초안이 이미 있습니다:
+app/services/channel_post_comment_replies.py::이 상태(
+app/services/channel_post_comment_replies.py::작성자:
+app/services/channel_post_comments.py::channel_publication을 찾을 수 없습니다:
+app/services/channel_post_comments.py::external_id가 없습니다
+app/services/channel_post_comments.py::fetch_replies dispatch가 없습니다:
+app/services/channel_post_comments.py::발행 기록을 찾을 수 없습니다:
+app/services/channel_post_comments.py::연결에 자격이 없습니다
+app/services/channel_post_comments.py::연결이 활성 상태가 아닙니다:
+app/services/channel_post_comments.py::초 뒤 다시 시도하세요
+app/services/channel_post_images.py::(허용:
+app/services/channel_post_images.py::) 한도
+app/services/channel_post_images.py::)이어야 합니다 — 현재
+app/services/channel_post_images.py:::1을 초과했습니다(변환으로 고칠 수 없음)
+app/services/channel_post_images.py:::1이 한도
+app/services/channel_post_images.py::bytes가 원본 업로드 상한
+app/services/channel_post_images.py::bytes가 한도
+app/services/channel_post_images.py::bytes를 초과했습니다
+app/services/channel_post_images.py::image_ids가 현재 이미지 집합과 정확히 일치해야 합니다(누락·중복·불일치 없이)
+app/services/channel_post_images.py::세로가 너무 길어(width/height
+app/services/channel_post_images.py::애니메이션 이미지는 지원하지 않습니다(
+app/services/channel_post_images.py::업로드된 객체를 찾을 수 없습니다(PUT 미완료?):
+app/services/channel_post_images.py::에 못 미칩니다(변환으로 고칠 수 없음)
+app/services/channel_post_images.py::은 이미지 첨부를 지원하지 않습니다
+app/services/channel_post_images.py::이 draft 소유 업로드 경로가 아님:
+app/services/channel_post_images.py::이미지는 최대
+app/services/channel_post_images.py::이미지를 찾을 수 없습니다:
+app/services/channel_post_images.py::이미지를 해독할 수 없습니다(손상됐거나 지원하지 않는 파일)
+app/services/channel_post_images.py::자동 변환 후에도
+app/services/channel_post_images.py::장까지 첨부할 수 있습니다
+app/services/channel_post_images.py::종횡비
+app/services/channel_post_images.py::지원하지 않는 형식입니다:
+app/services/channel_post_images.py::채널
+app/services/channel_post_images.py::채널 이미지 업로드가 이 환경에 구성되지 않았습니다(GCS_CHANNEL_MEDIA_BUCKET 미설정)
+app/services/channel_post_images.py::커버는 영상과 같은 비율(
+app/services/channel_post_images.py::파생본 업로드 실패:
+app/services/channel_post_images.py::프레임)
+app/services/channel_post_videos.py::(허용:
+app/services/channel_post_videos.py::)를 벗어났습니다(변환 불가)
+app/services/channel_post_videos.py::bytes가 영상 업로드 상한
+app/services/channel_post_videos.py::bytes를 초과했습니다
+app/services/channel_post_videos.py::업로드된 객체를 찾을 수 없습니다(PUT 미완료?):
+app/services/channel_post_videos.py::영상 규격을 읽을 수 없습니다
+app/services/channel_post_videos.py::영상 길이
+app/services/channel_post_videos.py::영상 비율
+app/services/channel_post_videos.py::영상 업로드 실패:
+app/services/channel_post_videos.py::영상은 커버 이미지 1장과만 함께 갈 수 있습니다 — 이미지를 1장으로 줄인 뒤 첨부하세요.
+app/services/channel_post_videos.py::은 영상 첨부를 지원하지 않습니다
+app/services/channel_post_videos.py::이 draft 소유 업로드 경로가 아님:
+app/services/channel_post_videos.py::이 목표
+app/services/channel_post_videos.py::지원하지 않는 영상 코덱입니다:
+app/services/channel_post_videos.py::지원하지 않는 영상 형식입니다:
+app/services/channel_post_videos.py::채널
+app/services/channel_post_videos.py::초가 상한
+app/services/channel_post_videos.py::초가 하한
+app/services/channel_post_videos.py::초를 초과했습니다
+app/services/channel_post_videos.py::초에 못 미칩니다
+app/services/channel_posts.py::) — 잠시 후 다시 시도하세요
+app/services/channel_posts.py::) — 재인증이 필요합니다
+app/services/channel_posts.py::) — 조직 설정에서 기본 역할을 지정한 뒤 다시 상신하세요
+app/services/channel_posts.py::draft를 찾을 수 없습니다:
+app/services/channel_posts.py::published 행에 external_id가 없습니다
+app/services/channel_posts.py::s > 5분 상한(그라운딩 §②)
+app/services/channel_posts.py::같은 발행이 다른 요청에서 처리 중입니다(gate_id=
+app/services/channel_posts.py::발행 provider 호출 실패(
+app/services/channel_posts.py::발행 한도를 초과했습니다 —
+app/services/channel_posts.py::발행된 적이 없거나 이미 회수된 글입니다:
+app/services/channel_posts.py::버전을 찾을 수 없습니다:
+app/services/channel_posts.py::본문이 한도를 넘었습니다(한도
+app/services/channel_posts.py::연결 토큰이 만료됐습니다(connection_id=
+app/services/channel_posts.py::연결을 찾을 수 없거나 비활성 상태입니다:
+app/services/channel_posts.py::원문(content_item)을 찾을 수 없습니다:
+app/services/channel_posts.py::이 draft는 아직 상신된 적이 없습니다(취소/회수 대상 없음):
+app/services/channel_posts.py::이 work item은 다른 초안이 이미 승인 절차 중입니다(holding_draft_id=
+app/services/channel_posts.py::이 명령은 취소할 수 없는 상태입니다(command_id=
+app/services/channel_posts.py::이 연결에 필요한 스코프가 없습니다:
+app/services/channel_posts.py::이 채널은 발행 회수를 지원하지 않습니다:
+app/services/channel_posts.py::이 채널은 이미지 1장이 필요합니다.
+app/services/channel_posts.py::이 초안을 보관할 권한이 없습니다:
+app/services/channel_posts.py::이 초안을 폐기할 권한이 없습니다:
+app/services/channel_posts.py::이미 발행된 초안은 폐기할 수 없습니다(발행 취소를 이용하세요):
+app/services/channel_posts.py::이미지 컨테이너 처리 실패(gate_id=
+app/services/channel_posts.py::이후 재시도하세요
+app/services/channel_posts.py::자)
+app/services/channel_posts.py::자, 현재
+app/services/channel_posts.py::작성자가 폐기
+app/services/channel_posts.py::조직에 기본 결재 역할이 설정되지 않았습니다(org_id=
+app/services/channel_posts.py::채널은 릴스(영상) 발행을 지원하지 않습니다
+app/services/channel_posts.py::채널은 이미지 2장 이상(캐러셀)을 지원하지 않습니다
+app/services/channel_posts.py::취소할 발행 명령이 없습니다:
+app/services/chat_command_catalog.py::' 처리 중 오류가 발생했습니다.
+app/services/chat_command_catalog.py::'/assign' 사용법: `/assign <스토리#> <멤버명>`
+app/services/chat_command_catalog.py::'/assign' 실패 —
+app/services/chat_command_catalog.py::'/assign' 실패 — 「
+app/services/chat_command_catalog.py::'/assign' 실패 — 스토리 참조를 해석할 수 없습니다: `
+app/services/chat_command_catalog.py::'/assign' 완료 —
+app/services/chat_command_catalog.py::'/done' 사용법: `/done <스토리#>`
+app/services/chat_command_catalog.py::'/done' 실패 —
+app/services/chat_command_catalog.py::'/done' 실패 — 스토리 참조를 해석할 수 없습니다: `
+app/services/chat_command_catalog.py::'/done' 완료 — 스토리가 done으로 전이됐습니다.\n다음: 결과를 확인하세요.
+app/services/chat_command_catalog.py::'/priority' 사용법: `/priority <스토리#> <critical|high|medium|low>`
+app/services/chat_command_catalog.py::'/priority' 실패 —
+app/services/chat_command_catalog.py::'/priority' 실패 — 스토리 참조를 해석할 수 없습니다: `
+app/services/chat_command_catalog.py::'/priority' 실패 — 알 수 없는 우선순위: `
+app/services/chat_command_catalog.py::'/priority' 완료 — 우선순위가
+app/services/chat_command_catalog.py::(정확한 이름을 입력하세요)
+app/services/chat_command_catalog.py::` (critical/high/medium/low 중 하나)
+app/services/chat_command_catalog.py::」에 일치하는 멤버가 여럿입니다:
+app/services/chat_command_catalog.py::」에 일치하는 멤버를 찾을 수 없습니다.
+app/services/chat_command_catalog.py::로 변경됐습니다.\n다음: 결과를 확인하세요.
+app/services/chat_command_catalog.py::에게 배정됐습니다.\n다음: 결과를 확인하세요.
+app/services/chat_command_catalog.py::에서
+app/services/connector_registry.py::(허용된 키:
+app/services/connector_registry.py::].source는 'content' 또는 'org_config'여야 합니다.
+app/services/connector_registry.py::].type은
+app/services/connector_registry.py::]는 type=
+app/services/connector_registry.py::]는 시크릿류 이름 패턴(token/secret/password/api_key)이라 org_config로 등록할 수 없습니다 — 시크릿은 플러그인 로컬 env(requires_env)에만 둡니다.
+app/services/connector_registry.py::]의 원소는 전부 itemType=
+app/services/connector_registry.py::fields 항목은 object여야 합니다 —
+app/services/connector_registry.py::fields[].name은 비어있지 않은 문자열이어야 합니다 —
+app/services/connector_registry.py::fields는 배열이어야 합니다.
+app/services/connector_registry.py::kinds는 비어있지 않은 문자열의 배열이어야 합니다.
+app/services/connector_registry.py::requires_env 항목은 환경변수 이름(예: THREADS_ACCESS_TOKEN)이어야 합니다 — 값이 섞여 온 것으로 의심됨:
+app/services/connector_registry.py::requires_env는 배열이어야 합니다.
+app/services/connector_registry.py::등록이 없습니다 — 먼저 스키마를 등록하세요.
+app/services/connector_registry.py::에 connector_key=
+app/services/connector_registry.py::이 커넥터의 org_config로 선언되지 않은 키입니다:
+app/services/connector_registry.py::이어야 합니다 — 받은 값:
+app/services/connector_registry.py::이어야 합니다 — 어긋난 값:
+app/services/connector_registry.py::중 하나여야 합니다 —
+app/services/content_rules.py::CAS UPDATE가 방금 1행을 갱신했는데 재조회에서 사라질 수 없다
+app/services/content_rules.py::값을 링크에 직접 적어야 합니다.
+app/services/content_rules.py::건(rules_version=
+app/services/content_rules.py::버전 충돌(current_version=
+app/services/content_rules.py::콘텐츠 규칙 위반
+app/services/context_pack_items.py::(이유 미기록)
+app/services/context_pack_items.py::(종합 없음)
+app/services/context_pack_items.py::[과거 학습 종합 — 근거
+app/services/context_pack_items.py::[새 loop] 목표:
+app/services/context_pack_items.py::] 목표:
+app/services/context_pack_items.py::— 이유:
+app/services/context_pack_items.py::가설:
+app/services/context_pack_items.py::건]
+app/services/context_pack_items.py::기각:
+app/services/context_pack_items.py::다음은 새로 시작하는 loop의 목표와, 과거 유사 실행들에서 이미 종합된 학습(패턴·다음행동·회피·리스크)이다. 이 학습을 이 새 loop에 구체적으로 적용할 제안을 한국어 1~2문장으로 작성하라.\n\n성과(outcome) 우선: 학습 요약에 성과 데이터가 반영돼 있으면 그것을 최우선 근거로 삼아라 — 결과가 확인된 것이 가장 강한 신호다.\n\n톤: 단정적 지시가 아니라 제안형으로("~해보는 게 좋아 보입니다", "~을 고려해볼 만합니다" 등) — 최종 판단은 사람의 몫이다.\n\n요약 밖의 사실을 추정하거나 새로 만들어내지 마라. 근거(과거 사례 수)가 적거나 애매하면 단정적으로 처방하지 말고 '과거 N건 기준' 같은 정직한 hedge를 반드시 포함해 신중하게 제안하라.\n\n마지막 줄에 정확히 다음 형식으로 확신도를 표시하라(그 외 텍스트 없이 이 형식 그대로):\nconfidence: high|medium|low\n(성과 기반 근거가 있고 사례가 여럿이면 high, 결정 이유만 있고 사례가 적으면 low, 그 사이면 medium — 데이터 근거 강도에 정직하게 맞춰라.)
+app/services/context_pack_items.py::다음은 유사한 과거 실행(loop/가설)들의 실제 기록이다. 이 데이터를 분석해 다음 실행에 실질적으로 도움이 되는 통찰을 한국어로 작성하라.\n\n금지: "X가 채택되고 Y가 기각됐다" 같은 단순 재진술은 절대 하지 마라 — 이미 알고 있는 사실이다. 왜 그런 선택이 반복됐는지 한 단계 더 깊이 파고들어라.\n\n성과(outcome) 우선 원칙: 성과 데이터(hit/miss·수치)가 있으면 그것을 최우선 근거로 삼아라 — 무엇이 실제로 효과가 있었는지가 가장 강한 신호다. 성과가 없으면 결정 이유만으로 신중히 판단하고 그 불확실성을 명시하라.\n\n다음 구조로 답하라(각 항목 1문장, 데이터에 명시된 사실만 근거로):\n- 패턴: 표면적 선택이 아니라 그 이면의 원리(비-obvious). 근거 부족하면 "패턴 불명확(N건 부족)"이라고 정직하게 표시.\n- 다음 행동: 다음 실행에서 시도해볼 만한 것 1가지(제안형으로 — 단정적 지시 아님).\n- 회피: 반복하지 않는 게 좋아 보이는 것 1가지.\n- 리스크: 이 결론의 불확실성/예외 가능성 1가지.\n\n데이터에 없는 사실을 추정하거나 새로 만들어내지 마라.\n\n마지막 줄에 정확히 다음 형식으로 확신도를 표시하라(그 외 텍스트 없이 이 형식 그대로):\nconfidence: high|medium|low\n(성과 데이터가 있고 패턴이 명확하면 high, 결정 이유만 있고 사례가 적으면 low, 그 사이면 medium — 데이터 근거 강도에 정직하게 맞춰라.)
+app/services/context_pack_items.py::성과:
+app/services/context_pack_items.py::요약(2~3문장, 위 데이터에 명시된 사실만 근거로):
+app/services/context_pack_items.py::제안(1~2문장, hedge 포함):
+app/services/context_pack_items.py::채택:
+app/services/destination_url_safety.py::DNS 해석 실패:
+app/services/destination_url_safety.py::host가 없습니다
+app/services/destination_url_safety.py::https://가 아닙니다
+app/services/destination_url_safety.py::link-local(클라우드 메타데이터 169.254.169.254 포함 대역)
+app/services/destination_url_safety.py::가
+app/services/destination_url_safety.py::멀티캐스트
+app/services/destination_url_safety.py::목적지 URL이 안전하지 않습니다(
+app/services/destination_url_safety.py::미지정 주소
+app/services/destination_url_safety.py::사설 대역(RFC1918)
+app/services/destination_url_safety.py::예약 대역
+app/services/destination_url_safety.py::해석된 IP
+app/services/discord_webhook.py::대화 보기
+app/services/discord_webhook.py::상태:
+app/services/discord_webhook.py::스토리 보기
+app/services/discord_webhook.py::📩 **새 메시지**
+app/services/disposition_advisor.py::) 적합, 조정 불필요.
+app/services/disposition_advisor.py::). 더 쌓인 뒤 추천 가능.
+app/services/disposition_advisor.py::clean_pass_rate 없음 (verdict 있으나 SP 데이터 없음).
+app/services/disposition_advisor.py::→ allow_auto 완화 추천.
+app/services/disposition_advisor.py::건) — 신뢰 충분,
+app/services/disposition_advisor.py::건) — 통과율 하락, allow_auto → ask 강화 추천.
+app/services/disposition_advisor.py::건) — 현 disposition(
+app/services/disposition_advisor.py::무정정 통과율
+app/services/disposition_advisor.py::통과율
+app/services/disposition_advisor.py::표본 부족 (verdicts=
+app/services/doc.py::' 문서가 결재 대기 중입니다.
+app/services/doc.py::confirmed 전이는 휴먼만 가능합니다.
+app/services/doc.py::결재 대기 문서는 Gate 승인/반려로만 전이됩니다.
+app/services/doc.py::문서 결재 요청
+app/services/doc.py::문서를 찾을 수 없습니다.
+app/services/doc.py::본인을 결재자로 지정할 수 없습니다.
+app/services/doc.py::불법 전이:
+app/services/doc.py::상신하려면 결재자를 지정해야 합니다.
+app/services/doc.py::알 수 없는 doc status:
+app/services/doc.py::이 문서는 지정한 work item과 같은 프로젝트에 속하지 않습니다.
+app/services/doc.py::지정한 결재자는 결재 자격(owner/admin)이 없습니다.
+app/services/doc_share.py::더 이상 유효하지 않은 링크
+app/services/doc_share.py::유효하지 않은 링크
+app/services/email.py::" style="color:#8b8b8b;text-decoration:underline;">개인정보처리방침</a><br>\n          ©
+app/services/email.py::" style="color:#8b8b8b;text-decoration:underline;">이용약관</a> · <a href="
+app/services/email.py::· 대표이사
+app/services/email.py::· 사업자등록번호
+app/services/email.py::경기도 고양시 일산동구 무궁화로 20-38, 5층 502호
+app/services/email.py::윤도선
+app/services/email.py::주식회사 뭉클랩
+app/services/email_copy.py::<b>{grace_date}</b>까지 결제가 완료되지 않으면 조직의 플랜이 자동으로 Free로 전환됩니다. Free로 전환되어도 <b>기존 데이터는 삭제되지 않으며</b>, 신규 업로드만 제한됩니다. 이후 결제를 완료하시면 즉시 원래 플랜({tier_display})으로 복귀합니다.
+app/services/email_copy.py::<p>안녕하세요, Sprintable입니다.</p><p>조직의 스토리지 사용량이 <b>{pct}%</b>({used_mb}MB / {cap_mb}MB)에 도달했습니다.</p><p>업로드 제한을 피하려면 사용하지 않는 파일을 정리하거나 플랜을 업그레이드해 주세요.</p>
+app/services/email_copy.py::<p>안녕하세요, Sprintable입니다.</p><p>조직의 이번 달 자동화 사용량(AU)이 <b>{pct}%</b>({current} / {au_limit} AU)에 도달했습니다.</p><p>100%에 도달하면 MCP/API 쓰기 및 자동화가 일시 중지됩니다(읽기와 사람 UI는 계속 사용 가능합니다). 한도에 도달하기 전 플랜 업그레이드를 검토해 주세요.</p>
+app/services/email_copy.py::<strong>{inviter_name}</strong>님이 <strong>{org_name}</strong> 조직에 <strong>{role}</strong>로 초대했습니다.
+app/services/email_copy.py::Sprintable — 가입 완료까지 몇 단계 남았습니다
+app/services/email_copy.py::Sprintable 가입을 환영합니다. 아직 에이전트 연결이나 첫 지시를 완료하지 않으셨네요 — 몇 분이면 끝나는 남은 단계를 마무리하면 Sprintable의 진짜 가치를 바로 확인하실 수 있습니다.
+app/services/email_copy.py::Sprintable 결제가 완료됐습니다
+app/services/email_copy.py::Sprintable 비밀번호 설정을 완료해 주세요
+app/services/email_copy.py::Sprintable 비밀번호 재설정 안내
+app/services/email_copy.py::Sprintable 이메일 인증을 완료해 주세요
+app/services/email_copy.py::Sprintable에 가입해 주셔서 감사합니다.
+app/services/email_copy.py::[Sprintable] {org_name} 조직에 초대됐습니다
+app/services/email_copy.py::[Sprintable] {tier} 플랜으로 변경이 예약됐습니다
+app/services/email_copy.py::[Sprintable] {tier} 플랜으로 전환이 완료됐습니다
+app/services/email_copy.py::[Sprintable] 결제가 처리되지 않았습니다 — 확인해 주세요
+app/services/email_copy.py::[Sprintable] 구독 해지가 예약됐습니다
+app/services/email_copy.py::[Sprintable] 구독이 해지되어 Free 플랜으로 전환됐습니다
+app/services/email_copy.py::[Sprintable] 스토리지 사용량 {pct}% 도달
+app/services/email_copy.py::[Sprintable] 예약된 하향 전환이 취소되었습니다 — 좌석 한도 초과
+app/services/email_copy.py::[Sprintable] 자동화 사용량(AU) {pct}% 도달
+app/services/email_copy.py::{apply_date}까지는 현재 플랜을 그대로 이용하실 수 있고, 그 이후 Free 플랜으로 전환됩니다.
+app/services/email_copy.py::{apply_date}부터 {tier} 플랜으로 전환됩니다.
+app/services/email_copy.py::결제 금액: {amount}
+app/services/email_copy.py::결제 정보 확인하러 가기
+app/services/email_copy.py::결제가 정상적으로 완료됐습니다.
+app/services/email_copy.py::구독 해지가 예약됐습니다.
+app/services/email_copy.py::기존 데이터는 삭제되지 않고 그대로 보존되며, 변경된 플랜 한도 내에서 계속 이용하실 수 있습니다.
+app/services/email_copy.py::기존 데이터와 콘텐츠는 삭제되지 않고 그대로 보존됩니다 — 언제든 다시 업그레이드해 이어서 이용하실 수 있습니다.
+app/services/email_copy.py::기존 멤버는 제거되지 않았습니다. 팀 규모를 줄이거나 현재 플랜을 유지하신 뒤, 하향 전환이 여전히 필요하시면 다시 예약해 주세요.
+app/services/email_copy.py::문의사항이 있으시면 언제든 회신해 주세요.
+app/services/email_copy.py::버튼이 보이지 않으면 아래 주소를 브라우저에 붙여 넣으세요:
+app/services/email_copy.py::버튼이 열리지 않으면 아래 주소를 브라우저에 붙여넣어 주세요:
+app/services/email_copy.py::본인이 결제하지 않으셨다면 Sprintable에 로그인해 결제 내역을 확인해 주세요. 이 메일은 발신 전용입니다.
+app/services/email_copy.py::본인이 결제하지 않으셨다면 Sprintable에 로그인해 화면 하단의 지원 채팅으로 즉시 문의해 주세요.
+app/services/email_copy.py::본인이 요청하지 않으셨다면 Sprintable에 로그인해 구독 설정을 확인해 주세요. 이 메일은 발신 전용입니다.
+app/services/email_copy.py::본인이 요청하지 않으셨다면 Sprintable에 로그인해 플랜 설정을 확인해 주세요. 이 메일은 발신 전용입니다.
+app/services/email_copy.py::본인이 요청하지 않으셨다면 Sprintable에 로그인해 화면 하단의 지원 채팅으로 즉시 문의해 주세요.
+app/services/email_copy.py::본인이 요청하지 않으셨다면 이 메일을 무시하셔도 됩니다 — 비밀번호는 변경되지 않습니다.
+app/services/email_copy.py::본인이 요청하지 않으셨다면 이 메일을 무시하셔도 됩니다 — 비밀번호는 설정되지 않습니다.
+app/services/email_copy.py::본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.
+app/services/email_copy.py::비밀번호 설정 완료
+app/services/email_copy.py::비밀번호 설정을 요청하셨습니다.
+app/services/email_copy.py::비밀번호 재설정
+app/services/email_copy.py::비밀번호 재설정을 요청하셨습니다.
+app/services/email_copy.py::아래 버튼을 눌러 새 비밀번호를 설정해 주세요.
+app/services/email_copy.py::아래 버튼을 눌러 설정을 완료해 주세요.
+app/services/email_copy.py::아래 버튼을 눌러 이메일 인증을 완료하시면 바로 시작하실 수 있습니다.
+app/services/email_copy.py::아래 버튼을 클릭하면 초대를 수락할 수 있습니다. 링크는 7일간 유효합니다.
+app/services/email_copy.py::안녕하세요, Sprintable입니다.
+app/services/email_copy.py::영수증 보기
+app/services/email_copy.py::영수증은 결제사(Toss)가 제공하며, 이 링크로 언제든 다시 확인하실 수 있습니다.
+app/services/email_copy.py::예약 확인·철회하기
+app/services/email_copy.py::예약하신 {tier} 플랜으로 전환이 완료됐습니다.
+app/services/email_copy.py::예약하신 {tier} 플랜으로의 하향 전환이 자동으로 취소되었습니다. 현재 조직 멤버가 {seat_count}명으로, 해당 플랜의 포함 좌석({included_seats}석)을 초과하기 때문입니다.
+app/services/email_copy.py::예약하신 구독 해지가 적용되어 Free 플랜으로 전환됐습니다.
+app/services/email_copy.py::이 링크는 15분 동안 유효합니다.
+app/services/email_copy.py::이 링크는 24시간 동안 유효합니다.
+app/services/email_copy.py::이 링크는 30분 동안 유효합니다.
+app/services/email_copy.py::이 이메일은 초대 발송으로 자동 생성되었습니다.
+app/services/email_copy.py::이런 안내를 더 이상 받고 싶지 않다면 여기를 눌러 주세요
+app/services/email_copy.py::이메일 인증하기
+app/services/email_copy.py::이어서 진행하기
+app/services/email_copy.py::적용 전까지 언제든 예약을 철회하고 구독을 유지하실 수 있습니다.
+app/services/email_copy.py::적용 전까지 언제든 예약을 철회하고 현재 플랜을 유지하실 수 있습니다.
+app/services/email_copy.py::정기결제 시도가 처리되지 않았습니다. 저희 쪽에서 매일 자동으로 재시도하고 있으니, 등록하신 카드 정보를 확인해 주시면 감사하겠습니다.
+app/services/email_copy.py::초대 수락하기
+app/services/email_copy.py::팀 관리자
+app/services/email_copy.py::팀에 초대됐어요!
+app/services/email_copy.py::플랜 변경이 예약됐습니다.
+app/services/embedding_backlog.py::(반복 실패
+app/services/embedding_backlog.py::embed_text 반복 실패(
+app/services/embedding_backlog.py::회 연속 — 재시도 중단)
+app/services/embedding_backlog.py::회 연속) — 재시도 중단
+app/services/event_broker.py::event_broker_outbox_enabled=true인데 event_broker_redis_dispatch_enabled도=true — outbox로 발행된 이벤트는 instance_id가 없어 self-skip이 안 돼 중복 dispatch(실 전달) 위험이 있다(story #2138). outbox는 dispatch 경로를 대체하는 것이지 병행하는 게 아니다 — 전환 중이면 dispatch를 먼저 끄고 outbox를 켤 것.
+app/services/event_broker.py::event_broker_outbox_enabled=true인데 event_broker_redis_dual_publish_enabled도=true — 같은 이벤트가 Redis에 두 번(즉시 shadow-publish + 나중 outbox dispatch) 발행되고 서로 다른 broker_event_id를 써서 dedup도 안 걸린다(중복배달, story #2138). outbox는 dual-publish를 대체하는 것이지 병행하는 게 아니다 — 전환 중이면 dual_publish를 먼저 끄고 outbox를 켤 것.
+app/services/event_definition_registry.py::(허용:
+app/services/event_definition_registry.py::(허용된 stage:
+app/services/event_definition_registry.py::) 밖입니다 — #2633 해석기가 풀 수 없는 정의.
+app/services/event_definition_registry.py::) 밖입니다 — 웹훅 액션 등은 후속(명시 제외).
+app/services/event_definition_registry.py::) 밖입니다.
+app/services/event_definition_registry.py::)가 허용 문자셋(소문자·숫자·밑줄 [a-z0-9_]만, 하이픈·대문자 불가)을 벗어났습니다:
+app/services/event_definition_registry.py::)가 호출자 org의 slug(
+app/services/event_definition_registry.py::)는 비어있지 않은 text가 필요합니다.
+app/services/event_definition_registry.py::)와 일치하지 않습니다 — 타 org 네임스페이스 도용 차단.
+app/services/event_definition_registry.py::.kind='payload_field'는 member_id_field가 필수입니다.
+app/services/event_definition_registry.py::.kind='recipe_role_binding'은 member_id_field/target을 가질 수 없습니다(stage 기반 바인딩 조회이므로 추가 파라미터 불요).
+app/services/event_definition_registry.py::.kind='server_derived'는 member_id_field를 가질 수 없습니다 (payload 필드가 아니라 서버 파생 역할이므로).
+app/services/event_definition_registry.py::.kind='server_derived'는 org 커스텀 정의에 등록할 수 없습니다 — 서버가 모르는 파생 역할은 해석 불가능한 정의를 만듭니다(payload_field 또는 target='none'만 허용).
+app/services/event_definition_registry.py::.kind는
+app/services/event_definition_registry.py::](type=actions)는 비어있지 않은 actions 목록이 필요합니다.
+app/services/event_definition_registry.py::](type=fields)는 비어있지 않은 fields 목록이 필요합니다.
+app/services/event_definition_registry.py::].capability.connector_key는 있으면 비어있지 않은 문자열이어야 합니다.
+app/services/event_definition_registry.py::].capability.kind는 비어있지 않은 문자열이어야 합니다.
+app/services/event_definition_registry.py::].capability는 object({kind, connector_key?})여야 합니다 —
+app/services/event_definition_registry.py::].gate.approver는
+app/services/event_definition_registry.py::].gate.type은 비어있지 않은 문자열이어야 합니다.
+app/services/event_definition_registry.py::].gate는 object({type, approver})여야 합니다 —
+app/services/event_definition_registry.py::]는 object({role, action})여야 합니다 —
+app/services/event_definition_registry.py::]는 object여야 합니다.
+app/services/event_definition_registry.py::]는 {'label': str, 'value': str} 형태여야 합니다.
+app/services/event_definition_registry.py::]는 발행할 definition_key(str)가 필요합니다.
+app/services/event_definition_registry.py::]는 비어있지 않은 label이 필요합니다.
+app/services/event_definition_registry.py::]은 object여야 합니다.
+app/services/event_definition_registry.py::block_template.blocks는 최소 1개 블록이 필요합니다.
+app/services/event_definition_registry.py::block_template은 {'blocks': [...]} 형태의 object여야 합니다.
+app/services/event_definition_registry.py::block_template이 payload_schema.properties에 없는 payload 키를 참조합니다:
+app/services/event_definition_registry.py::block_template이 지원하지 않는 ref 종류를 참조합니다:
+app/services/event_definition_registry.py::human_only은 bool이어야 합니다.
+app/services/event_definition_registry.py::key의 네임스페이스 slug(
+app/services/event_definition_registry.py::key의 세그먼트(
+app/services/event_definition_registry.py::org 커스텀 정의는 org_slug 없이 검증할 수 없습니다(fail-closed).
+app/services/event_definition_registry.py::org 커스텀 정의의 key는 'org.{slug}.'로 시작해야 합니다:
+app/services/event_definition_registry.py::payload_schema는 top-level 'additionalProperties: false'를 명시해야 합니다 — 미선언 스키마는 모르는 필드를 조용히 통과시켜 등록을 거부합니다.
+app/services/event_definition_registry.py::payload가 payload_schema를 위반합니다(
+app/services/event_definition_registry.py::role은 문자열 목록이어야 합니다.
+app/services/event_definition_registry.py::stage_metadata가 있으려면 payload_schema.properties.stage.enum이 먼저 선언돼야 합니다.
+app/services/event_definition_registry.py::stage_metadata에 payload_schema.properties.stage.enum에 없는 키가 있습니다:
+app/services/event_definition_registry.py::건)
+app/services/event_definition_registry.py::는 비어있지 않은 문자열이어야 합니다.
+app/services/event_definition_registry.py::아님.
+app/services/event_definition_registry.py::은 server_derived 닫힌 어휘(
+app/services/event_definition_registry.py::은 v1 어휘(
+app/services/event_definition_registry.py::은 닫힌 어휘 밖입니다.
+app/services/event_definition_registry.py::은 제한 어휘 4종(
+app/services/event_definition_registry.py::이 없거나 object가 아닙니다.
+app/services/event_definition_registry.py::중 하나여야 합니다 —
+app/services/event_definition_registry.py::중 하나여야 합니다:
+app/services/event_definition_registry.py::키만 허용합니다(action_auth v1 어휘 — human_only·role).
+app/services/event_definition_registry.py::프리셋 정의(org_id=None)의 key는 'preset.'로 시작해야 합니다:
+app/services/event_routing_resolver.py::)가 이 org의 실존 회원이 아닙니다.
+app/services/event_routing_resolver.py::event_routing_resolver의 server_derived resolver 어휘가 event_definition_registry.SERVER_DERIVED_TARGETS와 어긋남
+app/services/event_routing_resolver.py::recipe_role_binding 해석에는 definition_key가 필요합니다.
+app/services/event_routing_resolver.py::routing이 요구하는 payload.
+app/services/event_routing_resolver.py::가 없거나 비었습니다.
+app/services/event_routing_resolver.py::이 올바른 UUID 형식이 아닙니다:
+app/services/event_taxonomy.py::ISO 8601 UTC 타임스탬프
+app/services/event_taxonomy.py::기존 담당자 UUID
+app/services/event_taxonomy.py::멤버 UUID
+app/services/event_taxonomy.py::변경 전 position(batch=list 직렬화)
+app/services/event_taxonomy.py::변경 전 trust stage(unknown/done이면 null)
+app/services/event_taxonomy.py::변경 전 글롭 배열(JSON 직렬화, 미설정 null)
+app/services/event_taxonomy.py::변경 전 기본 프로젝트(미설정이면 null)
+app/services/event_taxonomy.py::변경 전 상태
+app/services/event_taxonomy.py::변경 후 position(batch=list 직렬화)
+app/services/event_taxonomy.py::변경 후 trust stage(done이면 null·파이프라인 스코프 밖)
+app/services/event_taxonomy.py::변경 후 글롭 배열(JSON 직렬화, 해제 시 null)
+app/services/event_taxonomy.py::변경 후 기본 프로젝트
+app/services/event_taxonomy.py::변경 후 상태
+app/services/event_taxonomy.py::산출물 제목
+app/services/event_taxonomy.py::새 담당자 UUID
+app/services/event_taxonomy.py::스토리 UUID
+app/services/event_taxonomy.py::스토리 제목
+app/services/event_taxonomy.py::시각 산출물 UUID
+app/services/event_taxonomy.py::실행자 member UUID
+app/services/event_taxonomy.py::실행자 team_member UUID
+app/services/event_taxonomy.py::실행자 user UUID
+app/services/event_taxonomy.py::에픽 UUID
+app/services/event_taxonomy.py::에픽 UUID(배치 중 1건 대표 — items에 전체)
+app/services/event_taxonomy.py::에픽 제목
+app/services/event_taxonomy.py::조직 UUID
+app/services/event_taxonomy.py::트리거된 스토리 UUID
+app/services/event_taxonomy.py::프로젝트 UUID
+app/services/exclusion_report.py::리포트 전용 — 자동 마킹 없음. PO 리뷰 후 개별 PATCH로 적용
+app/services/facebook_publish.py::릴스 발행은 영상이 필수입니다
+app/services/facebook_sandbox_publish.py::sandbox: [sandbox:429] 마커 시뮬레이션
+app/services/facebook_sandbox_publish.py::sandbox: [sandbox:expire-after-publish] 마커 시뮬레이션(발행 후 토큰 만료)
+app/services/facebook_sandbox_publish.py::sandbox: [sandbox:expired-token] 마커 시뮬레이션
+app/services/facebook_sandbox_publish.py::sandbox: [sandbox:provider-error] 마커 시뮬레이션
+app/services/facebook_sandbox_publish.py::sandbox: [sandbox:reels-codec-rejected] 마커 시뮬레이션
+app/services/facebook_sandbox_publish.py::sandbox: [sandbox:reels-processing-failed] 마커 시뮬레이션
+app/services/facebook_sandbox_publish.py::릴스 발행은 영상이 필수입니다
+app/services/facebook_sandbox_publish.py::마커 시뮬레이션
+app/services/facebook_sandbox_publish.py::샌드박스 FB 댓글
+app/services/firebase_verifier.py::FIREBASE_AUTH_MOBILE_ISSUE=true인데 FIREBASE_AUTH_MOBILE_APP_CHECK_REQUIRED=false — App Check 없는 네이티브 부트스트랩 발급은 device binding 없는 단회코드를 공개 발급하는 것과 같다(fail-closed·산티아고 §9 finding 1).
+app/services/ga4_oauth.py::refresh_token이 응답에 없습니다 — Google 계정 설정에서 이 앱 권한을 해제한 뒤 다시 연결해 주세요(access_type=offline+prompt=consent 재동의 필요).
+app/services/gate_enforce.py::승인 필요:
+app/services/gate_enforce.py::승인자가 요청자와 동일 — self-approval 금지(다른 승인자 필요).
+app/services/gate_enforce.py::전이가 거부됨(rejected) — 차단 유지.
+app/services/gate_enforce.py::전이가 정책상 차단됨(block).
+app/services/gate_enforce.py::전이는 사람 승인 대기(HITL).
+app/services/gate_enforce.py::전이에 사람 승인이 필요합니다(게이트 레벨 ask).
+app/services/gate_github_check.py::Sprintable Gate — participation 미등록
+app/services/gate_github_check.py::Sprintable Gate — story 링크 필요
+app/services/gate_github_check.py::게이트 상태:
+app/services/gate_github_check.py::이 PR엔 연결된 Sprintable story가 없어 merge gate를 만들 수 없습니다.\n\n다음 중 하나로 연결하면 gate가 자동 생성됩니다:\n- PR 제목에 `[SID:<story-id>]` 태그 포함\n- Sprintable의 explicit PR-story link API로 연결\n\n연결 후 새 커밋을 push하면(또는 PR을 재오픈하면) 이 check가 자동으로 갱신됩니다.
+app/services/gate_github_check.py::이 PR이 연결된 story에 implementation participation이 등록돼 있지 않아 merge gate를 만들 수 없습니다(누가 이 작업을 구현했는지 알 수 없어 신뢰 판정을 할 수 없음).\n\nstory를 claim하거나 담당자로 지정하면(claim_story/assignee 설정) participation이 자동 등록됩니다.\n\n등록 후 새 커밋을 push하면(또는 PR을 재오픈하면) 이 check가 자동으로 갱신됩니다.
+app/services/gate_reason_signal.py::폐기|중단|금지|삭제
+app/services/gate_seal.py::) — 재상신 후 다시 승인받아야 합니다
+app/services/gate_seal.py::) — 재승인이 필요합니다
+app/services/gate_seal.py::승인된 버전과 현재 내용이 다릅니다(gate_id=
+app/services/gate_seal.py::이 게이트는 봉인된 버전이 없습니다(gate_id=
+app/services/gate_service.py::. pending에서만 approved|rejected로 전이 가능.
+app/services/gate_service.py::decision 은 approved|rejected 만 가능합니다.
+app/services/gate_service.py::doc 삭제 cascade — pending 결재 게이트 자동 무효화
+app/services/gate_service.py::override 는 pending gate 만 가능합니다 (현재
+app/services/gate_service.py::override 는 reason(사유)이 필수입니다.
+app/services/gate_service.py::owner 가 게이트를
+app/services/gate_service.py::void 사유(reason)는 필수입니다.
+app/services/gate_service.py::→ held. pending 게이트만 보류 가능.
+app/services/gate_service.py::→ pending. 보류(held) 게이트만 재개 가능.
+app/services/gate_service.py::→ voided. pending 게이트만 무효화 가능.
+app/services/gate_service.py::게이트가 강제 결정되었습니다
+app/services/gate_service.py::게이트가 승인/거부를 기다리고 있습니다.
+app/services/gate_service.py::게이트가 재제출되어 다시 승인/거부를 기다리고 있습니다.
+app/services/gate_service.py::결재 대기 중인 게이트가 있습니다
+app/services/gate_service.py::논의 요청 불가: 게이트가
+app/services/gate_service.py::논의 요청 사유(reason)는 필수입니다.
+app/services/gate_service.py::로 강제 결정했습니다:
+app/services/gate_service.py::반려(변경 요청) 사유(note) 입력이 필수입니다.
+app/services/gate_service.py::본인이 해소한 게이트만 취소할 수 있습니다.
+app/services/gate_service.py::분)이 지났습니다.
+app/services/gate_service.py::불법 전이:
+app/services/gate_service.py::상태입니다 (pending만 가능).
+app/services/gate_service.py::상태입니다 (승인/반려된 게이트만 취소 가능).
+app/services/gate_service.py::예약 명령 미생성(draft 해석 실패)
+app/services/gate_service.py::예약 명령 미생성(승인된 목적지와 초안의 현재 목적지 불일치)
+app/services/gate_service.py::이(가) 정본으로 확정됐습니다.
+app/services/gate_service.py::정본 확정:
+app/services/gate_service.py::취소 불가: 게이트가
+app/services/gate_service.py::취소 창(
+app/services/gate_service.py::컨셉 승인이 완료되지 않았습니다(gate_id=
+app/services/goal.py::(허용: hit/miss/unmeasurable)
+app/services/goal.py::active(activation) 전이는 휴먼만 가능합니다.
+app/services/goal.py::hit/miss 판정에는 실제 수치(outcome_result.actual)와 한 줄 근거(outcome_result.reason)가 모두 필요합니다.
+app/services/goal.py::unmeasurable 선언에는 사유(outcome_result.reason)가 필요합니다.
+app/services/goal.py::목표를 찾을 수 없습니다.
+app/services/goal.py::불법 전이:
+app/services/goal.py::알 수 없는 goal status:
+app/services/goal.py::알 수 없는 outcome_status:
+app/services/goal_events.py::목표
+app/services/hypothesis.py::agent caller는 휴먼 owner_member_id를 명시해야 합니다.
+app/services/hypothesis.py::guided 가설 생성은 휴먼 전용입니다.
+app/services/hypothesis.py::owner_member_id는 caller와 동일 org의 type='human' 멤버여야 합니다.
+app/services/hypothesis.py::— 이 실행 묶음이 목표 지표를 개선한다
+app/services/hypothesis.py::가설 문장(1문장):
+app/services/hypothesis.py::가설을 찾을 수 없습니다.
+app/services/hypothesis.py::다른 프로젝트의 스토리에는 연결할 수 없습니다.
+app/services/hypothesis.py::다른 프로젝트의 스프린트에는 연결할 수 없습니다.
+app/services/hypothesis.py::다른 프로젝트의 에픽에는 연결할 수 없습니다.
+app/services/hypothesis.py::다음은 새 가설(hypothesis)의 소재가 될 작업 맥락이다. 이 맥락에 명시된 내용만 근거로, "실행하면 목표 지표가 개선될 것이다" 형태의 검증 가능한 가설 문장을 한국어 1문장으로 작성하라. 맥락에 없는 지표/숫자/사실을 추정하거나 새로 만들어내지 마라. 사람이 검토·수정할 초안이니 간결하고 구체적으로 작성하라.
+app/services/hypothesis.py::달성/반증 처리에는 실제 수치(outcome_result.actual)와 한 줄 근거(outcome_result.reason)가 모두 필요합니다.
+app/services/hypothesis.py::불법 전이:
+app/services/hypothesis.py::생성 시 status는 proposed|active만 허용됩니다.
+app/services/hypothesis.py::설명:
+app/services/hypothesis.py::수정할 필드가 없습니다.
+app/services/hypothesis.py::알 수 없는 상태:
+app/services/hypothesis.py::요약:
+app/services/hypothesis.py::이 실행 묶음이 목표 지표를 개선한다
+app/services/hypothesis.py::전이는 휴먼만 가능합니다.
+app/services/hypothesis.py::제목:
+app/services/hypothesis_outcome_confirm.py::draft_target은
+app/services/hypothesis_outcome_confirm.py::measuring 상태만 판정 초안 대상입니다(현재=
+app/services/hypothesis_outcome_confirm.py::가설을 찾을 수 없습니다.
+app/services/hypothesis_outcome_confirm.py::불법 전이:
+app/services/hypothesis_outcome_confirm.py::중 하나여야 합니다.
+app/services/insight_snapshots.py::Facebook 서버 오류:
+app/services/insight_snapshots.py::Facebook 액세스 토큰이 만료되었습니다
+app/services/insight_snapshots.py::Facebook 인사이트 API 한도 초과
+app/services/insight_snapshots.py::Facebook 인사이트 요청 거부:
+app/services/insight_snapshots.py::Facebook 인사이트 인증 오류:
+app/services/insight_snapshots.py::Instagram 서버 오류:
+app/services/insight_snapshots.py::Instagram 액세스 토큰이 만료되었습니다
+app/services/insight_snapshots.py::Instagram 인사이트 API 한도 초과
+app/services/insight_snapshots.py::Instagram 인사이트 요청 거부:
+app/services/insight_snapshots.py::Instagram 인사이트 인증 오류:
+app/services/insight_snapshots.py::Threads 서버 오류:
+app/services/insight_snapshots.py::Threads 액세스 토큰이 만료되었습니다
+app/services/insight_snapshots.py::Threads 인사이트 API 한도 초과
+app/services/insight_snapshots.py::Threads 인사이트 요청 거부:
+app/services/insight_snapshots.py::Threads 인사이트 인증 오류:
+app/services/insight_snapshots.py::channel_publication을 찾을 수 없습니다:
+app/services/insight_snapshots.py::insight_metrics는 선언됐지만 fetch dispatch가 없습니다:
+app/services/insight_snapshots.py::site_post를 찾을 수 없습니다:
+app/services/insight_snapshots.py::연결에 자격이 없습니다
+app/services/insight_snapshots.py::연결이 활성 상태가 아닙니다:
+app/services/insights_board.py::수정
+app/services/insights_board.py::재발행
+app/services/insights_board.py::중단
+app/services/insights_board.py::최근 스냅샷(
+app/services/insights_board.py::최근 스냅샷: 없음
+app/services/insights_board.py::후속 작업 — 원문:
+app/services/insights_board.py::후속 작업 생성(publication
+app/services/instagram_publish.py::Instagram 미디어 삭제 API는 아직 확認되지 않아 구현하지 않았습니다
+app/services/instagram_publish.py::Instagram 발행은 이미지가 필수입니다(피드 이미지 1장)
+app/services/instagram_publish.py::릴스 발행은 영상이 필수입니다
+app/services/instagram_sandbox_publish.py::Instagram 미디어 삭제 API는 아직 확認되지 않아 구현하지 않았습니다
+app/services/instagram_sandbox_publish.py::Instagram 발행은 이미지가 필수입니다(피드 이미지 1장)
+app/services/instagram_sandbox_publish.py::sandbox: [sandbox:429] 마커 시뮬레이션
+app/services/instagram_sandbox_publish.py::sandbox: [sandbox:expire-after-publish] 마커 시뮬레이션(발행 후 토큰 만료)
+app/services/instagram_sandbox_publish.py::sandbox: [sandbox:expired-token] 마커 시뮬레이션
+app/services/instagram_sandbox_publish.py::sandbox: [sandbox:provider-error] 마커 시뮬레이션
+app/services/instagram_sandbox_publish.py::sandbox: [sandbox:reels-codec-rejected] 마커 시뮬레이션
+app/services/instagram_sandbox_publish.py::sandbox: [sandbox:reels-processing-failed] 마커 시뮬레이션
+app/services/instagram_sandbox_publish.py::릴스 발행은 영상이 필수입니다
+app/services/instagram_sandbox_publish.py::마커 시뮬레이션
+app/services/instagram_sandbox_publish.py::샌드박스 IG 댓글
+app/services/judgment_core.py::scope='general'이면 work_item_ids는 비어 있어야 합니다(일반 교훈)
+app/services/judgment_core.py::scope='items'면 work_item_ids가 최소 1개 필요합니다(아직 안 붙인 상태 금지)
+app/services/judgment_core.py::가 이 org에 존재하지 않습니다
+app/services/l2_heuristics.py::% 초과
+app/services/l2_heuristics.py::%인데 done
+app/services/l2_heuristics.py::SP < 기대
+app/services/l2_heuristics.py::SP가 capacity
+app/services/l2_heuristics.py::SP가 기대
+app/services/l2_heuristics.py::SP의
+app/services/l2_heuristics.py::h 남음(임계
+app/services/l2_heuristics.py::h 무활동(임계
+app/services/l2_heuristics.py::h 초과됨
+app/services/l2_heuristics.py::x 초과
+app/services/l2_heuristics.py::경과
+app/services/l2_heuristics.py::마감까지
+app/services/l2_heuristics.py::마감이
+app/services/l2_trigger_worker.py::상태 변경
+app/services/loop.py::'는 이 엔드포인트로 전이할 수 없습니다(전용 엔드포인트 사용).
+app/services/loop.py::'에 결정할 pending 아티팩트가 없습니다.
+app/services/loop.py::'의 chosen+rejections가 pending 아티팩트 집합과 정확히 일치해야 합니다.
+app/services/loop.py::hypothesis_id 또는 goal+metric_definition+measure_after가 필요합니다.
+app/services/loop.py::가설을 찾을 수 없습니다.
+app/services/loop.py::가설이 아직 active 상태(휴먼 확인)가 아니라 generating으로 전이할 수 없습니다.
+app/services/loop.py::가설이 이 루프와 같은 프로젝트에 속하지 않습니다.
+app/services/loop.py::루프가 deciding 상태가 아닙니다.
+app/services/loop.py::루프를 찾을 수 없습니다.
+app/services/loop.py::불법 전이:
+app/services/loop.py::이 루프의 결정은 이미 종결되었습니다.
+app/services/loop.py::자산을 찾을 수 없습니다.
+app/services/loop.py::자산이 이 루프와 같은 프로젝트에 속하지 않습니다.
+app/services/loop.py::해당 루프의 프로젝트 접근 권한이 없습니다.
+app/services/loop_briefing.py::## Context Pack\n\n관련된 과거 loop/결정/성과를 찾지 못했습니다.
+app/services/loop_briefing.py::## Context Pack\n\n임베딩 서비스 일시 불가로 관련 이력 조회를 생략했습니다.
+app/services/loop_briefing.py::(유사도:
+app/services/loop_briefing.py::건 발견.
+app/services/loop_briefing.py::과거 유사 항목
+app/services/loop_briefing.py::성과:
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(REST·MCP 양쪽 다 core 취급 — 이 스토리가 새로 벌리는 격차 아님)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(connectors.py, 위와 동형)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(domain_labels.py, 사이트 도메인 설정·admin류)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(gate_config.py, 승인 게이트 거버넌스 설정·admin류)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(measurement_connections.py, GA4 연결 설정)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(org_invites.py, org 멤버 초대·admin류)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(organizations.py, org 단건 조회/수정·admin류)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(organizations.py, org 목록/생성 자체·admin류)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(organizations.py, org 임팩트 조회·admin류)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(organizations.py, slug→org 해소·session 유틸류)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(pageview_metering.py, hosted-site pageview 조회)
+app/services/mcp_toolset.py::MCP 도구/키워드 0건(pageview_metering.py, hosted-site 계측 설정·admin류)
+app/services/mcp_toolset.py::MCP 도구/키워드 있음(sprintable_get_content_rules가 간접 소비, 3769) — REST 1:1 전용 도구는 여전히 0건, 세그먼트 직접 매핑은 범위 밖으로 보류
+app/services/member_resolver.py::이름 없는 구성원
+app/services/model_family.py::**기존 정체성을 덮지 말고, 당신 방식대로 자기화하세요.**
+app/services/model_family.py::**기존 정체성을 유지한 채, 당신 방식대로 자기화하세요.**
+app/services/model_family.py::워크플로는 고정 절차로 외우지 말고, 매번 `sprintable_get_workflow_guide`로 최신 확인
+app/services/model_family.py::워크플로는 매번 `sprintable_get_workflow_guide`로 최신 확인
+app/services/model_family.py::위 목록에 없는 도구 이름을 지어내지 마세요 — 확실하지 않으면 `sprintable_get_workflow_guide`로 먼저 확인하세요.
+app/services/model_family.py::위 목록에 있는 도구 이름만 사용하세요 — 확실하지 않으면 `sprintable_get_workflow_guide`로 먼저 확인하세요.
+app/services/model_family.py::이 파일 내용을 그대로 복사해 자신을 덮어쓰지 마세요
+app/services/model_family.py::이 파일 내용을 당신 언어로 바꿔 담으세요
+app/services/org_billing_key.py::) 이후 삭제할 수 있습니다.
+app/services/org_billing_key.py::)이 있어 결제수단을 지울 수 없습니다 — 구독 종료일(
+app/services/org_billing_key.py::는 활성 유료 구독(tier=
+app/services/org_billing_key.py::미정
+app/services/org_subscription_checkout.py::)입니다 — 플랜/결제주기 변경은 POST /api/v2/org-subscriptions/change-tier를 쓰세요. checkout은 신규 결제 전용입니다.
+app/services/org_subscription_checkout.py::구독 시작
+app/services/org_subscription_checkout.py::는 'monthly'/'annual'만 허용
+app/services/org_subscription_checkout.py::는 이미 활성 유료 구독(tier=
+app/services/org_subscription_checkout.py::는 체크아웃 대상이 아님(free 제외,
+app/services/org_subscription_checkout.py::만)
+app/services/org_subscription_checkout.py::에 다른 checkout이 이미 진행 중 — 완료 후 재시도
+app/services/org_subscription_checkout.py::의 활성 offering_version(krw)을 찾을 수 없음
+app/services/org_subscription_checkout.py::조직을 찾을 수 없음
+app/services/org_subscription_downgrade.py::)을 찾을 수 없음
+app/services/org_subscription_downgrade.py::current_period_end 없음 — 적용일을 정할 수 없음
+app/services/org_subscription_downgrade.py::구독 없음
+app/services/org_subscription_downgrade.py::는 유료 티어만(starter/team/business) — free 전환은 구독 취소(story #2882)
+app/services/org_subscription_downgrade.py::는 하향이 아님(상향/동일) — 상향은 story #2880(change-tier)
+app/services/org_subscription_downgrade.py::의 활성 offering_version(
+app/services/org_subscription_downgrade.py::철회할 예약된 하향이 없음
+app/services/org_subscription_downgrade.py::활성 유료 구독이 아님 — 하향/취소 예약 대상 아님
+app/services/org_subscription_tier_change.py::) — 상향 아님
+app/services/org_subscription_tier_change.py::)에 offering_version_id가 바인딩되지 않음
+app/services/org_subscription_tier_change.py::current_period_start/end 없음 — 일할 부분취소 계산 불가
+app/services/org_subscription_tier_change.py::— 연납 중 상향은 이 스토리 범위 밖(공식 문서 확定 선행, doc billing-policy-scenario-audit-20260821 §3)
+app/services/org_subscription_tier_change.py::는 상향이 아님(하향/동일) — 하향은 story #2881(예약+좌석 게이트)
+app/services/org_subscription_tier_change.py::는 유료 티어만(starter/team/business)
+app/services/org_subscription_tier_change.py::를 찾을 수 없음
+app/services/org_subscription_tier_change.py::상향
+app/services/org_subscription_tier_change.py::에 다른 결제 작업이 이미 진행 중 — 완료 후 재시도
+app/services/org_subscription_tier_change.py::의 활성 offering_version(krw)을 찾을 수 없음
+app/services/org_subscription_tier_change.py::활성 유료 구독이 아님 — 상향 엔진(change-tier)이 아니라 신규 결제(checkout)로 진입해야 함
+app/services/participation_helpers.py::구현
+app/services/payment/polar_adapter.py::PolarAdapter.cancel — 기존 backend 로직 없음(취소는 Polar 쪽 subscription.canceled 웹훅으로만 반영되는 현재 구조). 후속 스토리 대상.
+app/services/payment/polar_adapter.py::PolarAdapter.charge — 기존 backend 로직 없음(체크아웃 완료가 결제를 대신함). 후속 스토리 대상.
+app/services/payment/polar_adapter.py::PolarAdapter.create_customer — 기존 backend 로직 없음(체크아웃이 고객 생성을 암묵 처리). 후속 스토리 대상.
+app/services/payment/polar_adapter.py::PolarAdapter.open_portal — 기존 backend 로직 없음. 후속 스토리 대상.
+app/services/payment/polar_adapter.py::PolarAdapter.refund — 기존 backend 로직 없음. 후속 스토리 대상.
+app/services/payment/polar_adapter.py::create_billing_key는 Toss 개념(빌링키 기반 정기결제) — Polar는 구독 객체를 직접 관리해 해당 없음. TossAdapter(story C) 대상.
+app/services/payment/toss_adapter.py::TossAdapter.cancel — story C4 대상(빌링키 삭제 API). 구독 자체 취소는 정기결제 스케줄러(story C3)가 다음 결제를 안 돌리는 것으로 별도 처리.
+app/services/payment/toss_adapter.py::TossAdapter.create_checkout — Toss는 호스티드 체크아웃 세션이 아니라 빌링키 발급위젯 플로우(create_billing_key 참고). 해당 없음.
+app/services/payment/toss_adapter.py::TossAdapter.create_customer — Toss는 고객 개념이 빌링키에 암묵 포함(customerKey만 서버에서 발급). 별도 API 없음.
+app/services/payment/toss_adapter.py::TossAdapter.open_portal — Toss엔 고객 포털 API가 없다. 카드 교체는 새 빌링키 발급(create_billing_key 재호출)으로 대체 — FE가 재인증 플로우를 새로 띄운다.
+app/services/pg_pubsub.py::DB_PGBOUNCER=on requires DATABASE_URL_DIRECT — pg_pubsub LISTEN 은 transaction-mode PgBouncer 비호환이라 direct Cloud SQL URL 필수 (fail-closed·ee7794eb ③).
+app/services/pg_pubsub.py::앱 기동 시 1회 생성 — 자기 자신이 발행한 notify 재수신 방지용.
+app/services/platform_settings.py::platform_settings 테이블에 행이 없음 — migration 0255 미적용 또는 삭제됨
+app/services/project_auth.py::SELECT p.id\n            FROM projects p\n            WHERE p.org_id = :org_id\n              AND p.deleted_at IS NULL\n              AND (\n                EXISTS (\n                    SELECT 1 FROM team_members tm\n                    WHERE tm.project_id = p.id\n                      AND (tm.id = :user_id OR tm.user_id = :user_id)\n                      AND tm.is_active = true\n                      -- 35a0691e: has_project_access lockstep — team_member 분기 휴먼만(에이전트는 grant).\n                      AND tm.type = 'human'\n                )\n                OR EXISTS (\n                    SELECT 1 FROM project_access pa\n                    JOIN org_members om ON pa.org_member_id = om.id\n                    WHERE pa.project_id = p.id\n                      AND om.user_id = :user_id\n                      AND om.deleted_at IS NULL\n                      AND pa.permission = 'granted'\n                      AND om.org_id = :org_id\n                )\n                OR EXISTS (\n                    -- 18073a52: 에이전트 grant 분기 (has_project_access와 lockstep).\n                    -- story #2953: is_active=false(비활성·미삭제) 에이전트의 기존 grant가\n                    -- 계속 유효로 통과하던 비대칭 수정 — 위 team_member 분기(휴먼)와 정합.\n                    SELECT 1 FROM project_access pa\n                    JOIN members m ON pa.member_id = m.id\n                    WHERE pa.project_id = p.id\n                      AND m.id = :user_id\n                      AND m.type = 'agent'\n                      AND m.deleted_at IS NULL\n                      AND m.is_active = true\n                      AND pa.permission = 'granted'\n                      AND m.org_id = :org_id\n                )\n                OR EXISTS (\n                    SELECT 1 FROM org_members om\n                    WHERE om.user_id = :user_id\n                      AND om.deleted_at IS NULL\n                      AND om.role IN ('owner', 'admin')\n                      AND om.org_id = :org_id\n                )\n              )\n            ORDER BY p.created_at ASC
+app/services/project_auth.py::SELECT tm.project_id\n            FROM team_members tm\n            JOIN projects p ON p.id = tm.project_id\n            WHERE tm.org_id = :org_id\n              AND (tm.id = :user_id OR tm.user_id = :user_id)\n              AND tm.is_active = true\n              -- 35a0691e: has_project_access lockstep — team_member 분기 휴먼만(에이전트는 grant).\n              AND tm.type = 'human'\n              AND p.deleted_at IS NULL\n            ORDER BY tm.created_at ASC\n            LIMIT 1
+app/services/publication_command.py::게이트가 승인 상태가 아니거나 봉인이 최신 답변과 다릅니다
+app/services/publication_command.py::답변 기록을 찾을 수 없습니다
+app/services/publication_command.py::대상 댓글을 찾을 수 없습니다
+app/services/publication_command.py::대상 댓글이 삭제되어 답변을 보내지 못했습니다
+app/services/publication_command.py::연결에 자격이 없습니다
+app/services/publication_command.py::연결이 활성 상태가 아닙니다:
+app/services/publication_reconciliation.py::channel_publication을 찾을 수 없습니다:
+app/services/publication_reconciliation.py::이 채널은 실측 대조를 지원하지 않습니다:
+app/services/recipe_gate_hooks.py::recipe_gate_hooks의 approver role resolver 어휘가 event_definition_registry.APPROVER_ROLE_REFERENCES와 어긋남
+app/services/recipe_gate_hooks.py::미확認
+app/services/recipe_gate_hooks.py::에 role=owner인 org_member가 없습니다.
+app/services/recipe_repeat_schedule.py::repeat 형식을 해석할 수 없습니다:
+app/services/recipe_repeat_schedule.py::repeat은 ISO8601 duration(P로 시작)이어야 합니다:
+app/services/recipe_repeat_schedule.py::repeat이 0 이하로 해석됩니다(무한루프 방지로 거부):
+app/services/recipe_repeat_scheduler.py::' 정의의 반복 발행이 멈췄습니다 —
+app/services/recipe_repeat_scheduler.py::[반복 스케줄 정지] '
+app/services/recipe_repeat_scheduler.py::연속
+app/services/recipe_repeat_scheduler.py::정의가 더 이상 사이클형이 아닙니다
+app/services/recipe_repeat_scheduler.py::정의가 비활성화되었거나 삭제되었습니다
+app/services/recipe_repeat_scheduler.py::프로젝트가 삭제(archive)되었습니다
+app/services/recipe_repeat_scheduler.py::회 발행 실패
+app/services/reference_semantic_candidates.py::같은\\s*병|같은\\s*성질|같은\\s*계열|결함\\s*계열|같은\\s*클래스
+app/services/reference_semantic_candidates.py::머지\\s*`[0-9a-f]+`\\s*\\(PR\\s*#|PR\\s*#\\d+\\s*본문에\\s*기록|확認\\s*완료
+app/services/reference_semantic_candidates.py::신규\\s*스토리\\s*등재|중\\s*발견|중\\s*적출|발견\\s*\\(#|발단\\s*[—\\-]|검수\\s*중|수행\\s*중\\s*직접\\s*발견
+app/services/reference_semantic_candidates.py::의존[:：]|의존\\s*그래프|→.*→|앞에\\s*서는가
+app/services/reference_semantic_candidates.py::직교|무관(?!심)
+app/services/retro_export_i18n.py::## 개선할 점
+app/services/retro_export_i18n.py::## 아쉬운 점
+app/services/retro_export_i18n.py::## 액션 아이템
+app/services/retro_export_i18n.py::## 잘된 점
+app/services/retro_export_i18n.py::**단계:**
+app/services/retro_export_i18n.py::수집
+app/services/retro_export_i18n.py::액션
+app/services/retro_export_i18n.py::완료
+app/services/retro_export_i18n.py::우선순위
+app/services/retro_export_i18n.py::진행 중
+app/services/retro_export_i18n.py::표
+app/services/retro_synthesis.py::(실측
+app/services/retro_synthesis.py::가설 결과:
+app/services/retro_synthesis.py::개, 각각 "~할 것이다" 형태의 제안형 한국어 문장으로 작성하라. 각 후보에는 반드시 근거(종합의 어느 부분에서 나왔는지)를 rationale로 함께 제시하고, confidence(0.0~1.0, 확신도를 정직하게)를 매겨라.
+app/services/retro_synthesis.py::다음은 한 스프린트 회고의 종합(무엇을 배웠는지)이다. 이 종합만 근거로 다음 스프린트에서 검증할 만한 가설 후보를 최대
+app/services/retro_synthesis.py::다음은 한 스프린트의 가설 검증 결과와 팀 회고 상위 의견이다. 이 정보만 근거로 "이번 스프린트에서 배운 것"을 2~4개 항목으로 한국어로 종합하라. 각 항목은 반드시 근거(가설 statement 또는 회고 아이템 내용)를 함께 명시하라.
+app/services/retro_synthesis.py::맥락에 없는 사실/숫자를 지어내지 마라.
+app/services/retro_synthesis.py::맥락에 없는 사실을 지어내지 마라.
+app/services/retro_synthesis.py::반증된(falsified) 가설이나 부정적 회고 항목은 실패로 서술하지 마라 — "~을 확인했다", "~이 아님을 배웠다"처럼 학습 데이터로 서술하라. "실패했다"·"안 됐다" 같은 표현은 금지한다.
+app/services/retro_synthesis.py::종합:
+app/services/retro_synthesis.py::표)
+app/services/retro_synthesis.py::회고 상위 의견:
+app/services/sandbox_publish.py::sandbox: [sandbox:429] 마커 시뮬레이션
+app/services/sandbox_publish.py::sandbox: [sandbox:app-inactive] 마커 시뮬레이션
+app/services/sandbox_publish.py::sandbox: [sandbox:expired-token] 마커 시뮬레이션
+app/services/sandbox_publish.py::sandbox: [sandbox:page-unlinked] 마커 시뮬레이션
+app/services/sandbox_publish.py::sandbox: [sandbox:permission-error] 마커 시뮬레이션
+app/services/sandbox_publish.py::sandbox: [sandbox:provider-error] 마커 시뮬레이션
+app/services/sandbox_publish.py::sandbox: [sandbox:revoked] 마커 시뮬레이션
+app/services/sandbox_publish.py::샌드박스 댓글
+app/services/site_posts.py::) — 조직 설정에서 기본 역할을 지정한 뒤 다시 상신하세요
+app/services/site_posts.py::)는 블로그 목적지가 아닙니다
+app/services/site_posts.py::Phase 0은 미디어 입력을 지원하지 않습니다
+app/services/site_posts.py::draft를 찾을 수 없습니다:
+app/services/site_posts.py::external_publish 게이트가 승인되지 않았습니다(gate_id=
+app/services/site_posts.py::lang 형식이 올바르지 않습니다:
+app/services/site_posts.py::slug 형식이 올바르지 않습니다:
+app/services/site_posts.py::게이트가 승인 상태가 아닙니다(gate_id=
+app/services/site_posts.py::목적지 변경으로 자동 해제(destination changed
+app/services/site_posts.py::버전을 찾을 수 없습니다:
+app/services/site_posts.py::봉인된 본문과 현재 버전이 다릅니다(gate_id=
+app/services/site_posts.py::승인된 목적지와 draft의 현재 목적지가 다릅니다(gate_id=
+app/services/site_posts.py::알 수 없는 blog 채널:
+app/services/site_posts.py::연결에 자격이 없습니다:
+app/services/site_posts.py::연결을 찾을 수 없습니다:
+app/services/site_posts.py::이 draft에 현재 공개된 글이 없습니다:
+app/services/site_posts.py::이 work item에 승인된 external_publish 게이트가 없습니다
+app/services/site_posts.py::이 work item은 다른 초안이 이미 승인 절차 중입니다(holding_draft_id=
+app/services/site_posts.py::이 초안을 보관할 권한이 없습니다:
+app/services/site_posts.py::조직에 기본 결재 역할이 설정되지 않았습니다(org_id=
+app/services/site_posts.py::회수할 발행 기록이 없습니다
+app/services/sprint.py::불법 전이:
+app/services/sprint.py::스프린트를 찾을 수 없습니다.
+app/services/sprint.py::알 수 없는 sprint status:
+app/services/sprint.py::이 스프린트로 검증할 가설을 최소 1개 선언하세요.
+app/services/story_assignee_events.py::스토리 담당자로 지정됨:
+app/services/story_status_events.py::스토리 상태 변경:
+app/services/webhook_dispatch.py::Sprintable 알림 목적지 연결 테스트 — 이 메시지가 보이면 정상 연결입니다.
+app/services/webhook_publish.py::webhook target_url이 안전하지 않습니다:
+app/services/webhook_publish.py::webhook 수신측 오류(status=
+app/services/wordpress_publish.py::WordPress REST API 오류(status=
+app/services/wordpress_publish.py::WordPress site_url은 https://여야 합니다:
+app/services/workflow_line_config.py::draft 만 수정 가능합니다 (현재
+app/services/workflow_line_config.py::·published/approved 등은 immutable·수정은 새 draft).
+app/services/workflow_line_config.py::불법 version 전이:
+app/services/workflow_line_engine.py::merge-gate (dry-run preview · 정확 verdict 미계산: CI/PR 동적 상태 의존)
+app/services/workflow_line_status.py::라인 도입 전/off 전이(grandfathered) · 게이트 미적용
+app/services/workflow_line_status.py::전이는 진행됨 · 라인 관측만 실패(재시도 불필요)
+app/services/workflow_parallel_approval.py::old_approver_id 에 해당하는 pending 결재자가 없습니다.
+app/services/workflow_parallel_approval.py::게이트 결재 요청
+app/services/workflow_parallel_approval.py::결재가 대기 중입니다.
+app/services/workflow_parallel_approval.py::결재자가 여러 명입니다 — old_approver_id 를 지정하세요.
+app/services/workflow_parallel_approval.py::결재자로 재지정됨
+app/services/workflow_parallel_approval.py::관리자가 당신을 이 결재의 새 결재자로 지정했습니다.
+app/services/workflow_parallel_approval.py::새 결재자가 SoD 당사자(요청자/구현자/최초결재자)와 동일 — 자기승인 우회 금지.
+app/services/workflow_parallel_approval.py::새 결재자가 이 org 의 멤버가 아닙니다.
+app/services/workflow_parallel_approval.py::새 결재자가 해당 프로젝트 접근권이 없습니다.
+app/services/workflow_parallel_approval.py::이 게이트엔 재지정할 명시적 결재자(approver)가 없습니다 (parallel gate 전용).
+app/services/workflow_parallel_approval.py::이미 그 멤버가 결재자입니다.
+app/services/workflow_parallel_approval.py::항목의
+app/services/workflow_violation.py::' 전이:
+app/services/workflow_violation.py::단계 건너뜀

--- a/backend/scripts/measure_korean_user_string_reachability.py
+++ b/backend/scripts/measure_korean_user_string_reachability.py
@@ -1,0 +1,265 @@
+"""story #3779(2층, 페드루 PO 處方 2026-09-10 08:05Z) — 1층 baseline(1308건/176파일) 중
+«화면에 실제로 닿는» 부분집합을 실측한다. 이 스크립트는 CI에 물리지 않는다(카드 明示: 목록
+산출물이지 재발가드가 아니다 — 재발가드는 verify_no_new_korean_user_strings.py가 이미 맡는다).
+
+## 방법 — 휴리스틱 6종(파일/AST 패턴 기반, 페드루 判 기준 그대로)
+카드 기준: "응답 본문/message/detail/이메일/챗 커맨드 출력/문서 export처럼 FE나 사람이
+«그대로 그리는» 경로". 1308건 각각을 사람이 일일이 판정하는 대신, 구조적으로 식별 가능한
+6개 패턴으로 파일/자리를 분류한다(보수적 — 이 6종에 안 걸리면 "닿는다"로 안 센다. 즉 이
+숫자는 «최소치»다, 실제 도달 경로가 이 6종 밖에도 있을 수 있다):
+
+  ① `HTTPException(..., detail=<한글 포함 표현식>)` — 그 detail이 HTTP 응답 바디에 그대로
+     실린다(FastAPI 기본 동작). verify:no-raw-error-message가 FE 쪽에서 이미 "이런 자리가
+     화면에 raw로 닿는다"를 확인한 것과 대칭.
+  ② `CommandOutcome(...)` 호출의 인자 — 챗 커맨드 응답(chat_command_catalog.py:186 표본).
+  ③ `email_copy.py` 전체 — 파일 자체가 "발송 메일 7종의 locale별 카피 사전"(파일 자체
+     docstring, 2026-08-29 story #3205). 이메일 본문은 정의상 사람이 읽는 문장이라
+     파일 전체를 닿는 것으로 센다(per-string이 아니라 file-level 예외 — 유일 사례).
+  ④ dict/키워드 인자 값 중 키 이름이 HUMAN_FIELD_NAMES(message/detail/description/
+     summary/reason/subject/body/text/title/label/prompt/content)에 속하는 자리 — 응답
+     스키마·알림 payload에 흔히 쓰이는 사람이 읽는 필드 이름 관례.
+  ⑤ **커스텀 예외 `__init__`의 `super().__init__(...)` 인자**(channel_posts.py:72
+     표본 — `ChannelConnectionNotActiveError(ValueError)`) — ①만으로는 못 잡는다: 이
+     레포는 라우터에서 직접 `HTTPException`을 던지지 않고 도메인 예외를 만들어 던진 뒤
+     전역 핸들러(또는 각 라우터의 `except` 절)가 HTTP 응답으로 변환하는 관례가 63건
+     실측됐다 — 그 예외 메시지 자체가 최종 응답 문구가 되는 경우가 흔하다.
+  ⑥ **Pydantic validator(`@field_validator`/`@validator`/`@model_validator`) 안의
+     `raise ValueError(...)`**(gates.py:131-132 표본) — Pydantic이 이 예외를 잡아 422
+     응답의 `detail` 배열에 메시지 그대로 싣는다(FastAPI 기본 동작, 라우터 코드 개입 없음).
+
+## 한계(⚠️이 스크립트가 «못 잡는» 것)
+  ㉠ Pydantic 모델 인스턴스 생성(`FooResponse(message=...)`)에서 필드명이 HUMAN_FIELD_NAMES
+     밖의 이름(예: `outcome_text`, `guidance`)이면 못 잡는다.
+  ㉡ 여러 함수를 거쳐 값이 흘러가는 간접 경로(변수에 담겼다가 나중에 response에 실리는
+     경우) — 정적으로 값 흐름을 안 쫓는다(AST call-site 패턴 매칭만).
+  ㉢ email_copy.py를 제외한 나머지 파일은 file-level이 아니라 string-level 판정이라,
+     같은 파일 안에서도 "안 닿는" 나머지 문자열(내부 로그 인접 상수·설정값 등)은 이 수에
+     안 들어간다 — 그래서 파일별 합계 ≠ baseline 파일별 전체 건수.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from verify_no_new_korean_user_strings import (  # noqa: E402
+    APP_DIR,
+    _docstring_constant_ids,
+    _is_hangul,
+)
+
+HUMAN_FIELD_NAMES = {
+    "message", "detail", "description", "summary", "reason", "subject",
+    "body", "text", "title", "label", "prompt", "content",
+}
+EMAIL_COPY_FILE = "app/services/email_copy.py"
+
+
+@dataclass
+class ReachableHit:
+    file: str
+    line: int
+    text: str
+    reason: str  # "http_detail" | "chat_command" | "email_copy" | "response_field"
+
+
+def _build_parent_map(tree: ast.AST) -> dict[int, ast.AST]:
+    parents: dict[int, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+    return parents
+
+
+def _enclosing_call(node: ast.AST, parents: dict[int, ast.AST]) -> ast.Call | None:
+    cur = parents.get(id(node))
+    while cur is not None:
+        if isinstance(cur, ast.Call):
+            return cur
+        cur = parents.get(id(cur))
+    return None
+
+
+def _call_name(call: ast.Call) -> str | None:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def _enclosing_dict_key(node: ast.AST, parents: dict[int, ast.AST]) -> str | None:
+    """node가 dict literal의 value이면 그 key 이름을(문자열 리터럴 key일 때만) 반환."""
+    parent = parents.get(id(node))
+    if isinstance(parent, ast.Dict):
+        for k, v in zip(parent.keys, parent.values):
+            if v is node and isinstance(k, ast.Constant) and isinstance(k.value, str):
+                return k.value
+    return None
+
+
+def _enclosing_keyword_name(node: ast.AST, parents: dict[int, ast.AST]) -> str | None:
+    """node가 keyword=value(함수 호출 키워드 인자)의 value이면 그 키워드 이름을 반환."""
+    parent = parents.get(id(node))
+    if isinstance(parent, ast.keyword) and parent.arg is not None:
+        return parent.arg
+    return None
+
+
+def _is_super_init_call(call: ast.Call) -> bool:
+    """`super().__init__(...)` 형태인지 — 커스텀 예외 클래스의 메시지 생성부(⑤)."""
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "__init__"
+        and isinstance(call.func.value, ast.Call)
+        and isinstance(call.func.value.func, ast.Name)
+        and call.func.value.func.id == "super"
+    )
+
+
+VALIDATOR_DECORATOR_NAMES = {"field_validator", "validator", "model_validator"}
+
+
+def _decorator_name(dec: ast.expr) -> str | None:
+    if isinstance(dec, ast.Name):
+        return dec.id
+    if isinstance(dec, ast.Attribute):
+        return dec.attr
+    if isinstance(dec, ast.Call):
+        return _decorator_name(dec.func)
+    return None
+
+
+def _enclosing_function(node: ast.AST, parents: dict[int, ast.AST]) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    cur = parents.get(id(node))
+    while cur is not None:
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return cur
+        cur = parents.get(id(cur))
+    return None
+
+
+def _is_inside_raise(node: ast.AST, parents: dict[int, ast.AST]) -> bool:
+    """node가 (함수 경계를 넘지 않는 한도 내에서) `raise ...` statement 안에 있는지."""
+    cur = parents.get(id(node))
+    while cur is not None:
+        if isinstance(cur, ast.Raise):
+            return True
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return False
+        cur = parents.get(id(cur))
+    return False
+
+
+def scan_reachable(source: str, file_label: str) -> list[ReachableHit]:
+    if file_label == EMAIL_COPY_FILE:
+        # file-level 예외 — 파일 전체가 이메일 본문 카피 사전.
+        tree = ast.parse(source)
+        docstring_ids = _docstring_constant_ids(tree)
+        hits: list[ReachableHit] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if id(node) in docstring_ids or not _is_hangul(node.value):
+                continue
+            hits.append(ReachableHit(file=file_label, line=node.lineno, text=node.value.strip(), reason="email_copy"))
+        return hits
+
+    tree = ast.parse(source)
+    docstring_ids = _docstring_constant_ids(tree)
+    parents = _build_parent_map(tree)
+
+    hits: list[ReachableHit] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if id(node) in docstring_ids or not _is_hangul(node.value):
+            continue
+
+        text = node.value.strip()
+        line = node.lineno
+
+        kw_name = _enclosing_keyword_name(node, parents)
+        if kw_name == "detail":
+            call = _enclosing_call(node, parents)
+            if call is not None and _call_name(call) in {"HTTPException"}:
+                hits.append(ReachableHit(file=file_label, line=line, text=text, reason="http_detail"))
+                continue
+
+        call = _enclosing_call(node, parents)
+        if call is not None and _call_name(call) == "CommandOutcome":
+            hits.append(ReachableHit(file=file_label, line=line, text=text, reason="chat_command"))
+            continue
+
+        if call is not None and _is_super_init_call(call):
+            hits.append(ReachableHit(file=file_label, line=line, text=text, reason="custom_exception"))
+            continue
+
+        if _is_inside_raise(node, parents):
+            fn = _enclosing_function(node, parents)
+            if fn is not None:
+                dec_names = {_decorator_name(d) for d in fn.decorator_list}
+                if dec_names & VALIDATOR_DECORATOR_NAMES:
+                    hits.append(ReachableHit(file=file_label, line=line, text=text, reason="pydantic_validator"))
+                    continue
+
+        dict_key = _enclosing_dict_key(node, parents)
+        if dict_key in HUMAN_FIELD_NAMES:
+            hits.append(ReachableHit(file=file_label, line=line, text=text, reason="response_field"))
+            continue
+        if kw_name in HUMAN_FIELD_NAMES:
+            hits.append(ReachableHit(file=file_label, line=line, text=text, reason="response_field"))
+            continue
+
+    return hits
+
+
+def scan_repo(backend_root: Path) -> list[ReachableHit]:
+    app_root = backend_root / APP_DIR
+    files = sorted(p for p in app_root.rglob("*.py") if "__pycache__" not in p.parts)
+    hits: list[ReachableHit] = []
+    for f in files:
+        file_label = str(f.relative_to(backend_root))
+        source = f.read_text(encoding="utf-8")
+        try:
+            hits.extend(scan_reachable(source, file_label))
+        except SyntaxError:
+            continue
+    return hits
+
+
+def main() -> int:
+    backend_root = Path(__file__).resolve().parent.parent
+    hits = scan_repo(backend_root)
+
+    by_file: dict[str, list[ReachableHit]] = {}
+    for h in hits:
+        by_file.setdefault(h.file, []).append(h)
+
+    by_reason: dict[str, int] = {}
+    for h in hits:
+        by_reason[h.reason] = by_reason.get(h.reason, 0) + 1
+
+    print(f"[story #3779 2층] 화면 도달 부분집합(휴리스틱 6종, 최소치) — {len(hits)}건 / {len(by_file)}파일")
+    print(f"  사유별: {json.dumps(by_reason, ensure_ascii=False)}")
+    print()
+    for file_label in sorted(by_file):
+        file_hits = by_file[file_label]
+        print(f"  {file_label}: {len(file_hits)}건")
+
+    return 0
+
+
+if __name__ == "__main__":
+    if "--json" in sys.argv:
+        backend_root = Path(__file__).resolve().parent.parent
+        hits = scan_repo(backend_root)
+        print(json.dumps(
+            [{"file": h.file, "line": h.line, "text": h.text, "reason": h.reason} for h in hits],
+            ensure_ascii=False, indent=2,
+        ))
+    else:
+        sys.exit(main())

--- a/backend/scripts/verify_no_new_korean_user_strings.py
+++ b/backend/scripts/verify_no_new_korean_user_strings.py
@@ -29,10 +29,14 @@ grep(421파일/3539건)이 주석 안 따옴표 강조까지 오탐했던 것과
 문자열이 실제로 사용자에게 닿는가"는 안 본다(2층은 별도 스크립트/카드, 이 카드의 산출물
 목록으로 남긴다).
 
-## 계약 — story #3741/#2335와 동일
+## 계약 — 카드 處方 ① "stale RED"(3776 ③-b 형, story #3741/#2335보다 한 단계 더 엄격)
 baseline(`korean_user_strings_baseline.txt`)에 없는 새 한글 문자열 리터럴이 있으면 FAIL.
-baseline에 있는데 이번 스캔에서 안 걸리면(코드가 고쳐졌거나 삭제됐으면) stale로 경고만
-(비차단) — CI의 별도 git-diff 스텝이 baseline 파일 자체가 "줄기만" 허용되도록 막는다.
+baseline에 있는데 이번 스캔에서 안 걸리면(코드가 고쳐졌거나 삭제됐으면) **그것도 FAIL**
+(stale RED, 페드루 PO 지적 2026-09-10 08:17Z) — "줄기만 허용" git-diff CI 스텝은 baseline이
+«늘어나는» 것만 막지, 이미 있는 항목이 실물과 안 맞게 된 것(고쳤는데 목록에서 안 뺀 것)은
+못 잡는다. 그래서 stale도 이 스크립트 자신이 FAIL로 잡는다 — baseline 정리는 사람이 그
+FAIL 메시지를 보고 직접 그 줄을 지운다(자동 걷기 없음, story #3776의 grandfather 정리
+관례와 동일).
 
 ⚠️이 가드가 «못 잡는» 것:
   ㉠ f-string의 `{expr}` 안에 동적으로 조립되는 한글(변수 값 자체) — 리터럴 조각만 본다.
@@ -187,6 +191,16 @@ def write_baseline(path: Path, keys: set[str]) -> None:
     path.write_text(header + "\n".join(sorted(keys)) + "\n", encoding="utf-8")
 
 
+def evaluate(violations: list[Violation], baseline: set[str]) -> tuple[list[Violation], list[str]]:
+    """(new_violations, stale) — main()과 테스트가 같은 판정 심볼을 공유(story #3164
+    PR#3580 관례, verify-no-hardcoded-korean-ui-text.ts computeNewViolations와 동형).
+    파일시스템을 건드리지 않아 단위테스트로 직접 부를 수 있다."""
+    new_violations = [v for v in violations if violation_key(v) not in baseline]
+    grandfathered_keys = {violation_key(v) for v in violations if violation_key(v) in baseline}
+    stale = sorted(baseline - grandfathered_keys)
+    return new_violations, stale
+
+
 def main() -> int:
     backend_root = Path(__file__).resolve().parent.parent
     try:
@@ -196,19 +210,18 @@ def main() -> int:
         return 1
     baseline = load_baseline(backend_root / BASELINE_FILE)
 
-    new_violations = [v for v in violations if violation_key(v) not in baseline]
-    grandfathered_keys = {violation_key(v) for v in violations if violation_key(v) in baseline}
-    stale = sorted(baseline - grandfathered_keys)
+    new_violations, stale = evaluate(violations, baseline)
 
     file_count = len({v.file for v in violations})
     print(
         f"[story #3779] BE 한글 사용자 문장 스캔 — 검출 {len(violations)}건/{file_count}파일 · "
         f"baseline(grandfather) {len(baseline)}건 · 신규 {len(new_violations)}건"
     )
-    if stale:
-        print(f"  ⚠️ baseline에 등재됐으나 이번 스캔에서 안 걸린(고쳐졌다면 목록에서 빼도 되는): {len(stale)}건")
+
+    ok = True
 
     if new_violations:
+        ok = False
         print("\nFAIL: baseline에 없는 BE 한글 사용자 문장 발견(story #3779 회귀):")
         for v in sorted(new_violations, key=lambda v: (v.file, v.line)):
             print(f"  - {v.file}:{v.line} \"{v.text}\"")
@@ -217,9 +230,28 @@ def main() -> int:
             "(story #3778 retro_export_i18n.py류)로 옮기거나 코드/FE번역 축(story #3779 처방②)으로"
             " 옮길 것. logger.*(운영자 전용) 오탐이면 logger/_logger 호출로 감싸져 있는지 확認."
         )
+
+    # 페드루 PO 지적(2026-09-10 08:17Z) — stale을 경고(⚠️)로만 두고 exit 0을 반환하면
+    # 「고쳐졌는데 baseline에 죽은 항목으로 조용히 남는」 클래스가 재발한다(story #3776
+    # ③-b가 이미 잡은 그 성질, 이 카드 處方 ①이 원래 요구했던 "stale RED"). CI의 별도
+    # "baseline은 줄기만 허용" git-diff 스텝은 «늘어남»만 막지, 이미 있는 baseline 항목이
+    # 실물과 안 맞게 된 것(고쳤는데 안 뺀 것)은 못 잡는다 — 그래서 이 스크립트 자신이
+    # stale을 FAIL로 잡아야 한다(baseline 파일 수정은 사람이 직접, 자동 걷기 없음).
+    if stale:
+        ok = False
+        print(f"\nFAIL: baseline에 있으나 이번 스캔에서 안 걸린(stale) {len(stale)}건:")
+        for k in stale:
+            print(f"  - {k}")
+        print(
+            "\n→ 그 자리가 실제로 고쳐졌다면(더는 한글 리터럴이 아니게 됐거나 삭제됐다면) "
+            f"{BASELINE_FILE}에서 그 줄을 지울 것 — grandfather는 «지금 있는 걸 봐준다»지 "
+            "«한 번 등재되면 영원히 유효하다»가 아니다(story #2335/#3741과 동일 규율)."
+        )
+
+    if not ok:
         return 1
 
-    print("\nOK: baseline 초과 없음(0건 증가 — «전부 깨끗»이 아니라 «안 늘었다»는 뜻).")
+    print("\nOK: baseline 초과 없음(0건 증가) · stale 0건(모두 실물과 일치) — «전부 깨끗»이 아니라 «안 늘고 안 썩었다»는 뜻.")
     return 0
 
 

--- a/backend/scripts/verify_no_new_korean_user_strings.py
+++ b/backend/scripts/verify_no_new_korean_user_strings.py
@@ -1,0 +1,234 @@
+"""story #3779(1층, 페드루 PO 處方 2026-09-10 08:05Z) — BE 한글 사용자 문장 재발 가드.
+
+3778(회고 「내보내기」)이 닫은 건 `app/routers/retros.py::export_session` 딱 한 자리였다.
+그 카드 AC5를 `backend/app` 전체로 재측정하니(2026-09-10 미르코 AST 실측) 201개 파일·1681건
+— 훨씬 큰 클래스였다. 이 lint는 그 전체를 "더 늘지 않게" 얼린다(story #3741 FE판·#2335
+query-sentinel lint와 동일 계약 — grandfather baseline은 봐주되, 새로 추가되는 건 막는다).
+
+## 기전 — AST(`app/scripts/verify-no-hardcoded-korean-ui-text.ts`와 동형, 새 기전 발명 금지)
+정규식 줄 스캔이 아니라 Python `ast` 모듈로 `ast.Constant`(str) 노드를 walk한다 — 주석은
+AST 노드가 아니라 파서가 버려서(이 저장소 주석은 한글 천지) 구조적으로 안 걸린다. 1차
+grep(421파일/3539건)이 주석 안 따옴표 강조까지 오탐했던 것과 같은 이유로 AST가 필수.
+
+## 제외 대상(페드루 PO 明示, 2026-09-10 08:05Z)
+- **docstring** — 모듈/클래스/함수의 첫 statement가 문자열 리터럴인 경우. 개발자 문서지
+  사용자 문장이 아니다.
+- **logger.*** — `logger.info(...)`/`logger.warning(...)` 등 로깅 호출의 인자. 로그는
+  운영자가 읽지 최종 사용자가 읽지 않는다. 매치: `<Name>.{method}(...)`에서 Name이
+  `logger`/`_logger`(이 레포의 실제 관례, 2026-09-10 grep 확認)고 method가 표준 logging
+  메서드 집합에 속할 때 — 그 Call 노드의 시작~끝 span 안에 있는 모든 Constant를 제외한다
+  (인자가 f-string이어도 span으로 걸러지므로 안전).
+- **tests/·alembic/** — 스캔 루트를 `backend/app`으로 한정해 구조적으로 제외(둘 다
+  `app/`의 형제 디렉터리지 안이 아니다 — 별도 탐색 로직 불요).
+- **EXEMPT 0** — 카드 明示: 이 레이어는 무배제 원칙. 예외가 필요해지면 이 스크립트가
+  아니라 PO 승인 하 명시적으로 추가한다(지금은 빈 세트).
+
+## 대상 밖(다른 가드의 몫)
+`HTTPException(detail=...)`류 영문 에러 코드 문장은 이 가드가 아니라
+`verify:no-raw-error-message`(FE)가 다루는 축 — 이 가드는 "한글이 있는가"만 보지 "그
+문자열이 실제로 사용자에게 닿는가"는 안 본다(2층은 별도 스크립트/카드, 이 카드의 산출물
+목록으로 남긴다).
+
+## 계약 — story #3741/#2335와 동일
+baseline(`korean_user_strings_baseline.txt`)에 없는 새 한글 문자열 리터럴이 있으면 FAIL.
+baseline에 있는데 이번 스캔에서 안 걸리면(코드가 고쳐졌거나 삭제됐으면) stale로 경고만
+(비차단) — CI의 별도 git-diff 스텝이 baseline 파일 자체가 "줄기만" 허용되도록 막는다.
+
+⚠️이 가드가 «못 잡는» 것:
+  ㉠ f-string의 `{expr}` 안에 동적으로 조립되는 한글(변수 값 자체) — 리터럴 조각만 본다.
+  ㉡ dict/list 리터럴이 아닌 동적 생성 문자열(`''.join(...)`, `str.format` 등) — 정적
+     AST가 값을 못 좇는 자리는 원천적으로 스캔 밖.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+APP_DIR = "app"
+LOG_METHODS = {"debug", "info", "warning", "warn", "error", "exception", "critical", "log"}
+LOG_BASE_NAMES = {"logger", "_logger"}
+
+# self-assert — 재료가 비정상적으로 적으면(스캔이 헛돌고 있으면) 조용한 통과 대신 죽는다
+# (story #3164/#3741류 관례).
+MIN_EXPECTED_FILES = 500
+
+
+def _is_hangul(s: str) -> bool:
+    return any("가" <= ch <= "힣" for ch in s)
+
+
+def _docstring_constant_ids(tree: ast.AST) -> set[int]:
+    """모듈/클래스/함수 body의 첫 statement가 문자열 리터럴이면 그 Constant 노드의
+    id()를 모아 제외 대상으로 삼는다."""
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = node.body
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                ids.add(id(body[0].value))
+    return ids
+
+
+def _logger_call_spans(tree: ast.AST) -> list[tuple[int, int, int, int]]:
+    """logger.{method}(...) 호출의 (start_lineno, start_col, end_lineno, end_col) span
+    목록 — 이 범위 안의 Constant는 로그 인자라 제외한다."""
+    spans: list[tuple[int, int, int, int]] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in LOG_METHODS
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in LOG_BASE_NAMES
+        ):
+            end_lineno = getattr(node, "end_lineno", node.lineno)
+            end_col = getattr(node, "end_col_offset", node.col_offset)
+            spans.append((node.lineno, node.col_offset, end_lineno, end_col))
+    return spans
+
+
+def _within_span(node: ast.AST, spans: list[tuple[int, int, int, int]]) -> bool:
+    start = (node.lineno, node.col_offset)
+    end = (getattr(node, "end_lineno", node.lineno), getattr(node, "end_col_offset", node.col_offset))
+    for s_ln, s_col, e_ln, e_col in spans:
+        if start >= (s_ln, s_col) and end <= (e_ln, e_col):
+            return True
+    return False
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    text: str
+
+
+def scan_source(source: str, file_label: str) -> list[Violation]:
+    tree = ast.parse(source)
+    docstring_ids = _docstring_constant_ids(tree)
+    logger_spans = _logger_call_spans(tree)
+
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if id(node) in docstring_ids:
+            continue
+        if not _is_hangul(node.value):
+            continue
+        if _within_span(node, logger_spans):
+            continue
+        violations.append(Violation(file=file_label, line=node.lineno, text=node.value.strip()))
+    return violations
+
+
+def scan_repo(backend_root: Path) -> list[Violation]:
+    app_root = backend_root / APP_DIR
+    files = sorted(
+        p for p in app_root.rglob("*.py") if "__pycache__" not in p.parts
+    )
+    if len(files) < MIN_EXPECTED_FILES:
+        raise RuntimeError(
+            f"FAIL: 검사 대상 파일이 {len(files)}개뿐(app_root={app_root}) — 가드가 헛돌고 있다."
+        )
+    violations: list[Violation] = []
+    for f in files:
+        file_label = str(f.relative_to(backend_root))
+        source = f.read_text(encoding="utf-8")
+        try:
+            violations.extend(scan_source(source, file_label))
+        except SyntaxError:
+            continue
+    return violations
+
+
+BASELINE_FILE = "scripts/korean_user_strings_baseline.txt"
+
+
+def violation_key(v: Violation) -> str:
+    """안정 키 — 파일+텍스트(줄 번호 제외, 인접 편집에 안 흔들리게 — FE
+    verify-no-hardcoded-korean-ui-text.ts violationKey와 동일 계약).
+
+    baseline 파일이 줄 단위 텍스트라 텍스트 안의 개행을 그대로 두면 한 항목이 여러
+    physical line에 걸쳐 파일을 깨뜨린다(email_copy.py류 여러 줄 문자열 리터럴에서
+    실측 — write 시점 key 수(1308)와 파일 실제 줄 수(1545)가 어긋나 발견됨). `\\n`
+    리터럴 이스케이프로 한 줄에 눌러 담는다."""
+    escaped = v.text.replace("\\", "\\\\").replace("\n", "\\n")
+    return f"{v.file}::{escaped}"
+
+
+def load_baseline(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+
+def write_baseline(path: Path, keys: set[str]) -> None:
+    header = (
+        "# story #3779(1층, 미르코 실측 2026-09-10) grandfather baseline — 이 가드 첫 도입\n"
+        "# 시점 develop의 기존 BE 한글 사용자 문장(app/ 전수, docstring·logger.*·tests·\n"
+        "# alembic 제외).\n"
+        "# 마이그레이션 대상 아님 — 이 게이트는 \"더 늘지 않는다\"만 보장한다(freeze, 처방②\n"
+        "# 코드 정본+FE 번역 전환은 별건 카드).\n"
+        "# 형식: 파일::문자열(줄번호 제외, 편집마다 안 흔들리게) — story #2335 query_sentinel\n"
+        "# baseline과 동일 관례.\n"
+    )
+    path.write_text(header + "\n".join(sorted(keys)) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    backend_root = Path(__file__).resolve().parent.parent
+    try:
+        violations = scan_repo(backend_root)
+    except RuntimeError as e:
+        print(str(e))
+        return 1
+    baseline = load_baseline(backend_root / BASELINE_FILE)
+
+    new_violations = [v for v in violations if violation_key(v) not in baseline]
+    grandfathered_keys = {violation_key(v) for v in violations if violation_key(v) in baseline}
+    stale = sorted(baseline - grandfathered_keys)
+
+    file_count = len({v.file for v in violations})
+    print(
+        f"[story #3779] BE 한글 사용자 문장 스캔 — 검출 {len(violations)}건/{file_count}파일 · "
+        f"baseline(grandfather) {len(baseline)}건 · 신규 {len(new_violations)}건"
+    )
+    if stale:
+        print(f"  ⚠️ baseline에 등재됐으나 이번 스캔에서 안 걸린(고쳐졌다면 목록에서 빼도 되는): {len(stale)}건")
+
+    if new_violations:
+        print("\nFAIL: baseline에 없는 BE 한글 사용자 문장 발견(story #3779 회귀):")
+        for v in sorted(new_violations, key=lambda v: (v.file, v.line)):
+            print(f"  - {v.file}:{v.line} \"{v.text}\"")
+        print(
+            "\n→ 이 문자열이 사람에게 닿는(응답/알림/문서 export 등) 자리라면 로케일 인지 낱말표"
+            "(story #3778 retro_export_i18n.py류)로 옮기거나 코드/FE번역 축(story #3779 처방②)으로"
+            " 옮길 것. logger.*(운영자 전용) 오탐이면 logger/_logger 호출로 감싸져 있는지 확認."
+        )
+        return 1
+
+    print("\nOK: baseline 초과 없음(0건 증가 — «전부 깨끗»이 아니라 «안 늘었다»는 뜻).")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--write-baseline" in sys.argv:
+        _backend_root = Path(__file__).resolve().parent.parent
+        _violations = scan_repo(_backend_root)
+        _keys = {violation_key(v) for v in _violations}
+        write_baseline(_backend_root / BASELINE_FILE, _keys)
+        print(f"wrote {len(_keys)} keys to {BASELINE_FILE}")
+    else:
+        sys.exit(main())

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -60,6 +60,12 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "measure_destructive_durations_local.py",     # story #3383 — 로컬 1회성 재측정 도구
                                                    # (model_db_drift_audit.py와 동일 범주). 운영
                                                    # DB 무접속, throwaway 로컬 DB만 왕복.
+    "verify_no_new_korean_user_strings.py",       # story #3779(1층) — CI lint 게이트(app/ 재귀
+                                                   # AST 정적 스캔, 운영 DB 무접속).
+    "measure_korean_user_string_reachability.py", # story #3779(2층) — 로컬/카드용 1회성 목록
+                                                   # 산출 도구(model_db_drift_audit.py와 동일
+                                                   # 범주, CI 미등재). 운영 DB 무접속, app/ 정적
+                                                   # AST 스캔만.
 })
 
 

--- a/backend/tests/test_3779_korean_reachability_measure.py
+++ b/backend/tests/test_3779_korean_reachability_measure.py
@@ -1,0 +1,140 @@
+"""story #3779(2층) — measure_korean_user_string_reachability.py의 6종 휴리스틱 분류
+로직을 고정한다. 이 스크립트는 CI 게이트가 아니라 목록 산출물(카드 明示)이지만, 분류
+로직 자체가 조용히 깨지면 그 산출물이 틀린 숫자를 낼 수 있어 회귀가드를 둔다.
+
+⛔영구 표본 — 카드에 페드루 PO가 직접 지목한 3건(channel_posts.py:72·gates.py:131-132·
+chat_command_catalog.py:183,186)을 합성 소스로 재현해 고정한다. 실물 파일이 나중에
+바뀌어도(리팩터 등) 이 표본은 분류 로직 자체를 계속 검증한다.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from measure_korean_user_string_reachability import scan_reachable  # noqa: E402
+
+
+def test_http_exception_detail_is_reachable():
+    source = '''
+from fastapi import HTTPException
+
+def foo():
+    raise HTTPException(status_code=404, detail="찾을 수 없습니다")
+'''
+    hits = scan_reachable(source, "app/routers/fixture.py")
+    assert len(hits) == 1
+    assert hits[0].reason == "http_detail"
+    assert hits[0].text == "찾을 수 없습니다"
+
+
+def test_chat_command_outcome_is_reachable():
+    """카드 표본 — chat_command_catalog.py:183,186 형."""
+    source = '''
+def build():
+    return CommandOutcome("invalid_args", "'/done' 사용법: /done <스토리#>", None)
+'''
+    hits = scan_reachable(source, "app/services/chat_command_catalog.py")
+    assert len(hits) == 1
+    assert hits[0].reason == "chat_command"
+
+
+def test_custom_exception_super_init_is_reachable():
+    """카드 표본 — channel_posts.py:72(ChannelConnectionNotActiveError)."""
+    source = '''
+class ChannelConnectionNotActiveError(ValueError):
+    def __init__(self, *, connection_id):
+        self.connection_id = connection_id
+        super().__init__(f"연결을 찾을 수 없거나 비활성 상태입니다: {connection_id}")
+'''
+    hits = scan_reachable(source, "app/services/channel_posts.py")
+    assert len(hits) == 1
+    assert hits[0].reason == "custom_exception"
+
+
+def test_pydantic_field_validator_raise_is_reachable():
+    """카드 표본 — gates.py:131-132(@field_validator 안 raise ValueError)."""
+    source = '''
+from pydantic import BaseModel, field_validator
+
+class GateTransition(BaseModel):
+    status: str
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v):
+        if v not in {"approved", "rejected"}:
+            raise ValueError(f"generic transition 은 허용되지 않습니다: {v}")
+        return v
+'''
+    hits = scan_reachable(source, "app/routers/fixture.py")
+    assert len(hits) == 1
+    assert hits[0].reason == "pydantic_validator"
+
+
+def test_plain_raise_value_error_outside_validator_is_not_flagged():
+    """검증자 데코레이터가 없는 일반 raise ValueError는 6종 밖 — 과다 오탐 방지."""
+    source = '''
+def foo(x):
+    if not x:
+        raise ValueError("내부 전용 사유")
+'''
+    hits = scan_reachable(source, "app/services/fixture.py")
+    assert hits == []
+
+
+def test_response_field_dict_key_is_reachable():
+    source = '''
+def build_response():
+    return {"message": "저장되었습니다"}
+'''
+    hits = scan_reachable(source, "app/services/fixture.py")
+    assert len(hits) == 1
+    assert hits[0].reason == "response_field"
+
+
+def test_response_field_keyword_arg_is_reachable():
+    source = '''
+def build_response():
+    return SomeSchema(detail="저장되었습니다")
+'''
+    hits = scan_reachable(source, "app/services/fixture.py")
+    assert len(hits) == 1
+    assert hits[0].reason == "response_field"
+
+
+def test_non_human_field_name_dict_key_is_not_flagged():
+    """HUMAN_FIELD_NAMES 밖 키 이름은 6종 밖(과다 오탐 방지 — 한계 ㉠에 명시된 것)."""
+    source = '''
+def build_response():
+    return {"internal_note": "내부 메모용 한글"}
+'''
+    hits = scan_reachable(source, "app/services/fixture.py")
+    assert hits == []
+
+
+def test_email_copy_file_counts_whole_file():
+    source = '''
+"""발송 메일 카피."""
+
+WELCOME_SUBJECT = "환영합니다"
+WELCOME_BODY = "가입을 축하합니다"
+INTERNAL_CONSTANT = "무관한 한글 상수도"
+'''
+    hits = scan_reachable(source, "app/services/email_copy.py")
+    assert len(hits) == 3
+    assert all(h.reason == "email_copy" for h in hits)
+
+
+def test_english_only_string_is_never_flagged():
+    source = '''
+def foo():
+    raise HTTPException(status_code=404, detail="not found")
+'''
+    assert scan_reachable(source, "app/routers/fixture.py") == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/backend/tests/test_3779_korean_user_strings_lint.py
+++ b/backend/tests/test_3779_korean_user_strings_lint.py
@@ -1,0 +1,152 @@
+"""story #3779(1층) — BE 한글 사용자 문장 재발 가드(scripts/
+verify_no_new_korean_user_strings.py) 자체를 검증한다. 실PG 불요(순수 AST 정적분석).
+
+⛔영구 양성/음성표본 — 이 테스트 파일 자체가 고정 fixture(문자열 소스)로 표본을 둔다(story
+#2335 test_2335_query_sentinel_lint.py와 동일 관례) — 실물 site가 고쳐져도 표본은 그대로
+살아있어 "이 lint가 진짜 잡는가"를 언제든 재확認할 수 있다.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from verify_no_new_korean_user_strings import (  # noqa: E402
+    scan_source,
+    violation_key,
+)
+
+
+def test_hangul_string_literal_is_flagged():
+    source = '''
+def raise_error():
+    raise ValueError("연결을 찾을 수 없거나 비활성 상태입니다")
+'''
+    violations = scan_source(source, "app/routers/fixture.py")
+    assert len(violations) == 1
+    assert violations[0].text == "연결을 찾을 수 없거나 비활성 상태입니다"
+
+
+def test_english_only_string_is_not_flagged():
+    source = '''
+def raise_error():
+    raise ValueError("connection not found or inactive")
+'''
+    assert scan_source(source, "app/routers/fixture.py") == []
+
+
+def test_fstring_literal_fragment_is_flagged():
+    """f-string의 리터럴 조각(변수 자리 제외)은 ast.JoinedStr 하위 Constant로 잡힌다."""
+    source = '''
+def raise_error(connection_id):
+    raise ValueError(f"연결을 찾을 수 없음: {connection_id}")
+'''
+    violations = scan_source(source, "app/routers/fixture.py")
+    assert len(violations) == 1
+    assert violations[0].text == "연결을 찾을 수 없음:"
+
+
+# ─── ⭐docstring 제외 ────────────────────────────────────────────────────────
+
+
+def test_module_docstring_is_not_flagged():
+    source = '''
+"""이 모듈은 한글 docstring을 갖는다 — 개발자 문서지 사용자 문장이 아니다."""
+
+def foo():
+    pass
+'''
+    assert scan_source(source, "app/services/fixture.py") == []
+
+
+def test_function_docstring_is_not_flagged():
+    source = '''
+def foo():
+    """이 함수도 한글 docstring — 제외 대상."""
+    return 1
+'''
+    assert scan_source(source, "app/services/fixture.py") == []
+
+
+def test_non_docstring_string_after_docstring_is_still_flagged():
+    """docstring 제외가 "함수 body의 첫 문자열 literal Expr"로 정확히 한정되는지 —
+    두 번째 이후 문자열 상수는 여전히 걸려야 한다(과다 제외 방지)."""
+    source = '''
+def foo():
+    """이건 docstring."""
+    message = "이건 docstring이 아니다"
+    return message
+'''
+    violations = scan_source(source, "app/services/fixture.py")
+    assert len(violations) == 1
+    assert violations[0].text == "이건 docstring이 아니다"
+
+
+# ─── ⭐logger.* 제외 ─────────────────────────────────────────────────────────
+
+
+def test_logger_call_argument_is_not_flagged():
+    source = '''
+import logging
+logger = logging.getLogger(__name__)
+
+def foo():
+    logger.warning("auth.refresh 실패 reason=invalid_jwt")
+'''
+    assert scan_source(source, "app/routers/fixture.py") == []
+
+
+def test_underscore_logger_call_argument_is_not_flagged():
+    source = '''
+import logging
+_logger = logging.getLogger(__name__)
+
+def foo():
+    _logger.info("신규 project default 판정 실패", exc_info=True)
+'''
+    assert scan_source(source, "app/main.py") == []
+
+
+def test_non_logger_call_with_same_method_name_is_still_flagged():
+    """다른 객체의 .info(...)/.warning(...)까지 과다 배제하면 안 된다 — base 이름이
+    logger/_logger가 아니면 걸려야 한다(과다 제외 방지)."""
+    source = '''
+def foo(response):
+    response.info("사용자에게 보이는 정보 문구")
+'''
+    violations = scan_source(source, "app/routers/fixture.py")
+    assert len(violations) == 1
+    assert violations[0].text == "사용자에게 보이는 정보 문구"
+
+
+def test_logger_call_with_non_string_first_arg_still_excludes_later_korean_args():
+    """logger.warning("fmt %s", "한글 값") 형태 — span 기반 제외라 두 번째 인자도 잡힌다."""
+    source = '''
+import logging
+logger = logging.getLogger(__name__)
+
+def foo():
+    logger.warning("실패 reason=%s", "한글 사유")
+'''
+    assert scan_source(source, "app/routers/fixture.py") == []
+
+
+# ─── ⭐violation_key — 개행 이스케이프(baseline 파일이 줄 단위라 필수) ────────
+
+
+def test_violation_key_escapes_embedded_newlines():
+    """멀티라인 문자열 리터럴(예: email_copy.py류)이 그대로 baseline에 들어가면 한 항목이
+    여러 physical line을 차지해 파일을 깨뜨린다 — 실측으로 발견(write 시점 key 개수와 파일
+    실제 줄 수가 어긋남, 2026-09-10). `\\n`으로 이스케이프해 한 줄에 눌러 담는지 고정."""
+    from verify_no_new_korean_user_strings import Violation
+
+    v = Violation(file="app/services/email_copy.py", line=10, text="첫 줄\n둘째 줄")
+    key = violation_key(v)
+    assert "\n" not in key
+    assert key == "app/services/email_copy.py::첫 줄\\n둘째 줄"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/backend/tests/test_3779_korean_user_strings_lint.py
+++ b/backend/tests/test_3779_korean_user_strings_lint.py
@@ -14,6 +14,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from verify_no_new_korean_user_strings import (  # noqa: E402
+    evaluate,
     scan_source,
     violation_key,
 )
@@ -146,6 +147,36 @@ def test_violation_key_escapes_embedded_newlines():
     key = violation_key(v)
     assert "\n" not in key
     assert key == "app/services/email_copy.py::첫 줄\\n둘째 줄"
+
+
+# ─── ⭐stale RED(페드루 PO 지적 2026-09-10 08:17Z, 카드 處方 ① "stale RED") ──────
+#
+# 최초 구현은 stale을 ⚠️ 경고만 찍고 exit 0을 반환했다 — 「고쳐졌는데 baseline에 죽은
+# 항목으로 조용히 남는」 클래스(오늘 유나가 별건에서 잡은 것과 동형, story #3776 ③-b가
+# 이미 세운 성질)를 재발시켰던 자리. evaluate()가 stale을 정확히 보고하는지 고정한다.
+
+
+def test_evaluate_flags_baseline_entry_with_no_matching_violation_as_stale():
+    """baseline에 가짜(실물 없는) 키를 심으면 stale로 잡혀야 한다 — 되돌리면(stale을
+    다시 경고만으로 낮추면) main()이 exit 0을 반환해 이 클래스가 재발한다."""
+    source = 'x = "실제로 있는 한글"'
+    violations = scan_source(source, "app/services/fixture.py")
+    baseline = {
+        "app/services/fixture.py::실제로 있는 한글",
+        "app/services/fixture.py::가짜_유령_문자열_이제_없음",
+    }
+    new_violations, stale = evaluate(violations, baseline)
+    assert new_violations == []
+    assert stale == ["app/services/fixture.py::가짜_유령_문자열_이제_없음"]
+
+
+def test_evaluate_reports_no_stale_when_baseline_matches_exactly():
+    source = 'x = "실제로 있는 한글"'
+    violations = scan_source(source, "app/services/fixture.py")
+    baseline = {"app/services/fixture.py::실제로 있는 한글"}
+    new_violations, stale = evaluate(violations, baseline)
+    assert new_violations == []
+    assert stale == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
3778 AC5 재측정(201파일/1681건)을 PO 處方대로 두 층으로 좁힌 1차 카드(목표=②코드정본+FE번역, 전면전환은 별 카드).

### 1층 — BE 한글 문자열 재발 가드
- `backend/scripts/verify_no_new_korean_user_strings.py`: `app/` 전수 AST 스캔(docstring·logger.* 제외, tests/alembic은 구조적 제외). story #3741(FE)/#2335(query-sentinel)과 동일 baseline-freeze 계약.
- baseline 1308건/176파일. 원 "1681건"과의 차이는 logger.* 제외(-219, 이 카드에서 새로 추가된 축)+코드 drift로 설명 가능.
- **버그 발견·수정**: 여러 줄 문자열(email_copy.py류)의 개행이 baseline 파일을 깨뜨림 → `violation_key()`에 이스케이프 추가.
- ci.yml에 `be-korean-user-strings-lint` 잡 신설(query-sentinel과 동형: 스캔 + baseline "줄기만 허용" git-diff).
- **그라운딩 정정**: 카드의 "3739 메타 가드가 ci.yml 등재를 잡아준다"는 부정확 — 그 메타 가드는 FE `apps/web/package.json` `verify:*`만 본다. 명시적 CI 잡 등록을 직접 함.
- 뮤테이션 셀프체크 완료(gates.py 신규 한글 1줄 → RED → 원복).

### 2층 — 「화면에 실제로 닿는」 부분집합 실측
- `backend/scripts/measure_korean_user_string_reachability.py`(CI 미등재, 목록 산출물): 6종 휴리스틱.
- **카드 표본 3건 전부 재현**: channel_posts.py:72·gates.py:131-132·chat_command_catalog.py:186 — 처음 설계한 4종으로는 앞의 둘을 놓쳐서(커스텀 예외 `super().__init__`·Pydantic validator `raise`) 패턴 2종을 추가로 발견·구현했다.
- 결과: **532건/86파일**(http_detail 80·response_field 219·pydantic_validator 14·custom_exception 114·chat_command 23·email_copy 82). 전체 파일별 목록은 카드 코멘트에.
- FE측 대칭 실측(`verify:no-raw-error-message` 반대 방향): **44건/23파일**.

## 검증
- `uv run pytest` 신규 테스트 23건 GREEN, 전체 스위트 `--collect-only` 10448건 수집 에러 0
- test_2384(scripts 루트 allowlist) 갱신·GREEN
- 뮤테이션 셀프체크(1층): RED→원복→GREEN
- YAML 유효성 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ