### PR TITLE
[SID:3369] site_post 발행 경로 결함 2건 — 승인 메시지 오도·외부발행 감사 공백

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1442,9 +1442,9 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
                 )).first() is not None
             if is_site_post and site_post_command_exists:
                 lines.append(
-                    "- 다음 행동: 할 일 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 "
+                    "- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 "
                     "tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 "
-                    "확인합니다."
+                    "확認합니다."
                 )
             else:
                 lines.append("- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.")

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1403,7 +1403,20 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
             # draft_id가 site_post_drafts에 있는지로 도메인을 가른다 — destination
             # 문자열(hosted_site/wordpress/webhook vs threads)에 기대는 것보다
             # 채널 목록이 늘어나도 안 깨지는 축이다.
+            #
+            # story #3369 후속(자기점검 2차, 유나 실측·페드루 지시 2026-09-10) — 위
+            # #3487 주석은 "hosted_site 공통"이라 적었지만 실제로는 아니다:
+            # `gate_service.py::_maybe_create_scheduled_publication_command`가
+            # `destination_channel == "hosted_site"`면 publication_command 생성을
+            # 그 자리에서 건너뛴다("내부 동기 경로 그대로 — publication_command 불요").
+            # 즉 hosted_site 승인은 워커가 자동으로 발행하지 않는다 — 휴먼이 여전히
+            # 화면에서 «발행»/«재발행»을 직접 눌러야 한다. 이 표면의 수신자는 항상
+            # 에이전트(위 주석)라, hosted_site draft에 옛 문구("다음 워커 tick에
+            # 발행됩니다")를 그대로 보내면 에이전트가 "할 일 없음"으로 오판해 사람에게
+            # 재발행이 필요하다는 것을 못 알릴 수 있다 — connection_id 유무(외부 목적지
+            # 만 명령 자동생성)로 한 번 더 가른다.
             is_site_post = False
+            site_post_has_connection = False
             if draft_id:
                 try:
                     draft_uuid = uuid.UUID(draft_id)
@@ -1411,10 +1424,13 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
                     draft_uuid = None
                 if draft_uuid is not None:
                     from app.models.site_post_draft import SitePostDraft
