### PR TITLE
[SID:3793] gates.py http_detail 20건 en 치환 + email_copy 스냅샷 갭 7템플릿군

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -2311,12 +2311,18 @@ async def _toss_gate_endpoint(
     if _gate.status != "pending":
         raise HTTPException(
             status_code=409,
-            detail={"code": "gate_already_resolved", "message": "이미 처리된 결재는 토스할 수 없습니다."},
+            detail={
+                "code": "gate_already_resolved",
+                "message": t("gates.toss_gate_already_resolved", resolved_locale),
+            },
         )
     if _gate.designated_approver_id is None:
         raise HTTPException(
             status_code=422,
-            detail={"code": "no_designated_approver", "message": "지정 결재자가 없는 게이트는 토스할 수 없습니다."},
+            detail={
+                "code": "no_designated_approver",
+                "message": t("gates.toss_no_designated_approver", resolved_locale),
+            },
         )
 
     from app.services.gate_service import resolve_designatable_gate_context

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,6 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.error_envelope import human_error
 from app.dependencies.auth import get_current_user, get_scope_context, get_verified_org_id
 from app.dependencies.database import get_db
+from app.services.agent_onboarding_config import resolve_locale_from_request
+from app.services.i18n_catalog import t
 from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
 from app.models.gate_github_check_event import GateGithubCheckEvent
@@ -285,6 +287,25 @@ async def create_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙, i18n_catalog.py 모듈 docstring 참조). 직접-호출(realdb·유닛) 테스트는
+    `_create_gate_endpoint`를 불러야 한다."""
+    return await _create_gate_endpoint(
+        body, session=session, org_id=org_id, _auth=_auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _create_gate_endpoint(
+    body: GateCreateRequest,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    _auth,
+    resolved_locale: str,
 ) -> GateResponse:
     # ⚠️BLOCKER(codex gpt-5.5): doc_approval 게이트는 **doc 상신 경로(doc.py transition)로만** 생성.
     # 일반 엔드포인트는 client 가 work_item_id=<자기 doc>+forged neutral_facts.requested_by_member_id 로
@@ -293,7 +314,7 @@ async def create_gate_endpoint(
     if body.gate_type == "doc_approval":
         raise HTTPException(
             status_code=403,
-            detail="doc 결재 게이트는 doc 상신 경로로만 생성됩니다 (직접 생성 불가).",
+            detail=t("gates.create_doc_gate_not_allowed", resolved_locale),
         )
     # story #1968: 제네릭 게이트 생성은 story/doc/task 등 work_item 객체를 로드하지 않으므로
     # (client가 work_item_id/work_item_type만 보냄) resolve_work_item_project_id()로 신규 조회.
@@ -581,17 +602,22 @@ async def _non_doc_can_approve(
 
 async def _authorize_gate_approve_equivalent(
     session: AsyncSession, gate: Gate | None, resolved, auth, org_id: uuid.UUID,
+    resolved_locale: str,
 ) -> None:
     """story #2631 — transition_gate_endpoint 의 인가 블록(휴먼-only + doc/non-doc can_approve)을
     그대로 추출한 것. request_gate_discussion_endpoint(«보류·논의»)는 승인/반려 옆 3번째 버튼이라
     **같은 자격**을 요구한다(PO 판정 — "승인할 수 있는 사람만 논의도 요청할 수 있다", 승인 자격
     없는 제3자가 게이트를 pending에 묶어두는 건 별개 취약이 된다). 로직 자체는 신규가 아니라
     기존 transition 인가 규칙의 재사용 — 새 규칙을 만들지 않는다(DRY, 위 _non_doc_can_approve
-    표 주석과 같은 원칙)."""
+    표 주석과 같은 원칙).
+
+    story #3793 — `resolved_locale`은 호출부(라우트 진입점)가 이미
+    `resolve_locale_from_request()`로 풀어 넘기는 plain str(Header() DI 마커 없음, 까심 QA CI
+    FAILURE 원칙)."""
     if resolved.type != "human":
         raise HTTPException(
             status_code=403,
-            detail="게이트 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 승인 불가).",
+            detail=t("gates.approve_human_only", resolved_locale),
         )
     if gate is None:
         return
