### PR TITLE
[SID:3791] fix(FE): display_name 없는 계정 /settings 진입 시 Avatar 크래시

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -272,7 +272,11 @@ export default function ConversationPage() {
               <Avatar
                 // story #3203(카디르 QA·PO 지시) — 같은 participants 계약 소비처, 사람언어 폴백 통일.
                 // story #3758(9번째) — resolved 비트로 갈라 그린다.
-                name={participantDisplayLabel(headerAvatarParticipant, t, tc)}
+                // story #3791(페드루 재검토 12:23Z) — name(이니셜 재료)에 표시-폴백 문구를
+                // 넘기면 그 문구 첫 글자가 가짜 이니셜로 뜬다(「이름 없는 구성원」→「이」 등)
+                // — name은 원시, 표시 문구는 label로.
+                name={headerAvatarParticipant.name ?? null}
+                label={participantDisplayLabel(headerAvatarParticipant, t, tc)}
                 avatarUrl={headerAvatarParticipant.avatar_url ?? null}
                 actorType={headerAvatarParticipant.type === 'agent' ? 'agent' : 'human'}
                 size={24}

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -522,7 +522,12 @@ export function ChatBubble({
                 Avatar가 정본(사본 분화 금지) — shape(에이전트=circle·human=square)·idle blue 링·
                 working citron 펄스·human 테두리는 전부 avatar.tsx 내부가 결정한다. */}
             <Avatar
-              name={displayName}
+              // story #3791(페드루 재검토 12:23Z) — name(이니셜 재료)에 표시-폴백 문구
+              // (displayName="당신"/"팀" 등)를 넘기면 그 첫 글자가 가짜 이니셜로 뜬다 —
+              // name은 원시 sender_name(빈 문자열이면 자동으로 아이콘 tier), 표시 문구는
+              // label로.
+              name={message.sender_name}
+              label={displayName}
               avatarUrl={message.sender_avatar_url ?? null}
               actorType={isAgent ? 'agent' : 'human'}
               size={28}
@@ -791,6 +796,7 @@ export function ChatBubble({
           x={profilePopover.x}
           y={profilePopover.y}
           name={displayName}
+          rawName={message.sender_name}
           isAgent={isAgent}
           avatarUrl={message.sender_avatar_url ?? null}
           runtimeType={isAgent ? message.sender_runtime_type : null}

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -457,6 +457,64 @@ describe('ChatListView — 참가자 이름 해석 실패 폴백(story #3203)', 
   });
 });
 
+// story #3791(카디르 QA 정정 12:52Z) — oneOnOneParticipant.name이 null이 아니라 빈 문자열
+// ""인 경우(`??`는 null/undefined만 잡고 ""는 통과시켜 걸렸던 자리 — codex 재현, 일반/
+// 에이전트 탭 둘 다). Avatar의 label이 빈 문자열로 새면 아이콘 tier에서 aria-label=""가
+// 되는데, 되돌리면(?.trim() || fallback을 다시 ?? fallback으로) 이 두 테스트가 정확히
+// 그 결함을 재현해야 한다.
+describe('ChatListView — 참가자 name="" 폴백(story #3791, 카디르 재현)', () => {
+  it('일반(DM) 탭 — name=""이면 아바타 aria-label이 "DM"으로 뜬다(빈 문자열 아님)', async () => {
+    stubFetchWithConversations([{
+      id: 'conv-dm-empty-1', type: 'dm', title: null,
+      latest_message: null, updated_at: '2026-08-29T00:00:00Z', unread_count: 0,
+      participants: [
+        { member_id: 'me-1', name: '나', avatar_url: null, type: 'human', resolved: true },
+        { member_id: 'them-empty-1', name: '', avatar_url: null, type: 'human', resolved: true },
+      ],
+    }]);
+    await mount();
+    const avatarSpan = container.querySelector('span[aria-label]');
+    expect(avatarSpan).not.toBeNull();
+    expect(avatarSpan?.getAttribute('aria-label')).toBe('DM');
+  });
+
+  it('에이전트 탭 — name=""이면 아바타 aria-label이 "에이전트"로 뜬다(빈 문자열 아님)', async () => {
+    useDashboardContextMock.mockReturnValue({ role: 'admin' });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/conversations/recent-outside-project')) {
+        return { ok: true, json: async () => ({ data: [] }) };
+      }
+      if (url.includes('include_agent_conversations=true')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              id: 'conv-agent-dm-empty-1', type: 'dm', title: null,
+              latest_message: null, updated_at: '2026-08-23T00:00:00Z', unread_count: 0,
+              participants: [
+                { member_id: 'me-1', name: '나', avatar_url: null, type: 'human', resolved: true },
+                { member_id: 'agent-empty-1', name: '', avatar_url: null, type: 'agent', resolved: true },
+              ],
+            }],
+            total: 1,
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [], total: 0 }) };
+    }));
+    await mount();
+
+    const agentTab = [...container.querySelectorAll('[role="tab"]')].find((el) => el.textContent?.includes('에이전트'));
+    expect(agentTab).not.toBeUndefined();
+    await act(async () => { agentTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const avatarSpan = container.querySelector('span[aria-label]');
+    expect(avatarSpan).not.toBeNull();
+    expect(avatarSpan?.getAttribute('aria-label')).toBe('에이전트');
+  });
+});
+
 // story #3621(유나 CHANGES, 2026-09-07) — chat-view.tsx·chat-list-view.tsx 둘 다 같은
 // ConnectionLostBanner를 쓴다(단일화, 문구 갈라짐 방지). {connected:false, polling:true}를
 // 직접 모킹해 실제로 그 배너가 서는지 확인한다 — 이전엔 두 뷰 테스트가 전부 polling:false만

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -202,7 +202,11 @@ function ConversationRow({
           책임). group은 특정 1인 사진이 의미가 없어(다인원) 기존 아이콘 자리를 유지한다. */}
       {oneOnOneParticipant ? (
         <Avatar
-          name={oneOnOneParticipant.name ?? (isAgentConv ? t('agent') : 'DM')}
+          // story #3791(페드루 재검토 12:23Z) — name(이니셜 재료)에 표시-폴백 문구를 넘기면
+          // 그 문구 첫 글자가 가짜 이니셜로 뜬다(「에이전트」→「에」·"DM"→"D") — name은
+          // 원시, 표시 문구는 label로.
+          name={oneOnOneParticipant.name ?? null}
+          label={oneOnOneParticipant.name ?? (isAgentConv ? t('agent') : 'DM')}
           avatarUrl={oneOnOneParticipant.avatar_url ?? null}
           actorType={isAgentConv || oneOnOneParticipant.type === 'agent' ? 'agent' : 'human'}
           size={36}

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -205,8 +205,11 @@ function ConversationRow({
           // story #3791(페드루 재검토 12:23Z) — name(이니셜 재료)에 표시-폴백 문구를 넘기면
           // 그 문구 첫 글자가 가짜 이니셜로 뜬다(「에이전트」→「에」·"DM"→"D") — name은
           // 원시, 표시 문구는 label로.
+          // 카디르 QA 정정(12:52Z) — `??`는 null만 잡고 빈 문자열 name("")은 안 잡아
+          // label=""로 새(아이콘 tier에서 aria-label="" 재현, 일반/에이전트 탭 둘 다).
+          // trim 후 빈 값도 포괄하는 `?.trim() || …` 형으로.
           name={oneOnOneParticipant.name ?? null}
-          label={oneOnOneParticipant.name ?? (isAgentConv ? t('agent') : 'DM')}
+          label={oneOnOneParticipant.name?.trim() || (isAgentConv ? t('agent') : 'DM')}
           avatarUrl={oneOnOneParticipant.avatar_url ?? null}
           actorType={isAgentConv || oneOnOneParticipant.type === 'agent' ? 'agent' : 'human'}
           size={36}

--- a/apps/web/src/components/chat/sender-profile-popover.test.tsx
+++ b/apps/web/src/components/chat/sender-profile-popover.test.tsx
@@ -124,6 +124,23 @@ describe('SenderProfilePopover — story #3106 runtimeType 배선', () => {
   });
 });
 
+// story #3791(페드루 재검토 12:23Z) — chat-bubble.tsx가 표시-폴백 문구(displayName=
+// "당신"/"팀" 등)를 name으로, 원시 sender_name을 rawName으로 갈라 넘긴다. rawName이
+// 빈 문자열(이름 없는 발신자)이면 Avatar가 그 표시 문구의 첫 글자를 가짜 이니셜로
+// 짓지 않고 아이콘 tier로 떨어져야 한다 — 되돌리면(Avatar에 rawName 대신 name을 그대로
+// 넘기면) RED.
+describe('SenderProfilePopover — story #3791(rawName/name 분리)', () => {
+  it('rawName=""(이름 없는 발신자)이면 아이콘 tier로 떨어지고 표시 문구(name) 첫 글자를 지어내지 않는다', async () => {
+    await act(async () => {
+      root.render(wrap(<SenderProfilePopover x={0} y={0} name="팀" rawName="" isAgent={false} onClose={NOOP} />));
+    });
+    expect(container.querySelector('img')).toBeNull();
+    // 이니셜 tier였다면 initials('팀')="팀"이 렌더됐을 것 — 아이콘 tier이므로 그 텍스트가 없다.
+    const initialsSpan = container.querySelector('span[aria-label="팀"]');
+    expect(initialsSpan?.textContent).toBe('');
+  });
+});
+
 // story #3000 로드맵 PR-B(L1) — floating 팝업은 --elev-overlay 토큰이어야 한다(shadow-md
 // 리터럴 회귀가드).
 describe('SenderProfilePopover — 로드맵 PR-B L1(floating elev-overlay)', () => {

--- a/apps/web/src/components/chat/sender-profile-popover.tsx
+++ b/apps/web/src/components/chat/sender-profile-popover.tsx
@@ -8,7 +8,13 @@ import { Avatar } from '@/components/shared/avatar';
 interface SenderProfilePopoverProps {
   x: number;
   y: number;
+  /** 표시 텍스트(팝업 제목·aria-label) — 호출부가 이미 낱말 폴백("당신"/"팀" 등)을
+   * 적용해 넘긴다. */
   name: string;
+  /** story #3791(페드루 재검토 12:23Z) — Avatar 이니셜 «재료»(원시). name(표시 문구)을
+   * 그대로 Avatar에 넘기면 그 첫 글자가 가짜 이니셜로 뜬다 — 이 필드가 그 경계를
+   * 가른다. 생략 시(name 자체가 이미 실명인 소비처) name을 재료로도 그대로 쓴다. */
+  rawName?: string;
   isAgent: boolean;
   /** story #2968(카디르 QA #3397 MEDIUM) — chat-bubble.tsx가 이미 들고 있던 sender_avatar_url을
    * 안 넘겨 이 팝업만 Bot/User 하드코딩 아이콘에 머물러 있었다. avatar.tsx 정본 배선. */
@@ -24,7 +30,7 @@ interface SenderProfilePopoverProps {
 // story #2349 — "상대 프로필" 진입점. 이 제품에 다른 멤버를 보는 화면이 없었다(net-new 표면,
 // 그라운딩 확認됨) — message-context-menu.tsx와 같은 위치-고정 팝업 패턴을 그대로 재사용해
 // 새 상호작용 패턴을 발명하지 않는다.
-export function SenderProfilePopover({ x, y, name, isAgent, avatarUrl, runtimeType, onClose, onBlock }: SenderProfilePopoverProps) {
+export function SenderProfilePopover({ x, y, name, rawName, isAgent, avatarUrl, runtimeType, onClose, onBlock }: SenderProfilePopoverProps) {
   // story #3776(1층A) — "사용자 차단" 버튼, chats ns의 기존 blockUserConfirmConfirm 키 재사용.
   const tChats = useTranslations('chats');
   const ref = useRef<HTMLDivElement>(null);
@@ -57,7 +63,14 @@ export function SenderProfilePopover({ x, y, name, isAgent, avatarUrl, runtimeTy
       style={{ left: clampedX, top: clampedY }}
     >
       <div className="flex items-center gap-2.5 px-3 py-1.5">
-        <Avatar name={name} avatarUrl={avatarUrl ?? null} actorType={isAgent ? 'agent' : 'human'} size={32} runtimeType={runtimeType ?? null} />
+        <Avatar
+          name={rawName ?? name}
+          label={rawName !== undefined ? name : undefined}
+          avatarUrl={avatarUrl ?? null}
+          actorType={isAgent ? 'agent' : 'human'}
+          size={32}
+          runtimeType={runtimeType ?? null}
+        />
         <span className="truncate text-sm font-medium text-foreground">{name}</span>
       </div>
       {onBlock && (

--- a/apps/web/src/components/settings/my-profile-section.test.tsx
+++ b/apps/web/src/components/settings/my-profile-section.test.tsx
@@ -96,6 +96,87 @@ describe('MyProfileSection — 역할 낱말(story #3770 실사고 재현)', () 
   });
 });
 
+describe('MyProfileSection — display_name 없는 계정 크래시 재발 방지(story #3791)', () => {
+  // BE(app/schemas/me.py MeResponse)가 display_name 미설정 휴먼을 정직하게 name=null로
+  // 돌린다(story #3755/#3758) — 이 자리가 그 null을 그대로 Avatar에 넘겨 name.trim()이
+  // 죽던 실 크래시(디디 2026-09-10 11:55Z, #4141 캡처 中 발견) 재현·고정.
+  it('⭐profile.name=null이어도 크래시 없이 렌더되고 「이름 없는 구성원」이 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const fetchWithAuthMock = vi.fn((url: string) => {
+      if (url === '/api/me') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ data: { id: 'm-1', name: null, email: 'noname@moonklabs.com', type: 'human', role: 'member' } }),
+        });
+      }
+      if (url.startsWith('/api/team-members/')) return Promise.resolve({ ok: true, json: async () => ({ data: { avatar_url: null } }) });
+      return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
+    });
+    vi.doMock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+    vi.resetModules();
+    const { MyProfileSection: Section } = await import('./my-profile-section');
+
+    await act(async () => { root.render(wrap(<Section />)); });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.common.memberUnnamed);
+    vi.doUnmock('@/lib/db/client');
+  });
+
+  it('음성대조 — profile.name이 실 문자열이면 그대로 뜬다(회귀 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const fetchWithAuthMock = vi.fn((url: string) => {
+      if (url === '/api/me') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ data: { id: 'm-1', name: '홍길동', email: 'hong@moonklabs.com', type: 'human', role: 'member' } }),
+        });
+      }
+      if (url.startsWith('/api/team-members/')) return Promise.resolve({ ok: true, json: async () => ({ data: { avatar_url: null } }) });
+      return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
+    });
+    vi.doMock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+    vi.resetModules();
+    const { MyProfileSection: Section } = await import('./my-profile-section');
+
+    await act(async () => { root.render(wrap(<Section />)); });
+    await flush();
+
+    expect(container.textContent).toContain('홍길동');
+    expect(container.textContent).not.toContain(koMessages.common.memberUnnamed);
+    vi.doUnmock('@/lib/db/client');
+  });
+
+  it('편집 입력창은 name=null이어도 빈 문자열로 시작한다(「이름 없는 구성원」을 편집 가능한 값처럼 넣지 않음)', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const fetchWithAuthMock = vi.fn((url: string) => {
+      if (url === '/api/me') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ data: { id: 'm-1', name: null, email: null, type: 'human', role: 'member' } }),
+        });
+      }
+      if (url.startsWith('/api/team-members/')) return Promise.resolve({ ok: true, json: async () => ({ data: { avatar_url: null } }) });
+      return Promise.resolve({ ok: false, json: async () => ({ data: null }) });
+    });
+    vi.doMock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+    vi.resetModules();
+    const { MyProfileSection: Section } = await import('./my-profile-section');
+
+    await act(async () => { root.render(wrap(<Section />)); });
+    await flush();
+
+    const editButton = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.settings.profileEdit);
+    expect(editButton).toBeTruthy();
+    await act(async () => { editButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe('');
+    vi.doUnmock('@/lib/db/client');
+  });
+});
+
 describe('MyProfileSection — 실패 렌더에 「로딩 중」 잔존 재발 방지(story #3772 CHANGES, 페드루 픽셀 지적 2026-09-10)', () => {
   it('⭐/api/me 실패(500) → tc(\'loading\')("로딩 중...") 문구가 안 남는다(null 렌더)', async () => {
     vi.stubGlobal('fetch', vi.fn());

--- a/apps/web/src/components/settings/my-profile-section.tsx
+++ b/apps/web/src/components/settings/my-profile-section.tsx
@@ -10,10 +10,14 @@ import { AvatarEditCard } from '@/components/shared/avatar-edit-card';
 
 import { fetchWithAuth } from '@/lib/db/client';
 import { orgRoleLabel } from '@/lib/org-member-role';
+import { memberDisplayLabel } from '@/lib/member-display';
 
 interface MyProfile {
   id: string;
-  name: string;
+  // story #3791 — BE(app/schemas/me.py MeResponse)가 display_name 없는 휴먼을 정직하게
+  // name=null로 돌린다(story #3755/#3758) — 이 인터페이스가 그걸 안 반영해(non-null
+  // string으로 거짓말) Avatar의 name.trim()이 그대로 죽었다(로컬 타입 동기화 결함 클래스).
+  name: string | null;
   email: string | null;
   type: string;
   role: string;
@@ -62,7 +66,9 @@ export function MyProfileSection({ onLoadError }: MyProfileSectionProps = {}) {
     if (!res.ok) { setLoadFailed(true); onLoadError?.(); return; }
     const json = await res.json() as { data: MyProfile };
     setProfile(json.data);
-    setEditName(json.data.name);
+    // story #3791 — 편집 입력창은 "빈 채로 새로 타이핑" 시작이 맞다(memberDisplayLabel의
+    // 「이름 없는 구성원」 표시-문구를 편집 가능한 값인 척 입력창에 넣지 않는다).
+    setEditName(json.data.name ?? '');
     setAvatarUrl(await fetchAvatarUrl(json.data.id));
   }, [onLoadError]);
 
@@ -107,6 +113,7 @@ export function MyProfileSection({ onLoadError }: MyProfileSectionProps = {}) {
         <AvatarEditCard
           memberId={profile.id}
           name={profile.name}
+          label={memberDisplayLabel(profile.name, tc)}
           avatarUrl={avatarUrl}
           actorType="human"
           onUpdated={setAvatarUrl}
@@ -126,13 +133,13 @@ export function MyProfileSection({ onLoadError }: MyProfileSectionProps = {}) {
                 <Button size="sm" disabled={saving} onClick={() => void handleSave()}>
                   {saving ? tc('loading') : tc('save')}
                 </Button>
-                <Button size="sm" variant="ghost" disabled={saving} onClick={() => { setEditing(false); setEditName(profile.name); }}>
+                <Button size="sm" variant="ghost" disabled={saving} onClick={() => { setEditing(false); setEditName(profile.name ?? ''); }}>
                   {tc('cancel')}
                 </Button>
               </div>
             ) : (
               <div className="flex items-center gap-2">
-                <span>{profile.name}</span>
+                <span>{memberDisplayLabel(profile.name, tc)}</span>
                 <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={() => setEditing(true)}>
                   {t('profileEdit')}
                 </Button>

--- a/apps/web/src/components/shared/avatar-edit-card.tsx
+++ b/apps/web/src/components/shared/avatar-edit-card.tsx
@@ -14,10 +14,14 @@ type Stage = { kind: 'idle' } | { kind: 'cropping'; url: string } | { kind: 'upl
  * 에이전트 카드(workforce/[id]) 양쪽이 동일 컴포넌트를 소비 — 목업 규칙("설정 표면 = 양쪽").
  */
 export function AvatarEditCard({
-  memberId, name, avatarUrl, actorType, onUpdated, bigSize = 72,
+  memberId, name, label, avatarUrl, actorType, onUpdated, bigSize = 72,
 }: {
   memberId: string;
-  name: string;
+  // story #3791(유나 定) — Avatar와 같은 계약: 이니셜 재료(null 허용, 없으면 아이콘 tier).
+  // memberDisplayLabel() 같은 표시-문구를 여기 넘기지 말 것(가짜 이니셜) — 그건 label로.
+  name: string | null;
+  /** 표시 텍스트/접근성 이름. 생략 시 name을 그대로 쓴다. */
+  label?: string;
   avatarUrl: string | null;
   actorType: 'human' | 'agent';
   onUpdated: (newAvatarUrl: string | null) => void;
@@ -91,9 +95,9 @@ export function AvatarEditCard({
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-4">
-        <Avatar name={name} avatarUrl={avatarUrl} actorType={actorType} size={bigSize} />
+        <Avatar name={name} label={label} avatarUrl={avatarUrl} actorType={actorType} size={bigSize} />
         <div>
-          <div className="mb-2 text-sm font-semibold text-foreground">{name}</div>
+          <div className="mb-2 text-sm font-semibold text-foreground">{label ?? name}</div>
           <div className="flex gap-2">
             <Button size="sm" disabled={stage.kind === 'uploading'} onClick={() => inputRef.current?.click()}>
               {t('avatarChange')}

--- a/apps/web/src/components/shared/avatar.test.tsx
+++ b/apps/web/src/components/shared/avatar.test.tsx
@@ -147,6 +147,74 @@ describe('Avatar — story #2887 S2g', () => {
     expect(container.textContent).toContain('송');
   });
 
+  // story #3791(display_name 없는 계정 크래시, 유나 定 12:00Z·페드루 재검토 12:14Z) —
+  // BE(app/schemas/me.py MeResponse)가 display_name 미설정 휴먼을 정직하게 name=null로
+  // 돌린다(story #3755/#3758). 호출부가 그 null을 그대로 넘겨도(정규화 누락) Avatar
+  // 자신이 안 죽어야 한다 — 되돌리면(a11yName 걷고 원시 name.trim() 복원) 이 자리들이
+  // 정확히 RED(TypeError로 렌더 자체가 실패).
+  //
+  // ⚠️폴백 글자를 새로 짓지 않는다 — name=null이면 무조건 아이콘 tier(이미 있던 3단
+  // 폴백 그대로)다. memberDisplayLabel() 같은 표시-문구는 name이 아니라 label로 받아
+  // aria-label에만 쓴다 — label을 name에 잘못 넘기면 그 문구의 첫 글자가 가짜 이니셜로
+  // 뜬다(이 스토리가 막으려는 바로 그 결함, #4143 코드리뷰 실물 확認).
+  it('name=null이어도 안 죽고 아이콘 tier로 렌더된다(이니셜 텍스트 0)', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name={null} avatarUrl={null} actorType="human" />));
+    });
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull(); // User 아이콘 폴백.
+    expect(container.textContent).toBe(''); // 이니셜 텍스트가 전혀 없다(아이콘만).
+  });
+
+  it('name=null·label="이름 없는 구성원"이면 아이콘 tier를 유지하되(가짜 이니셜 「이」 없음) aria-label만 label을 쓴다', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name={null} label="이름 없는 구성원" avatarUrl={null} actorType="human" />));
+    });
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull(); // 여전히 아이콘 tier(이니셜 tier로 안 넘어감).
+    expect(container.textContent).toBe(''); // 「이」(label 첫 글자) 같은 가짜 이니셜이 안 뜬다.
+    const span = container.querySelector('span[aria-label]');
+    expect(span?.getAttribute('aria-label')).toBe('이름 없는 구성원');
+  });
+
+  it('name=""(빈 문자열)이어도 안 죽고 아이콘 폴백으로 렌더된다', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name="" avatarUrl={null} actorType="human" />));
+    });
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('name이 공백뿐이어도 안 죽고 아이콘 폴백으로 렌더된다(trim 후 빈 문자열과 동일 취급)', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name="   " avatarUrl={null} actorType="human" />));
+    });
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('name이 실명이면 이니셜 tier를 쓰고 aria-label도 name 그대로다(label 미지정 — 회귀 없음)', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name="송윤재" avatarUrl={null} actorType="human" />));
+    });
+    const span = container.querySelector('span[aria-label]');
+    expect(span?.getAttribute('aria-label')).toBe('송윤재');
+    expect(container.textContent).toContain('송');
+  });
+
+  it('name=null이어도 agent 아바타 툴팁이 안 죽는다(이름 없이 "Agent" 단독)', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name={null} actorType="agent" />));
+    });
+    const trigger = container.querySelector('[data-slot="tooltip-trigger"]') as HTMLElement;
+    expect(trigger).not.toBeNull();
+    await act(async () => {
+      trigger.focus();
+      await new Promise((r) => setTimeout(r, 900));
+    });
+    expect(document.body.querySelector('[data-slot="tooltip-content"]')).not.toBeNull();
+  });
+
   it('avatar_url이 바뀌면(교체 업로드) 이전 에러 상태를 잊고 새 URL을 다시 시도한다', async () => {
     await act(async () => {
       root.render(wrap(<Avatar name="송윤재" avatarUrl="https://example.com/broken.png" actorType="human" />));

--- a/apps/web/src/components/shared/avatar.test.tsx
+++ b/apps/web/src/components/shared/avatar.test.tsx
@@ -177,6 +177,27 @@ describe('Avatar — story #2887 S2g', () => {
     expect(span?.getAttribute('aria-label')).toBe('이름 없는 구성원');
   });
 
+  // story #3791(카디르 QA 정정 12:52Z) — 호출부가 `name ?? fallback`류로 label을 지어
+  // 넘기면 name=""일 때 `??`가 ""를 안 잡아(null/undefined만 잡음) label 자체가 ""로
+  // 샐 수 있다(chat-list-view.tsx 실측 재현). Avatar 자신이 label=""을 곧이곧대로 쓰지
+  // 않고 name으로 폴백해야 호출부 실수에도 aria-label=""이 안 새는 단일 방어선이 된다.
+  it('label=""(빈 문자열)·name="송윤재"면 label을 곧이곧대로 안 쓰고 name으로 폴백한다', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name="송윤재" label="" avatarUrl={null} actorType="human" />));
+    });
+    const span = container.querySelector('span[aria-label]');
+    expect(span?.getAttribute('aria-label')).toBe('송윤재'); // "" 그대로가 아니라 name.
+  });
+
+  it('label=""·name=null(또는 "")이면 aria-label 속성 자체를 생략한다(빈 문자열 노출 0)', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name={null} label="" avatarUrl={null} actorType="human" />));
+    });
+    const span = container.querySelector('span');
+    expect(span).not.toBeNull();
+    expect(span?.hasAttribute('aria-label')).toBe(false);
+  });
+
   it('name=""(빈 문자열)이어도 안 죽고 아이콘 폴백으로 렌더된다', async () => {
     await act(async () => {
       root.render(wrap(<Avatar name="" avatarUrl={null} actorType="human" />));

--- a/apps/web/src/components/shared/avatar.tsx
+++ b/apps/web/src/components/shared/avatar.tsx
@@ -56,10 +56,15 @@ export interface AvatarProps {
 export function Avatar({
   name, label, avatarUrl, actorType, size = 32, presenceStatus, isWorking = false, runtimeType = null, className,
 }: AvatarProps) {
-  // story #3791(유나 定 12:00Z) — 접근성 이름은 label 우선, 없으면 name 그대로(빈 문자열
-  // 대신 attribute 자체를 생략 — 아래 undefined). 이니셜 계산은 이 값이 아니라 원시
-  // name?.trim()으로 따로 판정한다(밑 tier 분기).
-  const a11yName = label ?? name ?? undefined;
+  // story #3791(유나 定 12:00Z·카디르 QA 정정 12:52Z) — 접근성 이름은 label 우선, 없으면
+  // name 그대로(빈 문자열 대신 attribute 자체를 생략 — 아래 undefined). `??`는 null/
+  // undefined만 잡고 빈 문자열은 통과시켜 호출부가 `name ?? fallback`류로 label을 지어
+  // 넘기면(빈 이름이 ??를 안 타 그대로 온다) aria-label=""로 새는 결함이 있었다(카디르
+  // 재현 — chat-list-view.tsx 일반/에이전트 탭 둘 다) — label·name 둘 다 trim 후 빈
+  // 값이면 다음 단계로 넘어가는 형으로 방어한다(호출부 실수에도 이 컴포넌트 자신이
+  // 안 새는 단일 지점). 이니셜 계산은 이 값이 아니라 원시 name?.trim()으로 따로
+  // 판정한다(밑 tier 분기).
+  const a11yName = (label?.trim() ? label : undefined) ?? (name?.trim() ? name : undefined);
   const isAgent = actorType === 'agent';
   const dotSize = size >= 40 ? 'md' : 'sm';
   const iconSize = Math.round(size * 0.5);

--- a/apps/web/src/components/shared/avatar.tsx
+++ b/apps/web/src/components/shared/avatar.tsx
@@ -10,7 +10,17 @@ import { avatarColor, initials } from '@/lib/storage/format';
 import { cn } from '@/lib/utils';
 
 export interface AvatarProps {
-  name: string;
+  // story #3791(display_name 없는 계정 크래시, 유나 定 2026-09-10 12:00Z) — 이니셜 계산
+  // «재료»다. null이면 아이콘 tier로 떨어진다(이미 있던 3단 폴백 그대로) — 폴백 글자를
+  // 새로 짓지 않는다. 호출부가 memberDisplayLabel() 같은 표시-문구를 여기 넘기면 그
+  // 문구의 첫 글자가 가짜 이니셜로 뜬다(이 카드가 피하려는 바로 그 일, 페드루 재검토
+  // 12:14Z 실물 확認) — 그 문구는 아래 label로 넘길 것.
+  name: string | null;
+  // story #3791 — 접근성 이름(aria-label/alt/tooltip 첫 줄). 생략 시 name을 그대로 쓴다.
+  // name이 null/빈 값일 때만 호출부가 memberDisplayLabel() 결과를 여기로 넘긴다(이니셜
+  // 재료와 분리 — «없는 이름을 지어내지 않는다»와 «그래도 스크린리더는 뭔가 말한다»를
+  // 동시에 만족).
+  label?: string;
   avatarUrl?: string | null;
   actorType: 'human' | 'agent';
   /** px 정사각. 기본 32(채팅 L1~L3 표준 규격은 호출부가 size로 스케일). */
@@ -44,8 +54,12 @@ export interface AvatarProps {
  * presence-dot.tsx — 옛 WORKING_RING_CLASS 개명+색 스왑, 그 파일 주석 참고).
  */
 export function Avatar({
-  name, avatarUrl, actorType, size = 32, presenceStatus, isWorking = false, runtimeType = null, className,
+  name, label, avatarUrl, actorType, size = 32, presenceStatus, isWorking = false, runtimeType = null, className,
 }: AvatarProps) {
+  // story #3791(유나 定 12:00Z) — 접근성 이름은 label 우선, 없으면 name 그대로(빈 문자열
+  // 대신 attribute 자체를 생략 — 아래 undefined). 이니셜 계산은 이 값이 아니라 원시
+  // name?.trim()으로 따로 판정한다(밑 tier 분기).
+  const a11yName = label ?? name ?? undefined;
   const isAgent = actorType === 'agent';
   const dotSize = size >= 40 ? 'md' : 'sm';
   const iconSize = Math.round(size * 0.5);
@@ -110,12 +124,12 @@ export function Avatar({
           // (storage-uploader-avatar.tsx·team-presence-panel.tsx·profile-menu.tsx 전부 동일
           // 이유로 raw img)와 동형. next/image 전환은 별도 remotePatterns 검토 스토리 몫.
           // eslint-disable-next-line @next/next/no-img-element
-          <img src={avatarUrl} alt={name} className="h-full w-full object-cover" onError={() => setImgError(true)} />
-        ) : name.trim() ? (
+          <img src={avatarUrl} alt={a11yName ?? ''} className="h-full w-full object-cover" onError={() => setImgError(true)} />
+        ) : name?.trim() ? (
           <span
             className={cn('flex h-full w-full items-center justify-center font-semibold', avatarColor(isAgent))}
             style={{ fontSize: initSize }}
-            aria-label={name}
+            aria-label={a11yName}
           >
             {initials(name)}
           </span>
@@ -125,7 +139,7 @@ export function Avatar({
               'flex h-full w-full items-center justify-center',
               isAgent ? 'bg-accent-claim/15 text-accent-claim' : 'bg-muted text-muted-foreground',
             )}
-            aria-label={name}
+            aria-label={a11yName}
           >
             {isAgent ? <Bot style={{ width: iconSize, height: iconSize }} /> : <User style={{ width: iconSize, height: iconSize }} />}
           </span>
@@ -197,7 +211,7 @@ export function Avatar({
       <TooltipTrigger render={avatarNode} />
       <TooltipContent side="top">
         <div className="flex flex-col gap-0.5 py-0.5">
-          <span className="text-xs font-medium">{name}</span>
+          <span className="text-xs font-medium">{a11yName}</span>
           {/* 툴팁 팝업 자체가 bg-foreground(반전 배경)라 text-background가 이미 고대비
               "본문" 색이다(popup 기본값 상속) — 유나 규격의 text-muted-foreground는 이
               반전 배경에서 그대로 쓰면 대비가 깨져(라이트/다크 실측 재계산: 8.49/7.11로


### PR DESCRIPTION
## Summary
- display_name 미설정 휴먼 계정으로 `/settings` 진입 시 `Avatar` 컴포넌트가 `name.trim()`을 호출해 null 참조로 화면이 깨짐(#4141 캡처 준비 中 발견).
- 근본원인: BE(`app/schemas/me.py MeResponse.name: str | None`)는 정직하게 `null`을 돌리는데, `my-profile-section.tsx`의 `MyProfile` 타입이 `name: string`으로 거짓말해 그 null을 그대로 Avatar에 흘려보냄(로컬 타입 동기화 결함 클래스).
- 처방(이중): (1) 근본 — `MyProfile.name`을 `string | null`로 정정, 기존 SSOT `memberDisplayLabel()`(story #3755 「이름 없는 구성원」)로 정규화 후 사용. (2) 방어 — `Avatar` 프리미티브 자신도 `name: string | null`을 받아 내부 정규화(다른 호출부의 같은 실수를 완충).
- 같은 형(`.trim()`을 이름/표시명에 부르는 자리) 전수 grep — 다른 후보(trust/page.tsx·team-activity-view.tsx·memo.ts)는 이미 `??`/optional-chaining으로 안전했음. 이 파일 하나만 누락이었음.

## Test plan
- [x] tsc 무오류
- [x] `verify-i18n-keys-exist`/하드코딩 한글 가드 GREEN
- [x] `verify:*` 37개 전부 GREEN
- [x] 뮤테이션 2건 — Avatar의 safeName 정규화 되돌리면 신규 테스트 RED(TypeError) · my-profile-section의 memberDisplayLabel 적용 되돌리면 신규 테스트 RED(「이름 없는 구성원」 부재)
- [x] vitest 7477 passed(avatar.test.tsx 4건 신규 + my-profile-section.test.tsx 3건 신규)
- [ ] 유나 라이브 검증(이름 없는 픽스처 계정 → /settings 200·깨짐 0)
- [ ] PO 캡처 눈

🤖 Generated with [Claude Code](https://claude.com/claude-code)