-                    is_site_post = (await db.execute(
-                        select(SitePostDraft.id).where(SitePostDraft.id == draft_uuid)
-                    )).scalar_one_or_none() is not None
-            if is_site_post:
+                    _site_draft_row = (await db.execute(
+                        select(SitePostDraft.connection_id).where(SitePostDraft.id == draft_uuid)
+                    )).one_or_none()
+                    if _site_draft_row is not None:
+                        is_site_post = True
+                        site_post_has_connection = _site_draft_row[0] is not None
+            if is_site_post and site_post_has_connection:
                 lines.append(
                     "- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 "
                     "tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 "

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1413,10 +1413,18 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
             # 화면에서 «발행»/«재발행»을 직접 눌러야 한다. 이 표면의 수신자는 항상
             # 에이전트(위 주석)라, hosted_site draft에 옛 문구("다음 워커 tick에
             # 발행됩니다")를 그대로 보내면 에이전트가 "할 일 없음"으로 오판해 사람에게
-            # 재발행이 필요하다는 것을 못 알릴 수 있다 — connection_id 유무(외부 목적지
-            # 만 명령 자동생성)로 한 번 더 가른다.
+            # 재발행이 필요하다는 것을 못 알릴 수 있다.
+            #
+            # story #4155 유나 CHANGES(2026-09-10) — 위 수정이 connection_id 유무를
+            # 대리값으로 썼는데, `gate_service.py:1037-1072`엔 외부 목적지(connection_id
+            # 있음)인데도 command를 안 만들고 return하는 경로가 6개(_mark_unresolved 5·
+            # _mark_scope_mismatch 1 — scope mismatch는 설계된 도달 상태) 있어 그 경로
+            # 에서도 이 대리값이 "명령이 만들어졌다"로 잘못 읽었다. 대리값을 버리고 실제
+            # `PublicationCommand` 존재 여부를 직접 조회한다(gate_id로, 인덱스 有) — 이
+            # 한 조회가 hosted_site(애초에 명령 자체가 없는 경로)와 외부-이지만-생성
+            # 실패(위 6경로) 둘 다를 같은 방식으로 정확히 잡는다.
             is_site_post = False
-            site_post_has_connection = False
+            site_post_command_exists = False
             if draft_id:
                 try:
                     draft_uuid = uuid.UUID(draft_id)
@@ -1424,17 +1432,19 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
                     draft_uuid = None
                 if draft_uuid is not None:
                     from app.models.site_post_draft import SitePostDraft
-                    _site_draft_row = (await db.execute(
-                        select(SitePostDraft.connection_id).where(SitePostDraft.id == draft_uuid)
-                    )).one_or_none()
-                    if _site_draft_row is not None:
-                        is_site_post = True
-                        site_post_has_connection = _site_draft_row[0] is not None
-            if is_site_post and site_post_has_connection:
+                    is_site_post = (await db.execute(
+                        select(SitePostDraft.id).where(SitePostDraft.id == draft_uuid)
+                    )).scalar_one_or_none() is not None
+            if is_site_post and gate_row is not None:
+                from app.models.publication_command import PublicationCommand
+                site_post_command_exists = (await db.execute(
+                    select(PublicationCommand.id).where(PublicationCommand.gate_id == gate_row.id)
+                )).first() is not None
+            if is_site_post and site_post_command_exists:
                 lines.append(
-                    "- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 "
+                    "- 다음 행동: 할 일 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 "
                     "tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 "
-                    "확認합니다."
+                    "확인합니다."
                 )
             else:
                 lines.append("- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.")

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -1452,6 +1452,26 @@ async def publish_site_post_external_command(db: AsyncSession, command: "Publica
     else:
         row.status, row.external_id, row.permalink, row.published_at = "published", external_id, permalink, now
 
+    # story #3369 후속(자기점검 2차, 유나 실측·페드루 지시 2026-09-10) — 이 워커
+    # 경로(외부 목적지 발행)는 site_post_published 감사 로그를 한 번도 남기지 않고
+    # 있었다. hosted_site 동기 경로(publish_site_post_from_draft, 위쪽)는 매 호출마다
+    # 이 액션을 남기는데, 이 함수는 e4fc29fa③c로 나중에 추가된 별도 구현이라(channel_
+    # posts.py처럼 즉시/예약 두 경로가 publish_channel_post_draft 하나를 공유하는 형이
+    # 아니다) 그 기록이 안 옮겨왔다 — 재승인→재발행 감사 이력이 외부 목적지 draft에서는
+    # 처음부터 끝까지 전무했다(재발행만의 결함이 아니라 최초 발행부터). entity_type은
+    # channel_posts.py::publish_channel_post_draft의 channel_post_published 관례를
+    # 그대로 따른다(row가 여기서도 ChannelPublication이므로 같은 축).
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(db).record(
+        org_id=command.org_id, action="site_post_published", actor_type="platform", actor_id=None,
+        entity_type="channel_publication", entity_id=row.id,
+        context={
+            "gate_id": str(command.gate_id), "version_id": str(version.id),
+            "permalink": row.permalink, "external_id": row.external_id,
+            "requested_by_member_id": str(command.requested_by_member_id),
+        },
+    )
     # story #3497 — 발행 성공 콜백(같은 트랜잭션, commit은 호출자 몫 — publication_
     # command.py::_process_one_site_post_command와 동형 경계).
     from app.services.insight_snapshots import schedule_insight_snapshots

--- a/backend/scripts/korean_user_strings_baseline.txt
+++ b/backend/scripts/korean_user_strings_baseline.txt
@@ -194,10 +194,10 @@ app/routers/events.py::- 다음 단계로 넘기는 발행 예시: publish_event
 app/routers/events.py::- 다음 행동:
 app/routers/events.py::- 다음 행동: channel=
 app/routers/events.py::- 다음 행동: 산출물을 수정한 뒤, 같은 레시피 정의의 approve stage 이벤트를 다시 발행하세요(payload.previous_output_doc_id=수정본 id) — 게이트는 그 발행으로 자동 재오픈됩니다.
+app/routers/events.py::- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 확認합니다.
 app/routers/events.py::- 다음 행동: 이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 이 승인 게이트를 확인하는 발행 도구를 쓰세요).
 app/routers/events.py::- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다.
 app/routers/events.py::- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.
-app/routers/events.py::- 다음 행동: 할 일 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 확인합니다.
 app/routers/events.py::- 단계 `
 app/routers/events.py::- 대상 산출물:
 app/routers/events.py::- 사유:

--- a/backend/scripts/korean_user_strings_baseline.txt
+++ b/backend/scripts/korean_user_strings_baseline.txt
@@ -194,10 +194,10 @@ app/routers/events.py::- 다음 단계로 넘기는 발행 예시: publish_event
 app/routers/events.py::- 다음 행동:
 app/routers/events.py::- 다음 행동: channel=
 app/routers/events.py::- 다음 행동: 산출물을 수정한 뒤, 같은 레시피 정의의 approve stage 이벤트를 다시 발행하세요(payload.previous_output_doc_id=수정본 id) — 게이트는 그 발행으로 자동 재오픈됩니다.
-app/routers/events.py::- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 확認합니다.
 app/routers/events.py::- 다음 행동: 이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 이 승인 게이트를 확인하는 발행 도구를 쓰세요).
 app/routers/events.py::- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다.
 app/routers/events.py::- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.
+app/routers/events.py::- 다음 행동: 할 일 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 확인합니다.
 app/routers/events.py::- 단계 `
 app/routers/events.py::- 대상 산출물:
 app/routers/events.py::- 사유:

--- a/backend/tests/test_3369_site_post_external_publish_activity_log.py
+++ b/backend/tests/test_3369_site_post_external_publish_activity_log.py
@@ -1,0 +1,96 @@
+"""story #3369 후속(자기점검 2차, 유나 실측·페드루 지시 2026-09-10) — 외부 목적지
+(WordPress·webhook) site_post 발행 경로(`site_posts.py::publish_site_post_external_
+command`, 워커가 호출)는 `activity_logs`에 `site_post_published`를 한 번도 남기지
+않고 있었다. hosted_site 동기 경로(`publish_site_post_from_draft`)는 매 호출마다
+이 액션을 남기는데, 이 워커 경로는 e4fc29fa③c로 나중에 별도 구현이 추가되면서 그
+기록이 안 옮겨왔다(channel_post는 즉시/예약 두 경로가 `publish_channel_post_draft`
+하나를 공유해 이 종류의 드리프트가 원천적으로 없다 — site_post만 걸린 결함).
+
+세팅 헬퍼는 test_3474_publication_attempts.py::_seed_and_approve와 동형(그 파일이
+이미 test_e4fc29fa_site_post_orchestration.py에서 중복 재발명 금지로 재사용한 것을
+한 번 더 재사용)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.test_3474_publication_attempts import _seed_and_approve
+from tests.test_e4fc29fa_site_post_orchestration import (
+    live_wordpress_stub,  # noqa: F401 — pytest fixture import
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.mark.anyio
+async def test_external_publish_records_site_post_published_activity_log(live_wordpress_stub):
+    """뮤테이션 대상: site_posts.py::publish_site_post_external_command의 신규
+    ActivityLogService.record(action="site_post_published", ...) 호출을 지우면 이
+    테스트가 RED가 되어야 한다(행이 0개)."""
+    from sqlalchemy import select
+
+    from app.models.activity_log import ActivityLog
+    from app.models.channel_publication import ChannelPublication
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session, app, org_id, _draft_id, gate_id, human_id = await _seed_and_approve(
+        live_wordpress_stub_url=live_wordpress_stub,
+    )
+    try:
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        async with Session() as s:
+            logs = (await s.execute(
+                select(ActivityLog).where(
+                    ActivityLog.org_id == org_id, ActivityLog.action == "site_post_published",
+                )
+            )).scalars().all()
+            pub = (await s.execute(
+                select(ChannelPublication).where(ChannelPublication.gate_id == gate_id)
+            )).scalar_one()
+
+        assert len(logs) == 1, "외부 목적지 발행도 hosted_site와 동형으로 감사 행을 남겨야 한다"
+        log = logs[0]
+        assert log.actor_type == "platform"
+        assert log.entity_type == "channel_publication"
+        assert log.entity_id == pub.id
+        assert log.context["gate_id"] == str(gate_id)
+        assert log.context["requested_by_member_id"] == str(human_id)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3387_gate_verdict_agent_next_action.py
+++ b/backend/tests/test_3387_gate_verdict_agent_next_action.py
@@ -39,43 +39,34 @@ class _FakeResult:
     def one_or_none(self):
         return self._row
 
-
-class _NoConnection:
-    """site_post_draft_exists=True인데 connection_id를 안 정한 기존 호출부(옛
-    "아무 connection이나" 뜻) — 하위호환 sentinel, 실제로는 안 쓰인다(모든 호출부가
-    아래 site_post_connection_id를 명시)."""
+    def first(self):
+        return self._row
 
 
 def _fake_db(
     gate_row=None, *, site_post_draft_exists: bool = False,
-    site_post_connection_id: uuid.UUID | None = _NoConnection,
+    site_post_command_exists: bool = False,
 ):
-    """story #3487 — 두 번째 db.execute 호출(SitePostDraft.connection_id 조회, verdict==
-    approved·draft_id 있을 때만 일어난다)을 첫 번째(Gate 조회)와 다르게 응답해야
-    한다 — 호출 순서로 가른다(이 함수의 유일한 소비자가 순서를 그렇게 고정한다).
-    `db.get(Gate, ...)`(gate_id 있는 신규 경로)도 같은 gate_row를 돌려준다.
+    """story #3487 — SitePostDraft 존재 조회(verdict==approved·draft_id 있을 때만
+    일어난다)를 Gate 조회와 다르게 응답해야 한다 — 쿼리가 겨누는 테이블로 직접
+    가른다(호출 순서·개수에 안 기댄다, story #3369 후속 교정 재사용: payload에
+    gate_id가 있으면 db.get(Gate, ...)이 gate row를 얻어 execute를 아예 안 타므로
+    call-count 가정은 그 경로에서 깨진다). `db.get(Gate, ...)`(gate_id 있는 신규
+    경로)도 같은 gate_row를 돌려준다.
 
-    story #3369 후속(자기점검 2차, 2026-09-10) — 이전엔 "site_post 존재 여부"만
-    boolean으로 흉내냈다(연결 없는 값은 uuid.uuid4()를 그냥 채워 hosted_site도 늘
-    "connection 있음"으로 오분류했다). 이제 `select(SitePostDraft.connection_id)`가
-    Row(단일 컬럼)를 돌려주므로, 없으면 None(draft 자체 없음)·있으면 (connection_id,)
-    (hosted_site면 그 값 자체가 None)를 흉내낸다 — `site_post_connection_id`가
-    명시(`_NoConnection` sentinel 아님)되면 그 값을, 아니면(하위호환) site_post_draft_
-    exists만 보고 hosted_site(connection_id=None)로 기본 흉내낸다."""
+    story #4155 유나 CHANGES(2026-09-10) — connection_id 유무 대리값(#3369 후속의
+    최초 처방)을 버리고 실제 `PublicationCommand` 존재 여부를 직접 조회하는 걸로
+    바뀌었다(`gate_service.py`의 6개 조용한 return 경로가 "external인데 명령 없음"을
+    만들 수 있어 그 대리값이 틀렸었다). 세 번째 쿼리 대상(publication_commands)도
+    따로 흉내낸다."""
     db = AsyncMock()
-    conn_id = None if site_post_connection_id is _NoConnection else site_post_connection_id
 
     async def _execute(query, *_args, **_kwargs):
-        # story #3369 후속(2026-09-10) — 이전엔 "첫 execute=gate, 둘째 execute=
-        # site_post"를 호출 순서로만 가르는 call-count 흉내였다. payload에 gate_id가
-        # 있으면 실제 코드는 db.get(Gate, ...)로 gate row를 얻어(execute를 아예 안
-        # 탄다) 그 뒤 SitePostDraft 조회가 execute의 «첫» 호출이 된다 — call-count
-        # 가정이 그 경로에서 깨진다(뮤테이션 테스트가 실제로 이 자리에서 TypeError로
-        # 적발했다). 쿼리가 겨누는 테이블로 직접 가른다 — 호출 순서·개수에 안 기댄다.
-        if "site_post_drafts" in str(query):
-            if not site_post_draft_exists:
-                return _FakeResult(None)
-            return _FakeResult((conn_id,))
+        q = str(query)
+        if "site_post_drafts" in q:
+            return _FakeResult(uuid.uuid4() if site_post_draft_exists else None)
+        if "publication_commands" in q:
+            return _FakeResult(uuid.uuid4() if site_post_command_exists else None)
         return _FakeResult(gate_row)
 
     db.execute = AsyncMock(side_effect=_execute)
@@ -110,14 +101,14 @@ def _stub_work_item_ref(monkeypatch):
 
 async def _render(
     payload: dict, gate_row=None, *, site_post_draft_exists: bool = False,
-    site_post_connection_id: uuid.UUID | None = _NoConnection,
+    site_post_command_exists: bool = False,
 ) -> str:
     from app.routers.events import _render_gate_verdict_message
 
     return await _render_gate_verdict_message(
         _fake_db(
             gate_row, site_post_draft_exists=site_post_draft_exists,
-            site_post_connection_id=site_post_connection_id,
+            site_post_command_exists=site_post_command_exists,
         ),
         org_id=uuid.uuid4(), payload=payload,
     )
@@ -147,36 +138,63 @@ class TestExternalPublishAgentNextAction:
         assert "- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다." in text
 
     async def test_site_post_external_destination_approved_says_worker_tick_not_human_screen(self):
-        """story #3487 — site_post 외부 목적지(WordPress 등, connection_id 있음)는
-        승인 즉시 워커가 다음 tick에 발행한다(실동작). draft_id가 site_post_drafts에
-        있고 connection_id도 있으면 새 문구."""
+        """story #3487 — site_post 외부 목적지(WordPress 등)는 승인 즉시 워커가
+        다음 tick에 발행한다(실동작). draft_id가 site_post_drafts에 있고 실제
+        PublicationCommand도 있으면(gate_service.py가 정상적으로 명령을 만든 경우)
+        새 문구."""
         draft_id = str(uuid.uuid4())
         gate_row = _FakeGateRow({"draft_id": draft_id})
         text = await _render(
             _payload(gate_type="external_publish", verdict="approved"),
-            gate_row=gate_row, site_post_draft_exists=True, site_post_connection_id=uuid.uuid4(),
+            gate_row=gate_row, site_post_draft_exists=True, site_post_command_exists=True,
         )
         assert "발행은 휴먼이 화면에서 합니다" not in text
         assert "다음 워커 tick" in text
         assert "발행 결과" in text
 
     async def test_site_post_hosted_site_approved_keeps_human_screen_text(self):
-        """story #3369 후속(자기점검 2차, 2026-09-10) — hosted_site(connection_id=
-        None)는 #3487 옛 주석이 틀리게 "공통"이라 적었던 그 자리: 승인해도
-        publication_command가 안 생긴다(gate_service.py::_maybe_create_scheduled_
-        publication_command가 destination_channel=="hosted_site"면 그 자리에서
-        return한다) — 휴먼이 여전히 화면에서 직접 «발행»/«재발행»을 눌러야 한다.
-        이 표면 수신자(에이전트)에게 "다음 워커 tick에 발행됩니다"(거짓)를 보내면
-        사람에게 재발행이 필요하다는 것을 못 알릴 위험이 있다 — 옛 문구 그대로여야
-        한다.
+        """story #3369 후속(자기점검 2차, 2026-09-10) — hosted_site는 #3487 옛
+        주석이 틀리게 "공통"이라 적었던 그 자리: 승인해도 publication_command가 안
+        생긴다(gate_service.py::_maybe_create_scheduled_publication_command가
+        destination_channel=="hosted_site"면 그 자리에서 return한다) — 휴먼이
+        여전히 화면에서 직접 «발행»/«재발행»을 눌러야 한다. 이 표면 수신자
+        (에이전트)에게 "다음 워커 tick에 발행됩니다"(거짓)를 보내면 사람에게
+        재발행이 필요하다는 것을 못 알릴 위험이 있다 — 옛 문구 그대로여야 한다.
 
-        뮤테이션 대상: events.py의 `site_post_has_connection` 체크를 지우면(즉 예전처럼
-        is_site_post만 보면) 이 테스트가 RED가 되어야 한다."""
+        story #4155 유나 CHANGES(2026-09-10) — connection_id 대리값에서 실제
+        PublicationCommand 존재 조회로 바뀐 뒤에도, hosted_site는 애초에 명령
+        자체가 안 생기므로 이 테스트는 site_post_command_exists=False로 그대로
+        같은 결론을 낸다(같은 조회 하나가 hosted_site·외부-생성실패 둘 다 잡는다).
+
+        뮤테이션 대상: events.py의 `site_post_command_exists` 체크를 지우면(즉
+        예전처럼 is_site_post만 보면) 이 테스트가 RED가 되어야 한다."""
         draft_id = str(uuid.uuid4())
         gate_row = _FakeGateRow({"draft_id": draft_id})
         text = await _render(
             _payload(gate_type="external_publish", verdict="approved"),
-            gate_row=gate_row, site_post_draft_exists=True, site_post_connection_id=None,
+            gate_row=gate_row, site_post_draft_exists=True, site_post_command_exists=False,
+        )
+        assert "- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다." in text
+        assert "다음 워커 tick" not in text
+
+    async def test_site_post_external_destination_scope_mismatch_keeps_human_screen_text(self):
+        """story #4155 유나 CHANGES(2026-09-10) — 외부 목적지(connection_id 있음)
+        인데도 `gate_service.py::_mark_scope_mismatch`(설계된 도달 상태 — 승인된
+        목적지와 draft의 현재 목적지가 갈린 경우)나 `_mark_unresolved`(5경로) 중
+        하나를 타면 publication_command가 안 만들어진다. 이전 처방(connection_id
+        유무만 봄)은 이 경로를 "명령이 만들어졌다"로 잘못 읽어 거짓 문구를 냈다 —
+        이제는 실제 명령 존재 여부로만 판단하므로(site_post_draft_exists=True인데
+        site_post_command_exists=False) hosted_site와 같은 «할 일 없음» 문구가
+        나와야 한다.
+
+        뮤테이션 대상: 위 hosted_site 테스트와 같은 자리(site_post_command_exists
+        체크)를 지우면 이 테스트도 함께 RED가 되어야 한다 — 외부 목적지인데 명령이
+        없는 이 시나리오가 정확히 원래 결함이 재현되던 자리."""
+        draft_id = str(uuid.uuid4())
+        gate_row = _FakeGateRow({"draft_id": draft_id})
+        text = await _render(
+            _payload(gate_type="external_publish", verdict="approved"),
+            gate_row=gate_row, site_post_draft_exists=True, site_post_command_exists=False,
         )
         assert "- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다." in text
         assert "다음 워커 tick" not in text
@@ -200,7 +218,7 @@ class TestExternalPublishAgentNextAction:
         site_post_draft_exists=True를 반영 못 하고 RED가 된다."""
         draft_id = str(uuid.uuid4())
         gate_row = _FakeGateRow({"draft_id": draft_id}, id_=uuid.uuid4())