@@ -602,12 +628,12 @@ async def _authorize_gate_approve_equivalent(
         if _reason == "self_or_unverified":
             raise HTTPException(
                 status_code=403,
-                detail="본인이 상신한 doc 결재는 본인이 승인/거부할 수 없습니다 (self-approval 금지·상신자 미검증 차단).",
+                detail=t("gates.approve_self_not_allowed", resolved_locale),
             )
         if _reason is not None:
             raise HTTPException(
                 status_code=403,
-                detail="doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).",
+                detail=t("gates.approve_no_doc_access", resolved_locale),
             )
     else:
         _project_id = await resolve_work_item_project_id(
@@ -619,10 +645,7 @@ async def _authorize_gate_approve_equivalent(
         ):
             raise HTTPException(
                 status_code=403,
-                detail=(
-                    "이 게이트를 승인/거부할 권한이 없습니다 (해당 프로젝트의 owner/admin이어야 "
-                    "합니다). 프로젝트 관리자에게 권한을 요청하세요."
-                ),
+                detail=t("gates.approve_no_project_admin_access", resolved_locale),
             )
 
 
@@ -1500,6 +1523,26 @@ async def transition_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출(realdb·유닛) 테스트는 `_transition_gate_endpoint`를 불러야 한다."""
+    return await _transition_gate_endpoint(
+        id, body, background_tasks, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _transition_gate_endpoint(
+    id: uuid.UUID,
+    body: GateTransitionRequest,
+    background_tasks: BackgroundTasks,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> GateResponse:
     # authz(93fc7aeb): 게이트 approve/reject는 **휴먼 member만**. 에이전트(API key)가 사람 검증
     # 게이트를 승인하면 "agent-assisted·human-validated" 웨지 전제가 무너지므로 차단(403).
@@ -1516,7 +1559,7 @@ async def transition_gate_endpoint(
     _gate = (await session.execute(
         select(Gate).where(Gate.id == id, Gate.org_id == org_id).with_for_update()
     )).scalar_one_or_none()
-    await _authorize_gate_approve_equivalent(session, _gate, resolved, auth, org_id)
+    await _authorize_gate_approve_equivalent(session, _gate, resolved, auth, org_id, resolved_locale)
     # story #2982(선생님 실사용 리포트, PO 확定 2026-08-24) — 이미 해소된(pending 아닌) 게이트에
     # 승인/반려를 시도하면 여기까지 도달해 transition_gate()의 is_valid_transition이 ValueError를
     # 던졌고, 그게 그대로 "불법 전이: approved → rejected. pending에서만..." 개발자 문구로 화면에
@@ -1570,13 +1613,13 @@ async def transition_gate_endpoint(
             if not (body.note or "").strip():
                 raise HTTPException(
                     status_code=422,
-                    detail="고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.",
+                    detail=t("gates.transition_high_risk_note_required", resolved_locale),
                 )
             # story #2027 AC2: note와 같은 자리 — 근거 열람(evidence_viewed) 확인도 서버가 강제.
             if body.evidence_viewed is not True:
                 raise HTTPException(
                     status_code=422,
-                    detail="고위험(risk_grade=high) 게이트 승인은 근거 열람 확인(evidence_viewed=true)이 필수입니다.",
+                    detail=t("gates.transition_high_risk_evidence_required", resolved_locale),
                 )
     # story #2975(HIGH, 게이트 신선도 구멍 근본처방·페드루 PO 설계 확定 2026-08-24) — merge 게이트
     # 승인의 anchor SHA 레이스. 위 FOR UPDATE로 이 gate 행을 이미 잠근 상태이므로 여기서 읽는
@@ -1692,6 +1735,25 @@ async def reevaluate_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_reevaluate_gate_endpoint`를 불러야 한다."""
+    return await _reevaluate_gate_endpoint(
+        id, background_tasks, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _reevaluate_gate_endpoint(
+    id: uuid.UUID,
+    background_tasks: BackgroundTasks,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> GateResponse:
     """story #2893(설계안 §3 B3) — 명시적 재평가 API. reopen(PR을 실제로 close→reopen)이나
     「참여등록 후 빈 커밋 push」 같은 우회(오늘 #3324가 실제로 쓴 수동 경로)를 표준 경로로
@@ -1724,7 +1786,7 @@ async def reevaluate_gate_endpoint(
         raise HTTPException(status_code=404, detail="Gate not found")
 
     if gate.gate_type != MERGE_GATE_TYPE:
-        raise HTTPException(status_code=422, detail="merge 게이트만 재평가를 지원합니다.")
+        raise HTTPException(status_code=422, detail=t("gates.reevaluate_merge_only", resolved_locale))
     if gate.status not in ("pending", "auto_passed"):
         raise HTTPException(
             status_code=422,
@@ -1750,7 +1812,7 @@ async def reevaluate_gate_endpoint(
         pr_number = pr_number or (_link.pr_number if _link else None)
     if not repo or not pr_number:
         raise HTTPException(
-            status_code=422, detail="게이트에 연결된 PR 정보가 없어 재평가할 수 없습니다.",
+            status_code=422, detail=t("gates.reevaluate_no_pr_info", resolved_locale),
         )
 
     installation = (
@@ -1761,17 +1823,17 @@ async def reevaluate_gate_endpoint(
         )
     ).scalar_one_or_none()
     if installation is None:
-        raise HTTPException(status_code=422, detail="GitHub App 설치가 없어 재평가할 수 없습니다.")
+        raise HTTPException(status_code=422, detail=t("gates.reevaluate_no_github_app", resolved_locale))
     token = await get_installation_token(installation.installation_id)
     if not token:
-        raise HTTPException(status_code=502, detail="GitHub 인증 토큰 발급 실패 — 잠시 후 다시 시도해 주세요.")
+        raise HTTPException(status_code=502, detail=t("gates.reevaluate_token_fetch_failed", resolved_locale))
 
     pr = await get_pull_request(installation.installation_id, repo, pr_number)
     if pr is None:
-        raise HTTPException(status_code=502, detail="GitHub PR 정보 조회 실패 — 잠시 후 다시 시도해 주세요.")
+        raise HTTPException(status_code=502, detail=t("gates.reevaluate_pr_fetch_failed", resolved_locale))
     head_sha = (pr.get("head") or {}).get("sha")
     if not head_sha:
-        raise HTTPException(status_code=502, detail="GitHub PR head SHA를 확인할 수 없습니다.")
+        raise HTTPException(status_code=502, detail=t("gates.reevaluate_head_sha_unavailable", resolved_locale))
     merged = bool(pr.get("merged"))
     ci_result, _ci_reason = await fetch_status_check_rollup(repo, head_sha, token)
 
@@ -1881,6 +1943,25 @@ async def void_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_void_gate_endpoint`를 불러야 한다."""
+    return await _void_gate_endpoint(
+        id, body, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _void_gate_endpoint(
+    id: uuid.UUID,
+    body: GateVoidRequest,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> GateResponse:
     """⭐S30 admin recovery: 잘못 생성된 pending gate 무효화(void). admin-only(project_auth canonical).
 
@@ -1889,7 +1970,7 @@ async def void_gate_endpoint(
     resolved = await resolve_member(auth, org_id, session)
     # Q4: canonical project_auth admin 게이팅(ad-hoc role 금지·S27/S29 교훈). org owner/admin 만.
     if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
-        raise HTTPException(status_code=403, detail="게이트 무효화는 org owner/admin 만 가능합니다.")
+        raise HTTPException(status_code=403, detail=t("gates.void_owner_admin_only", resolved_locale))
     try:
         gate = await void_gate(session, org_id, id, resolved.id, body.reason)
         await session.commit()
@@ -1905,12 +1986,15 @@ class GateHoldRequest(BaseModel):
     held_until: datetime | None = None  # 시한부 만료(무기한이면 None)
 
 
-async def _require_gate_admin(session, auth, org_id):
+async def _require_gate_admin(session, auth, org_id, resolved_locale: str):
     """⭐S31/S30 공통: gate 파괴적/관리 액션 admin 게이팅(canonical project_auth·ad-hoc role 금지).
-    반환 resolved member(holder/voider=인증 caller 강제용·body 신뢰 0)."""
+    반환 resolved member(holder/voider=인증 caller 강제용·body 신뢰 0).
+
+    story #3793 — `resolved_locale`은 호출부(라우트 진입점)가 이미 `resolve_locale_from_request()`
+    로 풀어 넘기는 plain str(Header() DI 마커 없음, 까심 QA CI FAILURE 원칙)."""
     resolved = await resolve_member(auth, org_id, session)
     if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
-        raise HTTPException(status_code=403, detail="이 액션은 org owner/admin 만 가능합니다.")
+        raise HTTPException(status_code=403, detail=t("gates.require_admin_generic", resolved_locale))
     return resolved
 
 
@@ -1921,9 +2005,28 @@ async def hold_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_hold_gate_endpoint`를 불러야 한다."""
+    return await _hold_gate_endpoint(
+        id, body, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _hold_gate_endpoint(
+    id: uuid.UUID,
+    body: GateHoldRequest,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> GateResponse:
     """⭐S31 admin hold: pending gate 일시 보류(held·SLA pause). admin-only·holder=인증 caller 강제."""
-    resolved = await _require_gate_admin(session, auth, org_id)
+    resolved = await _require_gate_admin(session, auth, org_id, resolved_locale)
     try:
         gate = await hold_gate(session, org_id, id, resolved.id, body.reason, body.held_until)
         await session.commit()
@@ -1940,9 +2043,27 @@ async def unhold_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_unhold_gate_endpoint`를 불러야 한다."""
+    return await _unhold_gate_endpoint(
+        id, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _unhold_gate_endpoint(
+    id: uuid.UUID,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> GateResponse:
     """⭐S31 admin unhold: held gate 재개(→pending·SLA resume). admin-only·actor=인증 caller."""
-    resolved = await _require_gate_admin(session, auth, org_id)
+    resolved = await _require_gate_admin(session, auth, org_id, resolved_locale)
     try:
         gate = await unhold_gate(session, org_id, id, resolved.id)
         await session.commit()
@@ -1991,16 +2112,36 @@ async def request_gate_discussion_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
 ) -> GateResponse:
     """story #2631 AC2 — 승인/거부 옆 3번째 응답: 「보류(논의 필요)」. 게이트는 pending
     그대로(전이 없음) — 순수 회신+감사 기록. 인가는 승인/거부와 **동일 자격**
     (_authorize_gate_approve_equivalent — 승인 못 하는 제3자가 게이트를 논의-보류로
-    묶어두는 것도 막아야 하므로)."""
+    묶어두는 것도 막아야 하므로).
+
+    story #3793 — `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE 원칙). 직접-호출
+    테스트는 `_request_gate_discussion_endpoint`를 불러야 한다."""
+    return await _request_gate_discussion_endpoint(
+        id, body, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _request_gate_discussion_endpoint(
+    id: uuid.UUID,
+    body: GateDiscussionRequest,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
+) -> GateResponse:
     resolved = await resolve_member(auth, org_id, session)
     _gate = (await session.execute(
         select(Gate).where(Gate.id == id, Gate.org_id == org_id)
     )).scalar_one_or_none()
-    await _authorize_gate_approve_equivalent(session, _gate, resolved, auth, org_id)
+    await _authorize_gate_approve_equivalent(session, _gate, resolved, auth, org_id, resolved_locale)
     try:
         gate = await request_gate_discussion(session, org_id, id, resolved.id, body.reason)
         await session.commit()
@@ -2022,6 +2163,25 @@ async def delegate_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_delegate_gate_endpoint`를 불러야 한다."""
+    return await _delegate_gate_endpoint(
+        id, body, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _delegate_gate_endpoint(
+    id: uuid.UUID,
+    body: GateDelegateRequest,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> GateResponse:
     """story #3001(선생님 정책 확定 2026-08-24) — 지정 결재자 본인이 다른 결재자에게
     「튕겨낸다」(위임). #2985가 만들었던 "대신 처리" 폴드의 대체 정책 — 「감사는 읽기만
@@ -2044,9 +2204,9 @@ async def delegate_gate_endpoint(
             detail={"code": "gate_already_resolved", "message": "이미 처리된 결재는 위임할 수 없습니다."},
         )
     if _gate.designated_approver_id is None or _gate.designated_approver_id != resolved.id:
-        raise HTTPException(status_code=403, detail="지정 결재자 본인만 위임할 수 있습니다.")
+        raise HTTPException(status_code=403, detail=t("gates.delegate_designated_only", resolved_locale))
     if body.new_approver_member_id == resolved.id:
-        raise HTTPException(status_code=422, detail="본인에게 위임할 수 없습니다.")
+        raise HTTPException(status_code=422, detail=t("gates.delegate_self_not_allowed", resolved_locale))
 
     # story #2985와 동일 fail-safe 축(approval_delivery.dispatch_approval_request_cards의
     # designated_approver_id 밖 값 처리와 동형) — 여기선 서버가 400으로 명시 거부한다(라우터
@@ -2112,6 +2272,25 @@ async def toss_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateTossResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_toss_gate_endpoint`를 불러야 한다."""
+    return await _toss_gate_endpoint(
+        id, body, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _toss_gate_endpoint(
+    id: uuid.UUID,
+    body: GateTossRequest,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> GateTossResponse:
     """story #3084(2026-08-25, 선생님 지시 — 결재 카드 «토스») — 상신자 또는 designated
     결재자 본인이, designated 본인이 참여한 다른 conversation에 카드 **사본**을 심는다
@@ -2143,11 +2322,11 @@ async def toss_gate_endpoint(
     from app.services.gate_service import resolve_designatable_gate_context
     ctx = await resolve_designatable_gate_context(session, _gate)
     if ctx is None:
-        raise HTTPException(status_code=422, detail="이 게이트 유형은 토스를 지원하지 않습니다.")
+        raise HTTPException(status_code=422, detail=t("gates.toss_unsupported_gate_type", resolved_locale))
     title, project_id, requester_id = ctx
 
     if resolved.id not in (requester_id, _gate.designated_approver_id):
-        raise HTTPException(status_code=403, detail="상신자 또는 지정 결재자 본인만 토스할 수 있습니다.")
+        raise HTTPException(status_code=403, detail=t("gates.toss_requester_or_designated_only", resolved_locale))
 
     # story #3001 정책 집행 — 대상 conversation에 designated 본인이 참여자여야 한다(카드=
     # 지정 라인 전용, 임의 방으로 액션 링크가 새는 것 방지). org 스코프도 함께 강제.
@@ -2250,10 +2429,28 @@ async def list_gate_approvers_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> list[GateApproverResponse]:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_list_gate_approvers_endpoint`를 불러야 한다."""
+    return await _list_gate_approvers_endpoint(
+        id, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _list_gate_approvers_endpoint(
+    id: uuid.UUID,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> list[GateApproverResponse]:
     """⭐S32 FE conditional-display: gate approver row 목록(있으면 parallel gate→reassign 노출·없으면
     단일/merge gate→reassign 미노출로 422 원천차단). admin-only. 재지정 메타(누가/언제) enrich."""
-    await _require_gate_admin(session, auth, org_id)
+    await _require_gate_admin(session, auth, org_id, resolved_locale)
     from app.services.workflow_parallel_approval import list_gate_approvers
     rows = await list_gate_approvers(session, org_id, id)
     return await _enrich_approvers(session, org_id, rows)
@@ -2266,10 +2463,29 @@ async def reassign_gate_approver_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> list[GateApproverResponse]:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_reassign_gate_approver_endpoint`를 불러야 한다."""
+    return await _reassign_gate_approver_endpoint(
+        id, body, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _reassign_gate_approver_endpoint(
+    id: uuid.UUID,
+    body: GateReassignRequest,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> list[GateApproverResponse]:
     """⭐S32 admin reassign: parallel gate 의 pending 결재자 교체. admin-only·reassigner=인증 caller 강제
     (body 신뢰 0·S23 RC①). gate.status 불변(pending 유지·재결정 대상). 단일 gate=422(parallel 전용)."""
-    resolved = await _require_gate_admin(session, auth, org_id)
+    resolved = await _require_gate_admin(session, auth, org_id, resolved_locale)
     from app.services.workflow_parallel_approval import list_gate_approvers, reassign_approver
     try:
         await reassign_approver(
@@ -2289,12 +2505,15 @@ class GateOverrideRequest(BaseModel):
     reason: str    # 필수 — 가장 민감한 액션이라 사유 의무
 
 
-async def _require_gate_owner(session, auth, org_id):
+async def _require_gate_owner(session, auth, org_id, resolved_locale: str):
     """⭐S33 owner-only 게이팅 — override 는 SoD 우회=가장 강력이라 admin(void/hold/reassign)보다 좁게
-    owner 만. is_org_owner(role='owner') canonical. 반환 resolved(owner_id=인증 caller 강제·body 신뢰 0)."""
+    owner 만. is_org_owner(role='owner') canonical. 반환 resolved(owner_id=인증 caller 강제·body 신뢰 0).
+
+    story #3793 — `resolved_locale`은 호출부(라우트 진입점)가 이미 `resolve_locale_from_request()`
+    로 풀어 넘기는 plain str(Header() DI 마커 없음, 까심 QA CI FAILURE 원칙)."""
     resolved = await resolve_member(auth, org_id, session)
     if not await is_org_owner(session, uuid.UUID(auth.user_id), org_id):
-        raise HTTPException(status_code=403, detail="이 액션은 org owner 만 가능합니다.")
+        raise HTTPException(status_code=403, detail=t("gates.require_owner_generic", resolved_locale))
     return resolved
 
 
@@ -2306,11 +2525,31 @@ async def override_gate_endpoint(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> GateResponse:
+    """story #3793 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙). 직접-호출 테스트는 `_override_gate_endpoint`를 불러야 한다."""
+    return await _override_gate_endpoint(
+        id, body, background_tasks, session=session, org_id=org_id, auth=auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _override_gate_endpoint(
+    id: uuid.UUID,
+    body: GateOverrideRequest,
+    background_tasks: BackgroundTasks,
+    *,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    auth,
+    resolved_locale: str,
 ) -> GateResponse:
     """⭐S33 owner force-resolve: owner 가 막힌/긴급 gate 를 강제 결정(approved|rejected). owner-only·
     reason 필수·owner_id=인증 caller 강제(S23 RC①)·정상 결재(quorum/SoD) 우회. 가장 민감한 액션."""
     from app.services.gate_service import override_gate
-    resolved = await _require_gate_owner(session, auth, org_id)
+    resolved = await _require_gate_owner(session, auth, org_id, resolved_locale)
     _pending_deliveries: list[dict] = []
     try:
         gate = await override_gate(

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -143,7 +143,9 @@ _CATALOG: dict[str, dict[str, str]] = {
         # 「다른 방에도 보내기」로 정렬(별건 승인, 이 카드에 동봉). 「게이트 유형」도 화면
         # 낱말 「결재」로.
         "ko": "이 결재는 다른 방에 보낼 수 없습니다.",
-        "en": "This gate type cannot be sent to another room",
+        # 유나 정정(2026-09-10 13:50Z, 페드루 전달) — 시트 en이 "this approval"이라
+        # ko와 같은 화면·같은 낱말("gate type"이 아니라 "approval")로 맞춘다.
+        "en": "This approval can't be sent to another room",
     },
     "gates.toss_requester_or_designated_only": {
         "ko": "상신자 또는 지정 결재자 본인만 다른 방에 보낼 수 있습니다.",

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -63,6 +63,96 @@ _CATALOG: dict[str, dict[str, str]] = {
         "ko": "의존성을 찾을 수 없음",
         "en": "Dependency not found",
     },
+    # story #3793(3779 3층 ②) — gates.py http_detail 20건. en = 유나 定(2026-09-10, 카드
+    # 코멘트 착지) — 이 레포 라우터 en detail 768건 실측 관례(마침표 0%·문장 첫 글자
+    # 대문자·"X — Y" em-dash 안내형·집안 어순 "admin/owner") 근거로 확定됨. 마지막 두 건
+    # (toss_unsupported_gate_type/toss_requester_or_designated_only)은 「토스」를 그대로
+    # 옮기지 않는다 — 화면 어디에도 그 낱말이 없고(`chats.approvalRequestTossTrigger` 등의
+    # 표시 문구는 ko/en 둘 다 「다른 방에 보내기/Send to another room」) 유나가 그 은유
+    # 누출을 지적했다(ko 원문 두 건의 「토스」 자체는 이 카드 범위 밖 — 별건으로 남김).
+    "gates.create_doc_gate_not_allowed": {
+        "ko": "doc 결재 게이트는 doc 상신 경로로만 생성됩니다 (직접 생성 불가).",
+        "en": "Doc approval gates are created only through the doc submission flow — direct creation is not allowed",
+    },
+    "gates.approve_human_only": {
+        "ko": "게이트 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 승인 불가).",
+        "en": "Only human members can approve or reject a gate — agents cannot approve",
+    },
+    "gates.approve_self_not_allowed": {
+        "ko": "본인이 상신한 doc 결재는 본인이 승인/거부할 수 없습니다 (self-approval 금지·상신자 미검증 차단).",
+        "en": "You cannot approve or reject a doc approval you submitted — self-approval is not allowed",
+    },
+    "gates.approve_no_doc_access": {
+        "ko": "doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).",
+        "en": "No permission to act on this doc approval — access to the target project is required",
+    },
+    "gates.approve_no_project_admin_access": {
+        "ko": "이 게이트를 승인/거부할 권한이 없습니다 (해당 프로젝트의 owner/admin이어야 합니다). 프로젝트 관리자에게 권한을 요청하세요.",
+        "en": "No permission to approve or reject this gate — project owner/admin required; ask a project admin for access",
+    },
+    "gates.transition_high_risk_note_required": {
+        "ko": "고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.",
+        "en": "Approving a high-risk gate (risk_grade=high) requires a note",
+    },
+    "gates.transition_high_risk_evidence_required": {
+        "ko": "고위험(risk_grade=high) 게이트 승인은 근거 열람 확인(evidence_viewed=true)이 필수입니다.",
+        "en": "Approving a high-risk gate (risk_grade=high) requires confirming you reviewed the evidence (evidence_viewed=true)",
+    },
+    "gates.reevaluate_merge_only": {
+        "ko": "merge 게이트만 재평가를 지원합니다.",
+        "en": "Only merge gates support re-evaluation",
+    },
+    "gates.reevaluate_no_pr_info": {
+        "ko": "게이트에 연결된 PR 정보가 없어 재평가할 수 없습니다.",
+        "en": "Cannot re-evaluate — this gate has no linked PR",
+    },
+    "gates.reevaluate_no_github_app": {
+        "ko": "GitHub App 설치가 없어 재평가할 수 없습니다.",
+        "en": "Cannot re-evaluate — no GitHub App installation",
+    },
+    "gates.reevaluate_token_fetch_failed": {
+        "ko": "GitHub 인증 토큰 발급 실패 — 잠시 후 다시 시도해 주세요.",
+        "en": "GitHub auth token request failed — please try again shortly",
+    },
+    "gates.reevaluate_pr_fetch_failed": {
+        "ko": "GitHub PR 정보 조회 실패 — 잠시 후 다시 시도해 주세요.",
+        "en": "GitHub PR lookup failed — please try again shortly",
+    },
+    "gates.reevaluate_head_sha_unavailable": {
+        "ko": "GitHub PR head SHA를 확인할 수 없습니다.",
+        "en": "Couldn't determine the GitHub PR head SHA",
+    },
+    "gates.void_owner_admin_only": {
+        "ko": "게이트 무효화는 org owner/admin 만 가능합니다.",
+        "en": "Voiding a gate requires org admin/owner",
+    },
+    "gates.require_admin_generic": {
+        "ko": "이 액션은 org owner/admin 만 가능합니다.",
+        "en": "This action requires org admin/owner",
+    },
+    "gates.delegate_designated_only": {
+        "ko": "지정 결재자 본인만 위임할 수 있습니다.",
+        "en": "Only the designated approver can delegate",
+    },
+    "gates.delegate_self_not_allowed": {
+        "ko": "본인에게 위임할 수 없습니다.",
+        "en": "You cannot delegate to yourself",
+    },
+    "gates.toss_unsupported_gate_type": {
+        # 페드루 PO 전달 유나 定(2026-09-10 13:08Z) — ko도 「토스」 은유를 걷어 화면 낱말
+        # 「다른 방에도 보내기」로 정렬(별건 승인, 이 카드에 동봉). 「게이트 유형」도 화면
+        # 낱말 「결재」로.
+        "ko": "이 결재는 다른 방에 보낼 수 없습니다.",
+        "en": "This gate type cannot be sent to another room",
+    },
+    "gates.toss_requester_or_designated_only": {
+        "ko": "상신자 또는 지정 결재자 본인만 다른 방에 보낼 수 있습니다.",
+        "en": "Only the submitter or the designated approver can send this approval to another room",
+    },
+    "gates.require_owner_generic": {
+        "ko": "이 액션은 org owner 만 가능합니다.",
+        "en": "This action requires org owner",
+    },
 }
 
 

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -151,6 +151,20 @@ _CATALOG: dict[str, dict[str, str]] = {
         "ko": "상신자 또는 지정 결재자 본인만 다른 방에 보낼 수 있습니다.",
         "en": "Only the submitter or the designated approver can send this approval to another room",
     },
+    # story #3793 후속(페드루 전달 유나 定, 2026-09-10 13:57Z) — 원래 http_detail 20건
+    # 밖(이미 code 붙어 있어 스캐너가 안 잡음, 카드 코멘트 표 주석 참고)이었으나, toss
+    # 어휘 정렬 김에 이 둘도 같은 PR에서 카탈로그로 이관.
+    "gates.toss_no_designated_approver": {
+        "ko": "지정 결재자가 없는 결재는 다른 방에 보낼 수 없습니다.",
+        "en": "An approval with no designated approver can't be sent to another room.",
+    },
+    # 페드루 判(2026-09-10 13:57Z, "선택·미르코 판단") — 같은 toss 자리·같은 어휘 정렬
+    # 이유라 같이 이관. FE는 code로 갈아끼우지만 API 직접 소비자(에이전트 등)에겐
+    # message 원문이 그대로 노출된다.
+    "gates.toss_gate_already_resolved": {
+        "ko": "이미 처리된 결재는 다른 방에 보낼 수 없습니다.",
+        "en": "An approval that's already been decided can't be sent to another room.",
+    },
     "gates.require_owner_generic": {
         "ko": "이 액션은 org owner 만 가능합니다.",
         "en": "This action requires org owner",

--- a/backend/scripts/korean_user_strings_baseline.txt
+++ b/backend/scripts/korean_user_strings_baseline.txt
@@ -240,41 +240,21 @@ app/routers/evidence.py::중 하나)가 필요하고, note는 있으면 문자�
 app/routers/gate_metrics.py::window 끝(이하)
 app/routers/gate_metrics.py::window 시작(이상)
 app/routers/gates.py::)는 재평가 대상이 아닙니다(pending/auto_passed만 가능).
-app/routers/gates.py::GitHub App 설치가 없어 재평가할 수 없습니다.
-app/routers/gates.py::GitHub PR head SHA를 확인할 수 없습니다.
-app/routers/gates.py::GitHub PR 정보 조회 실패 — 잠시 후 다시 시도해 주세요.
-app/routers/gates.py::GitHub 인증 토큰 발급 실패 — 잠시 후 다시 시도해 주세요.
 app/routers/gates.py::comma-separated gate ids — 배치 앵커 조회
-app/routers/gates.py::doc 결재 게이트는 doc 상신 경로로만 생성됩니다 (직접 생성 불가).
-app/routers/gates.py::doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).
 app/routers/gates.py::generic transition 은
-app/routers/gates.py::merge 게이트만 재평가를 지원합니다.
 app/routers/gates.py::게이트 대상 커밋이 승인 확인 이후 변경되었습니다. 최신 내용을 다시 확인한 뒤 승인해주세요.
-app/routers/gates.py::게이트 무효화는 org owner/admin 만 가능합니다.
 app/routers/gates.py::게이트 상태(
-app/routers/gates.py::게이트 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 승인 불가).
-app/routers/gates.py::게이트에 연결된 PR 정보가 없어 재평가할 수 없습니다.
 app/routers/gates.py::결정 요청
 app/routers/gates.py::결정 요청은 결재자를 지정해야 합니다.
-app/routers/gates.py::고위험(risk_grade=high) 게이트 승인은 근거 열람 확인(evidence_viewed=true)이 필수입니다.
-app/routers/gates.py::고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.
 app/routers/gates.py::답변 대상 댓글이 삭제되어 승인할 수 없습니다.
 app/routers/gates.py::대상 대화에 지정 결재자가 참여하고 있지 않습니다.
 app/routers/gates.py::만 허용합니다. voided/held/unhold 는 전용 엔드포인트(/void·/hold·/unhold)를 사용하세요.
-app/routers/gates.py::본인에게 위임할 수 없습니다.
 app/routers/gates.py::본인을 결재자로 지정할 수 없습니다.
-app/routers/gates.py::본인이 상신한 doc 결재는 본인이 승인/거부할 수 없습니다 (self-approval 금지·상신자 미검증 차단).
-app/routers/gates.py::상신자 또는 지정 결재자 본인만 토스할 수 있습니다.
 app/routers/gates.py::승인 뒤 내용이 바뀌었습니다. 재상신(submit)한 뒤 다시 승인해주세요.
 app/routers/gates.py::위임 대상이 이 조직의 결재 권한자(owner/admin)가 아닙니다.
-app/routers/gates.py::이 게이트 유형은 토스를 지원하지 않습니다.
-app/routers/gates.py::이 게이트를 승인/거부할 권한이 없습니다 (해당 프로젝트의 owner/admin이어야 합니다). 프로젝트 관리자에게 권한을 요청하세요.
-app/routers/gates.py::이 액션은 org owner 만 가능합니다.
-app/routers/gates.py::이 액션은 org owner/admin 만 가능합니다.
 app/routers/gates.py::이미 처리된 결재는 위임할 수 없습니다.
 app/routers/gates.py::이미 처리된 결재는 토스할 수 없습니다.
 app/routers/gates.py::이미 처리된 결재입니다. 되돌리려면 PO에게 재검토를 요청해주세요.
-app/routers/gates.py::지정 결재자 본인만 위임할 수 있습니다.
 app/routers/gates.py::지정 결재자가 없는 게이트는 토스할 수 없습니다.
 app/routers/gates.py::지정한 결재자는 결재 자격(owner/admin)이 없습니다.
 app/routers/goals.py::"glance"면 participant_ids/focal_story가 추가로 붙는다(story #2298, 옵트인).

--- a/backend/scripts/korean_user_strings_baseline.txt
+++ b/backend/scripts/korean_user_strings_baseline.txt
@@ -253,9 +253,7 @@ app/routers/gates.py::본인을 결재자로 지정할 수 없습니다.
 app/routers/gates.py::승인 뒤 내용이 바뀌었습니다. 재상신(submit)한 뒤 다시 승인해주세요.
 app/routers/gates.py::위임 대상이 이 조직의 결재 권한자(owner/admin)가 아닙니다.
 app/routers/gates.py::이미 처리된 결재는 위임할 수 없습니다.
-app/routers/gates.py::이미 처리된 결재는 토스할 수 없습니다.
 app/routers/gates.py::이미 처리된 결재입니다. 되돌리려면 PO에게 재검토를 요청해주세요.
-app/routers/gates.py::지정 결재자가 없는 게이트는 토스할 수 없습니다.
 app/routers/gates.py::지정한 결재자는 결재 자격(owner/admin)이 없습니다.
 app/routers/goals.py::"glance"면 participant_ids/focal_story가 추가로 붙는다(story #2298, 옵트인).
 app/routers/goals.py::Goal 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)

--- a/backend/scripts/measure_korean_user_string_reachability.py
+++ b/backend/scripts/measure_korean_user_string_reachability.py
@@ -246,6 +246,14 @@ def main() -> int:
     print(f"[story #3779 2층] 화면 도달 부분집합(휴리스틱 6종, 최소치) — {len(hits)}건 / {len(by_file)}파일")
     print(f"  사유별: {json.dumps(by_reason, ensure_ascii=False)}")
     print()
+
+    # story #3793(email_copy 82→0 목표가 3786 EXEMPT_FILES와 동형 함정이었던 그라운딩,
+    # 페드루 PO 재가 2026-09-10 12:51Z) — email_copy.py는 패턴③ file-level 설계상 ko 카피가
+    # 존재하는 한 구조적으로 0 불가(움직일 수 없는 바닥). 다음 카드가 이 수를 또 "줄일 목표"로
+    # 잘못 집지 않도록 요약에 바닥을 분리해 명시한다.
+    email_copy_floor = len(by_file.get(EMAIL_COPY_FILE, []))
+    print(f"  닿는 합계 {len(hits)} · email_copy 바닥 {email_copy_floor}(구조적, 0 불가) · 줄일 수 있는 것 {len(hits) - email_copy_floor}")
+    print()
     for file_label in sorted(by_file):
         file_hits = by_file[file_label]
         print(f"  {file_label}: {len(file_hits)}건")

--- a/backend/tests/test_1968_gate_project_id_threading.py
+++ b/backend/tests/test_1968_gate_project_id_threading.py
@@ -13,7 +13,7 @@ step_run)=None 폴백도 `gate_service.resolve_work_item_project_id()`로 projec
 테스트 구성:
 - resolve_work_item_project_id 타입별 분기(story/task/doc/미인식) — mocked session, 신규 쿼리
   없이 검증(요청 순수 로직).
-- routers/gates.py 제네릭 create_gate_endpoint — mocked session, project_id 조회→threading 확인.
+- routers/gates.py 제네릭 _create_gate_endpoint — mocked session, project_id 조회→threading 확인.
 - merge_verdict_gate.evaluate_merge_gate — mocked cage 의존성, project_id threading 확인.
 - workflow_line_config.request_publish — 실 Postgres(org-level None·project-level 값 둘 다).
 - gate_service.override_gate — 실 Postgres, sr=None 폴백이 실제로 project_id를 조회하는지 확인.
@@ -114,7 +114,7 @@ async def test_generic_gate_endpoint_threads_resolved_project_id():
     """POST /api/v2/gates(work_item_type='story')가 project_id를 조회해 create_gate로
     넘겨야 한다(story #1968 스코프①)."""
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+    from app.routers.gates import GateCreateRequest, _create_gate_endpoint
 
     org_id, work_item_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     session = AsyncMock()
@@ -133,7 +133,8 @@ async def test_generic_gate_endpoint_threads_resolved_project_id():
          patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "create_gate", AsyncMock(return_value=gate)) as create_spy, \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
-        await create_gate_endpoint(body=body, session=session, org_id=org_id, _auth=auth)
+        await _create_gate_endpoint(
+                resolved_locale="ko",body=body, session=session, org_id=org_id, _auth=auth)
 
     resolve_spy.assert_awaited_once_with(session, org_id, "story", work_item_id)
     assert create_spy.await_args.kwargs["project_id"] == project_id
@@ -144,7 +145,7 @@ async def test_generic_gate_endpoint_known_agnostic_type_passes_none():
     """#2237(②): KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES 명시 allowlist(예: wf_line_version)에
     있는 타입만 project_id=None 그대로 통과한다(진짜 project-무관 타입 — 크래시 아님)."""
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+    from app.routers.gates import GateCreateRequest, _create_gate_endpoint
 
     org_id, work_item_id = uuid.uuid4(), uuid.uuid4()
     session = AsyncMock()
@@ -159,7 +160,8 @@ async def test_generic_gate_endpoint_known_agnostic_type_passes_none():
                        AsyncMock(return_value=None)), \
          patch.object(gates_mod, "create_gate", AsyncMock(return_value=gate)) as create_spy, \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
-        await create_gate_endpoint(body=body, session=session, org_id=org_id, _auth=SimpleNamespace())
+        await _create_gate_endpoint(
+                resolved_locale="ko",body=body, session=session, org_id=org_id, _auth=SimpleNamespace())
 
     assert create_spy.await_args.kwargs["project_id"] is None
 
@@ -171,7 +173,7 @@ async def test_generic_gate_endpoint_unclassified_type_rejected_fail_closed():
     통과였다 — 새 work_item_type이 조용히 다시 뚫리는 재발 클래스를 막는다)."""
     from fastapi import HTTPException
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+    from app.routers.gates import GateCreateRequest, _create_gate_endpoint
 
     org_id, work_item_id = uuid.uuid4(), uuid.uuid4()
     session = AsyncMock()
@@ -182,7 +184,8 @@ async def test_generic_gate_endpoint_unclassified_type_rejected_fail_closed():
 
     with patch.object(gates_mod, "resolve_work_item_project_id", AsyncMock(return_value=None)):
         with pytest.raises(HTTPException) as ei:
-            await create_gate_endpoint(
+            await _create_gate_endpoint(
+                resolved_locale="ko",
                 body=body, session=session, org_id=org_id,
                 _auth=SimpleNamespace(user_id=str(uuid.uuid4())),
             )

--- a/backend/tests/test_2198_non_doc_gate_authz_realdb.py
+++ b/backend/tests/test_2198_non_doc_gate_authz_realdb.py
@@ -4,13 +4,13 @@ artifact_canonicalize 등) 인가 갭 — 세 증상이 하나의 뿌리(rule B 
 ```
 ① 큐 필터        _non_doc_gate_approvable (story #1974)                ← 이미 옳게 좁았음
 ② can_approve    list_gates·get_gate_endpoint 둘 다 non-doc 은 계산 자체를 안 해 기본값 False  ← 없음
-③ 승인 엔드포인트 transition_gate_endpoint = 휴먼 org 멤버이기만 하면 통과                    ← 가장 넓음
+③ 승인 엔드포인트 _transition_gate_endpoint = 휴먼 org 멤버이기만 하면 통과                    ← 가장 넓음
 ```
 
 처방 = 새 규칙 발명 없이 이미 있던 rule B(``_non_doc_gate_approvable``)를 ②③에 마저 배선.
 
 ⛔SoD(self-approval) 는 의도적으로 안 넣는다(오르테가 PO 판정, 2026-07-27) — 근거는 gates.py
-transition_gate_endpoint 의 non-doc elif 분기 주석에 그대로 남겨 뒀다(저자성 없음·상신자=에이전트라
+_transition_gate_endpoint 의 non-doc elif 분기 주석에 그대로 남겨 뒀다(저자성 없음·상신자=에이전트라
 사람 대 사람 SoD 자리가 거의 없음·1인 org 교착 재발 위험·추적은 resolver_id 강제 기록으로 이미 확보).
 
 ⛔라이브 승인 POST 로 검증하지 않는다(오르테가 지시) — 이 파일은 격리된 로컬 throwaway realdb만
@@ -140,13 +140,13 @@ async def test_get_gate_can_approve_true_for_project_owner_false_for_member():
         await eng.dispose()
 
 
-# ───────────────────────── transition_gate_endpoint: 실 인가 강제 ─────────────────────────
+# ───────────────────────── _transition_gate_endpoint: 실 인가 강제 ─────────────────────────
 
 @pytest.mark.anyio
 async def test_transition_non_doc_gate_forbidden_for_member_allowed_for_owner():
     """#2198 의 본체 — ③(가장 넓던 자리)이 실제로 좁아졌는지. 격리 로컬 throwaway DB 에서 실제
     transition 을 수행(라이브 배포 시스템 무접촉) — #2027 과 동일한 검증 방식."""
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     eng, Session = await _engine()
     try:
         async with Session() as s:
@@ -154,7 +154,8 @@ async def test_transition_non_doc_gate_forbidden_for_member_allowed_for_owner():
         # 무자격(project member, owner/admin 아님) → 403·상태 미변경.
         async with Session() as s:
             with pytest.raises(HTTPException) as ei:
-                await transition_gate_endpoint(
+                await _transition_gate_endpoint(
+                resolved_locale="ko",
                     id=gate_id, body=GateTransitionRequest(status="approved", note="시도"),
                     background_tasks=BackgroundTasks(), session=s, org_id=ORG, auth=_auth(MEMBER_USER),
                 )
@@ -165,7 +166,8 @@ async def test_transition_non_doc_gate_forbidden_for_member_allowed_for_owner():
             assert g == "pending"  # 403 이 실제로 상태변경을 막았는지(뮤테이션 0) 재조회로 확認.
         # 자격자(project owner) → 승인 성공.
         async with Session() as s:
-            resp = await transition_gate_endpoint(
+            resp = await _transition_gate_endpoint(
+                resolved_locale="ko",
                 # story #2027 AC2: note+evidence_viewed 동봉 — 이 파일의 관심사(#2198 인가)와
                 # 무관한 고위험 사유-강제 가드를 우회.
                 id=gate_id, body=GateTransitionRequest(status="approved", note="승인 사유", evidence_viewed=True),
@@ -180,7 +182,7 @@ async def test_transition_non_doc_gate_forbidden_for_member_allowed_for_owner():
 async def test_transition_doc_approval_gate_still_unaffected():
     """#2198 이 doc_approval 분기(elif 이전 if)를 안 건드렸는지 회귀 확認 — 무관 gate_type 은
     non-doc elif 에 아예 안 들어간다(SimpleNamespace work_item_type 몰라도 무관)."""
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     eng, Session = await _engine()
     try:
         async with Session() as s:
@@ -216,7 +218,8 @@ async def test_transition_doc_approval_gate_still_unaffected():
             await s.commit()
             gate_id = gate.id
         async with Session() as s:
-            resp = await transition_gate_endpoint(
+            resp = await _transition_gate_endpoint(
+                resolved_locale="ko",
                 # story #2027 AC2: note+evidence_viewed 동봉 — 이 파일의 관심사(#2198 인가)와
                 # 무관한 고위험 사유-강제 가드를 우회.
                 id=gate_id, body=GateTransitionRequest(status="approved", note="doc 승인", evidence_viewed=True),
@@ -234,7 +237,7 @@ async def test_transition_artifact_canonicalize_gate_human_only_not_project_owne
     없는, merge 게이트라면 위 테스트에서 403 나는 바로 그 사용자)로도 승인이 통과해야 한다.
     이 테스트가 없으면 다음 사람이 #2198 의 rule B 를 "전 타입 균일"로 되돌려 이 회귀를
     재현할 수 있다 — _non_doc_can_approve 표를 직접 겨냥해 고정."""
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     eng, Session = await _engine()
     try:
         async with Session() as s:
@@ -275,7 +278,8 @@ async def test_transition_artifact_canonicalize_gate_human_only_not_project_owne
             await s.commit()
             gate_id_holder["id"] = gate.id
         async with Session() as s:
-            resp = await transition_gate_endpoint(
+            resp = await _transition_gate_endpoint(
+                resolved_locale="ko",
                 # story #2027 AC2: note+evidence_viewed 동봉 — 이 파일의 관심사(#2198 인가)와
                 # 무관한 고위험 사유-강제 가드를 우회.
                 id=gate_id_holder["id"], body=GateTransitionRequest(status="approved", note="정본화 승인", evidence_viewed=True),

--- a/backend/tests/test_2237_gate_create_project_scope_realdb.py
+++ b/backend/tests/test_2237_gate_create_project_scope_realdb.py
@@ -1,6 +1,6 @@
-"""#2237(WRITE②) — POST /api/v2/gates(create_gate_endpoint) project-scope IDOR, 실 PG.
+"""#2237(WRITE②) — POST /api/v2/gates(_create_gate_endpoint) project-scope IDOR, 실 PG.
 
-갭: create_gate_endpoint 는 resolve_work_item_project_id() 로 project_id 를 조회만 할 뿐(gate_service.py),
+갭: _create_gate_endpoint 는 resolve_work_item_project_id() 로 project_id 를 조회만 할 뿐(gate_service.py),
 caller 가 그 project 에 접근권이 있는지는 전혀 검증하지 않았다 — 형제 get_gate_endpoint(GET /{id})는
 동일 project_id 에 has_project_access 를 강제하는데(story #1970) create 경로만 빠져 있었다(#2200 A급
 전수 적출). 同org 비-project 멤버가 접근권 없는 project 의 story/doc/task 를 work_item 으로 임의
@@ -87,13 +87,14 @@ async def _gate_count(Session, work_item_id):
 @pytest.mark.anyio
 async def test_create_gate_own_project_200():
     """회귀0: PROJ_A grant caller가 PROJ_A story를 work_item으로 qa 게이트 생성 → 성공."""
-    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+    from app.routers.gates import GateCreateRequest, _create_gate_endpoint
     eng, Session = await _engine()
     try:
         async with Session() as s:
             await _seed(s)
         async with Session() as s:
-            resp = await create_gate_endpoint(
+            resp = await _create_gate_endpoint(
+                resolved_locale="ko",
                 body=GateCreateRequest(
                     work_item_id=STORY_A, work_item_type="story", gate_type="qa",
                     member_id=uuid.uuid4(), role_id=uuid.uuid4(),
@@ -110,14 +111,15 @@ async def test_create_gate_own_project_200():
 async def test_create_gate_cross_project_blocked_404_not_created():
     """봉인: 접근권 없는 PROJ_B story를 work_item으로 게이트 생성 시도 → 404 + **생성 0건**
     (직전 재조회로 뮤테이션 실증). 수정 前엔 project_id 조회만 하고 접근권 검증이 없어 201로 통과했다."""
-    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+    from app.routers.gates import GateCreateRequest, _create_gate_endpoint
     eng, Session = await _engine()
     try:
         async with Session() as s:
             await _seed(s)
         async with Session() as s:
             with pytest.raises(HTTPException) as ei:
-                await create_gate_endpoint(
+                await _create_gate_endpoint(
+                resolved_locale="ko",
                     body=GateCreateRequest(
                         work_item_id=STORY_B, work_item_type="story", gate_type="qa",
                         member_id=uuid.uuid4(), role_id=uuid.uuid4(),

--- a/backend/tests/test_2631_gate_undo_discuss.py
+++ b/backend/tests/test_2631_gate_undo_discuss.py
@@ -442,7 +442,7 @@ async def test_undo_endpoint_maps_window_expired_to_403():
 async def test_discuss_endpoint_non_approver_403_service_not_called():
     """⭐discuss는 승인/거부와 동일 자격 — non-doc 게이트에서 project owner/admin 아니면 403."""
     from app.routers import gates as gates_mod
-    from app.routers.gates import request_gate_discussion_endpoint, GateDiscussionRequest
+    from app.routers.gates import _request_gate_discussion_endpoint, GateDiscussionRequest
     from fastapi import HTTPException
     caller = _resolved_human()
     # story #3319 — designated_approver_id: _authorize_gate_approve_equivalent가 이제 이 필드를
@@ -460,7 +460,8 @@ async def test_discuss_endpoint_non_approver_403_service_not_called():
         session = AsyncMock()
         session.execute = AsyncMock(return_value=result)
         with pytest.raises(HTTPException) as ei:
-            await request_gate_discussion_endpoint(
+            await _request_gate_discussion_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateDiscussionRequest(reason="사유"), session=session,
                 org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())),
             )
@@ -472,7 +473,7 @@ async def test_discuss_endpoint_non_approver_403_service_not_called():
 async def test_discuss_endpoint_agent_caller_403():
     """⭐승인/거부와 동일하게 에이전트(비휴먼)는 discuss 요청도 불가."""
     from app.routers import gates as gates_mod
-    from app.routers.gates import request_gate_discussion_endpoint, GateDiscussionRequest
+    from app.routers.gates import _request_gate_discussion_endpoint, GateDiscussionRequest
     from fastapi import HTTPException
     from app.services.member_resolver import ResolvedMember
     caller = ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="agent", type="agent",
@@ -481,7 +482,8 @@ async def test_discuss_endpoint_agent_caller_403():
         session = AsyncMock()
         session.execute = AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: None))
         with pytest.raises(HTTPException) as ei:
-            await request_gate_discussion_endpoint(
+            await _request_gate_discussion_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateDiscussionRequest(reason="사유"), session=session,
                 org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())),
             )
@@ -491,7 +493,7 @@ async def test_discuss_endpoint_agent_caller_403():
 @pytest.mark.anyio
 async def test_discuss_endpoint_forces_actor_from_auth():
     from app.routers import gates as gates_mod
-    from app.routers.gates import request_gate_discussion_endpoint, GateDiscussionRequest
+    from app.routers.gates import _request_gate_discussion_endpoint, GateDiscussionRequest
     caller = _resolved_human()
     fake_gate = SimpleNamespace(id=uuid.uuid4(), gate_type="artifact_canonicalize", work_item_type="visual_artifact",
                                 work_item_id=uuid.uuid4(), designated_approver_id=None)
@@ -502,7 +504,8 @@ async def test_discuss_endpoint_forces_actor_from_auth():
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
         session = AsyncMock()
         session.execute = AsyncMock(return_value=result)
-        await request_gate_discussion_endpoint(
+        await _request_gate_discussion_endpoint(
+                resolved_locale="ko",
             id=uuid.uuid4(), body=GateDiscussionRequest(reason="사유"), session=session,
             org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())),
         )

--- a/backend/tests/test_3365_external_publish_gate_human_only.py
+++ b/backend/tests/test_3365_external_publish_gate_human_only.py
@@ -1,5 +1,5 @@
 """story #3365(Phase0 S1) AC4(승인 절반) — 페드루 PO 확定(2026-09-03): «승인 API» 403은
-신규 엔드포인트·신규 코드가 아니라 기존 gates.py `transition_gate_endpoint`
+신규 엔드포인트·신규 코드가 아니라 기존 gates.py `_transition_gate_endpoint`
 (`_authorize_gate_approve_equivalent`, `resolved.type != "human"` → 403)가 이미 전 gate_type에
 걸쳐 강제한다. 이 테스트는 그 기존 가드를 `external_publish` gate_type에 회귀로 고정한다
 (신규 동작 없음 — 기존 가드 재확인).
@@ -23,7 +23,7 @@ async def test_agent_cannot_approve_external_publish_gate_existing_guard_pinned(
     from fastapi import BackgroundTasks, HTTPException
 
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     from app.services.member_resolver import ResolvedMember
 
     agent = ResolvedMember(
@@ -36,7 +36,8 @@ async def test_agent_cannot_approve_external_publish_gate_existing_guard_pinned(
 
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=agent)):
         with pytest.raises(HTTPException) as exc_info:
-            await transition_gate_endpoint(
+            await _transition_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(),
                 body=GateTransitionRequest(status="approved"),
                 background_tasks=BackgroundTasks(),
@@ -61,7 +62,7 @@ async def test_resubmit_required_guard_does_not_fire_for_non_site_post_gate_type
     from fastapi import BackgroundTasks, HTTPException
 
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     from app.services.member_resolver import ResolvedMember
 
     human = ResolvedMember(
@@ -93,7 +94,8 @@ async def test_resubmit_required_guard_does_not_fire_for_non_site_post_gate_type
          patch.object(gates_mod, "transition_gate", _fake_transition), \
          patch.object(gates_mod.GateResponse, "model_validate", staticmethod(lambda g: g)):
         try:
-            await transition_gate_endpoint(
+            await _transition_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(),
                 body=GateTransitionRequest(status="approved", note="테스트 사유", evidence_viewed=True),
                 background_tasks=BackgroundTasks(),

--- a/backend/tests/test_3367_site_post_submit_gate_seal.py
+++ b/backend/tests/test_3367_site_post_submit_gate_seal.py
@@ -365,7 +365,7 @@ async def test_approve_after_edit_is_blocked_until_resubmit_seals_new_version():
     길은 gates.py가 409 SITE_POST_RESUBMIT_REQUIRED로 막는다 — 빠져나가는 길은 submit()
     재호출(새 버전으로 재봉인+플래그 해제) 뿐이다."""
     from app.main import app
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     from app.services.member_resolver import ResolvedMember
 
     engine, Session = await _session_factory()
@@ -431,7 +431,8 @@ async def test_approve_after_edit_is_blocked_until_resubmit_seals_new_version():
             with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=approver)), \
                  patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
                 with pytest.raises(HTTPException) as exc_info:
-                    await transition_gate_endpoint(
+                    await _transition_gate_endpoint(
+                resolved_locale="ko",
                         id=gate_id, body=GateTransitionRequest(status="approved"),
                         background_tasks=BackgroundTasks(), session=s, org_id=org_id, auth=_FakeAuth(),
                     )
@@ -486,7 +487,7 @@ async def test_double_edit_without_resubmit_between_still_requires_and_allows_re
     수정 後 기대값 — submit()이 조기 return을 안 타고 reapproval_required=False까지
     재봉인해, 그 뒤 승인이 200으로 통과한다."""
     from app.main import app
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     from app.services.member_resolver import ResolvedMember
 
     engine, Session = await _session_factory()
@@ -581,7 +582,8 @@ async def test_double_edit_without_resubmit_between_still_requires_and_allows_re
                 # 추정) — 이 테스트의 관심사(SITE_POST_RESUBMIT_REQUIRED 해소)와 무관한
                 # 별도 가드라 note를 채워 지나간다(위 test_approve_after_edit_...는 그
                 # 가드 前에 409로 끝나 이 자리에 안 닿았을 뿐, 신규 요구사항이 아니다).
-                approved = await transition_gate_endpoint(
+                approved = await _transition_gate_endpoint(
+                resolved_locale="ko",
                     id=gate_id, body=GateTransitionRequest(status="approved", note="재검토 완료", evidence_viewed=True),
                     background_tasks=BackgroundTasks(), session=s, org_id=org_id, auth=_FakeAuth(),
                 )

--- a/backend/tests/test_3374_channel_posts.py
+++ b/backend/tests/test_3374_channel_posts.py
@@ -358,7 +358,7 @@ async def test_approve_after_edit_is_blocked_until_resubmit_seals_new_version():
     "external_publish"로만 스코프, site 특정 로직 0)가 코드 변경 없이 channel_posts의
     external_publish 게이트에도 그대로 적용됨을 직접 확認한다."""
     from app.main import app
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     from app.services.member_resolver import ResolvedMember
 
     engine, Session = await _session_factory()
@@ -425,7 +425,8 @@ async def test_approve_after_edit_is_blocked_until_resubmit_seals_new_version():
             with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=approver)), \
                  patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
                 with pytest.raises(HTTPException) as exc_info:
-                    await transition_gate_endpoint(
+                    await _transition_gate_endpoint(
+                resolved_locale="ko",
                         id=gate_id, body=GateTransitionRequest(status="approved"),
                         background_tasks=BackgroundTasks(), session=s, org_id=org_id, auth=_FakeAuth(),
                     )
@@ -456,7 +457,7 @@ async def test_double_edit_without_resubmit_between_still_requires_and_allows_re
     "이미 봉인돼 있다"로 조용히 넘어가 승인이 영구히 409 SITE_POST_RESUBMIT_REQUIRED
     로 막힌다."""
     from app.main import app
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     from app.services.member_resolver import ResolvedMember
 
     engine, Session = await _session_factory()
@@ -540,7 +541,8 @@ async def test_double_edit_without_resubmit_between_still_requires_and_allows_re
         async with Session() as s:
             with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=approver)), \
                  patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
-                approved = await transition_gate_endpoint(
+                approved = await _transition_gate_endpoint(
+                resolved_locale="ko",
                     id=gate_id, body=GateTransitionRequest(status="approved", note="재검토 완료", evidence_viewed=True),
                     background_tasks=BackgroundTasks(), session=s, org_id=org_id, auth=_FakeAuth(),
                 )

--- a/backend/tests/test_3516_comment_scope_and_runbook.py
+++ b/backend/tests/test_3516_comment_scope_and_runbook.py
@@ -195,7 +195,7 @@ async def test_agent_scope_matrix():
             assert resolved.type == "agent"
             gate_row = await s.get(Gate, gate_id)
             with pytest.raises(HTTPException) as exc_info:
-                await _authorize_gate_approve_equivalent(s, gate_row, resolved, auth, org_id)
+                await _authorize_gate_approve_equivalent(s, gate_row, resolved, auth, org_id, "ko")
             assert exc_info.value.status_code == 403
     finally:
         await engine.dispose()

--- a/backend/tests/test_3793_email_locale_snapshot.py
+++ b/backend/tests/test_3793_email_locale_snapshot.py
@@ -1,0 +1,150 @@
+"""story #3793(email_copy 82건 그라운딩 후속, 페드루 PO 재가 2026-09-10 12:51Z) — #3205가
+이미 완성한 7개 메일 템플릿(verify_email·reset_password·set_password_confirm·
+payment_receipt·storage_warn·au_warn·reminder)에 en 전용 더미-트랜스포트(실발송 0) 렌더
+스냅샷이 없던 갭을 채운다.
+
+"email_copy 82→0"은 3786 EXEMPT_FILES와 동형인 구조적 바닥(2층 스크립트 자기 docstring
+패턴③이 파일 전체를 human-read 텍스트로 file-level 세는 설계) — PO 그라운딩 재확認 후
+카드 목표에서 이미 걷어냈다. 이 파일의 계약은 그 대신 PO가 재가한 두 가지뿐이다:
+① en 렌더 결과에 한글 문자가 0인지, ② 그 단언이 실제로 걸리는(tautological pass가
+아닌) 뮤테이션 양성대조.
+
+_is_hangul은 verify_no_new_korean_user_strings.py의 기존 판정을 그대로 재사용한다(새
+기전 발명 금지) — 뮤테이션은 en 필드를 대응하는 ko 필드 값으로 스왑하는 방식만 쓴다
+(placeholder 이름이 ko/en 간 동일해 .format()이 안 깨지고, 임의로 지어낸 문자열도 아니다).
+
+⚠️스코프 경계(그라운딩 중 발견, 별도 보고 済 — 페드루 PO 판단 대기, 2026-09-10 12:54Z):
+`render_email_shell()`의 공용 푸터(회사정보+약관 링크 라벨)는 `locale` 파라미터와 무관하게
+항상 한글이다 — email_copy.py 밖(app/services/email.py) 문제라 이 스토리 스코프가 아니다.
+`_strip_shell_footer()`로 그 자리를 제외한 content 영역만 zero-korean 단언 대상으로
+좁힌다(발견을 감추는 게 아니라 이 슬라이스가 책임질 자리만 정확히 그은 것)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from verify_no_new_korean_user_strings import _is_hangul  # noqa: E402
+
+from app.services.email import render_action_email, render_email_shell
+from app.services.email_copy import (
+    AU_WARN_COPY,
+    REMINDER_COPY,
+    STORAGE_WARN_COPY,
+    TRANSACTIONAL_COPY,
+    resolve_urgent_contact_note,
+)
+from app.services.onboarding_activation import _reminder_email_body
+
+
+_SHELL_FOOTER_MARKER = 'border-top:1px solid #ececec;padding:16px 32px'
+
+
+def _strip_shell_footer(html_body: str) -> str:
+    """render_email_shell()의 공용 푸터(회사정보+약관 라벨, locale 무관 항상 한글 —
+    스코프 경계 주석 참고)를 잘라내고 그 앞(헤더+content_html) 부분만 남긴다."""
+    idx = html_body.find(_SHELL_FOOTER_MARKER)
+    assert idx != -1, "render_email_shell 구조가 바뀌어 footer marker를 못 찾음 — 이 헬퍼도 갱신 필요"
+    return html_body[:idx]
+
+
+def _render_action_template(copy: dict, *, locale: str, security_note: str | None = None) -> str:
+    return render_action_email(
+        intro_lines=copy["intro_lines"],
+        cta_label=copy["cta_label"],
+        cta_url="https://app.sprintable.ai/action?token=dummy",
+        expiry_note=copy["expiry_note"],
+        security_note=security_note if security_note is not None else copy["security_note"],
+        fallback_label=copy["fallback_label"],
+        locale=locale,
+    )
+
+
+def _render_payment_receipt(*, locale: str) -> str:
+    copy = TRANSACTIONAL_COPY["payment_receipt"][locale]
+    amount_display = "12,000원" if locale == "ko" else "₩12,000"
+    intro_lines = [line.format(amount=amount_display) for line in copy["intro_lines"]]
+    return render_action_email(
+        intro_lines=intro_lines,
+        cta_label=copy["cta_label"],
+        cta_url="https://app.sprintable.ai/receipt/dummy",
+        expiry_note=copy["expiry_note"],
+        security_note=resolve_urgent_contact_note("payment_receipt", locale),
+        fallback_label=copy["fallback_label"],
+        locale=locale,
+    )
+
+
+def _render_storage_warn(*, locale: str) -> str:
+    copy = STORAGE_WARN_COPY[locale]
+    content = copy["body"].format(pct=82.5, used_mb=8250, cap_mb=10000)
+    return render_email_shell(content, locale=locale)
+
+
+def _render_au_warn(*, locale: str) -> str:
+    copy = AU_WARN_COPY[locale]
+    content = copy["body"].format(pct=91.0, current=910, au_limit=1000)
+    return render_email_shell(content, locale=locale)
+
+
+def _render_reminder(*, locale: str) -> str:
+    return _reminder_email_body(
+        app_url="https://app.sprintable.ai",
+        unsub_link="https://app.sprintable.ai/unsubscribe?token=dummy",
+        locale=locale,
+    )
+
+
+# (템플릿명, render(locale)->body, 뮤테이션 대상 dict/필드 — en 값을 ko 값으로 스왑할 자리)
+TEMPLATE_CASES = [
+    (
+        "verify_email",
+        lambda locale: _render_action_template(TRANSACTIONAL_COPY["verify_email"][locale], locale=locale),
+        TRANSACTIONAL_COPY["verify_email"],
+        "cta_label",
+    ),
+    (
+        "reset_password",
+        lambda locale: _render_action_template(TRANSACTIONAL_COPY["reset_password"][locale], locale=locale),
+        TRANSACTIONAL_COPY["reset_password"],
+        "cta_label",
+    ),
+    (
+        "set_password_confirm",
+        lambda locale: _render_action_template(TRANSACTIONAL_COPY["set_password_confirm"][locale], locale=locale),
+        TRANSACTIONAL_COPY["set_password_confirm"],
+        "cta_label",
+    ),
+    ("payment_receipt", lambda locale: _render_payment_receipt(locale=locale), TRANSACTIONAL_COPY["payment_receipt"], "cta_label"),
+    ("storage_warn", lambda locale: _render_storage_warn(locale=locale), STORAGE_WARN_COPY, "body"),
+    ("au_warn", lambda locale: _render_au_warn(locale=locale), AU_WARN_COPY, "body"),
+    ("reminder", lambda locale: _render_reminder(locale=locale), REMINDER_COPY, "cta_label"),
+]
+
+TEMPLATE_IDS = [c[0] for c in TEMPLATE_CASES]
+
+
+@pytest.mark.parametrize("name,render,_copy,_field", TEMPLATE_CASES, ids=TEMPLATE_IDS)
+def test_en_render_has_zero_korean(name, render, _copy, _field):
+    body = _strip_shell_footer(render("en"))
+    assert not _is_hangul(body), f"{name} en 렌더 결과(셸 푸터 제외)에 한글 문자가 섞여 있음(#3205 QA가 잡은 fallback_label류 반회귀 클래스)"
+
+
+@pytest.mark.parametrize("name,render,_copy,_field", TEMPLATE_CASES, ids=TEMPLATE_IDS)
+def test_ko_render_has_korean(name, render, _copy, _field):
+    """양성대조① sanity — ko 경로가 실제로 한글을 담는지(빈 렌더·폴백 오염이면 위 zero-korean
+    단언이 en도 ko도 전부 통과하는 무의미한 상태가 된다)."""
+    body = render("ko")
+    assert _is_hangul(body), f"{name} ko 렌더 결과에 한글이 없음 — 렌더 경로 자체가 깨졌을 가능성"
+
+
+@pytest.mark.parametrize("name,render,copy,field", TEMPLATE_CASES, ids=TEMPLATE_IDS)
+def test_mutation_hangul_leak_into_en_would_be_caught(name, render, copy, field, monkeypatch):
+    """양성대조② — en 카피의 실제 렌더 대상 필드를 대응 ko 값으로 스왑하면(플레이스홀더
+    이름이 ko/en 동일해 .format()도 안 깨짐) 위 zero-korean 단언이 진짜로 RED가 되는지.
+    tautological pass(항상 통과하는 무의미한 단언)가 아님을 고정한다."""
+    monkeypatch.setitem(copy["en"], field, copy["ko"][field])
+    body = _strip_shell_footer(render("en"))
+    assert _is_hangul(body), f"{name} — en 필드를 ko 값으로 바꿨는데도 한글이 안 잡힘, zero-korean 단언이 무력화된 상태"

--- a/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
+++ b/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
@@ -161,7 +161,7 @@ async def test_transition_gate_endpoint_wakes_after_commit(monkeypatch):
     가 실제로 호출되는지 검증(전엔 무호출=무음)."""
     from fastapi import BackgroundTasks
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     from app.services.member_resolver import ResolvedMember
     from unittest.mock import AsyncMock, patch
 
@@ -196,7 +196,8 @@ async def test_transition_gate_endpoint_wakes_after_commit(monkeypatch):
                 bg = BackgroundTasks()
                 # story #2027: gate_type="custom_review"는 risk 매트릭스 폴백(미분류→고위험)이라
                 # 이 파일의 관심사(wake 배선)와 무관한 사유-강제 가드를 note+evidence_viewed로 우회.
-                await transition_gate_endpoint(
+                await _transition_gate_endpoint(
+                resolved_locale="ko",
                     id=seeded["gate"], body=GateTransitionRequest(status="approved", note="테스트 사유", evidence_viewed=True),
                     background_tasks=bg,
                     session=s2, org_id=seeded["org"],

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -76,9 +76,10 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     # 검증을 우회하므로, mock 이 대신 그 불변식(auth.user_id 가 resolved 대상과 일관됨)을 지켜야
     # 한다. 이 파일의 관심사(resolver_id 강제)와는 무관 — patch 로 rule B 자체도 우회한다.
     monkeypatch.setattr(gm, "_non_doc_gate_approvable", AsyncMock(return_value=True))
-    await gm.transition_gate_endpoint(
+    await gm._transition_gate_endpoint(
         uuid.uuid4(), body, background_tasks=BackgroundTasks(),
-        session=_sess, org_id=uuid.uuid4(), auth=MagicMock(user_id=str(caller_id)))
+        session=_sess, org_id=uuid.uuid4(), auth=MagicMock(user_id=str(caller_id)),
+        resolved_locale="ko")
     assert captured["resolver_id"] == caller_id  # ⭐조작된 spoofed 가 아니라 인증 caller
     assert captured["resolver_id"] != spoofed
 

--- a/backend/tests/test_edg_s30_void_recovery.py
+++ b/backend/tests/test_edg_s30_void_recovery.py
@@ -161,13 +161,14 @@ async def test_void_endpoint_non_admin_403():
     from unittest.mock import AsyncMock, patch
     from fastapi import HTTPException
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateVoidRequest, void_gate_endpoint
+    from app.routers.gates import GateVoidRequest, _void_gate_endpoint
     voidfn = AsyncMock()
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved_human())), \
          patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=False)), \
          patch.object(gates_mod, "void_gate", voidfn):
         with pytest.raises(HTTPException) as ei:
-            await void_gate_endpoint(
+            await _void_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateVoidRequest(reason="x"), session=AsyncMock(),
                 org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())))
     assert ei.value.status_code == 403
@@ -180,14 +181,15 @@ async def test_void_endpoint_forces_voider_from_auth():
     from types import SimpleNamespace
     from unittest.mock import AsyncMock, patch
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateVoidRequest, void_gate_endpoint
+    from app.routers.gates import GateVoidRequest, _void_gate_endpoint
     caller = _resolved_human()
     voidfn = AsyncMock(return_value=SimpleNamespace())
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
          patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "void_gate", voidfn), \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
-        await void_gate_endpoint(
+        await _void_gate_endpoint(
+                resolved_locale="ko",
             id=uuid.uuid4(), body=GateVoidRequest(reason="오발행"), session=AsyncMock(),
             org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())))
     # void_gate(session, org_id, gate_id, voider_id, reason) — 위치인자 voider=caller.id·reason 전달.

--- a/backend/tests/test_edg_s31_hold.py
+++ b/backend/tests/test_edg_s31_hold.py
@@ -182,17 +182,19 @@ async def test_hold_unhold_endpoints_non_admin_403():
     from unittest.mock import AsyncMock, patch
     from fastapi import HTTPException
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateHoldRequest, hold_gate_endpoint, unhold_gate_endpoint
+    from app.routers.gates import GateHoldRequest, _hold_gate_endpoint, _unhold_gate_endpoint
     holdfn, unholdfn = AsyncMock(), AsyncMock()
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved_human())), \
          patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=False)), \
          patch.object(gates_mod, "hold_gate", holdfn), \
          patch.object(gates_mod, "unhold_gate", unholdfn):
         with pytest.raises(HTTPException) as ei1:
-            await hold_gate_endpoint(id=uuid.uuid4(), body=GateHoldRequest(), session=AsyncMock(),
+            await _hold_gate_endpoint(
+                resolved_locale="ko",id=uuid.uuid4(), body=GateHoldRequest(), session=AsyncMock(),
                                      org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())))
         with pytest.raises(HTTPException) as ei2:
-            await unhold_gate_endpoint(id=uuid.uuid4(), session=AsyncMock(),
+            await _unhold_gate_endpoint(
+                resolved_locale="ko",id=uuid.uuid4(), session=AsyncMock(),
                                        org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())))
     assert ei1.value.status_code == 403 and ei2.value.status_code == 403
     holdfn.assert_not_awaited()
@@ -205,14 +207,15 @@ async def test_hold_endpoint_forces_holder_from_auth():
     from types import SimpleNamespace
     from unittest.mock import AsyncMock, patch
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateHoldRequest, hold_gate_endpoint
+    from app.routers.gates import GateHoldRequest, _hold_gate_endpoint
     caller = _resolved_human()
     holdfn = AsyncMock(return_value=SimpleNamespace())
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
          patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "hold_gate", holdfn), \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
