### PR TITLE
[SID:3449] fix(FE): dead_letter 재시도 성공 문구가 반복을 약속하던 결함 정정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2525,7 +2525,7 @@
     "channelPostsRetryConfirmChecklist": "I checked the channel",
     "channelPostsRetryConfirmAction": "Retry",
     "channelPostsRetryConfirmPendingCta": "Retrying…",
-    "channelPostsRetrySuccess": "Retry requested — it's back in the automatic retry queue.",
+    "channelPostsRetrySuccess": "Retry requested — it'll try once more on the next pass, and stop again if that fails.",
     "channelPostsRetryFailed": "Couldn't retry.",
     "errorPublicationCommandNotFound": "There's no schedule to cancel.",
     "errorChannelPostNotPublished": "This hasn't been published yet, so it can't be removed.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2525,7 +2525,7 @@
     "channelPostsRetryConfirmChecklist": "채널에서 확인했습니다",
     "channelPostsRetryConfirmAction": "다시 시도",
     "channelPostsRetryConfirmPendingCta": "시도하는 중…",
-    "channelPostsRetrySuccess": "다시 시도 요청을 보냈습니다 — 자동 재시도 대기열에 올라갔습니다.",
+    "channelPostsRetrySuccess": "다시 시도 요청을 보냈습니다 — 다음 처리 때 한 번 더 시도하고, 그래도 실패하면 다시 멈춥니다.",
     "channelPostsRetryFailed": "다시 시도하지 못했습니다.",
     "errorPublicationCommandNotFound": "취소할 예약이 없습니다.",
     "errorChannelPostNotPublished": "아직 발행되지 않아 회수할 수 없습니다.",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -2213,6 +2213,16 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
       expect(container.querySelector('[data-testid="channel-post-failure-badge"]')).toBeNull();
     });
 
+    it('story #3449(유나 실측·페드루 정정 2026-09-10) — 재시도 성공 문구가 반복을 약속하지 않는다(1회뿐, 실패하면 다시 멈춘다)', async () => {
+      // 실제로는 다음 tick 한 번만 더 시도하고(attempt_count 보존) 실패하면 곧바로
+      // dead_letter로 되돌아간다(서비스 :227) — "자동 재시도 대기열"이라는 옛 문구는
+      // 반복 재시도를 약속하는 것으로 읽혀 이 실동작과 어긋났다. 새 문구는 "한 번 더
+      // 시도하고, 그래도 실패하면 다시 멈춘다"는 뜻을 정확히 담아야 한다.
+      expect(koMessages.content.channelPostsRetrySuccess).not.toContain('대기열');
+      expect(koMessages.content.channelPostsRetrySuccess).toContain('한 번 더');
+      expect(koMessages.content.channelPostsRetrySuccess).toContain('그래도 실패하면');
+    });
+
     it('AC1 — 403(HUMAN_ONLY)은 서버 문장을 그대로 보인다(삼키지 않음)', async () => {
       stubFetch({
         draftDetail: { command_status: 'dead_letter', command_id: 'cmd-1' },


### PR DESCRIPTION
## Summary
유나 실측(2026-09-10) — 「다시 시도」 클릭 → pending → 다음 tick 한 번 시도 → `attempt_count` 보존(`publication_command.py:227`, PO 권장 그대로)이라 곧바로 다시 `>= MAX_RETRIES` → dead_letter. 왕복 11초. 동작 자체는 의도대로(즉시 피드백이 30분 침묵보다 낫고, 원인은 사람이 먼저 고치는 게 맞다) — 문구만 「자동 재시도 대기열에 올라갔습니다」로 반복 재시도를 약속하는 것으로 읽혔다.

「한 번 더 시도하고, 그래도 실패하면 다시 멈춘다」는 실동작 그대로의 뜻으로 정정(ko/en 둘 다, `content.channelPostsRetrySuccess`).

## Test plan
- [x] 기존 pin 테스트(`page.test.tsx:2210`, `koMessages` 동적 참조)는 값 변경과 무관하게 그대로 GREEN
- [x] 신규 테스트 — 새 문구가 「대기열」을 포함하지 않고 「한 번 더」·「그래도 실패하면」을 포함하는지 직접 pin. 뮤테이션(옛 문구로 되돌림) → RED 확認 후 복구
- [x] tsc 무오류 · verify:* 38개 전부 GREEN · vitest 7513 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)