### PR TITLE
[SID:3370] 판정 통지에 gate_id·version_id 관측 가능 — AC2 갭 닫기

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1307,6 +1307,13 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
         lines.append(f"- work_item_id: {work_item_id_raw}")
 
     lines.append(f"- 게이트: {gate_type} → {verdict}")
+    # story #3370 AC2(유나 실측 2026-09-10 13:23Z) — 게이트가 종류로만 표기되고 있었다
+    # (gate_id는 아래 재조회 대상으로만 쓰이고 사람이 읽는 줄로는 한 번도 안 나갔다).
+    # 에이전트 표면(이 함수)이 AC2의 「gate ID」 요구를 실제로 충족하려면 값 자체를 찍어야
+    # 한다 — payload에 항상 있음(story #3487, 이 함수의 유일한 발행부가 항상 채움).
+    gate_id_raw = payload.get("gate_id")
+    if gate_id_raw:
+        lines.append(f"- gate_id: {gate_id_raw}")
 
     # story 1cd72bfc(2026-09-02, 담롱 4바퀴 승인 실측·PO 확定) — 이전엔 verdict=="rejected"
     # 게이트가 있어 승인(approved) 판정에 사유가 있어도(예: "Ddddd") 원천 차단됐다.
@@ -1318,6 +1325,7 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
 
     draft_doc_ref: str | None = None
     draft_id: str | None = None
+    version_id: str | None = None
     # story #3359 — 레시피 stage 게이트의 neutral_facts엔 게이트 생성 시점(recipe_gate_
     # hooks.py::_build_approval_neutral_facts)에 이미 stage/channel이 박혀 있다. 이
     # payload 자체엔 없어(preset.gate.verdict 계약 불변) 아래 gate_row 재조회에서만
@@ -1330,7 +1338,7 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
     # gate_type, status) 재조회+`order_by(resolved_at desc).limit(1)`는 "가장 최근
     # resolved"인 게이트를 고르는 것이지 "지금 이 이벤트가 말하는" 그 게이트가 아니다
     # — 옛 payload(gate_id 없음, 레거시 큐 재생 등)에 대한 하위호환 폴백으로만 유지.
-    gate_id_raw = payload.get("gate_id")
+    # (gate_id_raw는 위에서 이미 구했다 — 「gate_id:」 줄과 이 재조회가 같은 값을 쓴다.)
     if work_item_type and work_item_id is not None and gate_type:
         if gate_id_raw:
             try:
@@ -1355,6 +1363,13 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
             # 모두에서 만들어지지 않는다) — 링크가 아니라 참조로만 싣는다(PO 2026-09-03
             # 13:33Z, 실행 권유 아님).
             draft_id = facts.get("draft_id")
+            # story #3370 AC2(유나 실측 2026-09-10 13:23Z) — draft_id(초안 자체 식별)와
+            # version_id(그 초안 중 «이번에 봉인·판정된» 특정 버전)는 다른 축이다. 이전엔
+            # version 자리가 아예 없어 draft_id를 version처럼 오독할 여지가 있었다 —
+            # site_posts.py/channel_posts.py의 submit/reseal 훅이 neutral_facts에 새로
+            # stamp한 값(gate.sealed_content_sha256과 동시에 찍히는, 그 sha256이 가리키는
+            # 실제 버전 행의 id)을 그대로 읽는다.
+            version_id = facts.get("version_id")
             gate_stage = facts.get("stage")
             _channel_raw = facts.get("channel")
             gate_channel = _channel_raw if isinstance(_channel_raw, str) and _channel_raw and _channel_raw != "미확認" else None
@@ -1362,6 +1377,8 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
         lines.append(f"- 대상 산출물: {draft_doc_ref}")
     if draft_id:
         lines.append(f"- draft_id: {draft_id}")