-        await hold_gate_endpoint(id=uuid.uuid4(), body=GateHoldRequest(reason="대기"), session=AsyncMock(),
+        await _hold_gate_endpoint(
+                resolved_locale="ko",id=uuid.uuid4(), body=GateHoldRequest(reason="대기"), session=AsyncMock(),
                                  org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())))
     # hold_gate(session, org_id, gate_id, holder_id, reason, held_until) — holder=caller.id
     assert holdfn.call_args.args[3] == caller.id

--- a/backend/tests/test_edg_s32_reassign.py
+++ b/backend/tests/test_edg_s32_reassign.py
@@ -185,11 +185,12 @@ async def test_reassign_endpoint_non_admin_403():
     from unittest.mock import AsyncMock, patch
     from fastapi import HTTPException
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateReassignRequest, reassign_gate_approver_endpoint
+    from app.routers.gates import GateReassignRequest, _reassign_gate_approver_endpoint
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved_human())), \
          patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=False)):
         with pytest.raises(HTTPException) as ei:
-            await reassign_gate_approver_endpoint(
+            await _reassign_gate_approver_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateReassignRequest(new_approver_id=uuid.uuid4()),
                 session=AsyncMock(), org_id=uuid.uuid4(),
                 auth=SimpleNamespace(user_id=str(uuid.uuid4())))

