### PR TITLE
[SID:3784] fix(FE): 문서 색인이 로드 완료 前에 「없다」를 단정하던 결함 — 로딩/0건/실패 3분기

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2649,6 +2649,7 @@
     "selectDoc": "Select a document",
     "emptyTitle": "No docs yet",
     "emptyDescription": "Docs are where your org's knowledge, decisions, and context build up. The more that piles up, the easier the next decision gets.",
+    "indexLoadError": "Couldn't load the document list.",
     "lastUpdated": "Last updated",
     "newDoc": "New Document",
     "save": "Save",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2649,6 +2649,7 @@
     "selectDoc": "문서를 선택하세요",
     "emptyTitle": "아직 쌓인 문서가 없어요",
     "emptyDescription": "문서는 조직의 지식과 결정, 맥락이 쌓이는 곳입니다. 쌓일수록 다음 결정이 더 쉬워집니다.",
+    "indexLoadError": "문서 목록을 불러오지 못했습니다.",
     "lastUpdated": "최종 수정",
     "newDoc": "새 문서",
     "save": "저장",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
@@ -329,6 +329,37 @@ describe('DocsClientLayout — story #3784 loading/loadError 컨텍스트 실 �
     expect(container.textContent).toContain('불러오지 못했습니다');
   });
 
