### PR TITLE
[SID:3618] 후속 작업 생성률 — 생성부/집계부 엔드투엔드 테스트(선언≠구현 갭 재발가드)

### DIFF
--- a/backend/tests/test_3618_phase2_metrics.py
+++ b/backend/tests/test_3618_phase2_metrics.py
@@ -326,6 +326,74 @@ async def test_follow_up_creation_rate_direct_and_indirect_matches():
         await engine.dispose()
 
 
+@pytest.mark.anyio
+async def test_follow_up_creation_rate_end_to_end_via_real_endpoint_not_hand_seeded_evidence():
+    """페드루 자기점검 요청(2026-09-10 14:04Z)이 잡은 갭 — 위 세 테스트는 전부
+    `Evidence(payload={"publication_id": ...})`를 **손으로 직접** 심는다
+    (`create_publication_follow_up`을 한 번도 안 부른다). 그래서 그 함수가 실제로
+    찍는 payload 모양이 이 계산 로직이 찾는 모양과 «우연히» 같은지, 아니면 어느 한쪽만
+    고쳐져도 조용히 갈리는지(story #3696류 선언≠구현 갭)를 이 세 테스트로는 못 잡는다
+    — 뮤테이션으로 실증(아래 주석).
+
+    이 테스트는 실제 라우터(`POST .../follow-ups`)를 호출해 진짜로 만들어진 Story+
+    Evidence 위에서 지표를 재계산한다 — 두 코드 경로(생성부·집계부)가 정말로 같은
+    자리(payload.publication_id)를 보는지 엔드투엔드로 잠근다.
+
+    뮤테이션 self-check(수행 済, 기록만) — `create_publication_follow_up`의
+    `Evidence.payload`에서 `"publication_id": str(publication_id)` 키를 제거하면:
+    기존 3개 테스트(위)는 **전부 그대로 GREEN**(직접 Evidence를 심어 그 함수 자체를
+    안 거치므로) — 이 테스트만 RED(생성률이 0으로 떨어짐, 정확히 카드가 요청한
+    「링크 stamp 제거 → 생성률 0」). 원복 후 재GREEN 확인 완료."""
+    from app.main import app
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.measured_metrics import compute_measured_metrics
+    from tests.test_3471_org_content_rules_lint import _seed_human
+    from tests.test_3502_insights_board_endpoints import _seed_site_post
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="member")
+            from tests.test_3471_org_content_rules_lint import _seed_story
+            story_id = await _seed_story(s, org_id, project_id, title="원문 글")
+            sp = await _seed_site_post(
+                s, org_id=org_id, work_item_id=story_id, slug="post-e2e-fu", title="E2E FU",
+                published_at=datetime.now(timezone.utc) - timedelta(days=1),
+            )
+            now = datetime.now(timezone.utc)
+            s.add(InsightSnapshot(
+                id=uuid.uuid4(), org_id=org_id, publication_id=sp.id, publication_kind="site_post",
+                work_item_id=story_id, channel="sandbox", external_id=None,
+                due_at=now, captured_at=now, status="captured",
+            ))
+            await s.commit()
+
+        from tests.test_3471_org_content_rules_lint import _client_for, _setup_org_scoped_app
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/publications/{sp.id}/follow-ups",
+                json={"kind": "republish"},
+            )
+        assert r.status_code == 201, r.text
+
+        async with Session() as s:
+            result = await compute_measured_metrics(s, org_id=org_id, days=7)
+            metric = result["follow_up_creation_rate"]
+            assert metric["denominator"] == 1
+            assert metric["numerator"] == 1, (
+                "실 엔드포인트가 만든 Evidence가 집계 쿼리에 안 잡혔다 — "
+                "create_publication_follow_up의 payload 모양과 _compute_follow_up_creation_rate가 "
+                "찾는 모양이 갈렸을 가능성(story #3696류 선언≠구현 갭)"
+            )
+            assert metric["value"] == 1.0
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 # ─── 뮤테이션 대조 ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## 요약
페드루 자기점검 요청(2026-09-10 14:04Z, Phase 2 회차의 마지막 칸): "성과 보드에서 재발행/수정/중단 후속 작업을 직접 생성하는 버튼·API가 어느 스토리/PR로 착지했는지, 3618 «후속 작업 생성률»이 세는 대상이 정확히 무엇인지" 확認 요청.

## 그라운딩 결과 — 있다 (지어내지 않음)
- **생성**: `app/services/insights_board.py::create_publication_follow_up` — `POST /api/v2/organizations/{org}/publications/{publication_id}/follow-ups`(휴먼 전용). 원장 Story를 새로 만들고(신규 마케팅 전용 객체 발명 0) `Evidence(type="report", payload={"kind":"follow_up_created","publication_id":...,"story_id":...})`를 남긴다.
- **집계**: `app/services/measured_metrics.py::_compute_follow_up_creation_rate` — 분모=기간 내 captured 스냅샷 있는 발행 집합(3618/3620 공유), 분자=그 발행 id가 `Evidence.payload["publication_id"]`(직접) 또는 댓글 경유 간접 매치로 걸리는 발행 수.
- **FE**: 성과 보드·글 상세(content/[draftId])에 버튼 배선 済(BFF 프록시 라우트 확認).
- **중복 생성**: 멱등 가드 0 — 같은 발행물에 두 번 호출하면 Story+Evidence가 매번 새로 생긴다(의도로 보임 — kind가 republish/edit/stop으로 다를 수 있어 자연스러운 설계, metric 자체는 발행 단위 distinct라 이중집계는 안 됨).

## 발견한 진짜 갭
기존 `test_3618_phase2_metrics.py`의 `follow_up_creation_rate` 테스트 3건은 전부 `Evidence`를 **손으로 직접 심는다** — `create_publication_follow_up`을 한 번도 안 거친다. 그 함수의 실제 payload 모양과 집계 쿼리가 찾는 모양이 우연히 같은지, 한쪽만 바뀌어도 조용히 갈리는지(story #3696류 "선언≠구현" 갭과 동형 리스크)를 기존 표본으로는 검증 불가.

## 변경
신규 `test_follow_up_creation_rate_end_to_end_via_real_endpoint_not_hand_seeded_evidence` — 실 라우터(`POST .../follow-ups`)를 호출해 진짜로 만들어진 Story+Evidence 위에서 지표를 재계산, 생성부·집계부 두 경로가 정말 같은 자리(`payload.publication_id`)를 보는지 엔드투엔드로 고정한다. **코드 변경 0(테스트 1건 추가만)**.

## 뮤테이션 self-check(카드 지정 「링크 stamp 제거 → 생성률 0」)
`create_publication_follow_up`의 `Evidence.payload`에서 `"publication_id"` 키 제거:
- 기존 3건: **그대로 GREEN**(갭을 직접 증명 — 생성 함수를 안 거치므로 뮤테이션을 못 봄).
- 신규 테스트만 **RED**(`numerator 0 == 1` 실패, 카드 기대 그대로 재현).
- 원복 후 `git diff` 확認(완전 원상복구) → 신규 포함 18/18 재GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