--- a/backend/tests/test_edg_s33_override.py
+++ b/backend/tests/test_edg_s33_override.py
@@ -197,11 +197,12 @@ async def test_override_endpoint_non_owner_403():
     from unittest.mock import AsyncMock, patch
     from fastapi import BackgroundTasks, HTTPException
     from app.routers import gates as gates_mod
-    from app.routers.gates import GateOverrideRequest, override_gate_endpoint
+    from app.routers.gates import GateOverrideRequest, _override_gate_endpoint
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved_owner())), \
          patch.object(gates_mod, "is_org_owner", AsyncMock(return_value=False)):  # admin이지만 owner 아님
         with pytest.raises(HTTPException) as ei:
-            await override_gate_endpoint(
+            await _override_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateOverrideRequest(decision="approved", reason="x"),
                 background_tasks=BackgroundTasks(),
                 session=AsyncMock(), org_id=uuid.uuid4(),

--- a/backend/tests/test_gate_can_approve_48f064e5.py
+++ b/backend/tests/test_gate_can_approve_48f064e5.py
@@ -17,8 +17,8 @@ from app.routers import gates as gates_mod
 from app.routers.gates import (
     GateCreateRequest,
     GateTransitionRequest,
-    create_gate_endpoint,
-    transition_gate_endpoint,
+    _create_gate_endpoint,
+    _transition_gate_endpoint,
 )
 from app.services.member_resolver import ResolvedMember
 from tests.gate_mock_factory import make_gate
@@ -73,7 +73,8 @@ async def _call(resolved, *, execute_results, has_access=None, status="approved"
     with contextlib.ExitStack() as stack:
         for p in patches:
             stack.enter_context(p)
-        result = await transition_gate_endpoint(
+        result = await _transition_gate_endpoint(
+                resolved_locale="ko",
             # note+evidence_viewed 동봉: risk_grade 폴백(미분류 gate_type→고위험)이 이 authz
             # 테스트의 관심사가 아닌 사유-강제 가드(story #2027 AC1/AC2)에 걸리지 않도록.
             id=uuid.uuid4(), body=GateTransitionRequest(status=status, note="테스트 사유", evidence_viewed=True),
@@ -95,7 +96,8 @@ async def test_doc_gate_self_approval_forbidden():
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_human(mid))), \
          patch.object(gates_mod, "transition_gate", transition):
         with pytest.raises(HTTPException) as ei:
-            await transition_gate_endpoint(
+            await _transition_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
                 background_tasks=BackgroundTasks(),
                 session=session, org_id=uuid.uuid4(), auth=auth,
@@ -115,7 +117,8 @@ async def test_doc_gate_missing_requester_fail_closed():
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_human(uuid.uuid4()))), \
          patch.object(gates_mod, "transition_gate", transition):
         with pytest.raises(HTTPException) as ei:
-            await transition_gate_endpoint(
+            await _transition_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
                 background_tasks=BackgroundTasks(),
                 session=session, org_id=uuid.uuid4(), auth=auth,
@@ -137,7 +140,8 @@ async def test_doc_gate_no_project_access_forbidden():
          patch.object(gates_mod, "has_project_access", AsyncMock(return_value=False)), \
          patch.object(gates_mod, "transition_gate", transition):
         with pytest.raises(HTTPException) as ei:
-            await transition_gate_endpoint(
+            await _transition_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
                 background_tasks=BackgroundTasks(),
                 session=session, org_id=uuid.uuid4(), auth=auth,
@@ -158,7 +162,8 @@ async def test_doc_gate_deleted_doc_forbidden():
          patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "transition_gate", transition):
         with pytest.raises(HTTPException) as ei:
-            await transition_gate_endpoint(
+            await _transition_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
                 background_tasks=BackgroundTasks(),
                 session=session, org_id=uuid.uuid4(), auth=auth,
@@ -201,7 +206,8 @@ async def test_generic_endpoint_rejects_doc_approval_defense_in_depth():
     create = AsyncMock()
     with patch.object(gates_mod, "create_gate", create):
         with pytest.raises(HTTPException) as ei:
-            await create_gate_endpoint(
+            await _create_gate_endpoint(
+                resolved_locale="ko",
                 body=body, session=AsyncMock(), org_id=uuid.uuid4(), _auth=SimpleNamespace()
             )
     assert ei.value.status_code == 403

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -14,7 +14,7 @@ import pytest
 from fastapi import BackgroundTasks, HTTPException
 
 from app.routers import gates as gates_mod
-from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
 from app.services.member_resolver import ResolvedMember
 from tests.gate_mock_factory import make_gate
 
@@ -59,7 +59,8 @@ async def _call(status: str, member_type: str):
          patch.object(gates_mod, "transition_gate", transition), \
          patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)), \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
-        result = await transition_gate_endpoint(
+        result = await _transition_gate_endpoint(
+                resolved_locale="ko",
             id=uuid.uuid4(), body=body, background_tasks=BackgroundTasks(),
             session=session, org_id=org_id, auth=SimpleNamespace(user_id=str(uuid.uuid4())),
         )
@@ -89,7 +90,8 @@ async def test_agent_approve_does_not_call_transition():
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved("agent"))), \
          patch.object(gates_mod, "transition_gate", transition):
         with pytest.raises(HTTPException):
-            await transition_gate_endpoint(
+            await _transition_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
                 background_tasks=BackgroundTasks(),
                 session=AsyncMock(), org_id=uuid.uuid4(), auth=SimpleNamespace(),

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -86,7 +86,7 @@ def test_transition_rejects_non_review_status():
 async def test_transition_forces_resolver_ignoring_body():
     """⭐resolver_id = 인증 caller 강제(body.resolver_id[타인 UUID] 무시)."""
     from app.routers import gates as mod
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     caller = _human()
     forged = uuid.uuid4()  # 타인 UUID
     captured = {}
@@ -104,7 +104,8 @@ async def test_transition_forces_resolver_ignoring_body():
          patch.object(mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
         # story #2027: _non_doc_gate_session()의 gate_type="merge"는 고위험(_HIGH_RISK_GATE_TYPES)이라
         # 이 파일의 관심사(resolver_id 강제)와 무관한 사유-강제 가드를 note+evidence_viewed로 우회.
-        await transition_gate_endpoint(
+        await _transition_gate_endpoint(
+                resolved_locale="ko",
             id=uuid.uuid4(), body=GateTransitionRequest(status="approved", resolver_id=forged, note="테스트 사유", evidence_viewed=True),
             background_tasks=BackgroundTasks(),
             session=_non_doc_gate_session(), org_id=uuid.uuid4(),
@@ -117,7 +118,7 @@ async def test_transition_forces_resolver_ignoring_body():
 async def test_transition_agent_rejected_403():
     """agent caller 는 approve/reject 403(휴먼 전용)."""
     from app.routers import gates as mod
-    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.routers.gates import GateTransitionRequest, _transition_gate_endpoint
     from app.services.member_resolver import ResolvedMember
     from fastapi import HTTPException
     agent = ResolvedMember(id=uuid.uuid4(), user_id=None, name="a", type="agent",
@@ -125,7 +126,8 @@ async def test_transition_agent_rejected_403():
     from fastapi import BackgroundTasks
     with patch.object(mod, "resolve_member", AsyncMock(return_value=agent)):
         with pytest.raises(HTTPException) as ei:
-            await transition_gate_endpoint(
+            await _transition_gate_endpoint(
+                resolved_locale="ko",
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
                 background_tasks=BackgroundTasks(),
                 session=AsyncMock(), org_id=uuid.uuid4(),


### PR DESCRIPTION
## 요약
- 3779 3층 ② 슬라이스: gates.py http_detail 20건을 공용 i18n 카탈로그(`t(key, locale)`)로 이관 — #3786(dependencies.py)과 동형 Header()-DI-split 패턴, en은 유나 定(이 레포 en detail 768건 실측 관례 근거).
- email_copy.py: 카드 "82→0" 목표가 그라운딩 결과 구조적으로 불가능함을 발견(3786 EXEMPT_FILES와 동형 함정) — PO 재가로 목표를 "en 스냅샷 부재 7템플릿군 테스트 신설"로 정정, 더미 트랜스포트 스냅샷+뮤테이션 양성대조로 채움.
- 2층 reachability: http_detail 72→52(카드 목표 일치) · 합계 524→504.
- 1층 baseline: 1303→1283(-20, 카탈로그로 이관).

⚠️ **이 PR은 #4138(3786)에 stack** — #4138이 develop에 먼저 머지되면 diff가 이 슬라이스만 남는다(dependencies.py 변경분은 #4138 자체 커밋).

## gates.py 20건
Header()-DI-split 9함수(create_gate_endpoint·_authorize_gate_approve_equivalent·transition_gate_endpoint·reevaluate_gate_endpoint·void_gate_endpoint·_require_gate_admin·delegate_gate_endpoint·toss_gate_endpoint·_require_gate_owner) + 공유 헬퍼 호출부 연쇄 업데이트(hold/unhold/list_approvers/reassign/discuss/override). 상세 ko/en 표는 카드 코멘트 참조.

「토스」 어휘 — en 2건은 화면이 실제로 쓰는 "send to another room"을 썼고(유나 지적, 은유 누출 회피), ko 원문 2건도 같은 어휘로 별건 교정(페드루 전달 유나 定).

FE 문자열매칭 사각 재확인: `gates/[id]/page.tsx`는 이미 raw `error.message` 통과 경로(code 있는 자리만 code→i18n 분기) — 이 20건엔 #3786류 반창고가 없어 en 치환만으로 FE 자동 정상화.

## email_copy.py
그라운딩 결과: 수신자 locale 분기(`resolve_locale(user.locale)`)·ko/en 카피 둘 다 이미 완비(#3205 산출물, 신규 en 0건). 실제 갭은 en 전용 렌더 스냅샷 테스트 부재 7템플릿군(verify_email·reset_password·set_password_confirm·payment_receipt·storage_warn·au_warn·reminder) — `test_3793_email_locale_snapshot.py` 신설(더미 트랜스포트, en 렌더에 한글 0 단언 + ko sanity + en→ko 뮤테이션 양성대조, 21케이스).

부수 발견(범위 밖, 별도 보고): `render_email_shell()`의 공용 푸터가 locale 무관 항상 한글 — 회사정보는 전자상거래법 표기라 의도적 가능성, 약관 링크 라벨 2건은 순수 UX 갭. PO에 보고, 이 PR 스코프 아님(`_strip_shell_footer`로 테스트 스코프 제외).

## 검증
- `test_3786_i18n_catalog.py`·`test_3779_korean_reachability_measure.py`·`test_3779_korean_user_strings_lint.py`·`test_authz_project_scope_coverage.py` 전부 GREEN.
- `verify_no_new_korean_user_strings.py`: 신규 0건·stale 0건(baseline 1283 갱신).
- gates.py 직접-호출 기존 테스트 16파일(non-destructive+destructive 분리 실행) 전부 GREEN — Header() DI 마커가 공개 함수 기본값이 되며 직접-호출 시 leak하던 까심 QA CI FAILURE 클래스를 전부 `_private` 함수 호출 전환으로 방어.
- gates 관련 폭넓은 118파일 회귀 스윕: 관련 260(non-destructive)+196(destructive, 수집분) GREEN. 나머지 32건 실패는 `PARITY_TEST_DATABASE_URL` 전용 별도 통합 하네스 요구 파일(test_2893/2932/3115 등, gates.py 라우터 미호출)로 이 PR과 무관한 로컬 환경 갭 — 발생 파일들이 내가 수정한 8개 함수의 직접 호출자 목록과 전혀 겹치지 않음을 확인.
- `import app.main` 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ

---

## CI RED 정정 — 17번째 누락 호출부(head 28802c4bb)

`test_3516_comment_scope_and_runbook.py::test_agent_scope_matrix`(gates.py 밖·comment scope 전용 파일)가 `_authorize_gate_approve_equivalent`를 직접 호출하며 `resolved_locale` 누락 → CI RED(shard 3).

**재검증(16개가 아니라 N개 — 갈라진 함수 9개 이름 전부로 `app/`+`tests/` 전체 grep, 목록째)**: 누락은 이 1건뿐. 총 **39개 호출부·17개 파일**(app/ 0건, 전부 tests/), 함수별 파일 목록:

| 함수 | 호출 파일 |
|---|---|
| `_authorize_gate_approve_equivalent` | test_3516_comment_scope_and_runbook.py |
| `_require_gate_admin` | (직접 호출 0 — 외부 테스트 없음) |
| `_require_gate_owner` | (직접 호출 0 — 외부 테스트 없음) |
| `_create_gate_endpoint` | test_1968_gate_project_id_threading.py · test_2237_gate_create_project_scope_realdb.py · test_gate_can_approve_48f064e5.py |
| `_transition_gate_endpoint` | test_2198_non_doc_gate_authz_realdb.py · test_3365_external_publish_gate_human_only.py · test_3367_site_post_submit_gate_seal.py · test_3374_channel_posts.py · test_ccbcd9da_gate_wake_wiring_realdb.py · test_edg_s23_hypothesis_overlay.py · test_gate_can_approve_48f064e5.py · test_gate_transition_human_only.py · test_rc1_body_trust_actor.py |
| `_reevaluate_gate_endpoint` | (직접 호출 0) |
| `_void_gate_endpoint` | test_edg_s30_void_recovery.py |
| `_delegate_gate_endpoint` | (직접 호출 0) |
| `_toss_gate_endpoint` | (직접 호출 0) |
| `_request_gate_discussion_endpoint` | test_2631_gate_undo_discuss.py |
| `_hold_gate_endpoint` / `_unhold_gate_endpoint` | test_edg_s31_hold.py |
| `_reassign_gate_approver_endpoint` | test_edg_s32_reassign.py |
| `_override_gate_endpoint` | test_edg_s33_override.py |

**검증**: non-destructive 260 passed · destructive **572 passed**(119파일 전체 배치, 0 failed) · test_3516 단독 5/5(문제의 `test_agent_scope_matrix` 포함) · 카탈로그/2층/email 스냅샷 36 GREEN · `import app.main` 정상.