+  // story #3784(카디르 QA·페드루 재현, 10:02Z) — 실패 뒤 「다시 시도」를 누른 순간부터 그
+  // 재시도가 응답하기 전까지, fetchTree()가 loading을 다시 켜지 않으면
+  // loading=false·loadError=false·tree=[]인 순간이 생겨 두 페인이 또 "없어요"를 단정한다
+  // (원 결함의 재발 — 뮤테이션 대상: fetchTree 시작의 setLoading(true)를 걷으면 이 자리가
+  // 정확히 RED).
+  it('실패 뒤 「다시 시도」 pending 中엔 양쪽 다 "없어요"가 아니라 로딩 문구가 선다', async () => {
+    let resolveRetry!: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, json: async () => null })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveRetry = resolve; }));
+    vi.stubGlobal('fetch', fetchMock);
+    await mountWithIndex();
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('불러오지 못했습니다');
+
+    const retryButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('다시 시도'));
+    expect(retryButton).toBeTruthy();
+    await act(async () => { retryButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // 재시도 fetch가 아직 안 풀린 시점(pending) — 양쪽 다 "없어요" 단정 0, 로딩 문구는 有.
+    expect(container.textContent).not.toContain('아직 쌓인 문서가 없어요');
+    expect(container.textContent).not.toContain('불러오지 못했습니다');
+    expect(container.textContent).toContain('불러오는 중');
+
+    await act(async () => {
+      resolveRetry({ ok: true, json: async () => ({ data: [DOC_A, DOC_B], meta: { hasMore: false, nextCursor: null } }) });
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    expect(container.textContent).toContain('문서A'); // 재시도 성공 후엔 정상 렌더.
+  });
+
   // story #3784(유나 짚음, 09:34Z) — 오른쪽 DocsIndex만 가르면 왼쪽 사이드바 트리가
   // "0건"(빈 EmptyState "문서를 선택하세요")으로 조용히 남아 같은 화면이 두 말을 한다.
   it('트리 fetch 실패 시 왼쪽 사이드바도 "문서를 선택하세요"가 아니라 같은 실패 문구+다시 시도를 그린다', async () => {

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
@@ -11,6 +11,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../../../../messages/ko.json';
 import { DocsClientLayout } from './docs-client-layout';
+import { DocsIndex } from './docs-index';
 
 const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
 vi.mock('next/navigation', () => ({
@@ -290,5 +291,56 @@ describe('DocsClientLayout — 로드맵 P2·PR-E L1(모바일 드로어 elevati
     expect(panel).toBeTruthy();
     expect(panel?.className).toContain('shadow-[var(--elev-overlay)]');
     expect(panel?.className).not.toMatch(/(^|\s)shadow-lg(\s|$)/);
+  });
+});
+
+// story #3784(카디르 QA·PO 짚음) — DocsLayoutContextType에 loading이 없어 DocsIndex가
+// "아직 안 옴"과 "0건"을 못 가르던 실사고. 실 소비처 구성(page.tsx = DocsClientLayout이
+// DocsIndex를 children으로 감싸는 형)을 그대로 재현해 컨텍스트 실 배선을 검증한다 —
+// docs-index.test.tsx의 useDocsLayout() 모킹 테스트는 컴포넌트 로직만 잰다(배선 자체는
+// 안 잰다).
+describe('DocsClientLayout — story #3784 loading/loadError 컨텍스트 실 배선(DocsIndex 실 자식)', () => {
+  async function mountWithIndex() {
+    await act(async () => {
+      root.render(wrap(
+        <DocsClientLayout wsSlug="ws1" projSlug="proj1" projectId="proj-1"><DocsIndex /></DocsClientLayout>,
+      ));
+    });
+  }
+
+  it('트리 fetch가 아직 안 끝난 순간엔 DocsIndex가 "아직 쌓인 문서가 없어요"를 안 그린다(로딩 게이트 실 배선)', async () => {
+    let resolveFetch!: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
+    vi.stubGlobal('fetch', vi.fn(() => new Promise((resolve) => { resolveFetch = resolve; })));
+    await mountWithIndex();
+    // fetch가 아직 안 풀린 시점(pending) — 로딩 中.
+    expect(container.textContent).not.toContain('아직 쌓인 문서가 없어요');
+    await act(async () => {
+      resolveFetch({ ok: true, json: async () => ({ data: [DOC_A, DOC_B], meta: { hasMore: false, nextCursor: null } }) });
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    expect(container.textContent).toContain('문서A'); // 로드 완료 후엔 정상 렌더.
+  });
+
+  it('트리 fetch가 실패(ok:false)하면 DocsIndex가 "아직 쌓인 문서가 없어요"가 아니라 실패 배너를 그린다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => null })));
+    await mountWithIndex();
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).not.toContain('아직 쌓인 문서가 없어요');
+    expect(container.textContent).toContain('불러오지 못했습니다');
+  });
+
+  // story #3784(유나 짚음, 09:34Z) — 오른쪽 DocsIndex만 가르면 왼쪽 사이드바 트리가
+  // "0건"(빈 EmptyState "문서를 선택하세요")으로 조용히 남아 같은 화면이 두 말을 한다.
+  it('트리 fetch 실패 시 왼쪽 사이드바도 "문서를 선택하세요"가 아니라 같은 실패 문구+다시 시도를 그린다', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: false, json: async () => null }));
+    vi.stubGlobal('fetch', fetchMock);
+    await mount();
+    expect(container.textContent).not.toContain('문서를 선택하세요');
+    expect(container.textContent).toContain('불러오지 못했습니다');
+    const callsBefore = fetchMock.mock.calls.length;
+    const retryButton = [...container.querySelectorAll('button')].find((b) => b.textContent === '다시 시도');
+    expect(retryButton).toBeTruthy();
+    await act(async () => { retryButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsBefore); // 재시도가 fetchTree()를 다시 친다.
   });
 });

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
@@ -343,4 +343,15 @@ describe('DocsClientLayout — story #3784 loading/loadError 컨텍스트 실 �
     await act(async () => { retryButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(fetchMock.mock.calls.length).toBeGreaterThan(callsBefore); // 재시도가 fetchTree()를 다시 친다.
   });
+
+  // story #3784(페드루 짚음, 09:49Z) — 로드 완료·진짜 0건일 때도 왼쪽("문서를
+  // 선택하세요")과 오른쪽("아직 쌓인 문서가 없어요")이 다른 말을 하던 자리. 같은
+  // 사실은 같은 낱말로 — 왼쪽도 emptyTitle 한 줄만(CTA는 오른쪽+상단 바에 이미
+  // 있어 뺀다).
+  it('로드 완료·진짜 0건이면 왼쪽 사이드바도 "문서를 선택하세요"가 아니라 "아직 쌓인 문서가 없어요"를 그린다(CTA 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [], meta: { hasMore: false, nextCursor: null } }) })));
+    await mount();
+    expect(container.textContent).not.toContain('문서를 선택하세요');
+    expect(container.textContent).toContain('아직 쌓인 문서가 없어요');
+  });
 });

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
@@ -138,6 +138,44 @@ describe('DocsClientLayout — 레일 v2 재조립 후 6 능력 회귀가드(§1
     expect(calls.some((u) => u.includes('tags='))).toBe(true);
   });
 