+    if version_id:
+        lines.append(f"- version_id: {version_id}")
 
     # story #3387(결함·오도 문구, PO 2026-09-03 13:33Z 스코프 확定) — gate_type=
     # external_publish는 이 아래 레시피 전용 문구(다른 gate_type용, 변경 없음)를 타지

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -681,6 +681,9 @@ async def _reseal_gate_on_new_version(
     gate.sealed_content_sha256 = version.body_sha256
     gate.sealed_content_body = version.text
     gate.sealed_media_sha256 = version.image_sha256
+    # story #3370 AC2 — site_posts.py 동형(JSONB in-place 미감지, 항상 재할당).
+    # neutral_facts.version_id를 최신 버전으로 계속 동기화(pending 中 편집마다).
+    gate.neutral_facts = {**(gate.neutral_facts or {}), "version_id": str(version.id)}
 
 
 async def get_channel_post_draft(
@@ -1137,6 +1140,8 @@ async def submit_channel_post_draft(
         # story #3404 — 이 게이트 슬롯을 "쥔" 초안 식별(위 차단 판정의 유일한 근거).
         # 재상신·재승인 요청도 매번 같은 값을 다시 써 넣는다(no-op이지만 명시).
         "draft_id": str(draft.id),
+        # story #3370 AC2 — site_posts.py 동형(target=지금 봉인되는 그 버전 행).
+        "version_id": str(target.id),
     }
 
     role_id = await _default_role_id(db, org_id)

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -557,6 +557,9 @@ async def _reseal_gate_on_new_version(
     gate.sealed_content_version = version.version
     gate.sealed_content_sha256 = version.body_sha256
     gate.sealed_content_body = version.body_md
+    # story #3370 AC2 — submit() 경로와 동형(JSONB in-place 미감지, 항상 재할당).
+    # neutral_facts.version_id를 최신 버전으로 계속 동기화(pending 中 편집마다).
+    gate.neutral_facts = {**(gate.neutral_facts or {}), "version_id": str(version.id)}
     # story e4fc29fa(조각③a) — 목적지 축도 content 축과 동형으로 pending 中엔 매 편집마다
     # 최신 draft.connection_id로 계속 동기화한다(재상신 왕복 불요, content_version과 같은
     # 이유). approved 뒤 편집은 위 분기에서 이미 이 대입 자체에 도달 안 함(sealed_content_*
@@ -911,6 +914,11 @@ async def submit_site_post_draft(
         # 필드들과 동형으로 neutral_facts에 얹는다 — 링크가 아니라 참조 정보다(PO
         # 2026-09-03 13:33Z, 에이전트에겐 실행 권유 아님).
         "draft_id": str(draft.id),
+        # story #3370 AC2(유나 실측 2026-09-10 13:23Z) — 판정 통지(에이전트 표면)가
+        # draft_id를 version처럼 오독할 여지를 없앤다. target은 지금 (재)봉인되는 바로 그
+        # 버전 행(sealed_content_sha256==target.body_sha256과 동시에 찍힘) — draft_id와
+        # 다른 축(초안 자체 vs 그 초안의 특정 버전).
+        "version_id": str(target.id),
     }
 
     # 페드루 PO 리뷰(2026-09-03 05:59Z) — 기본 역할이 없으면 가짜 uuid로 게이트를 만드는

--- a/backend/tests/test_3370_gate_verdict_gate_id_version_id.py
+++ b/backend/tests/test_3370_gate_verdict_gate_id_version_id.py
@@ -1,0 +1,90 @@
+"""story #3370 AC2(유나 실측 2026-09-10 13:23Z, 페드루 전달) — 에이전트 수신 채널
+(`_render_gate_verdict_message`)이 게이트를 **종류로만**(`- 게이트: {type} → {verdict}`)
+표기하고 있었고, "version" 자리엔 실제로 `draft_id`(초안 자체 식별자)가 찍히고 있었다 —
+AC2가 요구하는 「gate ID·version ID·판정 상태」 중 gate ID는 사람이 읽는 줄로 한 번도
+안 나갔고, version ID는 draft_id로 오독될 자리에 있었다.
+
+헬퍼는 test_3387_gate_verdict_agent_next_action.py 것을 그대로 재사용한다(재발명 금지) —
+이 파일의 관심사는 그 헬퍼로 만든 렌더 결과에 `gate_id`/`version_id` 줄이 정확히 서고,
+`draft_id`와 값이 다른(같은 게이트 안에서도 서로 다른 축이라는) 것을 잡는 것뿐이다."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_3387_gate_verdict_agent_next_action import (
+    _FakeGateRow,
+    _payload,
+    _render,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _stub_work_item_ref(monkeypatch):
+    """pytest autouse fixture는 정의된 모듈에서만 자동 적용된다 — test_3387의 것을
+    import만 해선 안 걸려서(TypeError: 확인됨) 여기서도 등록한다. 로직은 그 파일의
+    사본 그대로(재발명 아님, fixture 배선의 필연적 반복)."""
+    from app.routers import events as events_module
+
+    async def _fake_ref(*_args, **_kwargs):
+        return "[제목](entity:story:11111111-1111-1111-1111-111111111111)"
+
+    monkeypatch.setattr(events_module, "_render_event_notification_work_item_ref", _fake_ref)
+
+
+async def test_gate_id_line_is_the_actual_gate_id_from_payload():
+    """AC2 — 「게이트: {type} → {verdict}」만으론 어느 게이트인지 알 수 없었다(종류만
+    표기). payload.gate_id(story #3487, 유일한 발행부가 항상 채움) 그대로 줄로 찍힌다."""
+    gate_id = str(uuid.uuid4())
+    text = await _render(
+        _payload(gate_type="external_publish", verdict="approved", gate_id=gate_id),
+        gate_row=_FakeGateRow({}, id_=uuid.UUID(gate_id)),
+    )
+    assert f"- gate_id: {gate_id}" in text
+
+
+async def test_version_id_line_distinct_from_draft_id_not_conflated():
+    """핵심 회귀 — version_id와 draft_id는 다른 축(초안 자체 vs 그 초안의 특정 승인된
+    버전)이다. 고치기 전엔 version 자리가 아예 없어 draft_id가 그 역할을 대신하는
+    것처럼 읽혔다 — 이제 둘 다, 서로 다른 값으로 나란히 선다."""
+    draft_id = str(uuid.uuid4())
+    version_id = str(uuid.uuid4())
+    assert draft_id != version_id  # 표본 전제 — 실제로 다른 UUID임을 못박는다.
+    gate_row = _FakeGateRow({"draft_id": draft_id, "version_id": version_id})
+    text = await _render(
+        _payload(gate_type="external_publish", verdict="approved"), gate_row=gate_row,
+    )
+    assert f"- draft_id: {draft_id}" in text
+    assert f"- version_id: {version_id}" in text
+    # 뮤테이션 킬 포인트 — draft_id 값이 version_id 줄로 새 나가면(과거 오독 재발) 잡는다.
+    assert f"- version_id: {draft_id}" not in text
+
+
+async def test_version_id_absent_when_neutral_facts_missing_it_no_error():
+    """구버전 게이트(이 스토리 착지 前 생성돼 neutral_facts에 version_id가 없는 행)는
+    그 줄만 조용히 생략한다(지어내지 않는다) — draft_id처럼 값 없으면 줄 자체가 없다."""
+    gate_row = _FakeGateRow({"draft_id": str(uuid.uuid4())})
+    text = await _render(
+        _payload(gate_type="external_publish", verdict="approved"), gate_row=gate_row,
+    )
+    assert "version_id" not in text
+
+
+async def test_no_gate_row_omits_both_gate_id_and_version_id_lines_gracefully():
+    """gate_row 재조회 자체가 실패(옛 payload·레거시 큐 재생 등)해도 gate_id 줄은
+    payload에서, version_id 줄은 gate_row 없이는 안 뜨는 것으로 각자 정직하게 갈린다."""
+    gate_id = str(uuid.uuid4())
+    text = await _render(
+        _payload(gate_type="external_publish", verdict="approved", gate_id=gate_id),
+        gate_row=None,
+    )
+    assert f"- gate_id: {gate_id}" in text  # payload 값이라 gate_row 무관하게 선다.
+    assert "version_id" not in text


### PR DESCRIPTION
## 요약
유나 실측(2026-09-10 13:23Z, 페드루 전달) — `preset.gate.verdict` 에이전트 통지가 게이트를 **종류로만** 표기하고(gate_id는 내부 재조회에만 쓰이고 사람이 읽는 줄로 한 번도 안 나감), "version" 자리엔 실제로 **draft_id**(초안 자체 식별자)가 찍히고 있었다. story #3370 AC2 「에이전트가 원작성자인 초안의 판정이 완료되면 에이전트 수신 채널에서 해당 gate ID·version ID·판정 상태를 관측할 수 있다」와 어긋남.

## 변경
- `app/routers/events.py::_render_gate_verdict_message`: `- gate_id: {gate_id}` 줄 신설(payload 값, gate_row 재조회 성패 무관 항상 표시) + `- version_id: {version_id}` 줄 신설(`draft_id`와 나란히, 다른 값으로 — 오독 여지 제거).
- `app/services/site_posts.py` / `channel_posts.py`: submit() 경로의 `neutral_facts` 구성과 `_reseal_gate_on_new_version` 재봉인 훅(pending 中 편집마다 재동기화) 양쪽에 `"version_id": str(target.id)`(또는 `version.id`) 신규 stamp — `sealed_content_sha256`과 동시에 찍히는 바로 그 버전 행의 실제 UUID(JSONB in-place 변경 미감지·항상 재할당하는 이 레포 기존 관례 그대로, `doc.py`/`merge_verdict_gate.py` 선례와 동형).

## 검증
- 신규 `test_3370_gate_verdict_gate_id_version_id.py`(4건, `test_3387_gate_verdict_agent_next_action.py`의 mock-db 헬퍼 재사용 — 새 기전 0) — gate_id 줄 존재·version_id/draft_id 값이 서로 다르게 병존·값 없을 때 줄 생략·gate_row 없어도 payload의 gate_id는 뜨는 4가지 축.
- 뮤테이션 self-check: `version_id` 줄 렌더 제거 → 해당 테스트 RED 확인 → 원복 → 재GREEN.
- 기존 회귀 전체(`test_3330_gate_verdict_notification`·`test_3340_gate_verdict_notify_reach`·`test_3387_gate_verdict_agent_next_action`·`test_e4fc29fa_site_post_orchestration`) 37건 GREEN — `neutral_facts` 재할당 지점 2곳(site_posts.py·channel_posts.py 재봉인 훅)이 기존 draft_author_member_id 등 다른 키를 안 건드리는지도 이 배치가 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