-        db = _fake_db(gate_row, site_post_draft_exists=True, site_post_connection_id=uuid.uuid4())
+        db = _fake_db(gate_row, site_post_draft_exists=True, site_post_command_exists=True)
         from app.routers.events import _render_gate_verdict_message
 
         text = await _render_gate_verdict_message(

--- a/backend/tests/test_3387_gate_verdict_agent_next_action.py
+++ b/backend/tests/test_3387_gate_verdict_agent_next_action.py
@@ -36,20 +36,47 @@ class _FakeResult:
     def scalar_one_or_none(self):
         return self._row
 
+    def one_or_none(self):
+        return self._row
 
-def _fake_db(gate_row=None, *, site_post_draft_exists: bool = False):
-    """story #3487 — 두 번째 db.execute 호출(SitePostDraft 존재 확인, verdict==
+
+class _NoConnection:
+    """site_post_draft_exists=True인데 connection_id를 안 정한 기존 호출부(옛
+    "아무 connection이나" 뜻) — 하위호환 sentinel, 실제로는 안 쓰인다(모든 호출부가
+    아래 site_post_connection_id를 명시)."""
+
+
+def _fake_db(
+    gate_row=None, *, site_post_draft_exists: bool = False,
+    site_post_connection_id: uuid.UUID | None = _NoConnection,
+):
+    """story #3487 — 두 번째 db.execute 호출(SitePostDraft.connection_id 조회, verdict==
     approved·draft_id 있을 때만 일어난다)을 첫 번째(Gate 조회)와 다르게 응답해야
     한다 — 호출 순서로 가른다(이 함수의 유일한 소비자가 순서를 그렇게 고정한다).