+  // story #3784(페드루 재검토 10:11Z) — 이미 트리가 있는 상태에서 태그를 토글하면
+  // fetchTree가 cursor 없이 재호출된다(:201 effect, selectedTags deps). 그 재호출이
+  // pending인 동안에도 «지금 보여줄 게 없다»는 거짓이므로 로딩 화면으로 전체를 갈아끼우면
+  // 안 된다(마스트헤드·필터행·기존 목록이 살아있어야 함) — hasContentRef가 이 판정을 진다.
+  it('③문서가 이미 있는 상태에서 태그 토글 — pending 中에도 로딩 화면으로 안 갈리고 기존 목록·필터행이 유지된다', async () => {
+    let resolveSecond!: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
+    let callCount = 0;
+    const fetchMock = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) return { ok: true, json: async () => ({ data: [DOC_A, DOC_B], meta: { hasMore: false, nextCursor: null } }) };
+      return new Promise((resolve) => { resolveSecond = resolve; });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await mount();
+    // 기본(grouped) 뷰는 그룹 헤더가 접혀 있어 문서명이 안 보인다 — "내 폴더"(DocTree)로
+    // 전환해 루트 문서를 바로 드러낸다(⑤뷰모드 테스트와 동형).
+    const foldersTab = [...container.querySelectorAll('button')].find((b) => b.textContent === '내 폴더');
+    await act(async () => { foldersTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.textContent).toContain('문서A');
+
+    const tagToggle = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('태그'));
+    expect(tagToggle).toBeTruthy();
+    await act(async () => { tagToggle!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const tagChip = [...container.querySelectorAll('button')].find((b) => b.textContent === '#스펙');
+    expect(tagChip).toBeTruthy();
+    await act(async () => { tagChip!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // 두 번째 fetch(태그 반영)가 아직 pending — 로딩 문구 0·기존 목록·필터행(「태그」 토글) 유지.
+    expect(container.textContent).not.toContain('불러오는 중');
+    expect(container.textContent).toContain('문서A');
+    expect(tagToggle!.isConnected).toBe(true);
+
+    await act(async () => {
+      resolveSecond({ ok: true, json: async () => ({ data: [DOC_B], meta: { hasMore: false, nextCursor: null } }) });
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    expect(container.textContent).toContain('문서B');
+  });
+
   // story #3053(2984-S5) — 선택 태그 칩은 헤어라인(border-proof-line+bg-transparent)을 쓰고
   // 옛 bg-proof-blue-soft 채움은 안 쓴다. 태그 접었을 때 카운트는 CountBadge(mono+엠보스)로.
   it('④재질 — 선택 태그 칩이 헤어라인을 쓰고 bg-proof-blue-soft는 안 쓴다, 접으면 CountBadge가 뜬다', async () => {

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -158,8 +158,12 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
 
   const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
     if (!projectId) return;
-    // story #3784 — 재시도(에러 배너의 「다시 시도」 포함)가 이전 실패 신호를 그대로 물고
-    // 있지 않도록, 시도 시작 시 먼저 걷는다(성공하면 그대로 false·실패하면 catch가 다시 켠다).
+    // story #3784(페드루 짚음 10:02Z) — 재시도(에러 배너의 「다시 시도」 포함)가 이전 실패
+    // 신호를 그대로 물고 있지 않도록, 시도 시작 시 먼저 걷는다(성공하면 그대로 false·실패하면
+    // catch가 다시 켠다). loading도 같이 켜야 한다 — 안 켜면 재시도 pending 동안 loading=false·
+    // loadError=false·tree=[]가 되어 양쪽이 다시 "없어요"를 잘못 단정한다(카디르 재현). cursor가
+    // 있는 "더 보기" 호출은 docsLoadingMore가 이미 그 UX를 담당하므로 건드리지 않는다.
+    if (!cursor) setLoading(true);
     setLoadError(false);
     try {
       // story #2191 — "view=tree"는 죽은 파라미터였다(/api/docs가 그 값을 아예 안 읽어
@@ -532,9 +536,19 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
           // 그 자리에 한 줄 + 텍스트 재시도로.
           <div className="px-2 py-4">
             <p className="text-xs text-muted-foreground">{t('indexLoadError')}</p>
-            <button type="button" onClick={() => void fetchTree(selectedTags.length ? selectedTags : undefined)} className="mt-1 text-xs text-foreground underline hover:no-underline">
+            {/* 유나 정정(10:01Z) — raw 버튼 요소가 DS 게이트 A(verify-no-new-raw-button)를
+                건드렸다. 이 레일 자리의 정본은 variant="link"(hover 배경 자체가 없음 —
+                content/page.tsx:248 실측 그대로, ghost는 좁은 레일에서 hover 사각형이
+                뜬다). 색은 문구가 아니라 행동에 싣는다(오른쪽 destructive 문구와 대칭). */}
+            <Button
+              type="button"
+              variant="link"
+              size="xs"
+              onClick={() => void fetchTree(selectedTags.length ? selectedTags : undefined)}
+              className="mt-1 h-auto px-0 text-xs"
+            >
               {tc('retry')}
-            </button>
+            </Button>
           </div>
         ) : tree.length === 0 ? (
           // story #3784(페드루 짚음 09:49Z) — 고를 문서가 0건인데 왼쪽은 "선택하세요"

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useTopBar } from '@/components/nav/top-bar-context';
 import { useMediaQuery } from '@/lib/use-media-query';
@@ -64,6 +64,11 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
   const [loading, setLoading] = useState(true);
   // story #3784 — DocsIndex가 "아직 로딩 중"과 "fetch 실패"를 "정말 0건"과 가르는 데 쓴다.
   const [loadError, setLoadError] = useState(false);
+  // story #3784(페드루 재검토 10:11Z) — 태그 필터 토글마다(:194 effect, cursor 없이
+  // fetchTree 재호출) loading을 다시 켜면 이미 보여줄 트리가 있는데도 마스트헤드·필터행까지
+  // 통째 비는 회귀가 생긴다. "fetch 中"이 아니라 "지금 보여줄 게 없다"를 로딩 조건으로
+  // 삼는다 — ref인 이유: tree를 deps에 넣으면 이 값을 쓰는 effect(:194)가 루프가 된다.
+  const hasContentRef = useRef(false);
   const [treeDrawerOpen, setTreeDrawerOpen] = useState(false);
   // 모바일 트리거 칩 breadcrumb: 현재 문서명(flat tree에서 slug 조회·미선택 시 폴백).
   const currentDocTitle = currentSlug ? (tree.find((d) => d.slug === currentSlug)?.title ?? null) : null;
@@ -158,12 +163,14 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
 
   const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
     if (!projectId) return;
-    // story #3784(페드루 짚음 10:02Z) — 재시도(에러 배너의 「다시 시도」 포함)가 이전 실패
-    // 신호를 그대로 물고 있지 않도록, 시도 시작 시 먼저 걷는다(성공하면 그대로 false·실패하면
-    // catch가 다시 켠다). loading도 같이 켜야 한다 — 안 켜면 재시도 pending 동안 loading=false·
-    // loadError=false·tree=[]가 되어 양쪽이 다시 "없어요"를 잘못 단정한다(카디르 재현). cursor가
-    // 있는 "더 보기" 호출은 docsLoadingMore가 이미 그 UX를 담당하므로 건드리지 않는다.
-    if (!cursor) setLoading(true);
+    // story #3784(페드루 짚음 10:02Z·10:11Z 재검토) — 재시도(에러 배너의 「다시 시도」
+    // 포함)가 이전 실패 신호를 그대로 물고 있지 않도록, 시도 시작 시 먼저 걷는다(성공하면
+    // 그대로 false·실패하면 catch가 다시 켠다). 로딩 조건은 «fetch 中»이 아니라 «지금 보여줄
+    // 게 없다»(hasContentRef) — 안 그러면 태그 필터 토글마다(:216 근방 effect, cursor 없이
+    // fetchTree 재호출) 이미 보여줄 트리가 있는데도 마스트헤드·필터행까지 통째 비는 회귀가
+    // 생긴다(유나 재현). cursor가 있는 "더 보기" 호출은 docsLoadingMore가 이미 그 UX를
+    // 담당하므로 건드리지 않는다.
+    if (!cursor && !hasContentRef.current) setLoading(true);
     setLoadError(false);
     try {
       // story #2191 — "view=tree"는 죽은 파라미터였다(/api/docs가 그 값을 아예 안 읽어
@@ -182,9 +189,13 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
       }
       setDocsHasMore(meta?.hasMore ?? false);
       setDocsNextCursor(meta?.nextCursor ?? null);
+      hasContentRef.current = (data?.length ?? 0) > 0;
     } catch {
       // tree fetch failed — keep existing
       setLoadError(true);
+      // 실패 뒤 재시도 때는 다시 로딩을 세워야 한다(카디르 재현) — hasContentRef를 걷어
+      // 위 setLoading(true) 조건이 다음 호출에서 막히지 않게 한다.
+      hasContentRef.current = false;
     } finally {
       setLoading(false);
       setDocsLoadingMore(false);

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -63,6 +63,8 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
 
   const [tree, setTree] = useState<Doc[]>([]);
   const [loading, setLoading] = useState(true);
+  // story #3784 — DocsIndex가 "아직 로딩 중"과 "fetch 실패"를 "정말 0건"과 가르는 데 쓴다.
+  const [loadError, setLoadError] = useState(false);
   const [treeDrawerOpen, setTreeDrawerOpen] = useState(false);
   // 모바일 트리거 칩 breadcrumb: 현재 문서명(flat tree에서 slug 조회·미선택 시 폴백).
   const currentDocTitle = currentSlug ? (tree.find((d) => d.slug === currentSlug)?.title ?? null) : null;
@@ -157,6 +159,9 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
 
   const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
     if (!projectId) return;
+    // story #3784 — 재시도(에러 배너의 「다시 시도」 포함)가 이전 실패 신호를 그대로 물고
+    // 있지 않도록, 시도 시작 시 먼저 걷는다(성공하면 그대로 false·실패하면 catch가 다시 켠다).
+    setLoadError(false);
     try {
       // story #2191 — "view=tree"는 죽은 파라미터였다(/api/docs가 그 값을 아예 안 읽어
       // 항상 무커서 일반 목록 분기로 떨어졌다). #2540 이후 BE/FE 둘 다 커서를 실제로
@@ -176,6 +181,7 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
       setDocsNextCursor(meta?.nextCursor ?? null);
     } catch {
       // tree fetch failed — keep existing
+      setLoadError(true);
     } finally {
       setLoading(false);
       setDocsLoadingMore(false);
@@ -520,6 +526,17 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
           />
         ) : loading ? (
           <p className="px-2 py-4 text-xs text-muted-foreground">{t('loading')}</p>
+        ) : loadError ? (
+          // story #3784(유나 짚음) — 오른쪽 DocsIndex가 실패 배너로 갈라졌는데 이 트리가
+          // "0건"으로 남으면 한 화면이 두 말을 하는 자리가 그대로 남는다. 같은 키
+          // (indexLoadError, "문서 목록")를 쓰되 폭이 좁아 Alert 대신 로딩 문구가 서던
+          // 그 자리에 한 줄 + 텍스트 재시도로.
+          <div className="px-2 py-4">
+            <p className="text-xs text-muted-foreground">{t('indexLoadError')}</p>
+            <button type="button" onClick={() => void fetchTree(selectedTags.length ? selectedTags : undefined)} className="mt-1 text-xs text-foreground underline hover:no-underline">
+              {tc('retry')}
+            </button>
+          </div>
         ) : tree.length === 0 ? (
           <EmptyState title={t('title')} description={t('selectDoc')} className="mt-2 bg-background/70" action={<Button size="sm" onClick={handleNewDoc}><Plus className="mr-1 h-4 w-4" />{t('newDoc')}</Button>} />
         ) : (
@@ -563,7 +580,7 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
 
 
   return (
-    <DocsLayoutContext.Provider value={{ wsSlug, projSlug, projectId, tree, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder, openTreeDrawer: openDrawer }}>
+    <DocsLayoutContext.Provider value={{ wsSlug, projSlug, projectId, tree, setTree, loading, loadError, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder, openTreeDrawer: openDrawer }}>
       {/* 근본 재구현(2076 회귀 후속, 유나양 규격) — currentSlug 없음(목록)=켬, 있음(문서 하나)=
           끔. 이 shell은 단일 문서가 화면을 꽉 채우는 구조(목록+본문 동시 2단 아님)라 이 분기가
           맞다(2단 shell이었다면 항상 켜야 함 — 유나양 규격 예외 조항). */}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -16,7 +16,6 @@ import { DocSearchResults, type DocSearchResult } from '@/components/docs/doc-se
 import { useTreeExpanded } from '@/components/docs/use-tree-expanded';
 import { Button } from '@/components/ui/button';
 import { CountBadge } from '@/components/ui/count-badge';
-import { EmptyState } from '@/components/ui/empty-state';
 import { useToast } from '@/components/ui/toast';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChevronDown, ChevronLeft, ChevronRight, FileText, FolderPlus, Plus, X } from 'lucide-react';
@@ -538,7 +537,13 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
             </button>
           </div>
         ) : tree.length === 0 ? (
-          <EmptyState title={t('title')} description={t('selectDoc')} className="mt-2 bg-background/70" action={<Button size="sm" onClick={handleNewDoc}><Plus className="mr-1 h-4 w-4" />{t('newDoc')}</Button>} />
+          // story #3784(페드루 짚음 09:49Z) — 고를 문서가 0건인데 왼쪽은 "선택하세요"
+          // (`selectDoc`)를 말하고 오른쪽(DocsIndex)은 "아직 쌓인 문서가 없어요"
+          // (`emptyTitle`)를 말하던 자리 — 같은 사실은 같은 낱말로. CTA도 뺀다(오른쪽
+          // 빈 상태+상단 바에 이미 「새 문서」 둘이 있어 여기까지 셋이면 과함).
+          // `selectDoc`은 그대로 둔다 — docs-shell-client.tsx의 "문서는 있는데 미선택"
+          // 자리는 이 분기가 아니라 별도 자리다.
+          <p className="px-2 py-4 text-xs text-muted-foreground">{t('emptyTitle')}</p>
         ) : (
           <>
             <RecentsSection

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-context.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-context.tsx
@@ -44,6 +44,13 @@ interface DocsLayoutContextType {
   projectId: string | undefined;
   tree: Doc[];
   setTree: Dispatch<SetStateAction<Doc[]>>;
+  /** story #3784 — 트리 fetch 진행 중(초기값 true, 로컬 sidebar와 동일 신호). 소비처(DocsIndex)가
+   * 이 필드 없이 `tree.length===0`만 보면 "아직 안 옴"과 "정말 0건"을 못 가른다. */
+  loading: boolean;
+  /** story #3784 — 트리 fetch가 실패했다(하드 실패, `docs-client-layout.tsx`의 catch가
+   * "keep existing"으로 조용히 삼키던 신호를 여기로 올린다). 성공하면 다음 fetch 시작 시 false로
+   * 되돌아간다(sticky 아님). */
+  loadError: boolean;
   handleNewDoc: () => void;
   fetchTree: () => Promise<void>;
   pendingDocUpdate: DocUpdate | null;

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.test.tsx
@@ -65,6 +65,43 @@ describe('DocsIndex — 빈 프로젝트(문서 0건)', () => {
   });
 });
 
+// story #3784(카디르 QA·PO 짚음) — 왼쪽 사이드바가 「불러오는 중…」인 동안 오른쪽 본문이
+// 이미 "아직 쌓인 문서가 없어요"+「새 문서」 CTA를 단정하던 결함. tree=[]는 "로딩 중"과
+// "진짜 0건"을 못 가르므로, loading/loadError를 컨텍스트에서 따로 받아 셋으로 가른다.
+describe('DocsIndex — story #3784 로딩/0건/실패 3분기', () => {
+  it('로딩 中(tree=[]·loading=true)이면 "아직 쌓인 문서가 없어요"도 「새 문서」 CTA도 안 뜬다(뮤테이션 대상 — loading 게이트 없이 tree.length===0만 보면 이 자리가 RED)', async () => {
+    useDocsLayoutMock.mockReturnValue({ ...BASE_CTX, tree: [], loading: true, loadError: false });
+    await mount();
+    expect(container.textContent).not.toContain('아직 쌓인 문서가 없어요');
+    expect(container.textContent).not.toContain('새 문서');
+  });
+
+  it('fetch 실패(loadError=true)면 「없다」가 아니라 실패 문구+다시 시도 버튼이 뜬다', async () => {
+    useDocsLayoutMock.mockReturnValue({ ...BASE_CTX, tree: [], loading: false, loadError: true });
+    await mount();
+    expect(container.textContent).not.toContain('아직 쌓인 문서가 없어요');
+    expect(container.textContent).toContain('불러오지 못했습니다');
+    const retryButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('다시 시도'));
+    expect(retryButton).toBeTruthy();
+  });
+
+  it('실패 배너의 「다시 시도」를 누르면 fetchTree()가 호출된다', async () => {
+    const fetchTreeMock = vi.fn();
+    useDocsLayoutMock.mockReturnValue({ ...BASE_CTX, tree: [], loading: false, loadError: true, fetchTree: fetchTreeMock });
+    await mount();
+    const retryButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('다시 시도'))!;
+    await act(async () => { retryButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(fetchTreeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('로드 완료·진짜 0건(loading=false·loadError=false·tree=[])이면 기존 빈 상태 + CTA가 그대로 뜬다(회귀 0)', async () => {
+    useDocsLayoutMock.mockReturnValue({ ...BASE_CTX, tree: [], loading: false, loadError: false });
+    await mount();
+    expect(container.textContent).toContain('아직 쌓인 문서가 없어요');
+    expect(container.textContent).toContain('새 문서');
+  });
+});
+
 describe('DocsIndex — 문서 있음(§2 마스트헤드+목록)', () => {
   const tree = [
     { id: 'f1', parent_id: null, title: '제품 스펙', slug: 'f1', icon: null, sort_order: 0, is_folder: true },

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { BookOpen, LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useDocsLayout, type Doc } from './docs-context';
 import { docUrl } from '@/components/docs/lib/doc-project-url';
 import { DOC_STATUS_TONE, toDocStatusFilter, docStatusLabelKey, type DocStatusFilter } from '@/components/docs/lib/doc-status-tone';
@@ -55,10 +56,11 @@ function StatusChip({ status }: { status: string | undefined }) {
 
 export function DocsIndex() {
   const t = useTranslations('docs');
+  const tc = useTranslations('common');
   const locale = useLocale();
   const displayTimezone = resolveDisplayTimezone().tz;
   const router = useRouter();
-  const { tree, handleNewDoc, wsSlug, projSlug } = useDocsLayout();
+  const { tree, handleNewDoc, wsSlug, projSlug, loading, loadError, fetchTree } = useDocsLayout();
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null); // null = 전체
   const [statusFilter, setStatusFilter] = useState<StatusFilter | null>(null);
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('list');
@@ -102,6 +104,27 @@ export function DocsIndex() {
   // 통일해 에디터 직행 1스텝으로 되돌린다 — 리더는 에디터 상단의 opt-in "읽기 보기" 링크로만
   // 진입(삭제 아님, default만 이동).
   const goToDoc = (slug: string) => router.push(docUrl(wsSlug, projSlug, slug));
+
+  // story #3784 — "아직 안 옴"·"실패"·"정말 0건"을 가른다. 로딩 中엔 조용히 아무것도
+  // 그리지 않는다(사이드바가 이미 로딩 중 신호를 그린다 — 이 존까지 스켈레톤을 겹칠 이유 0).
+  if (loading) {
+    return null;
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 lg:p-6">
+        <Alert variant="destructive" className="w-full max-w-lg">
+          <AlertDescription className="flex items-center justify-between gap-3">
+            <span>{t('indexLoadError')}</span>
+            <Button size="sm" variant="outline" onClick={() => void fetchTree()}>
+              {tc('retry')}
+            </Button>
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
 
   // story #2955 §6(PO 요건②) — "문서를 선택하세요" 재현 금지. 0건은 에러가 아니라 만들
   // 데이터로서 설계 — 첫 문서 CTA + 왜 0인지 맥락(신규 프로젝트) 병기.

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
@@ -6,7 +6,6 @@ import { useLocale, useTranslations } from 'next-intl';
 import { BookOpen, LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useDocsLayout, type Doc } from './docs-context';
 import { docUrl } from '@/components/docs/lib/doc-project-url';
 import { DOC_STATUS_TONE, toDocStatusFilter, docStatusLabelKey, type DocStatusFilter } from '@/components/docs/lib/doc-status-tone';
@@ -112,16 +111,21 @@ export function DocsIndex() {
   }
 
   if (loadError) {
+    // story #3784(유나 정정 09:40Z) — settings/page.tsx의 Alert destructive 배너는
+    // 배너 「아래」에 계속 그려지는 섹션들이 있다는 전제 위에 선다(870-873행). 이
+    // 0건 분기(아래)는 early return이라 "위"가 없는 빈 페인이 된다 — 배너를 얹을
+    // 자리 자체가 없다. 집안에 이미 같은 형(early return + 빈 페인 중앙)을 가른
+    // 정본이 chat-view.tsx의 messagesLoadFailed다 — 그 형 그대로.
     return (
       <div className="flex h-full items-center justify-center p-4 lg:p-6">
-        <Alert variant="destructive" className="w-full max-w-lg">
-          <AlertDescription className="flex items-center justify-between gap-3">
-            <span>{t('indexLoadError')}</span>
-            <Button size="sm" variant="outline" onClick={() => void fetchTree()}>
-              {tc('retry')}
-            </Button>
-          </AlertDescription>
-        </Alert>
+        <div className="flex flex-col items-center gap-3 text-center">
+          <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-destructive">
+            {t('indexLoadError')}
+          </p>
+          <Button size="sm" variant="outline" onClick={() => void fetchTree()}>
+            {tc('retry')}
+          </Button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## 배경
문서 화면 진입 시 왼쪽 트리는 「불러오는 중…」인데 오른쪽 본문(DocsIndex)은 이미 「아직 쌓인 문서가 없어요」+「새 문서」 CTA를 단정했다(디디가 3783(#4133) ko 표본 캡처 中 발견·PO가 짚음). `DocsLayoutContextType`에 `tree`만 있고 `loading`이 없어(같은 파일에 `loading` state는 있었으나 컨텍스트 타입에 안 실려 자식이 못 봄) `DocsIndex`가 "아직 안 옴"과 "정말 0건"을 `tree.length===0` 하나로 뭉뚱그려 판정하던 것이 근본 원인.

빈 상태는 「새 문서」 CTA를 같이 그리므로, 문서가 이미 많은 프로젝트에서도 로드가 끝나기 전에 사용자가 틀린 CTA를 보고 누를 수 있다(high 판정 근거).

## 처방
- `DocsLayoutContextType`에 `loading`·`loadError` 두 필드 추가(새 개념 0 — 기존 `loading` state를 그대로 내려보내고, `loadError`는 fetch 시작 시 false로 걷고 catch에서 true로 올리는 신규 state 하나).
- `DocsIndex` — 로딩 中엔 조용히 아무것도 안 그림(사이드바가 이미 로딩 신호를 그리므로 이 존까지 스켈레톤을 겹칠 이유 0) · 실패면 `Alert variant="destructive"` + `tc('retry')`(`settings/page.tsx`의 `accountInfoLoadError` 패턴 그대로 재사용) · 로드 완료·진짜 0건이면 기존 빈 상태 그대로(회귀 0).
- 왼쪽 사이드바 트리도 같은 결함이 다른 문구("문서를 선택하세요")로 남아있었다(유나 재검토 발견) — 「불러오는 중…」이 서던 자리에 같은 실패 문구 + 텍스트 「다시 시도」로 동형 처리(Alert이 안 맞는 좁은 폭이라 형만 갈림, 같은 키 재사용).
- 신규 키 `docs.indexLoadError`(유나 定, `settings.accountInfoLoadError`와 짝 맞춘 형) — ko "문서 목록을 불러오지 못했습니다." · en "Couldn't load the document list."

## ko 화면 표본 3장 — 로딩/실패/0건

### 로딩 中 — 왼쪽만 「불러오는 중…」, 오른쪽은 조용히 미표시(회귀 대상이던 「없다」 단정 0)
![loading](https://storage.googleapis.com/sprintable-memo-attachments/org/54bac162-5c0d-49fa-8e49-85977063a091/project/f3e6ed64-447d-4b1c-ad78-a00cfba715a7/canvas-import/a8061d4c-dd62-4b6b-a561-346b6f6905d3-3784_docs_loading_ko?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=cloudrun-runtime-dev%40sprintable-494803.iam.gserviceaccount.com%2F20260910%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20260910T093916Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&X-Goog-Signature=3a5c149a0d98fa19fcd89249c3f9971d67462acd028b08a8ccf269ebf06d1f31429ea4f9a445b0159e553ee2f88051a369c533572bdd58ebabeef5ed8481f05a56ae846715791351ce2391a61ace62a6cf2d878122af000fc6cadca31ca62793dfb65731b5a351260efd43061ade6474952c29957e9e9d87e8bace4ac6af8d98310256392942a088c75d3f2a91b53c30ff4a98149b1a590634c2981146edd24b218b26072cde0073a3e30b5d3db1b3d90829f72d7f4d4ab4741be48c976273218cc95ed9c7f117d93ad47de906063f91991be8ce5b932414ff393bc098e58c75d02443584fe0ec9e21d23c3db0b12a794b95b6114a5cc69aa7930855dc810330)

### 실패 — 왼쪽·오른쪽 둘 다 「문서 목록을 불러오지 못했습니다.」+ 재시도
![error](https://storage.googleapis.com/sprintable-memo-attachments/org/54bac162-5c0d-49fa-8e49-85977063a091/project/f3e6ed64-447d-4b1c-ad78-a00cfba715a7/canvas-import/f4e1ef8d-aa0d-4238-8af5-bd69a19a40a0-3784_docs_error_ko?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=cloudrun-runtime-dev%40sprintable-494803.iam.gserviceaccount.com%2F20260910%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20260910T093917Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&X-Goog-Signature=c9651106b0cbc5779367236ad488c93e5210686c7373ae1003ed9507edecf13ea913982aff17d1e4909fb3d42f8df9ee3e901b1c30ab96f8963645c09e72e2ce0889b41b3fd872ef8a63d24fab227d4c5e609f26e4cef6273b755d4ab13e8b8e636eef330768bee5fbb592adbb3b7b10f82de799c5f35ecfe12f8c40ef8dbc11d76dbcb3fbd4ebdc8313526aa74376ab3d28ac6508b2c19d3221744ce23c88b809c5822a0964b547faeee89ed3ec59b8af198a9ab244d5e9af9ea9db1a5f733e5d3804381e14a2abfb5828721952f9f64152ad71779dc58fc61e91e77859b5f059ac3a61da94bf0bff1794a402c6151cc1daf323c8757090f9bc745d6d515797)

### 로드 완료·진짜 0건 — 기존 빈 상태 그대로(회귀 0)
![empty](https://storage.googleapis.com/sprintable-memo-attachments/org/54bac162-5c0d-49fa-8e49-85977063a091/project/f3e6ed64-447d-4b1c-ad78-a00cfba715a7/canvas-import/0a9f7b81-a262-4fbf-b3d3-49a2f012ce5c-3784_docs_empty_ko?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=cloudrun-runtime-dev%40sprintable-494803.iam.gserviceaccount.com%2F20260910%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20260910T093919Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&X-Goog-Signature=66219683de7f8f46cf38c44a3e18dea5449338bac92bd1672af9066fe347f286d894f93468464efd540b2eead646f8854a4071caa3617533fe6254f16177a75b6ebf40a5e7960e1b05ea0365fd175827535774373c9518f6fa2f8cfce7aeeaa37c4e1606d3d292bd5d94f233c5a3259f3b5fbfe1c3edd521afc94f7102450ef5391887e5c7eefcba9de2fde951ef89f267d24ff4e3f4189e2a298a2d76464c65d970db0a2a29ae588c37e47dde5d26e27d2000dacc51e36d8ad550b08a9a3b920fb9a878608f7bcc5ce0cfa36a42542dc82f40864f01aee5082cb6c3a919fd01661f40a8c576b2ad7de8a3a7e6e0e4d709893bc1d6130b8014af534c2347b463)

## 검증
- 뮤테이션 4건(loading 게이트·loadError 게이트·컨텍스트 실 배선 2곳 — DocsIndex용·왼쪽 트리용) — 전부 걷으면 정확히 그 자리만 RED, 복구 확認.
- 신규 테스트 8건: DocsIndex 컴포넌트 로직(모킹) 4건 + DocsClientLayout↔DocsIndex 실 배선 통합 2건(실 소비처 구성 그대로 재현 — page.tsx가 DocsIndex를 DocsClientLayout의 children으로 감싸는 형) + 왼쪽 트리 실패 상태 1건 + 재시도 왕복 1건.
- tsc 무오류 · i18n 가드 5종(키 실존·ns 참조·중복 0·한자 0·하드코딩 0건 증가) 전부 GREEN · phrase-collision GREEN(20건, 원본) · vitest 7430 passed.
- push 후 `git diff HEAD origin/<branch>`로 원격 실물 대조(빈 diff) 확認.

## Test plan
- [x] tsc --noEmit 무오류
- [x] vitest 7430 passed(뮤테이션 4건 확認 포함)
- [x] i18n 가드 5종 GREEN
- [x] ko 화면 표본 3장(로딩/실패/0건) — 위 첨부
- [ ] 카디르 QA(되돌리면 RED: loading 필드 제거 시 로딩 중 CTA 렌더)
- [ ] 유나 design 라이브 둘(느린 네트워크·fetch 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
