### PR TITLE
[SID:3786] BFF 프록시 공통층에 Accept-Language forwarding 추가

### DIFF
--- a/apps/web/src/app/api/retro-sessions/[id]/export/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/export/route.test.ts
@@ -1,26 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// story #3778 CHANGES — 로케일 해석은 getLocale()(src/i18n/request.ts, 화면과 동일
-// 함수) 하나로 통일했다. 이 라우트는 그 결과 문자열을 그대로 Accept-Language로
-// forward만 한다 — 쿠키/헤더 폴백 로직 자체는 request.test.ts가 별도로 고정한다.
-const { getOrgProjectAuthContext, proxyToFastapiWithParams, getLocaleMock } = vi.hoisted(() => ({
+// story #3786 후속(2026-09-10) — 이 라우트가 직접 풀던 getLocale()→extraHeaders 배선은
+// 공통 프록시 계층(fastapi-proxy.ts::proxyToFastapi)의 기본 동작으로 이관됐다(공통층
+// 우선, 중복 계산 제거). 로케일 forwarding 자체의 회귀가드는 이제
+// apps/web/src/lib/fastapi-proxy.test.ts가 진다 — 이 파일은 이 라우트 고유의 계약
+// (markdown 원문 재봉투·401·4xx/5xx 그대로 전달)만 고정한다.
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
   getOrgProjectAuthContext: vi.fn(),
   proxyToFastapiWithParams: vi.fn(),
-  getLocaleMock: vi.fn(),
 }));
 
 vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
-vi.mock('@/i18n/request', () => ({ getLocale: getLocaleMock }));
 
 import { GET } from './route';
 
 function makeAgent() {
   return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
-
-function makeRequest() {
-  return new Request('http://localhost/api/retro-sessions/session-1/export?project_id=project-1');
 }
 
 // story #3774 — BE `retros.py::export_session`은 JSON 봉투가 아니라 마크다운 텍스트를
@@ -31,9 +27,7 @@ describe('GET /api/retro-sessions/[id]/export', () => {
   beforeEach(() => {
     getOrgProjectAuthContext.mockReset();
     proxyToFastapiWithParams.mockReset();
-    getLocaleMock.mockReset();
     getOrgProjectAuthContext.mockResolvedValue(makeAgent());
-    getLocaleMock.mockResolvedValue('en');
   });
 
   it('returns 401 when not authenticated', async () => {
@@ -94,65 +88,33 @@ describe('GET /api/retro-sessions/[id]/export', () => {
 
     expect(response.status).toBe(403);
   });
-});
-
-describe('GET /api/retro-sessions/[id]/export — story #3778 로케일 forward', () => {
-  beforeEach(() => {
-    getOrgProjectAuthContext.mockReset();
-    proxyToFastapiWithParams.mockReset();
-    getLocaleMock.mockReset();
-    getOrgProjectAuthContext.mockResolvedValue(makeAgent());
-    proxyToFastapiWithParams.mockResolvedValue(
-      new Response('# doc', { status: 200, headers: { 'Content-Type': 'text/markdown' } }),
-    );
-  });
-
-  it('⭐getLocale()의 결과(en)를 Accept-Language로 그대로 실어 BE 호출에 넘긴다', async () => {
-    getLocaleMock.mockResolvedValue('en');
-
-    await GET(makeRequest(), { params: Promise.resolve({ id: 'session-1' }) });
-
-    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
-      expect.anything(),
-      '/api/v2/retros/[id]/export',
-      { id: 'session-1' },
-      { extraHeaders: { 'Accept-Language': 'en' } },
-    );
-  });
-
-  it('getLocale()이 ko를 돌려주면 그대로 ko를 넘긴다', async () => {
-    getLocaleMock.mockResolvedValue('ko');
-
-    await GET(makeRequest(), { params: Promise.resolve({ id: 'session-1' }) });
-
-    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
-      expect.anything(),
-      '/api/v2/retros/[id]/export',
-      { id: 'session-1' },
-      { extraHeaders: { 'Accept-Language': 'ko' } },
-    );
-  });
-
-  // story #3778 CHANGES(유나 design:changes) — 최초본은 쿠키가 없으면 extraHeaders
-  // 자체를 안 보냈다(BE 기본값에 맡김 — 그게 바로 "화면은 en인데 문서는 ko"였던 병의
-  // 경로). 지금은 getLocale()이 항상 구체적인 로케일을 돌려주므로(자체 기본값 en까지
-  // 포함) extraHeaders가 never undefined다 — 그 자체가 회귀가드.
-  it('⭐getLocale()은 항상 구체값을 돌려주므로 extraHeaders가 undefined로 빠지는 경우가 없다', async () => {
-    getLocaleMock.mockResolvedValue('en'); // getLocale() 자신의 기본값(쿠키·헤더 둘 다 없을 때)
-
-    await GET(makeRequest(), { params: Promise.resolve({ id: 'session-1' }) });
-
-    const call = proxyToFastapiWithParams.mock.calls[0];
-    expect(call?.[3]).toEqual({ extraHeaders: { 'Accept-Language': 'en' } });
-    expect(call?.[3]?.extraHeaders).not.toBeUndefined();
-  });
 
   it('인증 실패면 401 — BE 호출 자체를 안 한다', async () => {
     getOrgProjectAuthContext.mockResolvedValue(null);
 
-    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'session-1' }) });
+    const res = await GET(
+      new Request('http://localhost/api/retro-sessions/session-1/export?project_id=project-1'),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
 
     expect(res.status).toBe(401);
     expect(proxyToFastapiWithParams).not.toHaveBeenCalled();
+  });
+
+  // story #3786 후속 — 이 라우트가 더는 extraHeaders를 스스로 계산하지 않는다는 것을
+  // 고정한다(공통 프록시 계층이 getLocale()을 기본으로 싣는다 — fastapi-proxy.test.ts
+  // 「Accept-Language 공통층 기본 forwarding」 블록에서 검증). options 인자 자체를
+  // 안 넘기는 3-arg 호출이 이 라우트의 정상 형이다.
+  it('proxyToFastapiWithParams를 options 없이(3-arg) 호출한다 — extraHeaders 자체 계산 없음', async () => {
+    await GET(
+      new Request('http://localhost/api/retro-sessions/session-1/export?project_id=project-1'),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/v2/retros/[id]/export',
+      { id: 'session-1' },
+    );
   });
 });