-    `db.get(Gate, ...)`(gate_id 있는 신규 경로)도 같은 gate_row를 돌려준다."""
-    db = AsyncMock()
-    call_count = {"n": 0}
+    `db.get(Gate, ...)`(gate_id 있는 신규 경로)도 같은 gate_row를 돌려준다.
 
-    async def _execute(*_args, **_kwargs):
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            return _FakeResult(gate_row)
-        return _FakeResult(uuid.uuid4() if site_post_draft_exists else None)
+    story #3369 후속(자기점검 2차, 2026-09-10) — 이전엔 "site_post 존재 여부"만
+    boolean으로 흉내냈다(연결 없는 값은 uuid.uuid4()를 그냥 채워 hosted_site도 늘
+    "connection 있음"으로 오분류했다). 이제 `select(SitePostDraft.connection_id)`가
+    Row(단일 컬럼)를 돌려주므로, 없으면 None(draft 자체 없음)·있으면 (connection_id,)
+    (hosted_site면 그 값 자체가 None)를 흉내낸다 — `site_post_connection_id`가
+    명시(`_NoConnection` sentinel 아님)되면 그 값을, 아니면(하위호환) site_post_draft_
+    exists만 보고 hosted_site(connection_id=None)로 기본 흉내낸다."""
+    db = AsyncMock()
+    conn_id = None if site_post_connection_id is _NoConnection else site_post_connection_id
+
+    async def _execute(query, *_args, **_kwargs):
+        # story #3369 후속(2026-09-10) — 이전엔 "첫 execute=gate, 둘째 execute=
+        # site_post"를 호출 순서로만 가르는 call-count 흉내였다. payload에 gate_id가
+        # 있으면 실제 코드는 db.get(Gate, ...)로 gate row를 얻어(execute를 아예 안
+        # 탄다) 그 뒤 SitePostDraft 조회가 execute의 «첫» 호출이 된다 — call-count
+        # 가정이 그 경로에서 깨진다(뮤테이션 테스트가 실제로 이 자리에서 TypeError로
+        # 적발했다). 쿼리가 겨누는 테이블로 직접 가른다 — 호출 순서·개수에 안 기댄다.
+        if "site_post_drafts" in str(query):
+            if not site_post_draft_exists:
+                return _FakeResult(None)
+            return _FakeResult((conn_id,))
+        return _FakeResult(gate_row)
 
     db.execute = AsyncMock(side_effect=_execute)
     db.get = AsyncMock(return_value=gate_row)
