### PR TITLE
[SID:3499] 성과 스냅샷 실패 문구 전용화 — 「실패」 한 낱말 → 자기설명 문장

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2389,6 +2389,7 @@
     "insightStatusUnsupported": "Not provided by channel",
     "insightSnapshotPendingWithDue": "Snapshot due · {due}",
     "insightSnapshotUnsupported": "This channel doesn't provide performance data",
+    "insightSnapshotFailed": "Couldn't collect performance data",
     "channelPostsTitle": "Channel Posts",
     "channelPostsDescription": "Manage drafts, approvals, and publishing for channel posts (Threads, etc.).",
     "channelPostsLoadFailed": "Failed to load channel posts.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2389,6 +2389,7 @@
     "insightStatusSuperseded": "새 회차로 대체됨",
     "insightSnapshotPendingWithDue": "스냅샷 예정 · {due}",
     "insightSnapshotUnsupported": "이 채널은 성과를 제공하지 않습니다",
+    "insightSnapshotFailed": "성과를 수집하지 못했습니다",
     "channelPostsTitle": "채널 포스트",
     "channelPostsDescription": "Threads 등 채널에 실릴 글의 초안·승인·발행을 관리합니다.",
     "channelPostsLoadFailed": "채널 포스트 목록을 불러오지 못했습니다.",

--- a/apps/web/src/components/content/insight-snapshot-block.test.tsx
+++ b/apps/web/src/components/content/insight-snapshot-block.test.tsx
@@ -136,13 +136,21 @@ describe('InsightSnapshotBlock — story #3499(게시물 성과 표면 1차)', (
     expect(container.querySelector('[data-testid="insight-metric-value"]')).toBeNull();
   });
 
-  it('failed — §17-10 라벨 재사용·destructive 톤', async () => {
+  it('failed — 전용 문장(insightSnapshotFailed)·destructive 톤·「다시 시도」 없음', async () => {
+    // story #3499 후속(페드루 지시·유나 3426 실픽셀, 2026-09-10) — §17-10 공유 라벨
+    // (insightStatusFailed, "실패" 한 낱말)은 insights-board-metric-cell.tsx의 표 셀
+    // 명사구 전제와 이 블록의 형제 unsupported 문장 전제가 부딪혀 더는 못 같이 쓴다
+    // (PO 채택 안 (b) — 소비처가 하나라는 전제가 깨져 전용 키 신설). attempt_count가
+    // 이 화면엔 안 내려오므로(모르는 것을 단정하지 않는다) "다시 시도" 낱말이 없어야
+    // 한다.
     const snap: InsightSnapshot = {
       normalized: { ...ALL_NULL }, captured_at: null, status: 'failed', due_at: null, source: 'threads',
     };
     await render([snap]);
     const el = container.querySelector('[data-testid="insight-snapshot-failure"]');
-    expect(el?.textContent).toBe(koMessages.content.insightStatusFailed);
+    expect(el?.textContent).toBe(koMessages.content.insightSnapshotFailed);
+    expect(el?.textContent).not.toBe(koMessages.content.insightStatusFailed);
+    expect(el?.textContent).not.toContain('다시 시도');
     expect(el?.className).toContain('text-destructive');
   });
 

--- a/apps/web/src/components/content/insight-snapshot-block.tsx
+++ b/apps/web/src/components/content/insight-snapshot-block.tsx
@@ -181,7 +181,13 @@ export function InsightSnapshotBlock({ snapshots, orgTimezone, locale, publicati
                 </span>
               ) : snap.status === 'failed' ? (
                 <span className={toneClass} data-testid="insight-snapshot-failure">
-                  {t(STATUS_LABEL_KEYS.failed)}
+                  {/* story #3499 후속(페드루 지시·유나 3426 실픽셀, 2026-09-10) —
+                      insights-board-metric-cell.tsx의 §17-10 상태 라벨(명사구·표 셀
+                      전제)과 이 블록(문장·형제 unsupported도 문장)은 다른 문법을 요구해
+                      한 키를 더는 같이 못 쓴다(전제가 바뀜 — 소비처 1곳 가정이 깨짐).
+                      「다시 시도합니다」는 쓰지 않는다 — 이 화면엔 attempt_count가 안
+                      내려와 재시도 여부를 화면이 모른다(모르는 것을 단정하지 않는다). */}
+                  {t('insightSnapshotFailed')}
                 </span>
               ) : snap.status === 'captured' && snap.captured_at ? (
                 <span data-testid="insight-snapshot-captured">


### PR DESCRIPTION
## 요약

유나 3426 실픽셀 — `insight-snapshot-block.tsx`(채널 포스트 상세)의
`status==='failed'` 분기가 형제 `unsupported`(문장 "이 채널은 성과를 제공하지
않습니다")와 달리 「실패」 한 낱말뿐이라 자기 설명이 없다.

## 처방(PO 채택 안 (b))

`insightStatusFailed`("실패")는 `insights-board-metric-cell.tsx`(조직 성과 보드
**표 셀**)와 공유 — 그 컴포넌트는 "상태 라벨만(명사구)" 전제로 지어졌고
형제 `insightStatusUnsupported`("채널 미제공")도 명사구라 그 화면 안에선 이미
정합(직접 확認). 값을 문장으로 바꾸면 표 셀 레이아웃이 밀릴 위험이 있어(이번
3426 실픽셀 범위 밖 화면) 공유 키는 그대로 두고, `insight-snapshot-block.tsx`
전용 신규 키 `insightSnapshotFailed`를 만들어 이 블록만 문장으로 바꿨다.

「다시 시도합니다」는 쓰지 않는다 — 이 화면엔 `attempt_count`가 안 내려와
재시도 여부를 화면이 단정할 근거가 없다.

| | ko | en |
|---|---|---|
| 표 셀(무변) | 실패 | Failed |
| 상세 블록(신규 키) | 성과를 수집하지 못했습니다 | Couldn't collect performance data |

## 확인

- `insight-snapshot-block.test.tsx` — 기존 pin 테스트를 신규 키 값 검증으로
  갱신 + "다시 시도" 부재 단언 추가. `insights-board-metric-cell.test.tsx`는
  무변경(공유 키 값을 안 건드렸으므로 회귀 0) — 둘 다 GREEN.
- `pnpm test -- apps/web`(전체 742파일/7530테스트) GREEN.
- `node scripts/check-i18n-keys.js` — missing 0건.
- `pnpm build` 성공·`type-check` 0에러·`lint` 0에러(기존 무관 warning 7개 그대로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