--- a/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
@@ -2,7 +2,6 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
-import { getLocale } from '@/i18n/request';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -14,19 +13,11 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    // story #3778 CHANGES(유나 design:changes 2026-09-10) — 최초본은 `locale` 쿠키를
-    // 여기서 직접 읽었는데, 쿠키가 없으면(로케일 스위처를 한 번도 안 건드린 신규
-    // 사용자 — 세팅 자리는 locale-switcher.tsx 단 한 곳) 헤더 자체를 안 보내 BE가
-    // 자기 기본값(ko)으로 떨어졌다 — 정작 화면은 같은 상황에서 Accept-Language로
-    // en을 고르므로(`src/i18n/request.ts::getLocale()`) "화면 폴백과 동형"이라던 주석이
-    // 거짓이었다(기본값 다름·헤더 폴백 단계가 아예 빠짐). 해석 로직을 그 함수 하나로
-    // 통일 — route는 결과만 그대로 forward한다(BE는 그 문자열 자체를 Accept-Language로
-    // 받는다, retros.py::export_session).
-    const locale = await getLocale();
-
-    const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/export', { id }, {
-      extraHeaders: { 'Accept-Language': locale },
-    });
+    // story #3778이 여기서 직접 풀던 로케일(getLocale())은 story #3786 후속(2026-09-10)
+    // 으로 공통 프록시 계층(fastapi-proxy.ts::proxyToFastapi)이 모든 라우트에 항상
+    // 싣는 값이 됐다 — 이 라우트만의 extraHeaders override는 그 공통 계층과 완전히
+    // 같은 값을 중복 계산하던 것이라 걷어낸다(공통층 우선, 단일 구현).
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/export', { id });
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     // story #3774 — BE(`retros.py::export_session`)는 JSON 봉투가 아니라 마크다운