@@ -81,11 +108,18 @@ def _stub_work_item_ref(monkeypatch):
     monkeypatch.setattr(events_module, "_render_event_notification_work_item_ref", _fake_ref)
 
 
-async def _render(payload: dict, gate_row=None, *, site_post_draft_exists: bool = False) -> str:
+async def _render(
+    payload: dict, gate_row=None, *, site_post_draft_exists: bool = False,
+    site_post_connection_id: uuid.UUID | None = _NoConnection,
+) -> str:
     from app.routers.events import _render_gate_verdict_message
 
     return await _render_gate_verdict_message(
-        _fake_db(gate_row, site_post_draft_exists=site_post_draft_exists), org_id=uuid.uuid4(), payload=payload,
+        _fake_db(
+            gate_row, site_post_draft_exists=site_post_draft_exists,
+            site_post_connection_id=site_post_connection_id,
+        ),
+        org_id=uuid.uuid4(), payload=payload,
     )
 
 
@@ -112,18 +146,40 @@ class TestExternalPublishAgentNextAction:
         ))
         assert "- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다." in text
 
-    async def test_site_post_approved_says_worker_tick_not_human_screen(self):
-        """story #3487 — site_post(외부 목적지·hosted_site 공통)는 승인 즉시 워커가
-        다음 tick에 발행한다(실동작). draft_id가 site_post_drafts에 있으면 새 문구."""
+    async def test_site_post_external_destination_approved_says_worker_tick_not_human_screen(self):
+        """story #3487 — site_post 외부 목적지(WordPress 등, connection_id 있음)는
+        승인 즉시 워커가 다음 tick에 발행한다(실동작). draft_id가 site_post_drafts에
+        있고 connection_id도 있으면 새 문구."""
         draft_id = str(uuid.uuid4())
         gate_row = _FakeGateRow({"draft_id": draft_id})
         text = await _render(
             _payload(gate_type="external_publish", verdict="approved"),
-            gate_row=gate_row, site_post_draft_exists=True,
+            gate_row=gate_row, site_post_draft_exists=True, site_post_connection_id=uuid.uuid4(),
         )
         assert "발행은 휴먼이 화면에서 합니다" not in text
         assert "다음 워커 tick" in text
         assert "발행 결과" in text
