### PR TITLE
[SID:3402] awaiting_container 상세 실패배지·알림 문장 중복 제거

### DIFF
--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -3334,6 +3334,31 @@ describe('ChannelPostEditPage — §17-15 processing_kind 오버레이 우선순
     expect(container.querySelector('[data-testid="channel-post-partial-success-notice"]')).toBeNull();
   });
 
+  // story #3402 갭(페드루 지시, 2026-09-10) — 실데이터는 processing_kind='awaiting_
+  // container'에 항상 command_status='pending'이 딸려 온다(위 주석 — BE 620beefc
+  // 판정식). 그 조합에서 FailureActionBadge(「자동으로 이어서 처리 중입니다.」)가
+  // 알림(그 문장을 글자 그대로 포함)과 겹쳐 서던 걸 배지 쪽만 억제한다. 뮤테이션
+  // 대상: page.tsx의 `failureAction.kind !== 'processing'` 가드를 걷으면 이 테스트가
+  // RED(문장이 정확히 1회가 아니라 2회 나옴)여야 한다.
+  it('행1-b — command_status=pending도 같이 오면(실데이터 형) 겹치는 문장이 정확히 1회만 선다', async () => {
+    stubFetch({
+      draftDetail: {
+        publication_status: 'container_created',
+        processing_kind: 'awaiting_container',
+        command_status: 'pending',
+      } as never,
+    });
+    await act(async () => {
+      root.render(wrap(<ChannelPostEditPage />));
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="channel-post-awaiting-container-notice"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="channel-post-failure-badge"]')).toBeNull();
+    const occurrences = container.textContent?.split(koMessages.content.channelPostsFailureProcessing).length ?? 0;
+    expect(occurrences - 1).toBe(1);
+  });
+
   it('행2 — processing_kind=null·container_created → partialSuccess 그대로(무회귀)', async () => {
     stubFetch({ draftDetail: { publication_status: 'container_created', processing_kind: null } as never });
     await act(async () => {

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1971,8 +1971,14 @@ export default function ChannelPostEditPage() {
             failureAction===undefined면(정상 대기·완료 등) 아예 안 그린다. story
             f061c1a3 — onRetryClick은 확認 다이얼로그를 여는 것까지만(실제 BFF 호출은
             다이얼로그의 onConfirm=handleRetry). dead_letter·needs_check가 아니면 배지가
-            버튼 자체를 안 그려 이 콜백은 안 쓰인다. */}
-        {failureAction ? (
+            버튼 자체를 안 그려 이 콜백은 안 쓰인다.
+
+            story #3402 갭(페드루 지시, 2026-09-10) — action.kind==='processing'은 아래
+            channelPostsAwaitingContainerNotice 알림과 문장이 겹친다(알림이 배지 문구를
+            글자 그대로 포함 + 「다음 발」까지 지님). 목록(page.tsx:427)엔 이 알림이 없어
+            배지가 유일한 신호라 그대로 두고, 상세는 알림이 대신하므로 이 상태에서만
+            배지를 안 그린다. */}
+        {failureAction && failureAction.kind !== 'processing' ? (
           <FailureActionBadge
             action={failureAction} displayTimezone={displayTimezone}
             onRetryClick={() => { setRetryChecklistConfirmed(false); setRetryConfirmOpen(true); }}


### PR DESCRIPTION
## 요약
상세 화면(`[draftId]/page.tsx`)에서 `processing_kind==='awaiting_container'`(실데이터는 항상 `command_status='pending'`과 동반, BE 620beefc 판정식)일 때 같은 문장이 두 번 섰다.

- 배지(`FailureActionBadge`, `action.kind==='processing'`) → `channelPostsFailureProcessing`(「자동으로 이어서 처리 중입니다.」)
- 알림 → `channelPostsAwaitingContainerNotice`(「자동으로 이어서 처리 중입니다. 잠시 후 다시 확인해 주세요.」) — 배지 문구를 글자 그대로 포함

## 처방(PO 안 그대로)
알림 쪽이 「다음 발」(잠시 후 다시 확인)까지 지녀 더 구체적이므로 알림을 남기고, **상세에서만** 이 상태일 때 배지를 안 그린다.

- 목록(`channel-posts/page.tsx:427`)은 그대로 — 목록엔 이 알림이 없어 배지가 유일한 신호.
- 문구 충돌 가드는 이 형(수 없는 완전동일 겹침)을 원래 안 잡는 것이 맞아 가드는 손 안 댐.

## 테스트
기존 §17-15 진리표(story #3428) 행1은 `command_status`를 안 채워 이 겹침을 가리고 있었다 — 행1-b 신설(실데이터 형 그대로 `command_status='pending'` 동반)로 배지 `null` + 겹치는 문장 정확히 1회를 단언.

뮤테이션(가드 걷기) → 정확히 그 1건만 RED(문장 2회 노출 직접 재현), 나머지 240건 GREEN 정합 확認 → 원복 241/241 재GREEN. 목록 페이지 45/45 무회귀.

## 검증
- `pnpm --filter web type-check`: 0 errors
- `pnpm --filter web lint`: 0 errors (무관 pre-existing warning 7개)
- `pnpm --filter web build`: 성공
- `pnpm --filter web exec vitest run`: 738파일/7513테스트 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