--- a/apps/web/src/lib/fastapi-proxy.test.ts
+++ b/apps/web/src/lib/fastapi-proxy.test.ts
@@ -3,14 +3,25 @@
 // FastAPI로 그대로 전달되는지(스테일 JWT project_id로 덮이지 않는지) 증명.
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getServerSessionMock } = vi.hoisted(() => ({
+const { getServerSessionMock, getLocaleMock } = vi.hoisted(() => ({
   getServerSessionMock: vi.fn(),
+  getLocaleMock: vi.fn(),
 }));
 
 vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
+vi.mock('@/i18n/request', () => ({ getLocale: getLocaleMock }));
 
 import { proxyToFastapi, proxyToFastapiWithParams, proxyToFastapiWrapped, mapApiError } from './fastapi-proxy';
 import { NotFoundError, ForbiddenError } from '@sprintable/core-storage';
+
+// story #3786 후속(2026-09-10) — 이 파일의 다른 describe 블록들은 Accept-Language와
+// 무관한 축을 검증하므로, 그 블록들에서 getLocale()이 매번 'en'을 주도록 파일 전역
+// 기본값을 하나 둔다(개별 블록에서 따로 안 건드리면 이 값). 아래 전용 블록만 이
+// 기본값을 재정의/실패시켜 실제 forwarding 로직을 검증한다.
+beforeEach(() => {
+  getLocaleMock.mockReset();
+  getLocaleMock.mockResolvedValue('en');
+});
 
 // story #2488 — packages/storage-api/src/utils.ts와 완전 동일한 사본(중복 구현)이라
 // 같은 회귀가드를 여기도 둔다(합치는 consolidation은 별개, PO 확定).
@@ -86,37 +97,76 @@ describe('fastapi-proxy — X-Project-Id override passthrough (story 7d6b770b �
   });
 });
 
