### PR TITLE
[SID:3419] fix(BE): can_unpublish truthy 가드 누락 — hosted_site·wordpress·webhook 오판정

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -180,8 +180,23 @@ def _to_response(row, *, reconnect_mismatch_target_id: uuid.UUID | None = None) 
     adapter = get_channel_adapter(row.channel)
     max_text_length = adapter.max_text_length if adapter is not None and adapter.max_text_length > 0 else None
     supports_unpublish = adapter is not None and adapter.supports_unpublish
+    # story #3419(유나 실측·페드루 지적 2026-09-10) — truthy 가드 누락 결함. hosted_site·
+    # wordpress·webhook(channel_adapters.py:397·424·439)은 「회수 지원·요구 스코프
+    # 비움」을 선언한다(supports_unpublish=True·unpublish_required_scope=None) — 그런데
+    # `None in scopes`는 scopes에 실제로 None이 들어있지 않은 한 항상 False라 이 세
+    # 채널이 전부 has_required_scope=False(→can_unpublish=False·scope_insufficient)로
+    # 나갔다. 회수 구현은 실재(site_posts.py:1187 _call_blog_module_unpublish)라
+    # 「되는 것을 권한 없음이라 단정」한 거짓 값이고, scope_insufficient의 뜻(재연결하면
+    # 풀림)이 요구 스코프 자체가 None이라 영영 안 풀리는 모순까지 낳는다. 서비스 층
+    # `channel_posts.py::unpublish_channel_post`(1832)가 이미 쓰는 truthy 가드(`if
+    # adapter.unpublish_required_scope and … not in`)와 같은 모양으로 맞춘다 — 요구
+    # 스코프가 아예 없으면 스코프 검사 자체를 통과시킨다.
     has_required_scope = bool(
-        supports_unpublish and adapter.unpublish_required_scope in (row.scopes or [])
+        supports_unpublish
+        and (
+            not adapter.unpublish_required_scope
+            or adapter.unpublish_required_scope in (row.scopes or [])
+        )
     )
     can_unpublish = supports_unpublish and has_required_scope
     if can_unpublish:

--- a/backend/tests/test_3419_cancel_unpublish.py
+++ b/backend/tests/test_3419_cancel_unpublish.py
@@ -838,3 +838,39 @@ async def test_connection_list_unpublish_blocked_reason_unsupported_for_adapter_
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_connection_list_can_unpublish_true_for_scopeless_adapters():
+    """story #3419(유나 실측·페드루 지적 2026-09-10) — truthy 가드 누락 회귀 pin.
+    hosted_site·wordpress·webhook(channel_adapters.py)은 「회수 지원(supports_
+    unpublish=True)·요구 스코프 비움(unpublish_required_scope=None)」을 선언한다 —
+    이 경우 `None in scopes`가 실제로 이 세 채널을 항상 can_unpublish=False+
+    scope_insufficient로 오판정했다(회수 구현이 실재하는데도, 재연결해도 영영 안
+    풀리는 자기모순까지). 스코프 없음=요구 스코프 자체가 없다는 뜻이라 그냥 통과해야
+    한다 — wordpress·webhook 둘 다 scopes=[](server_default) 그대로 검사.
+
+    뮤테이션 대상 — _to_response의 truthy 가드(`not adapter.unpublish_required_scope
+    or`)를 제거하면 이 테스트가 RED여야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="member")
+            wordpress_connection_id = await _seed_connection(s, org_id, channel="wordpress")
+            webhook_connection_id = await _seed_connection(s, org_id, channel="webhook")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+        assert r.status_code == 200, r.text
+        items = r.json()
+        for connection_id in (wordpress_connection_id, webhook_connection_id):
+            row = [it for it in items if it["id"] == str(connection_id)][0]
+            assert row["can_unpublish"] is True, row
+            assert row["unpublish_blocked_reason"] is None, row
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
페드루 지적(유나 3414·3426 실측, 2026-09-10) — `channel_connections.py:183-186`의 `has_required_scope = bool(supports_unpublish and adapter.unpublish_required_scope in (row.scopes or []))`에 truthy 가드가 없어, hosted_site·wordpress·webhook(어댑터가 「회수 지원(`supports_unpublish=True`)·요구 스코프 비움(`unpublish_required_scope=None`)」을 선언 — `channel_adapters.py:397·424·439`)이 `None in scopes` → 항상 `can_unpublish=false`·`unpublish_blocked_reason='scope_insufficient'`로 나갔다.

회수 구현은 실재한다(`site_posts.py::_call_blog_module_unpublish`) — 「되는 것을 권한 없음이라 단정한」 값이었고, `scope_insufficient`의 뜻("재연결하면 풀림")도 요구 스코프 자체가 `None`이라 영영 안 풀리는 모순을 낳았다. 서비스 층(`channel_posts.py::unpublish_channel_post`, 1832)은 이미 truthy 가드(`if adapter.unpublish_required_scope and … not in`)를 쓰고 있어 — 같은 판정이 두 자리에서 다른 산식이었다. 같은 모양으로 맞췄다.

오늘 이 값을 읽는 화면은 0(site-posts 상세는 role만 봄, 채널 포스트 상세 UI(#3426)는 아직 미머지)이라 사용자 피해는 0 — API에 틀린 값이 서 있는 것 자체가 결함(#3426 착지 시 그대로 노출될 값).

## Test plan
- [x] 신규 테스트(wordpress·webhook 둘 다 `scopes=[]` → `can_unpublish=true`·`unpublish_blocked_reason=null`) — 뮤테이션(truthy 가드 제거) RED 확認 후 복구(정확히 원 결함 재현)
- [x] 기존 `test_3419_cancel_unpublish.py` 17/17 GREEN(can_unpublish=true/scope_insufficient/unsupported 세 표본 전부 회귀 없음)
- [x] channel_connections 전체 회귀(`-k "channel_connection" -m destructive_schema`) 52 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)