+
+    async def test_site_post_hosted_site_approved_keeps_human_screen_text(self):
+        """story #3369 후속(자기점검 2차, 2026-09-10) — hosted_site(connection_id=
+        None)는 #3487 옛 주석이 틀리게 "공통"이라 적었던 그 자리: 승인해도
+        publication_command가 안 생긴다(gate_service.py::_maybe_create_scheduled_
+        publication_command가 destination_channel=="hosted_site"면 그 자리에서
+        return한다) — 휴먼이 여전히 화면에서 직접 «발행»/«재발행»을 눌러야 한다.
+        이 표면 수신자(에이전트)에게 "다음 워커 tick에 발행됩니다"(거짓)를 보내면
+        사람에게 재발행이 필요하다는 것을 못 알릴 위험이 있다 — 옛 문구 그대로여야
+        한다.
+
+        뮤테이션 대상: events.py의 `site_post_has_connection` 체크를 지우면(즉 예전처럼
+        is_site_post만 보면) 이 테스트가 RED가 되어야 한다."""
+        draft_id = str(uuid.uuid4())
+        gate_row = _FakeGateRow({"draft_id": draft_id})
+        text = await _render(
+            _payload(gate_type="external_publish", verdict="approved"),
+            gate_row=gate_row, site_post_draft_exists=True, site_post_connection_id=None,
+        )
+        assert "- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다." in text
+        assert "다음 워커 tick" not in text
 
     async def test_channel_post_approved_keeps_old_text_regression(self):
         """AC2 회귀 0 — channel_post(예약 상신)는 draft_id가 있어도(channel_posts.py도
@@ -144,7 +200,7 @@ class TestExternalPublishAgentNextAction:
         site_post_draft_exists=True를 반영 못 하고 RED가 된다."""
         draft_id = str(uuid.uuid4())
         gate_row = _FakeGateRow({"draft_id": draft_id}, id_=uuid.uuid4())