-// story #3778 — 회고 내보내기 BFF가 next-intl locale 쿠키를 Accept-Language로 실어
-// BE(retros.py::export_session)에 전달하는 경로. 전역 forward 목록(x-project-id 등)과
-// 달리 options.extraHeaders로 호출부가 명시 opt-in한 헤더만 실린다.
-describe('fastapi-proxy — extraHeaders opt-in passthrough(story #3778)', () => {
+// story #3778 최초본은 회고 내보내기 route 하나만 extraHeaders로 Accept-Language를
+// opt-in 하는 구조였다. story #3786 후속(유나 실측·페드루 그라운딩 2026-09-10) —
+// 그 opt-in 전제가 사고였다: 전역 forward 목록에 없어 BFF 경유 요청 484개 전부가
+// getLocale()이 실제로 아는 앱 언어를 BE에 못 실었다(BE i18n 카탈로그 en이 웹앱
+// 사용자에게 도달 0). 이제 공통 계층이 매 호출마다 getLocale()을 기본으로 싣고,
+// extraHeaders는 라우트별 override 용도로만 남는다.
+describe('fastapi-proxy — Accept-Language 공통층 기본 forwarding(story #3786 후속)', () => {
   beforeEach(() => {
     getServerSessionMock.mockReset();
     getServerSessionMock.mockResolvedValue({ access_token: 'token-1', org_id: 'org-1', project_id: 'proj-1' });
     global.fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
   });
 
-  it('extraHeaders로 넘긴 헤더가 그대로 FastAPI 호출에 실린다', async () => {
-    const request = new Request('http://localhost/api/retro-sessions/abc/export');
-
-    await proxyToFastapi(request, '/api/v2/retros/abc/export', { extraHeaders: { 'Accept-Language': 'en' } });
-
-    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
-    const headers = init.headers as Record<string, string>;
-    expect(headers['Accept-Language']).toBe('en');
-  });
-
-  it('extraHeaders를 안 넘기면 안 실림(옵트인 — 다른 라우트 무회귀)', async () => {
+  it('extraHeaders를 안 넘겨도 getLocale()의 값이 Accept-Language로 실린다(공통층 기본)', async () => {
+    getLocaleMock.mockResolvedValue('en');
     const request = new Request('http://localhost/api/retro-sessions/abc/export');
 
     await proxyToFastapi(request, '/api/v2/retros/abc/export');
 
     const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
     const headers = init.headers as Record<string, string>;
+    expect(headers['Accept-Language']).toBe('en');
+  });
+
+  it('ko 사용자는 ko가 실린다(getLocale()이 소스)', async () => {
+    getLocaleMock.mockResolvedValue('ko');
+    const request = new Request('http://localhost/api/gates/g1/toss');
+
+    await proxyToFastapi(request, '/api/v2/gates/g1/toss');
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Accept-Language']).toBe('ko');
+  });
+
+  it('extraHeaders로 명시 override하면 그 값이 getLocale() 기본값을 이긴다(라우트별 override 유지)', async () => {
+    getLocaleMock.mockResolvedValue('en');
+    const request = new Request('http://localhost/api/retro-sessions/abc/export');
+
+    await proxyToFastapi(request, '/api/v2/retros/abc/export', { extraHeaders: { 'Accept-Language': 'ko' } });
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Accept-Language']).toBe('ko');
+  });
+
+  it('getLocale()이 던지면(요청 스코프 밖 등) 원 요청의 Accept-Language 헤더로 폴백한다', async () => {
+    getLocaleMock.mockRejectedValue(new Error('next/headers 요청 스코프 밖'));
+    const request = new Request('http://localhost/api/me', { headers: { 'Accept-Language': 'ja' } });
+
+    await proxyToFastapi(request, '/api/v2/me');
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Accept-Language']).toBe('ja');
+  });
+
+  it('getLocale()이 던지고 원 요청에도 Accept-Language가 없으면 안 실린다(값을 지어내지 않는다)', async () => {
+    getLocaleMock.mockRejectedValue(new Error('next/headers 요청 스코프 밖'));
+    const request = new Request('http://localhost/api/me');
+
+    await proxyToFastapi(request, '/api/v2/me');
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
     expect(headers['Accept-Language']).toBeUndefined();
   });
 
-  it('proxyToFastapiWithParams도 extraHeaders를 그대로 전달한다', async () => {
+  it('proxyToFastapiWithParams도 getLocale()을 기본으로 싣고 extraHeaders가 넘어오면 override한다', async () => {
+    getLocaleMock.mockResolvedValue('en');
     const request = new Request('http://localhost/api/retro-sessions/abc/export');
 
     await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/export', { id: 'abc' }, {

--- a/apps/web/src/lib/fastapi-proxy.ts
+++ b/apps/web/src/lib/fastapi-proxy.ts
@@ -5,6 +5,7 @@
 
 import { getServerSession } from '@/lib/db/server';
 import { apiError, apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getLocale } from '@/i18n/request';
 
 // story #2499 — 이 파일이 packages/storage-api/src/utils.ts와 완전 동일한 mapApiError/
 // fastapiCall 사본을 따로 갖고 있어(#2488에서 같은 버그를 두 곳에 각각 고쳐야 했다),
@@ -39,10 +40,14 @@ async function resolveAuthHeader(request: Request): Promise<string | null> {
 interface ProxyOptions {
   /** 인증 없이도 허용할 경우 true */
   public?: boolean;
-  // story #3778 — 회고 내보내기처럼 BE가 낱말 선택(로케일)을 알아야 하는 소수 라우트용.
-  // 전역 forward 목록(line 68 부근)에 안 얹는다 — 그 목록은 "요청 자체가 원래 갖고
-  // 있던 신호"를 그대로 통과시키는 자리이고, 로케일은 그 라우트(route.ts)가 next-intl
-  // 쿠키에서 직접 읽어 이번 호출에만 실어야 하는 값이라 별도 옵션으로 좁힌다.
+  // story #3786 후속(유나 실측 2026-09-10 14:09Z, 페드루 그라운딩) — 예전엔 이 옵션이
+  // "로케일은 소수 라우트(#3778 회고 내보내기)만 개별로 싣는 값"이라고 적혀 있었으나,
+  // 그 전제 자체가 실 사고였다: 전역 forward 목록에 Accept-Language가 없어 BFF 경유
+  // 요청 전부(proxyToFastapi 소비 라우트 484개)에서 BE i18n 카탈로그(#3779/#3786/#3793)
+  // en 문장이 끊겼다 — BE 직접 호출(예: curl)은 en이 오는데 웹앱 경유는 ko 원문
+  // (toss-sheet류 raw message 통과 경로). 지금은 아래에서 getLocale()로 앱이 실제로
+  // 보여주는 언어를 항상 Accept-Language로 실어 보낸다 — 이 옵션은 그 값을 라우트별로
+  // override하고 싶을 때만 쓴다(대부분 안 써도 된다).
   extraHeaders?: Record<string, string>;
 }
 
@@ -73,6 +78,18 @@ export async function proxyToFastapi(
   for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id', 'x-project-id']) {
     const v = request.headers.get(h);
     if (v) headers[h] = v;
+  }
+  // story #3786 후속(유나 실측·페드루 그라운딩 2026-09-10) — getLocale()(쿠키→
+  // Accept-Language 헤더→기본값 순, src/i18n/request.ts)이 앱 화면이 실제로 그리는
+  // 그 언어를 그대로 돌려준다 — 화면과 BE 응답 언어가 갈리지 않게 항상 싣는다.
+  // getLocale()은 next/headers의 cookies()/headers()에 기대므로(요청 스코프 밖에서
+  // 부르면 던짐) 실패하면 원 요청의 Accept-Language를 그대로 통과시키는 것으로
+  // 폴백한다(집 밖 컨텍스트에서도 이 프록시가 안 죽게).
+  try {
+    headers['Accept-Language'] = await getLocale();
+  } catch {
+    const fallback = request.headers.get('Accept-Language');
+    if (fallback) headers['Accept-Language'] = fallback;
   }
   if (options.extraHeaders) Object.assign(headers, options.extraHeaders);
 


### PR DESCRIPTION
## 요약

유나 실측(2026-09-10 14:09Z)·페드루 그라운딩 — `apps/web/src/lib/fastapi-proxy.ts`의
`proxyToFastapi()` 전역 forward 헤더 목록(`x-forwarded-for`·`x-real-ip`·`x-api-key`·
`x-org-id`·`x-project-id` 5개)에 `Accept-Language`가 없어, 이 프록시를 소비하는
라우트 484개 전부에서 BE i18n 카탈로그(#3779/#3786/#3793) en 문장이 웹앱 사용자에게
도달하지 못했다.

- BE 직접 호출(curl 등): en 문장이 옴 (`An item cannot depend on itself`)
- 웹앱 경유(BFF 프록시): ko 원문 그대로 (FE가 `error.code`로 자기 키를 그리는 자리만
  살아있고, BE 원문 `detail.message`를 그대로 찍는 자리 — 예: gates.py toss-sheet — 는
  en 사용자가 ko를 봄)

## 변경

- `fastapi-proxy.ts::proxyToFastapi()` — 기존 5-헤더 forward 루프 뒤에 `getLocale()`
  (`src/i18n/request.ts`, 앱 화면이 실제로 그리는 언어 — 쿠키→`Accept-Language`
  헤더→기본값 순)을 `Accept-Language`로 기본 forwarding. `getLocale()`은 `next/headers`
  의 `cookies()`/`headers()`에 기대므로(요청 스코프 밖에서 부르면 던짐) 실패 시 원
  요청의 `Accept-Language` 헤더로 폴백(둘 다 없으면 값을 지어내지 않고 미설정).
  `options.extraHeaders`는 이 기본값 뒤에 `Object.assign`되므로 라우트별 override로
  여전히 유효.
- `apps/web/src/app/api/retro-sessions/[id]/export/route.ts` — story #3778이 여기서
  직접 하던 `getLocale()` 호출+`extraHeaders: { 'Accept-Language': locale }`는 이제
  공통층과 완전히 같은 값을 중복 계산하던 것이라 제거(공통층 우선, 단일 구현).

## 테스트

- `fastapi-proxy.test.ts` — 신규 블록 「Accept-Language 공통층 기본 forwarding」
  6케이스: 기본 forwarding(en/ko)·`extraHeaders` override가 기본값을 이김·`getLocale()`
  throw 시 원 요청 헤더 폴백·폴백도 없으면 미설정(값 안 지어냄)·`proxyToFastapiWithParams`
  동일 배선. 뮤테이션(forwarding 로직 제거) → 정확히 그 3케이스 RED 확인 후 원복,
  26/26 재GREEN.
- `retro-sessions/[id]/export/route.test.ts` — 구식(자체 `extraHeaders` 계산 검증)
  블록을 제거하고, 이 라우트가 이제 `proxyToFastapiWithParams`를 options 없이(3-arg)
  호출한다는 것만 고정(로케일 forwarding 자체의 회귀가드는 공통층 테스트가 짐).
- 전체 검증: `pnpm build`(성공)·`pnpm --filter web type-check`(0 에러)·
  `pnpm --filter web lint`(0 에러, 기존 무관 warning 7개 그대로)·`pnpm test`(repo
  전체, 763 파일/7773 테스트 GREEN)·`pnpm test -- apps/web`(742 파일/7521 테스트 GREEN).

## 라이브 검증(범위 밖 — 유나 몫)

배포 뒤 en 토스트/toss-sheet 문구가 BFF 경유로도 en으로 뜨는지는 이 PR 범위 밖(유나가
실물로 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