### PR TITLE
[SID:3402] 발행 실패 알림 문구에서 사람 행동 암시 제거

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2599,7 +2599,7 @@
     "channelPostsImageRemoveAction": "Remove",
     "channelPostsImageRemoveActionLabel": "Remove image {position}",
     "channelPostsAwaitingContainerNotice": "This is being automatically continued. Please check back shortly.",
-    "channelPostsPublicationFailedNotice": "Publishing failed — republishing this draft will continue that attempt."
+    "channelPostsPublicationFailedNotice": "Publishing failed — this attempt will continue on the next publish."
   },
   "docs": {
     "title": "Docs",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2599,7 +2599,7 @@
     "channelPostsImageRemoveAction": "삭제",
     "channelPostsImageRemoveActionLabel": "{position}번째 이미지 삭제",
     "channelPostsAwaitingContainerNotice": "자동으로 이어서 처리 중입니다. 잠시 후 다시 확인해 주세요.",
-    "channelPostsPublicationFailedNotice": "발행에 실패했습니다 — 이 초안을 다시 발행하면 이 시도를 이어서 처리합니다."
+    "channelPostsPublicationFailedNotice": "발행에 실패했습니다 — 이 시도는 다음 발행에서 이어서 처리됩니다."
   },
   "docs": {
     "title": "문서",


### PR DESCRIPTION
## 요약

story #3426 실픽셀(유나) — 채널 포스트 상세에 「다음 발」을 말하는 문장 셋이 동시에 선다:

1. 「발행에 실패했습니다 — 이 초안을 다시 발행하면 이 시도를 이어서 처리합니다」(`page.tsx:2189`, `view.publicationFailed`)
2. 「00:55에 자동으로 다시 시도합니다」
3. 「예약이나 자동 재시도가 서버에 걸려 있습니다 — 기다리거나 예약을 취소한 뒤…」+ [발행] 버튼 비활성

①이 사람의 행동("다시 발행하면")을 가리키는데 정작 그 발행 버튼은 비활성 — 같은 화면 세 문장이 서로 다른 세계를 말한다.

## 처방(유나 안·PO 채택)

①의 문면에서 사람의 행동을 뺀다. 「다음 발행」은 자동 재시도든 사람이 누르는 것이든 둘 다 참인 표현이라, 조건 분기 추가 없이 카탈로그 키 값만 교체한다(키 신설 0).

| | ko | en |
|---|---|---|
| 이전 | 발행에 실패했습니다 — 이 초안을 다시 발행하면 이 시도를 이어서 처리합니다. | Publishing failed — republishing this draft will continue that attempt. |
| 이후 | 발행에 실패했습니다 — 이 시도는 다음 발행에서 이어서 처리됩니다. | Publishing failed — this attempt will continue on the next publish. |

## 확인

- `channelPostsPublicationFailedNotice` 키를 pin하거나 옛 문구를 부정 assertion(`not.toContain`)으로 잡는 테스트 전체 grep — 0건(신규 키가 아니라 기존 키 값 교체이므로 회귀 대상 자체가 없음).
- `node scripts/check-i18n-keys.js` — missing 0건.
- `pnpm test -- apps/web/src/app/(authenticated)/content/channel-posts`(291개) GREEN.
- `pnpm test -- apps/web`(전체 742파일/7530테스트) GREEN.
- `pnpm build` 성공·`type-check` 0에러·`lint` 0에러(기존 무관 warning 7개 그대로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