-        db = _fake_db(gate_row, site_post_draft_exists=True)
+        db = _fake_db(gate_row, site_post_draft_exists=True, site_post_connection_id=uuid.uuid4())
         from app.routers.events import _render_gate_verdict_message
 
         text = await _render_gate_verdict_message(

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1572,6 +1572,11 @@
       "file": "tests/test_3367_gate_latest_author_and_destination.py",
       "sec": 3.1,
       "source": "story-3368(자기점검 갭, 2026-09-10) — 신규 파일 실측(로컬, sprintable/backend/.venv pytest --durations=0 직접 1회 실행, 3건 합계 3.11s — test_3766 등재 선례와 동일 방법론, 로컬이 CI보다 빠르다는 전제 그대로 원값 등재). 실 CI 샤드 로그로 재확認 필요(AC2 재측정 규칙)."
+    },
+    {
+      "file": "tests/test_3369_site_post_external_publish_activity_log.py",
+      "sec": 42.0,
+      "source": "story #3369 후속(2026-09-10) — 신규 destructive_schema 파일(외부 목적지 site_post 발행 감사로그 실 WordPress 스텁+실 워커 왕복). 로컬 실측 call+setup+teardown=6.85s(disposable PG, --durations=0) — story #3383 6배 스케일(로컬→CI) 적용해 ~42s로 등재. 실 CI 샤드 로그로 재확認 필요(AC2 재측정 규칙)."
     }
   ]
 }


