### PR TITLE
[SID:3370] fix(BE): 휴먼 상신자/작성자 member-id가 users.id로 봉인되던 결함 클래스 10곳 정정

### DIFF
--- a/backend/app/routers/activity_logs.py
+++ b/backend/app/routers/activity_logs.py
@@ -86,8 +86,6 @@ async def list_activity_logs(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> ActivityLogListResponse:
-    from app.models.team import TeamMember
-
     # ratchet round7(잔여 HIGH): project_id 필터(지정 시)에 caller 접근권 검증이 없어
     # same-org cross-project 감사 로그(actor/action/entity/context 전문)가 노출됐다 —
     # resource-actual project_id 직접검증. actor_id/entity_id/entity_type 등은 project로
@@ -116,22 +114,30 @@ async def list_activity_logs(
         q = q.where(ActivityLog.created_at <= to)
 
     # S-C4: EE RBAC — is_ee_enabled 시 role별 가시성 필터 적용
+    #
+    # ⚠️story #3370(유나 실측·페드루 정정 2026-09-10) — 이전엔 `TeamMember.id == auth.
+    # user_id`로 caller를 직접 조회했다. 휴먼(JWT)의 auth.user_id는 users.id다(auth.py
+    # 계약) — legacy team_member 행이 있는 휴먼(레거시 org)만 우연히 매치했고,
+    # grant-only 휴먼(org_member 경유, E-MEMBER-SSOT 이후 만들어진 org 다수)은
+    # `caller_tm=None`이라 `ee_applied`가 False로 남아 **필터가 통째로 스킵**됐다
+    # (member 역할 휴먼이 org 전체 flat 로그를 봄 — fail-open 권한 무력화, 유나 라이브
+    # 재현). ActivityLog.actor_id 자체도 record_created_activity가 resolve_member().id
+    # (canonical 멤버 id)로 쓴다 — 이 필터의 「본인 actor_id만」 분기(filter_activity_
+    # by_role의 member 축)도 같은 축이어야 정합. `resolve_member_db_verified()`(member_
+    # resolver.py, 이 스토리에서 신설)로 role·id 둘 다 한 호출에서 정확히 해소 —
+    # `resolve_member()`(클레임 기반)이 아니라 이 변형을 쓰는 이유는 agent 판정을 DB로
+    # 하기 위해서다(기존 테스트 하네스 정합, 그 함수 자신의 docstring 그라운딩).
     ee_applied = False
     if _ee_rbac_filter is not None:
         try:
-            caller_tm = (await db.execute(
-                select(TeamMember).where(
-                    TeamMember.id == uuid.UUID(auth.user_id),
-                    TeamMember.org_id == org_id,
-                ).limit(1)
-            )).scalar_one_or_none()
-            if caller_tm:
-                q = _ee_rbac_filter(q, caller_tm.role, caller_tm.id)
-                ee_applied = True
-                logger.info(
-                    "activity_logs EE RBAC applied role=%s member_id=%s",
-                    caller_tm.role, caller_tm.id,
-                )
+            from app.services.member_resolver import resolve_member_db_verified
+            resolved_caller = await resolve_member_db_verified(auth, org_id, db)
+            q = _ee_rbac_filter(q, resolved_caller.role, resolved_caller.id)
+            ee_applied = True
+            logger.info(
+                "activity_logs EE RBAC applied role=%s member_id=%s",
+                resolved_caller.role, resolved_caller.id,
+            )
         # 까심 QA(#2073 REQUEST_CHANGES): 여기서 광범위 Exception을 삼키면 NameError류
         # 코드버그까지 fail-open(무필터 flat log)으로 마스킹된다 — DB/타입 계열의 실제
         # "필터 적용 실패"만 fail-open 허용하고, 나머지 코드 버그(NameError/AttributeError

--- a/backend/app/routers/channel_post_comment_replies.py
+++ b/backend/app/routers/channel_post_comment_replies.py
@@ -24,8 +24,7 @@ from app.services.channel_post_comment_replies import (
     get_comment_reply_view,
     submit_comment_reply,
 )
-from app.services.member_resolver import resolve_member
-from app.services.site_posts import is_agent_caller
+from app.services.member_resolver import resolve_member, resolve_member_db_verified
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["channel-post-comment-replies"])
 
@@ -198,8 +197,12 @@ async def create_comment_reply_draft_endpoint(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
-    member_id = uuid.UUID(auth.user_id)
-    created_by_kind = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+    # story #3370(페드루 지적 2026-09-10 — site_posts.py:671과 동형 클래스) — auth.user_id는
+    # 휴먼(JWT)이면 users.id다, org 멤버 id가 아니다. created_by_member_id는 영속 컬럼이라
+    # `resolve_member_db_verified()`(member_resolver.py, agent 판정 DB 실측·기존 테스트
+    # 하네스와 정합 — 자신의 docstring 참고)의 멤버 id로 정정(actor_type도 같은 호출에서 나옴).
+    resolved = await resolve_member_db_verified(auth, org_id, db)
+    member_id, created_by_kind = resolved.id, resolved.type
 
     try:
         reply = await create_comment_reply_draft(

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -60,7 +60,6 @@ from app.services.channel_posts import (
     get_channel_post_draft,
     get_site_post_draft,
     get_source_titles_and_latest_versions,
-    is_agent_caller,
     list_channel_post_draft_versions,
     count_channel_post_drafts,
     list_channel_post_drafts,
@@ -115,7 +114,7 @@ from app.services.channel_post_videos import (
     get_channel_post_video_for_version,
 )
 from app.services.generation_budget import GenerationBudgetExceededError
-from app.services.member_resolver import resolve_member
+from app.services.member_resolver import resolve_member, resolve_member_db_verified
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["channel-posts"])
 
@@ -538,8 +537,18 @@ async def post_channel_post_draft_version(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
-    member_id = uuid.UUID(auth.user_id)
-    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+    # story #3370(페드루 지적, 유나 실측 2026-09-10 — site_posts.py:671과 동형 클래스) —
+    # auth.user_id는 휴먼(JWT)이면 users.id다(auth.py 계약) — org 멤버 id가 아니다.
+    # 원시로 author_member_id에 넣으면 휴먼 작성자가 org_member.id로 안 풀린다(FE
+    # 표시·알림 라우팅 등 멤버 id 소비처 전부 깨짐). `resolve_member_db_verified()`
+    # (member_resolver.py, 이 스토리에서 신설)가 API키(에이전트)는 team_member.id,
+    # JWT(휴먼)는 org_member.id로 갈라 돌려준다 — actor_type도 같은 호출에서 나와
+    # (is_agent_caller 별도 조회 불요) 쿼리 1회 절감. `resolve_member()`(클레임 기반)
+    # 대신 이 변형을 쓰는 이유는 이 파일의 기존 테스트 하네스가 agent 호출자를 api_key_id
+    # 클레임 없이 team_member.id만 넘기는 관례로 짜여 있어서다(resolve_member_db_verified
+    # 자신의 docstring에 그라운딩 기록 — 이 스토리에서 실측).
+    resolved = await resolve_member_db_verified(auth, org_id, db)
+    member_id, actor_type = resolved.id, resolved.type
 
     try:
         version, channel, violations = await create_channel_post_draft_version(
@@ -714,8 +723,9 @@ async def post_channel_post_video_confirm(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
-    member_id = uuid.UUID(auth.user_id)
-    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+    # story #3370(페드루 지적 2026-09-10 — 같은 클래스, post_channel_post_draft_version과 동형).
+    resolved = await resolve_member_db_verified(auth, org_id, db)
+    member_id, actor_type = resolved.id, resolved.type
 
     try:
         version, video_row = await confirm_channel_post_video_upload(
@@ -889,8 +899,9 @@ async def post_channel_post_image_confirm(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
-    member_id = uuid.UUID(auth.user_id)
-    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+    # story #3370(페드루 지적 2026-09-10 — 같은 클래스, post_channel_post_draft_version과 동형).
+    resolved = await resolve_member_db_verified(auth, org_id, db)
+    member_id, actor_type = resolved.id, resolved.type
 
     version, image_row = await _confirm_image_upload_or_raise(
         confirm_channel_post_image_upload(
@@ -945,8 +956,9 @@ async def post_channel_post_image_import(
             status_code=422, detail={"code": "IMAGE_CORRUPT", "message": exc.reason},
         ) from exc
 
-    member_id = uuid.UUID(auth.user_id)
-    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+    # story #3370(페드루 지적 2026-09-10 — 같은 클래스, post_channel_post_draft_version과 동형).
+    resolved = await resolve_member_db_verified(auth, org_id, db)
+    member_id, actor_type = resolved.id, resolved.type
 
     version, image_row = await _confirm_image_upload_or_raise(
         import_channel_post_image(
@@ -1060,10 +1072,17 @@ async def delete_channel_post_image_endpoint(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
-    member_id = uuid.UUID(auth.user_id)
-    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
-
-    await _require_channel_post_draft_project_access(db, org_id=org_id, draft_id=draft_id, member_id=member_id)
+    # story #3370(페드루 지적 2026-09-10) — 이 access 체크(_require_channel_post_draft_
+    # project_access → require_project_access)는 raw auth.user_id(users.id)를 받게 설계돼
+    # 있다(project_auth.py::_project_access_predicate가 OrgMember.user_id==user_id로 휴먼을
+    # 판정 — org_member.id를 넘기면 오히려 깨진다). 그래서 access 체크엔 raw id를 그대로
+    # 쓰고, author_member_id로 **영속되는** 값만 resolve_member()의 멤버 id로 분리한다
+    # (한 변수를 access축·저장축 둘 다에 쓰면 어느 한쪽이 깨진다 — 축 혼용 금지).
+    await _require_channel_post_draft_project_access(
+        db, org_id=org_id, draft_id=draft_id, member_id=uuid.UUID(auth.user_id),
+    )
+    resolved = await resolve_member_db_verified(auth, org_id, db)
+    member_id, actor_type = resolved.id, resolved.type
 
     try:
         new_version, remaining = await delete_channel_post_image(
@@ -1096,10 +1115,13 @@ async def reorder_channel_post_images_endpoint(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
-    member_id = uuid.UUID(auth.user_id)
-    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
-
-    await _require_channel_post_draft_project_access(db, org_id=org_id, draft_id=draft_id, member_id=member_id)
+    # story #3370(페드루 지적 2026-09-10) — delete_channel_post_image_endpoint와 동형 축
+    # 분리(access 체크=raw auth.user_id, author_member_id 영속=resolve_member() 멤버 id).
+    await _require_channel_post_draft_project_access(
+        db, org_id=org_id, draft_id=draft_id, member_id=uuid.UUID(auth.user_id),
+    )
+    resolved = await resolve_member_db_verified(auth, org_id, db)
+    member_id, actor_type = resolved.id, resolved.type
 
     try:
         new_version, ordered = await reorder_channel_post_images(
@@ -1479,10 +1501,14 @@ async def submit_channel_post_draft_endpoint(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
+    # story #3370(유나 실측·페드루 정정 2026-09-10) — site_posts.py::submit_site_post_
+    # draft_endpoint와 동형 결함(같은 클래스, 형제 엔드포인트) — auth.user_id는 휴먼(JWT)
+    # 이면 users.id다, org 멤버 id가 아니다. resolve_member()로 정정.
+    resolved_requester = await resolve_member_db_verified(auth, org_id, db)
     try:
         gate, version_id = await submit_channel_post_draft(
             db, org_id=org_id, draft_id=draft_id, version_id=body.version_id,
-            requester_member_id=uuid.UUID(auth.user_id), scheduled_at=body.scheduled_at,
+            requester_member_id=resolved_requester.id, scheduled_at=body.scheduled_at,
             estimated_cost_minor=body.estimated_cost_minor,
         )
     except GenerationBudgetExceededError as exc:

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.services.member_resolver import resolve_member
+from app.services.member_resolver import resolve_member, resolve_member_db_verified
 from app.routers.insight_snapshots import InsightSnapshotView
 from app.services.generation_budget import GenerationBudgetExceededError
 from app.services.insight_snapshots import get_latest_insight_snapshot
@@ -352,8 +352,14 @@ async def post_site_post_draft_version(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
-    member_id = uuid.UUID(auth.user_id)
-    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+    # story #3370(페드루 지적, 2차 리뷰 2026-09-10) — is_agent_caller 원시-id 조합은 이
+    # 라우트의 은형제 `submit_channel_post_draft_endpoint`류와 같은 결함이었다 —
+    # author_member_id가 **영속** 컬럼이라 원시 auth.user_id(휴먼이면 users.id)를 그대로
+    # 쓰면 휴먼 작성자가 org_member.id로 안 풀린다. `resolve_member_db_verified()`로
+    # 정정(agent 판정은 이전과 동일 DB 실측 — is_agent_caller 재발명 0, 내부에서 동일
+    # predicate를 쓴다).
+    resolved = await resolve_member_db_verified(auth, org_id, db)
+    member_id, actor_type = resolved.id, resolved.type
 
     # story #3437(페드루 PO 리뷰 B1) — 요청 body에 campaign_id 키가 실제로 있었을 때만
     # 서비스에 명시로 넘긴다(model_fields_set) — 생략은 캐리포워드, 서비스 기본 센티널이
@@ -674,7 +680,6 @@ async def submit_site_post_draft_endpoint(
     # 아니라 site_posts.py::is_agent_caller와 동형 DB 실측이라, 이 라우트를 왕복하는
     # 기존 destructive_schema 테스트(agent_id를 api_key_id 클레임 없이 넘기는 관례)가
     # 안 깨진다(그 함수 자신의 docstring에 그라운딩 기록).
-    from app.services.member_resolver import resolve_member_db_verified
     resolved_requester = await resolve_member_db_verified(auth, org_id, db)
     try:
         gate, version_id = await submit_site_post_draft(

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -665,10 +665,21 @@ async def submit_site_post_draft_endpoint(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
+    # story #3370(유나 실측·페드루 정정 2026-09-10) — auth.user_id는 휴먼(JWT)이면
+    # users.id다(auth.py:146 계약) — org 멤버 id가 아니다. 원시로 넘기면 휴먼 상신자가
+    # 어떤 멤버로도 안 풀려(event_routing_resolver.py의 멤버 id 통에 안 맞음) 3370
+    # AC1("상신자 포함")이 휴먼 상신에서 깨진다. `resolve_member_db_verified()`(member_
+    # resolver.py, 이 스토리에서 신설)가 API키(에이전트)는 team_member.id, JWT(휴먼)는
+    # org_member.id로 갈라 돌려준다 — agent 판정은 `resolve_member()`(클레임 기반)가
+    # 아니라 site_posts.py::is_agent_caller와 동형 DB 실측이라, 이 라우트를 왕복하는
+    # 기존 destructive_schema 테스트(agent_id를 api_key_id 클레임 없이 넘기는 관례)가
+    # 안 깨진다(그 함수 자신의 docstring에 그라운딩 기록).
+    from app.services.member_resolver import resolve_member_db_verified
+    resolved_requester = await resolve_member_db_verified(auth, org_id, db)
     try:
         gate, version_id = await submit_site_post_draft(
             db, org_id=org_id, draft_id=draft_id, version_id=body.version_id,
-            requester_member_id=uuid.UUID(auth.user_id),
+            requester_member_id=resolved_requester.id,
             estimated_cost_minor=body.estimated_cost_minor,
         )
     except GenerationBudgetExceededError as exc:

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -43,7 +43,7 @@ from app.schemas.visual_artifact import (
     VisualArtifactDetail,
     VisualArtifactSummary,
 )
-from app.services.member_resolver import filter_org_member_ids
+from app.services.member_resolver import filter_org_member_ids, resolve_member_db_verified
 from app.services.notification_dispatch import dispatch_notification
 from app.services.project_auth import assert_target_in_caller_org
 
@@ -154,7 +154,12 @@ async def create_artifact(
 
     await _assert_link_target_in_scope(session, org_id, project_id, body)
 
-    created_by = uuid.UUID(auth.user_id)
+    # story #3370(카디르 QA 지적, 페드루 재검토 2026-09-10 — #4156 리뷰) —
+    # VisualArtifact.created_by는 이 뒤 _notify_artifact_updated의 target_member_ids
+    # 계산(artifact.created_by - editor_id)에 그대로 쓰인다 — 영속 멤버 id 소비처라
+    # resolve_member_db_verified()로 정정(agent 판정은 DB 실측이라 이 파일의 기존
+    # 테스트 하네스와 정합, member_resolver.py 자신의 docstring 그라운딩 참고).
+    created_by = (await resolve_member_db_verified(auth, org_id, session)).id
     # 뷰어 통합 재설계(story 1948d19d): canvas_bounds SSOT=버전(아래 version.canvas_bounds).
     # artifact.canvas_bounds는 latest_version_number와 동형 denorm 캐시 — 항상 최신 버전과 동기화.
     canvas_bounds_dict = body.canvas_bounds.model_dump() if body.canvas_bounds else None
@@ -612,7 +617,11 @@ async def delete_artifact(
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
     if artifact is None:
         return _err("NOT_FOUND", "Artifact not found", 404)
-    if artifact.created_by != uuid.UUID(auth.user_id):
+    # story #3370(카디르 QA 지적 2026-09-10) — artifact.created_by는 이제(위 create_
+    # artifact 정정) 영속 멤버 id다. 이 소유권 비교도 같은 축으로 맞추지 않으면
+    # 원작성자 본인이 raw auth.user_id(≠자신의 멤버 id)와 안 맞아 자기 것도 못 지우는
+    # 회귀가 난다.
+    if artifact.created_by != (await resolve_member_db_verified(auth, org_id, session)).id:
         return _err("FORBIDDEN", "생성자만 삭제할 수 있습니다", 403)
     from datetime import datetime, timezone
     artifact.deleted_at = datetime.now(timezone.utc)
@@ -698,7 +707,9 @@ async def add_artifact_comment(
         if parent_owner != artifact.id:
             return _err("NOT_FOUND", "Parent comment not found on this artifact", 404)
 
-    created_by = uuid.UUID(auth.user_id)
+    # story #3370(카디르 QA 지적 2026-09-10) — created_by가 line 724의 target_member_ids
+    # 계산(dispatch_notification 수신자)에 직접 쓰인다 — 영속 멤버 id 소비처.
+    created_by = (await resolve_member_db_verified(auth, org_id, session)).id
     comment = ArtifactComment(
         id=uuid.uuid4(), artifact_id=artifact.id, org_id=org_id, project_id=project_id,
         node_id=body.node_id, anchor_x=body.anchor_x, anchor_y=body.anchor_y,
@@ -754,8 +765,10 @@ async def resolve_artifact_comment(
     if comment is None:
         return _err("NOT_FOUND", "Comment not found", 404)
     from datetime import datetime, timezone
+    # story #3370(카디르 QA 지적 2026-09-10) — resolved_by는 created_by와 동형 영속
+    # 「누가 했나」 필드(ArtifactComment.created_by와 같은 컬럼군) — 같은 축으로 정정.
     comment.resolved = True
-    comment.resolved_by = uuid.UUID(auth.user_id)
+    comment.resolved_by = (await resolve_member_db_verified(auth, org_id, session)).id
     comment.resolved_at = datetime.now(timezone.utc)
     await session.flush()
     await session.refresh(comment)
@@ -1048,7 +1061,10 @@ async def complete_png_export(
         from ee.plan_limits import check_storage_capacity  # type: ignore[import]
         await check_storage_capacity(session, org_id, [{"url": body.object_path}])
 
-    created_by = uuid.UUID(auth.user_id)
+    # story #3370(카디르 QA 지적 2026-09-10) — created_by가 이 함수 뒤쪽
+    # target_member_ids 계산(dispatch_notification 수신자)에 그대로 쓰인다 —
+    # 영속 멤버 id 소비처.
+    created_by = (await resolve_member_db_verified(auth, org_id, session)).id
     asset_id = await _upsert_export_asset(
         session, org_id=org_id, project_id=project_id, object_path=body.object_path,
         name=f"{artifact.title}-v{version_number}.png", content_type="image/png",
@@ -1122,7 +1138,10 @@ async def create_html_export(
         from ee.plan_limits import check_storage_capacity  # type: ignore[import]
         await check_storage_capacity(session, org_id, [{"url": object_path}])
 
-    created_by = uuid.UUID(auth.user_id)
+    # story #3370(카디르 QA 지적 2026-09-10) — created_by가 이 함수 뒤쪽
+    # target_member_ids 계산(dispatch_notification 수신자)에 그대로 쓰인다 —
+    # 영속 멤버 id 소비처.
+    created_by = (await resolve_member_db_verified(auth, org_id, session)).id
     asset_id = await _upsert_export_asset(
         session, org_id=org_id, project_id=project_id, object_path=object_path,
         name=f"{artifact.title}-v{version_number}.html", content_type="text/html; charset=utf-8",
@@ -1371,7 +1390,10 @@ async def edit_artifact(
         if comment_owner != artifact.id:
             return _err("FORBIDDEN", "source_comment_id가 이 artifact 소속이 아닙니다", 403)
 
-    actor_id = uuid.UUID(auth.user_id)
+    # story #3370(카디르 QA 지적 2026-09-10) — actor_id가 _apply_artifact_edit 내부
+    # ArtifactVersion.created_by(영속)와 _notify_artifact_updated의 editor_id(target_
+    # member_ids 제외 축) 둘 다에 쓰인다 — 영속 멤버 id 소비처.
+    actor_id = (await resolve_member_db_verified(auth, org_id, session)).id
 
     # 뷰어 통합 재설계(story 1948d19d): canvas_bounds는 버전 단위 SSOT — 무-mutate 버전 원칙대로
     # operations 없이 canvas_bounds만 와도(model_validator가 둘 다 없는 요청은 거름) 새 버전을
@@ -1422,7 +1444,9 @@ async def propose_canonical_version(
     if version is None:
         return _err("NOT_FOUND", "Artifact version not found", 404)
 
-    proposer_id = uuid.UUID(auth.user_id)
+    # story #3370(카디르 QA 지적 2026-09-10) — proposer_id가 create_gate의 requester
+    # member_id + neutral_facts.requested_by_member_id(영속) 둘 다에 쓰인다.
+    proposer_id = (await resolve_member_db_verified(auth, org_id, session)).id
     gate = await create_gate(
         session, org_id, artifact.id, "visual_artifact", "artifact_canonicalize",
         proposer_id, uuid.uuid4(),  # role_id: always-manual이라 disposition 미사용(placeholder)

--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -18,6 +18,7 @@ from app.dependencies.database import get_db
 from app.models.gate import Gate
 from app.models.workflow_line import ENTITY_TYPES, WorkflowLineDefinitionVersion
 from app.services.gate_service import transition_gate
+from app.services.member_resolver import resolve_member_db_verified
 from app.services.project_auth import get_project_role, is_org_owner_or_admin
 from app.services.workflow_line_config import (
     PublishLintError,
@@ -134,9 +135,18 @@ async def create_draft_version(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> VersionResponse:
+    # story #3370(카디르 QA 지적, 유나 실측·페드루 재검토 2026-09-10 — #4156 리뷰) —
+    # access 체크(project_auth.py::get_project_role/is_org_owner_or_admin)는 raw
+    # auth.user_id(휴먼이면 users.id)를 받게 설계돼 있다(그 함수들 자신의 docstring —
+    # "휴먼: project_access는 org_member_id→users.id로" — dual-accept 아니라 애초에
+    # users.id 축). 하지만 `create_draft()`가 영속하는 컬럼명 자체가
+    # `created_by_member_id` — 이름 그대로 멤버 id를 기대한다. 두 축을 분리한다
+    # (site_posts.py::post_site_post_draft_version과 동형 — access축=raw·저장축=
+    # resolve_member_db_verified()).
     actor = uuid.UUID(auth.user_id)
     await _require_draft_author(session, actor, org_id, body.project_id)
-    version = await create_draft(session, org_id, body.project_id, body.entity_type, body.config, actor)
+    resolved = await resolve_member_db_verified(auth, org_id, session)
+    version = await create_draft(session, org_id, body.project_id, body.entity_type, body.config, resolved.id)
     await session.commit()
     # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
     await session.refresh(version)
@@ -221,11 +231,17 @@ async def request_publish_version(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> PublishResponse:
+    # story #3370(카디르 QA 지적 2026-09-10) — access축(raw)·저장축(resolve_member_
+    # db_verified()) 분리. `request_publish()`가 `member_id`를 `requested_by_member_id`
+    # neutral_facts에 그대로 싣는다(workflow_line_config.py::request_publish 자신의
+    # create_gate 호출부) — self-approval 판정(assert_not_self_approval)이 그 값과
+    # 비교하므로 축이 틀리면 자기승인 탐지 자체가 무력화된다.
     actor = uuid.UUID(auth.user_id)
     await _require_publisher(session, actor, org_id)
+    resolved = await resolve_member_db_verified(auth, org_id, session)
     version = await _load_version(session, org_id, version_id)
     try:
-        version, gate = await request_publish(session, org_id, version, actor)
+        version, gate = await request_publish(session, org_id, version, resolved.id)
     except PublishLintError as e:
         await session.commit()  # lint_status/errors persist
         raise HTTPException(status_code=422, detail={"error": "publish_lint_failed", "lint_errors": e.errors})
@@ -246,8 +262,15 @@ async def approve_publish(
     auth: AuthContext = Depends(get_current_user),
 ) -> VersionResponse:
     """publish gate 승인 → version published 확정. org owner/admin + self-approval 금지."""
+    # story #3370(카디르 QA 지적 2026-09-10) — access축(raw)·저장축(resolve_member_
+    # db_verified()) 분리. `assert_not_self_approval`이 gate.neutral_facts["requested_
+    # by_member_id"](영속 멤버 id)와 문자열 비교한다(workflow_line_config.py 자신의
+    # docstring) — resolver_id를 raw auth.user_id 그대로 넘기면 휴먼끼리는 절대 같은
+    # 값이 될 수 없어(users.id vs org_member.id) 자기승인 탐지가 사실상 항상 통과(무력화)
+    # 였다. transition_gate(resolver_id=)·complete_publish(resolver_id=)도 같은 축.
     actor = uuid.UUID(auth.user_id)
     await _require_publisher(session, actor, org_id)
+    resolved = await resolve_member_db_verified(auth, org_id, session)
     version = await _load_version(session, org_id, version_id)
     if version.review_gate_id is None:
         raise HTTPException(status_code=409, detail="version has no publish gate (request-publish first)")
@@ -259,13 +282,13 @@ async def approve_publish(
     if gate is None:
         raise HTTPException(status_code=409, detail="publish gate not found")
     try:
-        assert_not_self_approval(gate, actor, version.id)
+        assert_not_self_approval(gate, resolved.id, version.id)
     except SelfApprovalError:
         raise HTTPException(status_code=403, detail="self-approval forbidden: requester cannot approve own publish")
     try:
         # transition_gate 레일 재사용 → 직후 complete_publish 콜백(내부 특수분기 금지).
-        gate = await transition_gate(session, org_id, version.review_gate_id, "approved", resolver_id=actor)
-        version = await complete_publish(session, version, gate, resolver_id=actor)
+        gate = await transition_gate(session, org_id, version.review_gate_id, "approved", resolver_id=resolved.id)
+        version = await complete_publish(session, version, gate, resolver_id=resolved.id)
     except SelfApprovalError:
         raise HTTPException(status_code=403, detail="self-approval forbidden: requester cannot approve own publish")
     except ValueError as e:
@@ -300,14 +323,17 @@ async def reject_publish(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> VersionResponse:
+    # story #3370(카디르 QA 지적 2026-09-10) — access축(raw)·저장축(resolve_member_
+    # db_verified()) 분리(승인 엔드포인트와 동형).
     actor = uuid.UUID(auth.user_id)
     await _require_publisher(session, actor, org_id)
+    resolved = await resolve_member_db_verified(auth, org_id, session)
     version = await _load_version(session, org_id, version_id)
     if version.review_gate_id is not None:
         try:
             await transition_gate(
                 session, org_id, version.review_gate_id, "rejected",
-                resolver_id=actor, note=body.reason,
+                resolver_id=resolved.id, note=body.reason,
             )
         except ValueError:
             pass  # gate already resolved — version 전이만 반영(body.reason은 위에서 이미 비어있지 않음이 보장됨)

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -161,7 +161,22 @@ async def resolve_member_db_verified(
     발명 0 — 기존 두 축의 조합일 뿐).
 
     project_id 스코프는 지원하지 않는다(이 축을 쓰는 현재 호출부가 전부 project 스코프
-    불요 — 필요해지면 그때 얹는다, resolve_member()를 쓰면 된다)."""
+    불요 — 필요해지면 그때 얹는다, resolve_member()를 쓰면 된다).
+
+    ⚠️fail-closed 안전성(페드루 2차 리뷰 지적 2026-09-10, `_resolve_member_legacy`류
+    폴백 없음이 안전한 이유) — 상위 `get_verified_org_id`→`_verify_org_membership`
+    (auth.py:593)은 더 넓게 받는다: `OrgMember(user_id==raw) ∪ TeamMember(id==raw,
+    active, **타입 무관**)`. 이 함수는 `OrgMember(user_id==raw) ∪ TeamMember(id==raw,
+    type=='agent')`만 받으므로 차집합은 「`type != 'agent'`인 TeamMember 행이 raw_id
+    (JWT 휴먼이면 users.id)로 매치하는」 호출자 — 그 집합이 **구조적으로 공집합**이다:
+    `team_members`는 0088부터 물리테이블이 아니라 VIEW(alembic/versions/0088_team_
+    members_projection_view.py)이고, `type='human'` 분기의 `id`는 `members.id`다.
+    0075(alembic/versions/0075_member_ssot_anchor_tables.py:11,110) 확定 — "휴먼
+    members.id = org_members.id(Phase0 ID 보존)" — `users.id`가 아니다. 즉 휴먼
+    TeamMember 행의 `id`는 애초에 `org_members.id`라 JWT의 `auth.user_id`(users.id)와
+    같은 값일 수가 없다(서로 다른 테이블의 독립 PK, uuid 충돌이 아니면 불가능) — 상위
+    가드가 그 `TeamMember(타입 무관)` 분기로 통과시키는 호출자는 전부 agent뿐이고, 그건
+    이 함수의 agent 분기가 이미 받는다. 막히는 집합=∅."""
     raw_id = uuid.UUID(auth.user_id)
 
     tm = (await session.execute(

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -137,6 +137,60 @@ async def resolve_member(
     return await _resolve_member_legacy(auth, org_id, session, project_id)
 
 
+async def resolve_member_db_verified(
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+) -> ResolvedMember:
+    """story #3370(페드루 지적 2026-09-10) — `resolve_member()`와 같은 목적(휴먼(JWT)=
+    auth.user_id(users.id)를 org_member.id로, 에이전트(API키)는 team_member.id 그대로)
+    이지만, agent 판정을 auth 클레임(``app_metadata.api_key_id``)이 아니라 **DB 실측**
+    (TeamMember.type=='agent'·is_active, site_posts.py::is_agent_caller와 동일 predicate)
+    으로 한다.
+
+    왜 별도 함수인가 — `resolve_member()`로 직접 바꿔 보니 site_posts.py/channel_posts.py
+    submit 계열 엔드포인트를 왕복하는 기존 destructive_schema 테스트 수십 개가 전부
+    400 "Organization member not found"로 깨졌다(실측: test_3367_site_post_submit_gate_
+    seal.py 등). 원인 — 그 테스트들의 `_setup_org_scoped_app(..., user_id=agent_id)`
+    호출부가 `agent=True`(api_key_id 클레임) 없이 agent의 team_member.id만 auth.user_id로
+    넘기는 관례로 광범위하게 짜여 있다(is_agent_caller가 원래 DB로 판정해 클레임 유무가
+    무관했던 계약에 맞춰진 테스트 하네스). 그 계약 자체가 `is_agent_caller`의 설계 의도
+    (클레임을 안 믿고 DB의 실제 멤버 타입으로 판정 — actor_type fail-closed, 이 함수
+    자신의 docstring 그대로)와 더 맞기도 해, 테스트 수십 곳을 고치는 대신 이 축을
+    보존하는 별도 해소 함수로 정정한다(site_posts.py 자신의 축과 정합·새 판정 원칙
+    발명 0 — 기존 두 축의 조합일 뿐).
+
+    project_id 스코프는 지원하지 않는다(이 축을 쓰는 현재 호출부가 전부 project 스코프
+    불요 — 필요해지면 그때 얹는다, resolve_member()를 쓰면 된다)."""
+    raw_id = uuid.UUID(auth.user_id)
+
+    tm = (await session.execute(
+        select(TeamMember).where(
+            TeamMember.org_id == org_id, TeamMember.id == raw_id, TeamMember.type == "agent",
+            TeamMember.is_active.is_(True),
+        ).limit(1)
+    )).scalars().first()
+    if tm is not None:
+        return ResolvedMember(
+            id=tm.id, user_id=None, name=tm.name, type="agent", role=tm.role,
+            org_id=tm.org_id, project_id=tm.project_id, avatar_url=tm.avatar_url,
+        )
+
+    om = (await session.execute(
+        select(OrgMember).where(
+            OrgMember.org_id == org_id, OrgMember.user_id == raw_id, OrgMember.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if om is None:
+        raise HTTPException(status_code=400, detail="Organization member not found")
+
+    user = (await session.execute(select(User).where(User.id == raw_id))).scalar_one_or_none()
+    return ResolvedMember(
+        id=om.id, user_id=raw_id, name=user.display_name if user else None, type="human",
+        role=om.role, org_id=org_id,
+    )
+
+
 async def _resolve_member_legacy(
     auth: AuthContext,
     org_id: uuid.UUID,

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -977,10 +977,17 @@ async def _resolve_public_url(
     db: AsyncSession, *, org_id: uuid.UUID, lang: str, slug: str, backend_base_url: str,
 ) -> str:
     """사람용 URL 조립 — 조직 설정 `site` 커넥터의 org_config.site_base_url이 있으면
-    그것 + `/{lang}/blog/{slug}`(PO 보정, doc 62fc03ee §4). 없으면(오늘은 어느 org도
-    `site` 커넥터를 등록하지 않았다 — 실측 확認) 공개 API URL로 fallback한다(AC4: "설정이
-    없으면 공개 API URL을 반환"). 새 env 상수를 만들지 않는다 — 공개 API가 이 백엔드
-    자신이 서빙하는 라우트라 호출 시점의 `request.base_url`(backend_base_url)로 충분하다."""
+    그것 + `/{lang}/blog/{slug}`(PO 보정, doc 62fc03ee §4). 없으면 공개 API URL로
+    fallback한다(AC4: "설정이 없으면 공개 API URL을 반환") — 공개 API가 이 백엔드 자신이
+    서빙하는 라우트라 호출 시점의 `request.base_url`(backend_base_url)로 조립한다.
+
+    ⚠️주석 정정(페드루 PO 지적, 2026-09-10) — "오늘은 어느 org도 site 커넥터를 등록하지
+    않았다"·"새 env 상수를 만들지 않는다"는 작성 당시 실측이었으나 낡았다. 전역
+    `settings.public_site_base_url`(deploy SSOT) 상수가 그 뒤 실제로 생겼고(§4의
+    `_resolve_public_site_display_url`이 씀) — 이 함수(발행 액션이 조립하는 URL)는
+    그 상수를 안 쓴다. 그 폴백(backend_base_url 조립)이 원인이었던 결함 때문에 S8 상세
+    화면 표시는 별도 함수로 분리됐다(`_resolve_public_site_display_url` 그 자체 docstring
+    참고) — 이 함수는 발행 시점 URL 조립 용도로 의도적으로 남아 있다."""
     from app.services.connector_registry import get_org_connector
 
     connector = await get_org_connector(db, org_id=org_id, connector_key="site")

--- a/backend/tests/test_04e059e5_artifact_created_event_realdb.py
+++ b/backend/tests/test_04e059e5_artifact_created_event_realdb.py
@@ -169,7 +169,10 @@ async def test_create_artifact_human_creator_gets_notification_self_notified():
                 id=uuid.uuid4(), project_id=seeded["project_id"], org_member_id=om.id, permission="granted",
             ))
             await s.commit()
-            creator_id = om.id
+            # resolve_member_db_verified()의 휴먼 분기는 OrgMember.user_id==raw_id로 매치한다
+            # (org_member.id 자체가 아니라 users.id 축) — auth.user_id에는 om.id가 아니라
+            # user.id를 태워야 한다(story #3370 축과 정합, member_resolver.py:194-200).
+            creator_id = user.id
 
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], creator_id)
         client = _client_for(app)
@@ -328,7 +331,25 @@ async def test_edit_and_comment_events_still_fire_no_regression():
             await client.aclose()
         app.dependency_overrides.clear()
 
-        human_editor_id = uuid.uuid4()
+        # resolve_member_db_verified()는 fail-closed(DB 실측) — unseeded 랜덤 uuid는
+        # OrgMember도 TeamMember(agent)도 못 찾아 400. 실 User+OrgMember를 심어야 한다
+        # (story #3370, member_resolver.py:194-200).
+        async with Session() as s:
+            from app.models.project import OrgMember
+            from app.models.user import User
+            editor_user = User(id=uuid.uuid4(), email=f"editor-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(editor_user)
+            await s.commit()
+            editor_om = OrgMember(id=uuid.uuid4(), org_id=seeded["org_id"], user_id=editor_user.id, role="member")
+            s.add(editor_om)
+            await s.commit()
+            from app.models.project_access import ProjectAccess
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=seeded["project_id"], org_member_id=editor_om.id, permission="granted",
+            ))
+            await s.commit()
+            human_editor_id = editor_user.id
+
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], human_editor_id)
         client = _client_for(app)
         try:

--- a/backend/tests/test_3367_site_post_submit_gate_seal.py
+++ b/backend/tests/test_3367_site_post_submit_gate_seal.py
@@ -238,7 +238,16 @@ async def test_submit_seals_pending_gate_with_target_version():
         assert gate.sealed_content_body == "# 제목\n\n본문입니다."
         assert gate.neutral_facts["destination"] == "hosted_site"
         assert gate.neutral_facts["draft_author_member_id"] == str(agent_id)
-        assert gate.neutral_facts["requested_by_member_id"] == str(human_id)
+        # story #3370(유나 실측·페드루 정정 2026-09-10) — human_id는 users.id(raw)다.
+        # 상신자는 org_member.id로 봉인돼야 한다(auth.py:146 계약) — users.id 그대로
+        # 봉인되던 게 3370의 실 결함이었다. 이 assert는 그 정정을 정확히 pin한다.
+        from app.models.project import OrgMember
+        async with Session() as s:
+            human_org_member_id = (await s.execute(
+                select(OrgMember.id).where(OrgMember.org_id == org_id, OrgMember.user_id == human_id)
+            )).scalar_one()
+        assert gate.neutral_facts["requested_by_member_id"] == str(human_org_member_id)
+        assert gate.neutral_facts["requested_by_member_id"] != str(human_id)
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3370_requester_member_id_human_resolve.py
+++ b/backend/tests/test_3370_requester_member_id_human_resolve.py
@@ -1,0 +1,273 @@
+"""story #3370(유나 실측·페드루 정정 2026-09-10) — 「상신자 포함」(AC1)이 휴먼 상신에서
+깨지던 결함의 회귀 pin. `auth.user_id`는 휴먼(JWT)이면 `users.id`다(auth.py:146 계약) —
+org 멤버 id(org_member.id/team_member.id)가 아니다. 여러 라우터가 이 값을 **영속되는**
+member-id 컬럼(author_member_id·created_by_member_id·requested_by_member_id)에 원시로
+넣고 있었다 — site_posts.py:671(이미 별도 커밋으로 정정)과 같은 클래스가 channel_posts.py
+계열 6곳 + channel_post_comment_replies.py 1곳에 번져 있었다(전수 grep, PR 본문 참고).
+전부 `resolve_member(auth, org_id, db)`(API키=team_member.id·JWT=org_member.id, auth.py
+계약 그대로)로 정정 — 새 해소 기전 발명 0, 기존 site_posts.py 처방 재사용뿐.
+
+기존 테스트가 전부 에이전트 상신만 다뤄 GREEN이었던 게 이 갭이다(에이전트는 auth.user_id
+가 이미 team_member.id라 원시로 넘겨도 우연히 맞았다) — 이 파일은 **휴먼** 호출자로 같은
+경로를 왕복해 정확히 그 자리만 잰다.
+
+세팅 헬퍼는 test_3374_channel_posts.py(channel_posts 계열)·test_3516_comment_reply.py
+(comment reply 계열) 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_3374_channel_posts import (
+    _client_for,
+    _draft_body,
+    _seed_connection,
+    _seed_default_role,
+    _seed_org,
+    _seed_story,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_human_org_member(session, org_id, *, role="owner"):
+    """test_3374_channel_posts.py::_seed_human과 동형(role 기본만 owner — 이 파일의
+    관심사는 authz가 아니라 member-id 축 정합이라 project 접근권 갭에 안 걸리게)."""
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id, om.id
+
+
+@pytest.mark.anyio
+async def test_submit_channel_post_draft_human_requester_resolves_to_org_member_id():
+    """뮤테이션 대상 — submit_channel_post_draft_endpoint의 resolve_member() 호출을
+    `uuid.UUID(auth.user_id)` 원시값으로 되돌리면 이 테스트가 RED여야 한다(gate.
+    neutral_facts.requested_by_member_id가 org_member.id가 아니라 users.id로 떨어짐)."""
+    from app.main import app
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            user_id, org_member_id = await _seed_human_org_member(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            draft_id = r_draft.json()["draft_id"]
+
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r_submit.status_code == 200, r_submit.text
+        gate_id = r_submit.json()["gate_id"]
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == uuid.UUID(gate_id)))).scalar_one()
+        # 상신자는 org_member.id로 봉인돼야 한다 — users.id(user_id)와는 반드시 달라야
+        # (OrgMember.id는 User.id와 별도 uuid로 발급된다) 이 회귀가 정확히 잡힌다.
+        assert gate.neutral_facts["requested_by_member_id"] == str(org_member_id)
+        assert gate.neutral_facts["requested_by_member_id"] != str(user_id)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_post_channel_post_draft_version_human_author_resolves_to_org_member_id():
+    """뮤테이션 대상 — post_channel_post_draft_version의 resolve_member() 호출을 되돌리면
+    RED(ChannelPostVersion.author_member_id가 users.id로 떨어짐)."""
+    from app.main import app
+    from app.models.channel_post_version import ChannelPostVersion
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human_org_member(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+        assert r_draft.status_code == 201, r_draft.text
+        payload = r_draft.json()
+        assert payload["author_kind"] == "human"
+        version_id = payload["version_id"]
+
+        async with Session() as s:
+            version = (
+                await s.execute(select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(version_id)))
+            ).scalar_one()
+        assert version.author_member_id == org_member_id
+        assert version.author_member_id != user_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_comment_reply_draft_human_author_resolves_to_org_member_id():
+    """뮤테이션 대상 — create_comment_reply_draft_endpoint의 resolve_member() 호출을
+    되돌리면 RED(CommentReply.created_by_member_id가 users.id로 떨어짐)."""
+    from app.main import app
+    from app.models.channel_post_comment import ChannelPostComment, ChannelPostCommentReply
+    from sqlalchemy import select
+    import hashlib
+    from datetime import datetime, timezone
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human_org_member(s, org_id)
+            text = "원 댓글"
+            comment = ChannelPostComment(
+                id=uuid.uuid4(), org_id=org_id, publication_id=uuid.uuid4(), channel="sandbox",
+                external_comment_id="c1", author_display_name="user1", text=text,
+                text_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                external_created_at=datetime.now(timezone.utc), captured_at=datetime.now(timezone.utc), raw={},
+            )
+            s.add(comment)
+            await s.commit()
+            comment_id = comment.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        async with _client_for(app) as client:
+            r_reply = await client.post(
+                f"/api/v2/organizations/{org_id}/comments/{comment_id}/replies", json={"text": "답변 초안"},
+            )
+        assert r_reply.status_code == 201, r_reply.text
+        reply_id = r_reply.json()["id"]
+
+        async with Session() as s:
+            reply = (
+                await s.execute(
+                    select(ChannelPostCommentReply).where(ChannelPostCommentReply.id == uuid.UUID(reply_id))
+                )
+            ).scalar_one()
+        assert reply.created_by_member_id == org_member_id
+        assert reply.created_by_member_id != user_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_activity_logs_ee_rbac_filters_grant_only_human_member_to_own_actor_id():
+    """유나 라이브 재현(2026-09-10) — activity_logs.py의 EE RBAC 필터가 `TeamMember.id
+    == auth.user_id`로 caller를 직접 조회했다. grant-only 휴먼(org_member 경유, 레거시
+    TeamMember 행 없음)은 이 조회가 항상 None이라 `ee_applied`가 False로 남아 role=
+    member 축의 「본인 행위만」 필터가 **통째로 스킵**됐다(org 전체 flat 로그 노출 —
+    fail-open 권한 무력화).
+
+    `_ee_rbac_filter`는 모듈 최상단에서 `settings.is_ee_enabled`(license_consent 환경
+    변수) 시에만 로드된다 — 로컬 pytest 프로세스가 그 값 없이 이미 import됐을 수 있어,
+    라이선스 게이트를 우회해 실 필터 함수(`ee.services.audit_rbac.filter_activity_by_
+    role`)를 직접 monkeypatch로 꽂는다(정정 대상 로직 자체는 그대로 — 게이트만 우회).
+
+    뮤테이션 대상 — activity_logs.py의 resolve_member() 호출을 되돌려 `TeamMember.id ==
+    auth.user_id` 직접조회로 복구하면 이 테스트가 RED여야 한다(member 역할 휴먼이 다른
+    사람의 activity까지 봄)."""
+    from app.main import app
+    from app.services.activity_log import ActivityLogService
+    from app.dependencies.auth import AuthContext, get_current_user
+    from ee.services.audit_rbac import filter_activity_by_role
+    import app.routers.activity_logs as activity_logs_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            # grant-only 휴먼(member 역할) — 레거시 TeamMember 행 없음(핵심 조건).
+            member_user_id, member_org_member_id = await _seed_human_org_member(s, org_id, role="member")
+            other_user_id, other_org_member_id = await _seed_human_org_member(s, org_id, role="member")
+
+            # 두 사람의 activity를 각자 이름으로 기록 — member 필터가 실제로 걸러내는지
+            # 관측하려면 caller 자신의 행위 vs 남의 행위가 둘 다 있어야 한다.
+            log_service = ActivityLogService(s)
+            await log_service.record(
+                org_id=org_id, action="story_created", actor_id=member_org_member_id, actor_type="human",
+            )
+            await log_service.record(
+                org_id=org_id, action="story_created", actor_id=other_org_member_id, actor_type="human",
+            )
+            await s.commit()
+
+        async def _db():
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        async def _auth():
+            return AuthContext(
+                user_id=str(member_user_id), email="caller@test",
+                claims={"app_metadata": {"org_id": str(org_id)}},
+            )
+
+        from tests.conftest import override_db_and_read
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+
+        from unittest.mock import patch
+        try:
+            with patch.object(activity_logs_mod, "_ee_rbac_filter", filter_activity_by_role):
+                from httpx import AsyncClient, ASGITransport
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                    resp = await client.get("/api/v2/activity-logs")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            actor_ids = {item["actor_id"] for item in body["items"]}
+            # member 역할은 본인 행위만 — 남(other_org_member_id)의 행이 안 보여야 한다.
+            assert actor_ids == {str(member_org_member_id)}
+            assert str(other_org_member_id) not in actor_ids
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3370_requester_member_id_human_resolve.py
+++ b/backend/tests/test_3370_requester_member_id_human_resolve.py
@@ -2,8 +2,10 @@
 깨지던 결함의 회귀 pin. `auth.user_id`는 휴먼(JWT)이면 `users.id`다(auth.py:146 계약) —
 org 멤버 id(org_member.id/team_member.id)가 아니다. 여러 라우터가 이 값을 **영속되는**
 member-id 컬럼(author_member_id·created_by_member_id·requested_by_member_id)에 원시로
-넣고 있었다 — site_posts.py:671(이미 별도 커밋으로 정정)과 같은 클래스가 channel_posts.py
-계열 6곳 + channel_post_comment_replies.py 1곳에 번져 있었다(전수 grep, PR 본문 참고).
+넣고 있었다 — site_posts.py:671과 같은 클래스가 site_posts.py 자신의 :356(페드루 2차
+리뷰 지적, is_agent_caller 원시-id 조합이 boolean 체크뿐인 :298/:838과 달리 :356은
+author_member_id를 실제로 영속한다)·channel_posts.py 계열 6곳·channel_post_comment_
+replies.py 1곳·activity_logs.py EE RBAC 필터에 번져 있었다(전수 grep, PR 본문 참고).
 전부 `resolve_member(auth, org_id, db)`(API키=team_member.id·JWT=org_member.id, auth.py
 계약 그대로)로 정정 — 새 해소 기전 발명 0, 기존 site_posts.py 처방 재사용뿐.
 
@@ -29,6 +31,9 @@ from tests.test_3374_channel_posts import (
     _seed_story,
     _session_factory,
     _setup_org_scoped_app,
+)
+from tests.test_3367_site_post_submit_gate_seal import (
+    _draft_body as _site_draft_body,
 )
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
@@ -140,6 +145,45 @@ async def test_post_channel_post_draft_version_human_author_resolves_to_org_memb
         async with Session() as s:
             version = (
                 await s.execute(select(ChannelPostVersion).where(ChannelPostVersion.id == uuid.UUID(version_id)))
+            ).scalar_one()
+        assert version.author_member_id == org_member_id
+        assert version.author_member_id != user_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_post_site_post_draft_version_human_author_resolves_to_org_member_id():
+    """뮤테이션 대상 — post_site_post_draft_version의 resolve_member_db_verified() 호출을
+    되돌리면 RED(SitePostVersion.author_member_id가 users.id로 떨어짐). 페드루 2차 리뷰
+    지적(2026-09-10) — channel_posts.py 형제는 고쳤으나 site_posts.py 자신의 :356이
+    빠져 있었다."""
+    from app.main import app
+    from app.models.site_post_version import SitePostVersion
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human_org_member(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_site_draft_body(work_item_id=story_id),
+            )
+        assert r_draft.status_code == 201, r_draft.text
+        payload = r_draft.json()
+        assert payload["author_kind"] == "human"
+        version_id = payload["version_id"]
+
+        async with Session() as s:
+            version = (
+                await s.execute(select(SitePostVersion).where(SitePostVersion.id == uuid.UUID(version_id)))
             ).scalar_one()
         assert version.author_member_id == org_member_id
         assert version.author_member_id != user_id

--- a/backend/tests/test_3370_workflow_line_and_visual_artifacts_member_id.py
+++ b/backend/tests/test_3370_workflow_line_and_visual_artifacts_member_id.py
@@ -1,0 +1,391 @@
+"""story #3370(카디르 QA 지적, 페드루 재검토 2026-09-10 — #4156 리뷰) — 전수 grep이
+「이름으로」(is_agent_caller 호출 여부) 걸렀던 탓에 놓친 같은 클래스 2파일:
+
+- `workflow_line_config.py`: `create_draft()`의 `created_by_member_id`(영속) ·
+  `request_publish()`가 짓는 `Gate.neutral_facts.requested_by_member_id`(영속) ·
+  `transition_gate(resolver_id=)`→`Gate.resolver_id`(영속, self-approval 판정의
+  비교 축이라 틀리면 **자기승인 탐지 자체가 무력화**되는 보안 결함까지 겹침).
+- `visual_artifacts.py`: `VisualArtifact.created_by`·`ArtifactComment.created_by`/
+  `resolved_by`·`ArtifactVersion.created_by`(전부 영속) · `create_gate`의
+  neutral_facts.requested_by_member_id. `VisualArtifact.created_by` 정정에 딸려
+  delete_artifact의 소유권 비교(`artifact.created_by != auth.user_id`)도 같은 축으로
+  안 맞추면 원작성자 본인이 자기 것도 못 지우는 회귀가 남(같은 커밋에서 동시 정정).
+
+둘 다 `resolve_member_db_verified()`(member_resolver.py, #3370에서 신설)로 정정 —
+access축(raw)·저장축(resolve) 분리는 기존 사이트들과 동형."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="3370 Follow-up Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_human(session, org_id, *, role="owner"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id, om.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, project_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims: dict = {"app_metadata": {"org_id": str(org_id)}}
+        if project_id is not None:
+            claims["app_metadata"]["project_id"] = str(project_id)
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+_PASSING_CONFIG = {"steps": [{"step_key": "s1", "step_type": "advisory"}]}
+
+
+# ─── workflow_line_config.py ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_draft_human_created_by_member_id_resolves_to_org_member_id():
+    """뮤테이션 대상 — create_draft_version_endpoint의 resolve_member_db_verified() 호출을
+    되돌리면 RED(WorkflowLineDefinitionVersion.created_by_member_id가 users.id로 떨어짐)."""
+    from app.main import app
+    from app.models.workflow_line import WorkflowLineDefinitionVersion
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": {}, "project_id": None},
+            )
+        assert r.status_code == 201, r.text
+        version_id = r.json()["id"]
+
+        async with Session() as s:
+            version = (
+                await s.execute(
+                    select(WorkflowLineDefinitionVersion).where(WorkflowLineDefinitionVersion.id == uuid.UUID(version_id))
+                )
+            ).scalar_one()
+        assert version.created_by_member_id == org_member_id
+        assert version.created_by_member_id != user_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_request_publish_human_requested_by_member_id_resolves_to_org_member_id():
+    """뮤테이션 대상 — request_publish_endpoint의 resolve_member_db_verified() 호출을
+    되돌리면 RED(Gate.neutral_facts.requested_by_member_id가 users.id로 떨어짐)."""
+    from app.main import app
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": _PASSING_CONFIG, "project_id": None},
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            version_id = r_draft.json()["id"]
+
+            r_pub = await client.post(f"/api/v2/workflow-line-config/versions/{version_id}/request-publish")
+        assert r_pub.status_code == 200, r_pub.text
+        gate_id = r_pub.json()["gate_id"]
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == uuid.UUID(gate_id)))).scalar_one()
+        assert gate.neutral_facts["requested_by_member_id"] == str(org_member_id)
+        assert gate.neutral_facts["requested_by_member_id"] != str(user_id)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_approve_publish_self_approval_detection_works_for_human_requester():
+    """story #3370(보안 결함) — 정정 前에는 self-approval 판정(assert_not_self_approval)이
+    gate.neutral_facts.requested_by_member_id(영속 멤버 id)와 raw auth.user_id(users.id)를
+    비교해 휴먼끼리는 절대 같을 수 없었다 — 같은 사람이 자기 request를 자기가 approve해도
+    항상 통과(무력화)했을 결함. 이 테스트는 그 탐지가 실제로 동작함을 확認한다.
+
+    뮤테이션 대상 — approve_publish_endpoint의 resolve_member_db_verified() 호출(assert_
+    not_self_approval에 넘기는 쪽)을 raw auth.user_id로 되돌리면 이 테스트가 RED여야
+    한다(자기승인이 403 대신 200으로 통과)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": _PASSING_CONFIG, "project_id": None},
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            version_id = r_draft.json()["id"]
+
+            r_pub = await client.post(f"/api/v2/workflow-line-config/versions/{version_id}/request-publish")
+            assert r_pub.status_code == 200, r_pub.text
+            # disposition 기본값이 auto라 이미 published면 이 테스트는 무의미 — pending
+            # 기대(승인 축을 직접 재는 게 목적이므로 auto 승인이면 스킵 사유를 명확히).
+            if r_pub.json()["gate_status"] != "pending":
+                pytest.skip(f"gate_status={r_pub.json()['gate_status']}(auto disposition) — self-approval 축 대상 아님")
+
+            r_approve = await client.post(f"/api/v2/workflow-line-config/versions/{version_id}/approve")
+        assert r_approve.status_code == 403, r_approve.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── visual_artifacts.py ─────────────────────────────────────────────────────
+
+
+async def _seed_artifact(session, org_id, project_id, *, created_by):
+    from app.models.visual_artifact import VisualArtifact
+
+    artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="A",
+        source="created", latest_version_number=1, created_by=created_by,
+    )
+    session.add(artifact)
+    await session.commit()
+    return artifact.id
+
+
+@pytest.mark.anyio
+async def test_create_artifact_human_created_by_resolves_to_org_member_id():
+    """뮤테이션 대상 — create_artifact의 resolve_member_db_verified() 호출을 되돌리면
+    RED(VisualArtifact.created_by가 users.id로 떨어짐)."""
+    from app.main import app
+    from app.models.visual_artifact import VisualArtifact
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id, project_id=project_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                "/api/v2/visual-artifacts", json={"title": "T", "source": "created", "nodes": [{"type": "text", "props": {}}]},
+            )
+        assert r.status_code == 201, r.text
+        artifact_id = r.json()["data"]["id"]
+
+        async with Session() as s:
+            artifact = (
+                await s.execute(select(VisualArtifact).where(VisualArtifact.id == uuid.UUID(artifact_id)))
+            ).scalar_one()
+        assert artifact.created_by == org_member_id
+        assert artifact.created_by != user_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_own_artifact_succeeds_human_ownership_axis_matches():
+    """story #3370 — create_artifact 정정(created_by=영속 멤버 id)에 딸린 회귀: delete_
+    artifact의 소유권 비교(artifact.created_by != auth.user_id)도 같은 축으로 안 맞추면
+    원작성자 본인이 자기 것도 못 지운다. 이 테스트는 그 회귀가 없음을 직접 확認한다.
+
+    뮤테이션 대상 — delete_artifact의 resolve_member_db_verified() 호출을 raw auth.
+    user_id로 되돌리면 이 테스트가 RED여야 한다(본인 삭제가 403)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id, project_id=project_id)
+        async with _client_for(app) as client:
+            r_create = await client.post(
+                "/api/v2/visual-artifacts", json={"title": "T", "source": "created", "nodes": [{"type": "text", "props": {}}]},
+            )
+            assert r_create.status_code == 201, r_create.text
+            artifact_id = r_create.json()["data"]["id"]
+
+            r_delete = await client.delete(f"/api/v2/visual-artifacts/{artifact_id}")
+        assert r_delete.status_code == 200, r_delete.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_add_comment_and_resolve_human_ids_resolve_to_org_member_id():
+    """뮤테이션 대상 — add_artifact_comment/resolve_artifact_comment의 resolve_member_
+    db_verified() 호출을 되돌리면 RED(ArtifactComment.created_by/resolved_by가 users.id
+    로 떨어짐)."""
+    from app.main import app
+    from app.models.visual_artifact import ArtifactComment
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human(s, org_id, role="owner")
+            artifact_id = await _seed_artifact(s, org_id, project_id, created_by=org_member_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id, project_id=project_id)
+        async with _client_for(app) as client:
+            r_comment = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/comments",
+                json={"content": "c1", "anchor_x": 0, "anchor_y": 0},
+            )
+            assert r_comment.status_code == 201, r_comment.text
+            comment_id = r_comment.json()["data"]["id"]
+
+            r_resolve = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/comments/{comment_id}/resolve",
+            )
+        assert r_resolve.status_code == 200, r_resolve.text
+
+        async with Session() as s:
+            comment = (
+                await s.execute(select(ArtifactComment).where(ArtifactComment.id == uuid.UUID(comment_id)))
+            ).scalar_one()
+        assert comment.created_by == org_member_id
+        assert comment.created_by != user_id
+        assert comment.resolved_by == org_member_id
+        assert comment.resolved_by != user_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_propose_canonical_version_human_requested_by_member_id_resolves_to_org_member_id():
+    """뮤테이션 대상 — propose_canonical_version의 resolve_member_db_verified() 호출을
+    되돌리면 RED(Gate.neutral_facts.requested_by_member_id가 users.id로 떨어짐)."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.visual_artifact import ArtifactVersion
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            user_id, org_member_id = await _seed_human(s, org_id, role="owner")
+            artifact_id = await _seed_artifact(s, org_id, project_id, created_by=org_member_id)
+            version = ArtifactVersion(
+                id=uuid.uuid4(), artifact_id=artifact_id, version_number=1,
+                created_by=org_member_id, canvas_bounds=None,
+            )
+            s.add(version)
+            await s.commit()
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=user_id, project_id=project_id)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/visual-artifacts/{artifact_id}/versions/1/canonicalize")
+        assert r.status_code == 201, r.text
+        gate_id = r.json()["data"]["gate_id"]
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == uuid.UUID(gate_id)))).scalar_one()
+        assert gate.neutral_facts["requested_by_member_id"] == str(org_member_id)
+        assert gate.neutral_facts["requested_by_member_id"] != str(user_id)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py
+++ b/backend/tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py
@@ -73,18 +73,23 @@ def _client_for(app):
 async def _setup_app_api_key(app, Session, org_id, project_id, *, scope: list[str]):
     """API-key AuthContext — api_key_id 마커가 있어야 _check_api_key_scope가 게이트를 적용.
 
-    story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실 TeamMember
-    행을 찾는다(예전엔 무작위 uuid로도 충분했다·범위 게이트 통과만 재는 이 파일의 관심사와
-    무관). 실 TeamMember(type=agent)를 심어 그 id를 그대로 쓴다."""
+    story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 team_members
+    VIEW에서 실측한다(예전엔 무작위 uuid로도 충분했다·범위 게이트 통과만 재는 이 파일의
+    관심사와 무관). team_members는 0088+부터 물리 테이블이 아니라 members⋈
+    agent_project_profiles를 투영하는 VIEW(CI 공유 alembic DB에서 직접 INSERT하면
+    "cannot insert into view" 크래시, #4156) — Member+AgentProjectProfile을 심어 그
+    id를 그대로 쓴다(TeamMember 직접 삽입 불필요·유해)."""
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
-    from app.models.team import TeamMember
+    from app.models.member import AgentProjectProfile, Member
 
     async with Session() as s:
-        tm = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name="agent", is_active=True)
-        s.add(tm)
+        m = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name="agent", is_active=True)
+        s.add(m)
         await s.commit()
-        agent_id = tm.id
+        s.add(AgentProjectProfile(id=uuid.uuid4(), member_id=m.id, project_id=project_id))
+        await s.commit()
+        agent_id = m.id
 
     async def _db():
         async with Session() as s:

--- a/backend/tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py
+++ b/backend/tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py
@@ -71,9 +71,20 @@ def _client_for(app):
 
 
 async def _setup_app_api_key(app, Session, org_id, project_id, *, scope: list[str]):
-    """API-key AuthContext — api_key_id 마커가 있어야 _check_api_key_scope가 게이트를 적용."""
+    """API-key AuthContext — api_key_id 마커가 있어야 _check_api_key_scope가 게이트를 적용.
+
+    story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실 TeamMember
+    행을 찾는다(예전엔 무작위 uuid로도 충분했다·범위 게이트 통과만 재는 이 파일의 관심사와
+    무관). 실 TeamMember(type=agent)를 심어 그 id를 그대로 쓴다."""
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
+    from app.models.team import TeamMember
+
+    async with Session() as s:
+        tm = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name="agent", is_active=True)
+        s.add(tm)
+        await s.commit()
+        agent_id = tm.id
 
     async def _db():
         async with Session() as s:
@@ -86,7 +97,7 @@ async def _setup_app_api_key(app, Session, org_id, project_id, *, scope: list[st
 
     async def _auth():
         return AuthContext(
-            user_id=str(uuid.uuid4()), email=None,
+            user_id=str(agent_id), email=None,
             claims={"app_metadata": {
                 "org_id": str(org_id), "project_id": str(project_id),
                 "api_key_id": str(uuid.uuid4()), "scope": scope,
@@ -98,8 +109,22 @@ async def _setup_app_api_key(app, Session, org_id, project_id, *, scope: list[st
 
 
 async def _setup_app_jwt(app, Session, org_id, project_id):
+    """story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실
+    OrgMember 행을 찾는다 — 실 휴먼을 심어 그 user_id를 그대로 쓴다(_setup_app류
+    다른 canvas 테스트 파일과 동형 처방)."""
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    async with Session() as s:
+        u = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+        s.add(u)
+        await s.commit()
+        om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=u.id, role="owner")
+        s.add(om)
+        await s.commit()
+        human_user_id = u.id
 
     async def _db():
         async with Session() as s:
@@ -112,7 +137,7 @@ async def _setup_app_jwt(app, Session, org_id, project_id):
 
     async def _auth():
         return AuthContext(
-            user_id=str(uuid.uuid4()), email="human@test",
+            user_id=str(human_user_id), email="human@test",
             claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
         )
 

--- a/backend/tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py
+++ b/backend/tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py
@@ -62,6 +62,8 @@ async def _seed(session):
     from app.models.organization import Organization
     from app.models.project import Project
     from app.models.pm import Story
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
 
     org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
     org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
@@ -78,9 +80,20 @@ async def _seed(session):
     session.add_all([story_a, story_b])
     await session.commit()
 
+    # resolve_member_db_verified()는 fail-closed(DB 실측) — 실 create_artifact 왕복(201)이
+    # 필요한 테스트는 실 org_a 멤버를 태워야 한다(story #3370, member_resolver.py:194-200).
+    member_a = Member(id=uuid.uuid4(), org_id=org_a.id, type="agent", name="importer-agent", is_active=True)
+    session.add(member_a)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, member_id=member_a.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
     return {
         "org_a_id": org_a.id, "project_a_id": project_a.id,
         "story_a_id": story_a.id, "story_b_id": story_b.id,
+        "member_a_id": member_a.id,
     }
 
 
@@ -252,7 +265,7 @@ async def test_import_image_success_creates_artifact_with_canonical_url():
     try:
         async with Session() as s:
             seeded = await _seed(s)
-        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"], user_id=seeded["member_a_id"])
         client = _client_for(app)
         try:
             image_bytes = _png_bytes()

--- a/backend/tests/test_e_canvas_1948d19d_canvas_bounds_realdb.py
+++ b/backend/tests/test_e_canvas_1948d19d_canvas_bounds_realdb.py
@@ -65,6 +65,23 @@ async def _setup_app(app, Session, org_id, project_id, user_id=None):
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
 
+    if user_id is None:
+        # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실
+        # DB 조회라, 예전처럼 "신원 무관, 무작위 uuid 하나면 충분"했던 관례가 더 이상
+        # 안 통한다(400 Organization member not found). 이 파일의 관심사는 caller
+        # 신원 자체가 아니라 다른 축이라 실 OrgMember 하나를 여기서 대신 심는다
+        # (개별 테스트 수정 없이 이 헬퍼 한 곳만 — 기존 명시 user_id 호출부는 그대로).
+        from app.models.project import OrgMember
+        from app.models.user import User
+        async with Session() as s:
+            u = User(id=uuid.uuid4(), email=f"phantom-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            s.add(u)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=u.id, role="owner")
+            s.add(om)
+            await s.commit()
+            user_id = u.id
+
     async def _db():
         async with Session() as s:
             try:

--- a/backend/tests/test_e_canvas_7fe16274_spec_pin_realdb.py
+++ b/backend/tests/test_e_canvas_7fe16274_spec_pin_realdb.py
@@ -67,6 +67,23 @@ async def _setup_app(app, Session, org_id, project_id, user_id=None):
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
 
+    if user_id is None:
+        # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실
+        # DB 조회라, 예전처럼 "신원 무관, 무작위 uuid 하나면 충분"했던 관례가 더 이상
+        # 안 통한다(400 Organization member not found). 이 파일의 관심사는 caller
+        # 신원 자체가 아니라 다른 축이라 실 OrgMember 하나를 여기서 대신 심는다
+        # (개별 테스트 수정 없이 이 헬퍼 한 곳만 — 기존 명시 user_id 호출부는 그대로).
+        from app.models.project import OrgMember
+        from app.models.user import User
+        async with Session() as s:
+            u = User(id=uuid.uuid4(), email=f"phantom-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            s.add(u)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=u.id, role="owner")
+            s.add(om)
+            await s.commit()
+            user_id = u.id
+
     async def _db():
         async with Session() as s:
             try:

--- a/backend/tests/test_e_canvas_c0_s1_comment_events_realdb.py
+++ b/backend/tests/test_e_canvas_c0_s1_comment_events_realdb.py
@@ -44,7 +44,7 @@ async def _session_factory():
 
 async def _seed(session):
     """org + project + 3 agents(author·assignee·mentioned) + story(assignee 배정)."""
-    from app.models.member import Member
+    from app.models.member import AgentProjectProfile, Member
     from app.models.organization import Organization
     from app.models.project import Project
     from app.models.project_access import ProjectAccess
@@ -67,6 +67,22 @@ async def _seed(session):
         for m in (author, assignee, mentioned)
     ]
     session.add_all(grants)
+    # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()가 team_members
+    # 테이블에서 agent를 찾는다(site_posts.py::is_agent_caller와 동형 predicate). 실서비스는
+    # 0088 VIEW가 members⋈agent_project_profiles를 그 이름으로 투영하지만, 이 스위트의
+    # `Base.metadata.create_all()`은 TeamMember 모델을 평 테이블로 만들어(VIEW SQL 미실행)
+    # anchor 시딩만으론 안 보인다 — 같은 id로 TeamMember 행도 나란히 심는다(agent_project_
+    # profiles도 함께 두는 건 실 VIEW 스키마와의 정합을 위해 — 어느 한쪽만 있어도 되는
+    # 환경이 아니라 실서비스 그림자를 그대로 남겨 둔다).
+    from app.models.team import TeamMember
+    session.add_all([
+        AgentProjectProfile(id=uuid.uuid4(), member_id=m.id, project_id=project.id)
+        for m in (author, assignee, mentioned)
+    ])
+    session.add_all([
+        TeamMember(id=m.id, org_id=org.id, project_id=project.id, type="agent", name=m.name, is_active=True)
+        for m in (author, assignee, mentioned)
+    ])
 
     story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="C0-S1 Story", status="in-progress")
     session.add(story)

--- a/backend/tests/test_e_canvas_c0_s1_comment_events_realdb.py
+++ b/backend/tests/test_e_canvas_c0_s1_comment_events_realdb.py
@@ -67,20 +67,17 @@ async def _seed(session):
         for m in (author, assignee, mentioned)
     ]
     session.add_all(grants)
-    # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()가 team_members
-    # 테이블에서 agent를 찾는다(site_posts.py::is_agent_caller와 동형 predicate). 실서비스는
-    # 0088 VIEW가 members⋈agent_project_profiles를 그 이름으로 투영하지만, 이 스위트의
-    # `Base.metadata.create_all()`은 TeamMember 모델을 평 테이블로 만들어(VIEW SQL 미실행)
-    # anchor 시딩만으론 안 보인다 — 같은 id로 TeamMember 행도 나란히 심는다(agent_project_
-    # profiles도 함께 두는 건 실 VIEW 스키마와의 정합을 위해 — 어느 한쪽만 있어도 되는
-    # 환경이 아니라 실서비스 그림자를 그대로 남겨 둔다).
-    from app.models.team import TeamMember
+    # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()가 team_members에서
+    # agent를 찾는다(site_posts.py::is_agent_caller와 동형 predicate). team_members는 0088+
+    # 부터 물리 테이블이 아니라 members⋈agent_project_profiles(+grant-only 3번째 분기,
+    # 0110)를 투영하는 VIEW다 — CI의 공유 alembic-migrated DB에서 이 VIEW는 진짜 쓰기 불가
+    # (INSERT 시 "cannot insert into view" 크래시, #4156). Member+AgentProjectProfile(+위
+    # ProjectAccess granted)만 심으면 VIEW의 agent 분기(0110 2번/3번 UNION 브랜치)가 그대로
+    # 투영하므로 TeamMember 직접 삽입은 불필요·유해(정적 가드 test_no_team_members_view_
+    # dml_in_tests.py 대상, list-comprehension 형태라 그 가드의 AST 스캔 사각을 뚫고 CI에서만
+    # 크래시했다).
     session.add_all([
         AgentProjectProfile(id=uuid.uuid4(), member_id=m.id, project_id=project.id)
-        for m in (author, assignee, mentioned)
-    ])
-    session.add_all([
-        TeamMember(id=m.id, org_id=org.id, project_id=project.id, type="agent", name=m.name, is_active=True)
         for m in (author, assignee, mentioned)
     ])
 

--- a/backend/tests/test_e_canvas_c1_s3_visual_artifact_realdb.py
+++ b/backend/tests/test_e_canvas_c1_s3_visual_artifact_realdb.py
@@ -76,6 +76,23 @@ async def _setup_app(app, Session, org_id, project_id, user_id=None):
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
 
+    if user_id is None:
+        # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실
+        # DB 조회라, 예전처럼 "신원 무관, 무작위 uuid 하나면 충분"했던 관례가 더 이상
+        # 안 통한다(400 Organization member not found). 이 파일의 관심사는 caller
+        # 신원 자체가 아니라 다른 축이라 실 OrgMember 하나를 여기서 대신 심는다
+        # (개별 테스트 수정 없이 이 헬퍼 한 곳만 — 기존 명시 user_id 호출부는 그대로).
+        from app.models.project import OrgMember
+        from app.models.user import User
+        async with Session() as s:
+            u = User(id=uuid.uuid4(), email=f"phantom-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            s.add(u)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=u.id, role="owner")
+            s.add(om)
+            await s.commit()
+            user_id = u.id
+
     async def _db():
         async with Session() as s:
             try:
@@ -246,8 +263,22 @@ async def test_delete_artifact_creator_only():
         async with Session() as s:
             seeded = await _seed(s)
 
-        creator_id = uuid.uuid4()
-        other_id = uuid.uuid4()
+        # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()가 실
+        # OrgMember 행을 찾는다 — creator/other 둘 다 실 휴먼으로 심는다(신원 자체를
+        # 재는 이 테스트의 관심사엔 role/이름이 무관해 owner로 통일).
+        from app.models.project import OrgMember
+        from app.models.user import User
+        async with Session() as s:
+            creator_user = User(id=uuid.uuid4(), email=f"creator-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            other_user = User(id=uuid.uuid4(), email=f"other-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            s.add_all([creator_user, other_user])
+            await s.commit()
+            s.add_all([
+                OrgMember(id=uuid.uuid4(), org_id=seeded["org_a_id"], user_id=creator_user.id, role="owner"),
+                OrgMember(id=uuid.uuid4(), org_id=seeded["org_a_id"], user_id=other_user.id, role="owner"),
+            ])
+            await s.commit()
+            creator_id, other_id = creator_user.id, other_user.id
 
         await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"], user_id=creator_id)
         client = _client_for(app)

--- a/backend/tests/test_e_canvas_c1_s5_artifact_export_realdb.py
+++ b/backend/tests/test_e_canvas_c1_s5_artifact_export_realdb.py
@@ -100,6 +100,23 @@ async def _setup_app(app, Session, org_id, project_id, user_id=None):
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
 
+    if user_id is None:
+        # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실
+        # DB 조회라, 예전처럼 "신원 무관, 무작위 uuid 하나면 충분"했던 관례가 더 이상
+        # 안 통한다(400 Organization member not found). 이 파일의 관심사는 caller
+        # 신원 자체가 아니라 다른 축이라 실 OrgMember 하나를 여기서 대신 심는다
+        # (개별 테스트 수정 없이 이 헬퍼 한 곳만 — 기존 명시 user_id 호출부는 그대로).
+        from app.models.project import OrgMember
+        from app.models.user import User
+        async with Session() as s:
+            u = User(id=uuid.uuid4(), email=f"phantom-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            s.add(u)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=u.id, role="owner")
+            s.add(om)
+            await s.commit()
+            user_id = u.id
+
     async def _db():
         async with Session() as s:
             try:

--- a/backend/tests/test_e_canvas_c2_s6_artifact_comments_realdb.py
+++ b/backend/tests/test_e_canvas_c2_s6_artifact_comments_realdb.py
@@ -93,6 +93,24 @@ async def _seed(session):
     }
 
 
+async def _seed_extra_human(session, org_id):
+    """story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()가 실
+    OrgMember 행을 찾는다. 이 파일의 resolver_id/commenter_id처럼 신원 자체가 관심사가
+    아닌 «그냥 호출자 하나 더» 자리에 쓴다. (user_id, org_member_id) 둘 다 반환 —
+    호출부가 auth 자리엔 user_id를, created_by/resolved_by 등 영속 필드 검증엔
+    org_member_id를 쓴다(둘은 이제 다른 값)."""
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="owner")
+    session.add(om)
+    await session.commit()
+    return user.id, om.id
+
+
 def _client_for(app):
     from httpx import AsyncClient, ASGITransport
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
@@ -101,6 +119,23 @@ def _client_for(app):
 async def _setup_app(app, Session, org_id, project_id, user_id=None):
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
+
+    if user_id is None:
+        # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실
+        # DB 조회라, 예전처럼 "신원 무관, 무작위 uuid 하나면 충분"했던 관례가 더 이상
+        # 안 통한다(400 Organization member not found). 이 파일의 관심사는 caller
+        # 신원 자체가 아니라 다른 축이라 실 OrgMember 하나를 여기서 대신 심는다
+        # (개별 테스트 수정 없이 이 헬퍼 한 곳만 — 기존 명시 user_id 호출부는 그대로).
+        from app.models.project import OrgMember
+        from app.models.user import User
+        async with Session() as s:
+            u = User(id=uuid.uuid4(), email=f"phantom-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            s.add(u)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=u.id, role="owner")
+            s.add(om)
+            await s.commit()
+            user_id = u.id
 
     async def _db():
         async with Session() as s:
@@ -300,8 +335,9 @@ async def test_resolve_comment():
         async with Session() as s:
             seeded = await _seed(s)
 
-        resolver_id = uuid.uuid4()
-        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=resolver_id)
+        async with Session() as s:
+            resolver_user_id, resolver_member_id = await _seed_extra_human(s, seeded["org_id"])
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=resolver_user_id)
         client = _client_for(app)
         try:
             create_resp = await client.post(
@@ -316,7 +352,11 @@ async def test_resolve_comment():
             assert resolve_resp.status_code == 200, resolve_resp.text
             body = resolve_resp.json()["data"]
             assert body["resolved"] is True
-            assert body["resolved_by"] == str(resolver_id)
+            # story #3370(유나 실측·페드루 정정 2026-09-10) — resolved_by는 이제 영속
+            # 멤버 id(org_member.id)다 — auth 자리에 쓴 raw user_id(resolver_user_id)와는
+            # 다른 값(구 버그를 그대로 pin하고 있던 자리를 정정).
+            assert body["resolved_by"] == str(resolver_member_id)
+            assert body["resolved_by"] != str(resolver_user_id)
             assert body["resolved_at"] is not None
         finally:
             await client.aclose()
@@ -338,7 +378,8 @@ async def test_comment_event_propagation_to_creator():
         async with Session() as s:
             seeded = await _seed(s)
 
-        commenter_id = uuid.uuid4()
+        async with Session() as s:
+            commenter_id, _ = await _seed_extra_human(s, seeded["org_id"])
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=commenter_id)
         client = _client_for(app)
         try:

--- a/backend/tests/test_e_canvas_c3_s7_artifact_edit_realdb.py
+++ b/backend/tests/test_e_canvas_c3_s7_artifact_edit_realdb.py
@@ -373,24 +373,20 @@ async def test_ac4_agent_edits_human_creator_notified():
         async with Session() as s:
             from app.models.member import Member
             from app.models.project_access import ProjectAccess
-            from app.models.team import TeamMember
             agent_editor = Member(
                 id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="editor-agent", is_active=True,
             )
             s.add(agent_editor)
             await s.commit()
+            # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()의 agent
+            # 판정은 team_members VIEW 실측(site_posts.py::is_agent_caller 동형 predicate)이다.
+            # team_members는 0088+부터 물리 테이블이 아니라 VIEW라 CI 공유 alembic DB에서
+            # TeamMember 직접 삽입은 크래시한다(#4156) — 0110 grant-only 3번째 UNION 브랜치가
+            # `project_access(permission='granted')`만으로 agent 행을 투영하므로 아래
+            # ProjectAccess 하나로 충분하다(TeamMember 직접 삽입 불필요·유해).
             s.add(ProjectAccess(
                 id=uuid.uuid4(), project_id=seeded["project_id"], member_id=agent_editor.id,
                 permission="granted", role="member",
-            ))
-            # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()의 agent
-            # 판정은 team_members 테이블 직접 조회(site_posts.py::is_agent_caller 동형
-            # predicate)다 — 이 스위트는 Base.metadata.create_all()이라 실서비스 0088 VIEW를
-            # 안 태워, Member(anchor)만으론 그 조회에 안 잡힌다. 같은 id로 TeamMember도
-            # 나란히 심는다(다른 파일과 동형 처방).
-            s.add(TeamMember(
-                id=agent_editor.id, org_id=seeded["org_id"], project_id=seeded["project_id"],
-                type="agent", name="editor-agent", is_active=True,
             ))
             await s.commit()
             agent_editor_id = agent_editor.id

--- a/backend/tests/test_e_canvas_c3_s7_artifact_edit_realdb.py
+++ b/backend/tests/test_e_canvas_c3_s7_artifact_edit_realdb.py
@@ -117,9 +117,26 @@ def _client_for(app):
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
-async def _setup_app(app, Session, org_id, project_id, user_id=None):
+async def _setup_app(app, Session, org_id, project_id, user_id=None, *, is_agent: bool = False):
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
+
+    if user_id is None:
+        # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()는 실
+        # DB 조회라, 예전처럼 "신원 무관, 무작위 uuid 하나면 충분"했던 관례가 더 이상
+        # 안 통한다(400 Organization member not found). 이 파일의 관심사는 caller
+        # 신원 자체가 아니라 다른 축이라 실 OrgMember 하나를 여기서 대신 심는다
+        # (개별 테스트 수정 없이 이 헬퍼 한 곳만 — 기존 명시 user_id 호출부는 그대로).
+        from app.models.project import OrgMember
+        from app.models.user import User
+        async with Session() as s:
+            u = User(id=uuid.uuid4(), email=f"phantom-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            s.add(u)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=u.id, role="owner")
+            s.add(om)
+            await s.commit()
+            user_id = u.id
 
     async def _db():
         async with Session() as s:
@@ -131,10 +148,13 @@ async def _setup_app(app, Session, org_id, project_id, user_id=None):
                 raise
 
     async def _auth():
-        return AuthContext(
-            user_id=str(user_id or uuid.uuid4()), email="caller@test",
-            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
-        )
+        claims: dict = {"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}}
+        if is_agent:
+            # story #3370(카디르 QA 지적 2026-09-10) — is_agent=True 호출부는 user_id가
+            # 실 TeamMember.id(에이전트)임을 스스로 보장해야 한다(agent_editor 케이스,
+            # resolve_member_db_verified의 agent 판정은 이 클레임 + DB 실측 둘 다 씀).
+            claims["app_metadata"]["api_key_id"] = "test-key"
+        return AuthContext(user_id=str(user_id or uuid.uuid4()), email="caller@test", claims=claims)
 
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
@@ -302,7 +322,17 @@ async def test_ac4_human_edits_agent_creator_notified():
         async with Session() as s:
             seeded = await _seed(s, creator_type="agent")
 
-        human_editor_id = uuid.uuid4()
+        # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()가 실
+        # OrgMember 행을 찾는다.
+        async with Session() as s:
+            from app.models.project import OrgMember
+            from app.models.user import User
+            human_editor_user = User(id=uuid.uuid4(), email=f"editor-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+            s.add(human_editor_user)
+            await s.commit()
+            s.add(OrgMember(id=uuid.uuid4(), org_id=seeded["org_id"], user_id=human_editor_user.id, role="owner"))
+            await s.commit()
+            human_editor_id = human_editor_user.id
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=human_editor_id)
         client = _client_for(app)
         try:
@@ -343,6 +373,7 @@ async def test_ac4_agent_edits_human_creator_notified():
         async with Session() as s:
             from app.models.member import Member
             from app.models.project_access import ProjectAccess
+            from app.models.team import TeamMember
             agent_editor = Member(
                 id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="editor-agent", is_active=True,
             )
@@ -352,10 +383,19 @@ async def test_ac4_agent_edits_human_creator_notified():
                 id=uuid.uuid4(), project_id=seeded["project_id"], member_id=agent_editor.id,
                 permission="granted", role="member",
             ))
+            # story #3370(카디르 QA 지적 2026-09-10) — resolve_member_db_verified()의 agent
+            # 판정은 team_members 테이블 직접 조회(site_posts.py::is_agent_caller 동형
+            # predicate)다 — 이 스위트는 Base.metadata.create_all()이라 실서비스 0088 VIEW를
+            # 안 태워, Member(anchor)만으론 그 조회에 안 잡힌다. 같은 id로 TeamMember도
+            # 나란히 심는다(다른 파일과 동형 처방).
+            s.add(TeamMember(
+                id=agent_editor.id, org_id=seeded["org_id"], project_id=seeded["project_id"],
+                type="agent", name="editor-agent", is_active=True,
+            ))
             await s.commit()
             agent_editor_id = agent_editor.id
 
-        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=agent_editor_id)
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=agent_editor_id, is_agent=True)
         client = _client_for(app)
         try:
             resp = await client.post(

--- a/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
+++ b/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
@@ -50,7 +50,6 @@ async def _seed(session):
     from app.models.organization import Organization
     from app.models.project import OrgMember, Project
     from app.models.project_access import ProjectAccess
-    from app.models.team import TeamMember
     from app.models.user import User
     from app.models.visual_artifact import ArtifactVersion, VisualArtifact
 
@@ -71,16 +70,11 @@ async def _seed(session):
     session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=creator.id, project_id=project.id))
     # story #3370(카디르 QA 지적 2026-09-10) — propose_canonical_version이 이제
     # resolve_member_db_verified()(DB 실측)를 탄다. agent 판정 predicate는 site_posts.py::
-    # is_agent_caller와 동형(TeamMember.id==raw_id) — 실서비스는 0088 VIEW가 members⋈
-    # agent_project_profiles를 team_members로 투영하지만, 이 테스트 스위트의 `Base.
-    # metadata.create_all()`는 TeamMember 모델을 그 이름 그대로 **평 테이블**로 만들어
-    # (진짜 VIEW SQL을 안 태움) anchor 시딩(Member+AgentProjectProfile)만으로는 그 자리에
-    # 아무것도 안 보인다 — 같은 id로 TeamMember 행도 나란히 심어야 실측 가능(멤버 id
-    # 값 자체는 그대로라 이 파일의 다른 creator.id 참조와 전부 정합).
-    session.add(TeamMember(
-        id=creator.id, org_id=org.id, project_id=project.id, type="agent",
-        name="creator-agent", is_active=True,
-    ))
+    # is_agent_caller와 동형(team_members VIEW 조회) — team_members는 0088+부터 물리
+    # 테이블이 아니라 members⋈agent_project_profiles(+grant-only 3번째 UNION 브랜치, 0110)를
+    # 투영하는 VIEW다. 위 ProjectAccess(granted)+AgentProjectProfile 두 실 테이블만으로
+    # VIEW가 그대로 agent 행을 투영하므로 TeamMember 직접 삽입은 불필요 — CI 공유
+    # alembic-migrated DB에서 그 삽입은 "cannot insert into view"로 크래시한다(#4156).
     await session.commit()
 
     approver_user = User(id=uuid.uuid4(), email=f"approver-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")

--- a/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
+++ b/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
@@ -46,10 +46,11 @@ async def _seed(session):
     propose 호출은 auth.user_id를 그대로 created_by/requested_by로 쓰므로(멤버 조회 없음)
     creator == proposer(agent, 자기 산출물 제안)로 단순화. approve/reject만 resolve_member를
     타므로 그 경로에만 실 휴먼 row가 필요하다."""
-    from app.models.member import Member
+    from app.models.member import AgentProjectProfile, Member
     from app.models.organization import Organization
     from app.models.project import OrgMember, Project
     from app.models.project_access import ProjectAccess
+    from app.models.team import TeamMember
     from app.models.user import User
     from app.models.visual_artifact import ArtifactVersion, VisualArtifact
 
@@ -66,6 +67,19 @@ async def _seed(session):
     await session.commit()
     session.add(ProjectAccess(
         id=uuid.uuid4(), project_id=project.id, member_id=creator.id, permission="granted", role="member",
+    ))
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=creator.id, project_id=project.id))
+    # story #3370(카디르 QA 지적 2026-09-10) — propose_canonical_version이 이제
+    # resolve_member_db_verified()(DB 실측)를 탄다. agent 판정 predicate는 site_posts.py::
+    # is_agent_caller와 동형(TeamMember.id==raw_id) — 실서비스는 0088 VIEW가 members⋈
+    # agent_project_profiles를 team_members로 투영하지만, 이 테스트 스위트의 `Base.
+    # metadata.create_all()`는 TeamMember 모델을 그 이름 그대로 **평 테이블**로 만들어
+    # (진짜 VIEW SQL을 안 태움) anchor 시딩(Member+AgentProjectProfile)만으로는 그 자리에
+    # 아무것도 안 보인다 — 같은 id로 TeamMember 행도 나란히 심어야 실측 가능(멤버 id
+    # 값 자체는 그대로라 이 파일의 다른 creator.id 참조와 전부 정합).
+    session.add(TeamMember(
+        id=creator.id, org_id=org.id, project_id=project.id, type="agent",
+        name="creator-agent", is_active=True,
     ))
     await session.commit()
 
@@ -99,7 +113,13 @@ def _client_for(app):
 
 
 async def _setup_propose_app(app, Session, org_id, project_id, user_id):
-    """propose 호출용 — get_db + get_current_user(app_metadata.org_id/project_id)."""
+    """propose 호출용 — get_db + get_current_user(app_metadata.org_id/project_id).
+
+    story #3370(카디르 QA 지적 2026-09-10) — user_id는 이 파일에서 항상 creator agent의
+    Member.id다. resolve_member_db_verified()의 agent 판정은 auth 클레임(api_key_id)이
+    아니라 DB 실측이지만, `_verify_org_membership`(상위 org 소속 검증)은 여전히 클레임
+    기반 스코프체크(_check_api_key_scope)를 거치므로 api_key_id를 실어 agent 호출임을
+    일관되게 밝힌다(propose는 «AI는 제안만» 문서화 의도와도 정합)."""
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
 
@@ -115,7 +135,7 @@ async def _setup_propose_app(app, Session, org_id, project_id, user_id):
     async def _auth():
         return AuthContext(
             user_id=str(user_id), email="proposer@test",
-            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id), "api_key_id": "test-key"}},
         )
 
     app.dependency_overrides[get_db] = _db

--- a/backend/tests/test_e_security_sec_s8_r_artifact_link_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_r_artifact_link_project_scope_realdb.py
@@ -76,11 +76,25 @@ async def _seed(session):
     session.add_all([story_a, story_b, epic_a, epic_b, doc_a, doc_b])
     await session.commit()
 
+    # resolve_member_db_verified()는 fail-closed(DB 실측) — link-scope 404로 조기 반환되지
+    # 않고 실제 create_artifact 201까지 가는 케이스는 project_a의 실 멤버가 필요하다
+    # (story #3370, member_resolver.py:194-200).
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+    member_a = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="linker-agent", is_active=True)
+    session.add(member_a)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, member_id=member_a.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
     return {
         "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
         "story_a_id": story_a.id, "story_b_id": story_b.id,
         "epic_a_id": epic_a.id, "epic_b_id": epic_b.id,
         "doc_a_id": doc_a.id, "doc_b_id": doc_b.id,
+        "member_a_id": member_a.id,
     }
 
 
@@ -89,7 +103,7 @@ def _client_for(app):
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
-async def _setup_app(app, Session, org_id, project_id):
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
 
@@ -104,7 +118,7 @@ async def _setup_app(app, Session, org_id, project_id):
 
     async def _auth():
         return AuthContext(
-            user_id=str(uuid.uuid4()), email="caller@test",
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
             claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
         )
 
@@ -203,7 +217,7 @@ async def test_create_artifact_same_project_story_link_still_works():
         async with Session() as s:
             seeded = await _seed(s)
 
-        await _setup_app(app, Session, seeded["org_id"], seeded["project_a_id"])
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_a_id"], user_id=seeded["member_a_id"])
         client = _client_for(app)
         try:
             resp = await client.post(

--- a/backend/tests/test_mcp_1920_create_artifact_empty_nodes_validation.py
+++ b/backend/tests/test_mcp_1920_create_artifact_empty_nodes_validation.py
@@ -189,6 +189,8 @@ async def _session_factory():
 async def _seed(session):
     from app.models.organization import Organization
     from app.models.project import Project
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
 
     org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
     session.add(org)
@@ -198,7 +200,17 @@ async def _seed(session):
     session.add(project)
     await session.commit()
 
-    return {"org_id": org.id, "project_id": project.id}
+    # resolve_member_db_verified()는 fail-closed(DB 실측) — 201까지 가는 케이스는 실 멤버가
+    # 필요하다(story #3370, member_resolver.py:194-200).
+    member = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="creator-agent", is_active=True)
+    session.add(member)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=member.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "member_id": member.id}
 
 
 def _client_for(app):
@@ -290,7 +302,7 @@ async def test_realdb_create_artifact_with_nodes_still_succeeds_201():
         async with Session() as s:
             seeded = await _seed(s)
 
-        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=seeded["member_id"])
         client = _client_for(app)
         try:
             resp = await client.post(

--- a/backend/tests/test_mcp_1922_delete_artifact_tool.py
+++ b/backend/tests/test_mcp_1922_delete_artifact_tool.py
@@ -141,6 +141,23 @@ async def _seed(session):
     return {"org_id": org.id, "project_id": project.id}
 
 
+async def _seed_member(session, org_id, project_id, name):
+    """resolve_member_db_verified()는 fail-closed(DB 실측) — unseeded 랜덤 uuid로는
+    auth.user_id를 못 통과한다. 실 org 멤버를 심어 그 id를 반환(story #3370,
+    member_resolver.py:194-200)."""
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    member = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name=name, is_active=True)
+    session.add(member)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=member.id, permission="granted", role="member",
+    ))
+    await session.commit()
+    return member.id
+
+
 def _client_for(app):
     from httpx import AsyncClient, ASGITransport
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
@@ -181,9 +198,8 @@ async def test_realdb_creator_only_403_readable_via_http():
     try:
         async with Session() as s:
             seeded = await _seed(s)
-
-        creator_id = uuid.uuid4()
-        other_id = uuid.uuid4()
+            creator_id = await _seed_member(s, seeded["org_id"], seeded["project_id"], "creator-agent")
+            other_id = await _seed_member(s, seeded["org_id"], seeded["project_id"], "other-agent")
 
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=creator_id)
         client = _client_for(app)
@@ -228,11 +244,12 @@ async def test_realdb_mcp_create_delete_then_get_and_list_exclude():
     try:
         async with Session() as s:
             seeded = await _seed(s)
+            # 고정 caller_id — _setup_app(user_id=None)은 매 요청마다 새 랜덤 uuid를 발급해(각
+            # _auth() 클로저 호출 시점 평가) create/delete 요청이 서로 다른 사용자로 인증될 수
+            # 있다(생성자-전용 게이트가 자기 자신의 delete까지 403으로 막는 self-testing 함정)
+            # — 고정 id로 회피. resolve_member_db_verified()가 fail-closed라 실 멤버여야 한다.
+            caller_id = await _seed_member(s, seeded["org_id"], seeded["project_id"], "caller-agent")
 
-        # 고정 caller_id — _setup_app(user_id=None)은 매 요청마다 새 랜덤 uuid를 발급해(각 _auth()
-        # 클로저 호출 시점 평가) create/delete 요청이 서로 다른 사용자로 인증될 수 있다(생성자-전용
-        # 게이트가 자기 자신의 delete까지 403으로 막는 self-testing 함정) — 고정 id로 회피.
-        caller_id = uuid.uuid4()
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=caller_id)
 
         os.environ.setdefault("SPRINTABLE_API_URL", "http://test")

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1580,8 +1580,8 @@
     },
     {
       "file": "tests/test_3370_requester_member_id_human_resolve.py",
-      "sec": 3.3,
-      "source": "story-3370(휴먼 requester/author member-id 회귀, 2026-09-10) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 4건 합계 3.31s — test_3766 등재 선례와 동일 방법론)"
+      "sec": 3.7,
+      "source": "story-3370(휴먼 requester/author member-id 회귀, 2026-09-10, 페드루 2차 리뷰 site_posts.py 11번째 자리 추가) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 5건 합계 3.71s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1582,6 +1582,11 @@
       "file": "tests/test_3370_requester_member_id_human_resolve.py",
       "sec": 3.7,
       "source": "story-3370(휴먼 requester/author member-id 회귀, 2026-09-10, 페드루 2차 리뷰 site_posts.py 11번째 자리 추가) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 5건 합계 3.71s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3370_workflow_line_and_visual_artifacts_member_id.py",
+      "sec": 3.0,
+      "source": "story-3370(카디르 QA 재발견 후속, 2026-09-10) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 7건 합계 약 3.0s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1577,6 +1577,11 @@
       "file": "tests/test_3369_site_post_external_publish_activity_log.py",
       "sec": 42.0,
       "source": "story #3369 후속(2026-09-10) — 신규 destructive_schema 파일(외부 목적지 site_post 발행 감사로그 실 WordPress 스텁+실 워커 왕복). 로컬 실측 call+setup+teardown=6.85s(disposable PG, --durations=0) — story #3383 6배 스케일(로컬→CI) 적용해 ~42s로 등재. 실 CI 샤드 로그로 재확認 필요(AC2 재측정 규칙)."
+    },
+    {
+      "file": "tests/test_3370_requester_member_id_human_resolve.py",
+      "sec": 3.3,
+      "source": "story-3370(휴먼 requester/author member-id 회귀, 2026-09-10) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 4건 합계 3.31s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }


### PR DESCRIPTION
## Summary
페드루 지적(2026-09-10, Phase 0 표 마지막 축) — `site_posts.py:671` submit이 `requester_member_id`에 `uuid.UUID(auth.user_id)`를 원시로 넣어 휴먼 상신자가 `org_member.id`가 아니라 `users.id`로 봉인됨(`auth.py:146` 계약 위반).

**카디르 QA 재적출(#4156 리뷰)** — 처음 grep은 335 자리(app/ 전체) 앞에서 「전수 감사 완료」가 참이 아니었다. 판별 기준을 「is_agent_caller를 부르나」에서 「그 값이 영속 멤버-id 컬럼에 들어가나」로 고쳐 카디르가 지목한 두 파일(`visual_artifacts.py`·`workflow_line_config.py`)의 9곳을 추가 정정(총 20곳).

### ① 정정한 20곳
- `site_posts.py::post_site_post_draft_version`(:356)·`submit_site_post_draft_endpoint` — `author_member_id`/`requester_member_id`
- `channel_posts.py`의 draft-version 생성·image/video confirm·import·delete·reorder·submit 6곳 — `author_member_id`/`requester_member_id`
- `channel_post_comment_replies.py::create_comment_reply_draft_endpoint` — `created_by_member_id`
- `activity_logs.py` EE RBAC 필터 — grant-only 휴먼은 필터가 통째로 스킵되어 member 역할이 org 전체 flat 로그를 봄(fail-open 권한 무력화, 유나 라이브 재현)
- `workflow_line_config.py`(4곳) — `create_draft`의 `created_by_member_id` · `request_publish`의 `Gate.neutral_facts.requested_by_member_id` · `approve_publish`의 self-approval 비교축(**보안 결함** — 정정 前엔 영속 멤버 id와 raw auth.user_id를 비교해 휴먼끼리 절대 같을 수 없어 자기승인 탐지가 무력화, 뮤테이션으로 재현: 200→403) + `transition_gate(resolver_id=)` · `reject_publish`의 `resolver_id`
- `visual_artifacts.py`(6곳) — `create_artifact`의 `created_by`(+ 소유권 비교 동시 정정) · `add_artifact_comment`의 `created_by` · `resolve_artifact_comment`의 `resolved_by` · `patch_artifact`(edit)의 `ArtifactVersion.created_by` · `propose_canonical_version`의 `requested_by_member_id`

### ② 결함 아님으로 확認한 곳(근거 포함, 총 36곳)
- **is_agent_caller boolean 존재검사**(site_posts.py :298·:843) — `TeamMember.id==member_id` 존재만 재는 boolean이라 축이 틀려도 "없음"으로 안전 fail, 영속 0.
- **access 체크(dual-accept predicate)** — `has_project_access`/`accessible_project_ids_in_org`/`get_project_role`/`is_org_owner_or_admin`은 `project_auth.py::_project_access_predicate`가 `TeamMember.id==raw OR TeamMember.user_id==raw`(OR)로 raw id를 받게 설계돼 있어 정확함: channel_posts.py(:1082·:1121, `_require_channel_post_draft_project_access`) · visual_artifacts.py(:410) · activity_logs.py(:95) · workflow_line_config.py(10곳 전부 — `_require_draft_author`/`_require_publisher` access축, 저장축은 이미 `resolve_member_db_verified()`로 분리 완료 확認) · standups.py(6곳, `has_project_access`/`accessible_project_ids_in_org` 동일 predicate) · api_keys.py(2곳, `_is_org_admin`이 `OrgMember.user_id==` 축).
- **auth.py**(13곳 중 11곳) — 9곳 `_get_user_by_id(session, uuid.UUID(auth.user_id))`(users 테이블 자체 조작, users.id가 맞는 축) · 1곳 `User.email_verified` 직접 조회(동형) · 1곳 `get_auth_me`의 api_key_id 분기 내부(에이전트 전용, auth.user_id=team_member.id 정확).
- **events.py**(1곳) — `is_api_key` 분기 안(에이전트 전용 경로).
- **member_resolver.py**(1곳) — `_resolve_member_anchor`의 에이전트 분기 내부 구현(auth.user_id=team_member.id가 정확한 그 자리).

⚠️**auth.py 잔여 2곳(:2237·:2264) — 감사 중 발견한 별도 의심 결함, 오늘 착수 안 함(페드루 지시 "완성 먼저")**: `get_auth_me`가 휴먼 JWT 분기에서도 `AuthMeResponse(member_id=auth.user_id, ...)`로 **users.id를 "member_id"라는 이름으로 그대로 응답**(FE가 그 값을 실제 멤버 id로 쓰면 오작동 가능) · `set_default_project`가 `Member.id == uuid.UUID(auth.user_id)`로 조회해 휴먼 JWT 호출자는 `member is None`이 되어(anchor `Member.id`≠`users.id`) 이 엔드포인트가 휴먼에게 항상 실패할 가능성. **코드 변경 0·재현 미검증** — 다음 사람이 여기서 시작.

### ③ 미감사 나머지(파일별, git grep -c, 총 289곳 — 위 ①②에 안 든 전부)
`docs.py` 20 · `retros.py` 18 · `gates.py` 15 · `standups.py` 잔여 7(위 6곳 제외) · `auth.py` 잔여 0(11 확認+2 의심, 전량 분류됨) · `team_members.py` 10 · `goals.py` 10 · `sprints.py` 9 · `hypotheses.py` 9 · `member_resolver.py` 잔여 7(1곳 확認 제외) · `stories.py` 8 · `organizations.py` 8 · `events.py` 잔여 6(1곳 확認 제외) · `projects.py`/`org_subscription_checkout.py`/`hitl_config.py`/`gate_config.py`/`conversations.py`/`agents.py` 각 6 · `tasks.py`/`github_integration.py`/`dependencies.py`/`billing_keys.py`/`assets.py`/`api_keys.py` 잔여 3(2곳 확認 제외)/`agent_runs.py`/`agent_message_policy.py`/`agent_deployments.py` 각 5 · `recipe_repeat_schedules.py`/`me.py`/`evidence.py` 각 4 · `rewards.py`/`references.py`/`participation.py`/`notifications.py`/`meetings.py`/`glance.py`/`domain_labels.py`/`attachments.py` 각 3 · `trust_scores.py`/`resolve.py`/`project_settings.py`/`project_access.py`/`org_members.py`/`org_invites.py`/`connectors.py`/`agent_routing_rules.py`/`agent_personas.py`/`agent_gateway.py`/`app/dependencies/auth.py` 각 2 · 나머지 22개 파일 각 1.

이 목록은 그대로 3370 카드 꼬리에 「후속·착수 아님」으로 남긴다 — 오늘은 이 PR 완성까지만.

### 처방
`resolve_member_db_verified()`(`member_resolver.py`, 신설) — agent 판정을 auth 클레임이 아니라 DB 실측(`site_posts.py::is_agent_caller`와 동일 predicate)으로 한다. `resolve_member()`(클레임 기반)로 바꾸면 기존 destructive_schema 테스트 수십 개가 `_setup_org_scoped_app(..., user_id=agent_id)`(api_key_id 클레임 없이 agent id만 넘기는 기존 관례) 탓에 400으로 깨져, 그 축을 보존하는 별도 해소 함수로 정정했다.

**fail-closed 안전성**(페드루 2차 리뷰) — 상위 `get_verified_org_id`(더 넓게 받음: `TeamMember(id·타입 무관)`)와의 차집합을 0088(team_members VIEW화)·0075("휴먼 members.id = org_members.id")로 구조적 공집합임을 확認, docstring에 그라운딩 기록.

## Test plan
- [x] 신규 테스트 12건(site_posts.py 5 + workflow_line_config.py/visual_artifacts.py 7) — 휴먼 호출자 경로마다 org_member.id로 정확히 풀림 + self-approval 탐지가 실제로 동작함을 직접 확認. 뮤테이션 다건 RED 확認 후 복구
- [x] `test_3367_site_post_submit_gate_seal.py`의 stale assertion 정정 — 13건 GREEN
- [x] **test-harness 부수 발견** — canvas/workflow_line 테스트 스위트 다수가 "호출자 신원은 무작위 uuid 하나로 충분"했던 관례가 실 DB 조회 요구로 광범위 400 노출(73건). 공유 헬퍼 6개 파일 수정으로 68건 정리 — 남은 8건은 git stash로 라우터 코드를 되돌려 재현해 이 PR과 무관함을 개별 확認(로컬 pg_notify 미가동 3건·dispatch_notification 자신의 team_members 의존 갭 5건, 전부 착수 前부터 있던 별개 결함)
- [x] 전체 회귀 스윕 다수(-m destructive_schema 25 passed 신규분 포함 · 위 16개 non-destructive 파일 98 passed) + `infra/destructive-schema-shard-weights.json` 신규 등재 + lint 로컬 재확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)