### PR TITLE
[SID:3785] fix(FE): 페이지 배경 위 테두리만 있는 상자 — 잔여 1스팟

### DIFF
--- a/apps/web/scripts/card-surfaceless-box-baseline.json
+++ b/apps/web/scripts/card-surfaceless-box-baseline.json
@@ -2,7 +2,8 @@
   "_comment": [
     "story #3785(PO 실측 2026-09-10) grandfather baseline — 이 가드 첫 도입 시점 develop의 기존 카드-표면-미적용 클래스(className=\"…rounded-(md|lg|xl) border border-border(/NN)?…\" · bg- 없음).",
     "마이그레이션 대상 아님 — 이 게이트는 \"더 늘지 않는다\"만 보장한다(freeze, 전량 정리는 후속 스윕 판).",
-    "정적 상한이지 실수가 아니다 — 라이브 하네스(e2e/card-surface-guard.spec.ts)가 주 가드, 이 baseline은 보조."
+    "정적 상한이지 실수가 아니다 — 라이브 하네스(e2e/card-surface-guard.spec.ts)가 주 가드, 이 baseline은 보조.",
+    "story #3785(2026-09-10, 유나 r67 라이브 재측 — 20→1 남은 마지막 스팟) — components/channel-connect/agent-setup-section.tsx:127(channels/page.tsx:1260이 부르는 자식, 선생님 원 캡처의 그 상자)를 Card로 전환. baseline에서 걷음."
   ],
   "counts": {
     "app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx": 1,
@@ -30,7 +31,6 @@
     "components/agents/member-notification-preferences-summary.tsx": 1,
     "components/agents/messaging-policy-section.tsx": 2,
     "components/canvas/import-artifact-dialog.tsx": 2,
-    "components/channel-connect/agent-setup-section.tsx": 1,
     "components/channel-connect/facebook-page-select-card.tsx": 1,
     "components/chat/delivery-contract-modal.tsx": 1,
     "components/content/comment-convert-to-task-dialog.tsx": 1,

--- a/apps/web/src/components/channel-connect/agent-setup-section.tsx
+++ b/apps/web/src/components/channel-connect/agent-setup-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import { ListRow, ListRowMark } from '@/components/ui/list-row';
 import { fetchWithAuth } from '@/lib/db/client';
 import { channelLabel, channelMarkColor, channelMarkInitials } from '@/lib/channel-label';
@@ -124,9 +125,11 @@ export function AgentSetupSection({ orgId }: { orgId: string }) {
         <h2 className="text-sm font-semibold text-foreground">{t('agentSetupTitle')}</h2>
         <p className="text-xs text-muted-foreground">{t('agentSetupDescription')}</p>
       </div>
-      <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
+      {/* story #3785(유나·페드루 라이브 재측 r67 — 선생님 원 캡처의 그 상자) — 1층 규칙:
+          Card(surface='solid'). */}
+      <Card className="divide-y divide-border overflow-hidden">
         {connectors.map((c) => <ConnectorRow key={c.connector_key} connector={c} t={t} />)}
-      </div>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 배포 67 라이브에서 유나 r67 재측(20→1) — 선생님 원 캡처의 그 상자(「담당 에이전트가 설정하는 것」 절)가 유나 정적 목록에서 라우트 파일(`channels/page.tsx`)로만 귀속돼 #4140에서 빠졌다. 실제로는 `channels/page.tsx:1260`이 부르는 자식 컴포넌트 `agent-setup-section.tsx` 안에 있었다.
- `components/channel-connect/agent-setup-section.tsx:127` — 손수 만든 목록 컨테이너를 `Card`(surface='solid')로 전환. #4140과 동형 처방.

## Test plan
- [x] tsc 무오류
- [x] `verify:no-card-surfaceless-box` GREEN(baseline 65→64, stale 1건 걷음)
- [x] `verify:*` 37개 전부 GREEN
- [x] vitest 7470 passed
- [ ] CI e2e(`card-surface-guard.spec.ts`) 첫 런 확認 — 실 dev-stack 필요해 로컬 미실행
- [ ] 유나 라이브 픽셀 재검
- [ ] 카디르 가드 뮤테이션 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)