### PR DESCRIPTION
## 요약

story #3369 자기점검 2차(페드루 지시, 유나 실측) — 「재승인 뒤 재발행에서 감사
site_post_published 행이 1줄뿐이었는데 projection은 두 번 바뀜」이라는 관측을
코드로 추적해 서로 독립적이지만 연관된 결함 2건을 확認했다.

## 결함 1 — 승인 이벤트 메시지가 hosted_site에는 거짓

`events.py`의 external_publish 승인 다음-행동 메시지(agent-only 표면)가 모든
site_post draft에 조건 없이 "승인으로 발행 명령이 만들어졌고 다음 워커 tick
(최대 1분)에 발행됩니다"를 보냈다. 실제로는:

- `gate_service.py::_maybe_create_scheduled_publication_command` —
  `destination_channel == "hosted_site"`면 `publication_command` 생성 자체를
  건너뛴다(`return  # 내부 동기 경로 그대로 — publication_command 불요`).
- 즉 hosted_site(대부분의 site_post가 쓰는 기본 목적지) 승인은 워커가 자동
  발행하지 않는다 — 휴먼이 여전히 화면에서 직접 «발행»/«재발행»을 눌러야 한다.
- 이 메시지의 수신자는 코드 주석 기준 항상 에이전트다. hosted_site draft에
  이 거짓 문구가 가면, 에이전트가 "할 일 없음"으로 오판해 사람에게 재발행이
  필요하다는 걸 못 알릴 수 있다.

**처방**: `draft_id`가 `site_post_drafts`에 있는지뿐 아니라 그 draft의
`connection_id` 유무로 한 번 더 가른다 — 외부 목적지(connection_id 있음)만
새 문구, hosted_site(connection_id=None)는 옛 문구("발행은 휴먼이 화면에서
합니다") 그대로.

## 결함 2 — 외부 목적지 발행이 감사 로그를 한 번도 안 남김

`site_posts.py::publish_site_post_external_command`(워커, WordPress/webhook
전용)는 `activity_logs`에 `site_post_published`를 **한 번도** 남기지 않는다
(재발행뿐 아니라 최초 발행부터). hosted_site 동기 경로
(`publish_site_post_from_draft`)는 매 호출마다 이 액션을 남기는데, 이 함수는
e4fc29fa③c로 나중에 추가된 완전히 별도의 구현이라(channel_post처럼 즉시/예약
두 트리거가 `publish_channel_post_draft` 하나를 공유하는 형이 **아니다** —
그래서 channel_post는 이 종류의 드리프트가 애초에 불가능하다) 그 기록이 안
옮겨왔다.

**처방**: `channel_posts.py::publish_channel_post_draft`의
`channel_post_published` 감사 로그 관례를 그대로 재사용해 추가
(`entity_type="channel_publication"`, hosted_site와 같은 `site_post_published`
액션명).

## 테스트 + 뮤테이션

- `test_3387_gate_verdict_agent_next_action.py` — hosted_site/외부 목적지
  분기 신규 케이스 2건(뮤테이션: connection_id 체크 제거 → hosted_site 케이스만
  RED) + 기존 site_post 케이스들을 connection_id 명시로 정정. `_fake_db`
  헬퍼를 call-count 방식에서 쿼리 대상 테이블 판별 방식으로 재작성(gate_id가
  payload에 있는 경로는 `db.get`이 gate 조회를 가로채 기존 call-count 가정이
  깨져 있었다 — 이번 뮤테이션 작업 중 실제로 TypeError로 적발). 17/17 GREEN.
- `test_3369_site_post_external_publish_activity_log.py`(신규) — 실 WordPress
  스텁 + 실 워커(`process_due_publication_commands`)로 승인→발행 성공까지
  왕복, 감사 로그 1건 + context 필드(`gate_id`/`version_id`/
  `requested_by_member_id`) 확認. 뮤테이션(신규 activity_log 호출 제거) →
  `assert 0 == 1` RED, 원복 재GREEN.
- 관련 realdb 스위트 전체(destructive 32개 · non-destructive 17개) 재확認
  GREEN — `test_e4fc29fa_destination_axis.py`·`test_3474_publication_
  attempts.py`·`test_e4fc29fa_site_post_orchestration.py`·
  `test_3370_gate_verdict_gate_id_version_id.py` 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