### PR TITLE
[SID:3402] needs_check 2단계 관문 — dead_letter 안에서도 선다

### DIFF
--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -2177,7 +2177,9 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
         .toBe(koMessages.content.channelPostsRetryConfirmWhatDeadLetter);
       expect(document.body.querySelector('[data-testid="channel-post-retry-confirm-reversible"]')?.textContent)
         .toBe(koMessages.content.channelPostsRetryConfirmReversible);
-      // dead_letter는 체크리스트가 없다(needs_check 전용).
+      // story #3402 갭(2026-09-10) 회귀 — failure_kind가 needs_check가 아닌 dead_letter
+      // (여기는 기본값 null=transient류)는 체크리스트가 없다. needs_check인 dead_letter는
+      // 아래 별도 테스트("dead_letter ∧ needs_check").
       expect(document.body.querySelector('[data-testid="channel-post-retry-confirm-checklist"]')).toBeNull();
 
       // story #3641 — cancelBtn이 undefined면 dispatchEvent가 옵셔널 체이닝으로 조용히
@@ -2263,6 +2265,39 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
       await flush();
       expect(document.body.querySelector('[data-testid="channel-post-retry-confirm-what"]')?.textContent)
         .toBe(koMessages.content.channelPostsRetryConfirmWhatNeedsCheck);
+    });
+
+    // story #3402 갭(유나 실측·PO 채택 ㉡, 2026-09-10) — BE가 needs_check를 즉시
+    // dead_letter로 접어(publication_command.py:695-698) 위 「pending ∧ needs_check」
+    // 조합은 라이브에서 사실상 도달 불가였다. 실제로 오는 형은 이 「dead_letter ∧
+    // failure_kind=needs_check」다 — 이 조합에서도 같은 2단계 관문(배지 문면·CTA
+    // 라벨·체크리스트·다이얼로그 "무엇이" 전부 needs_check 것)이 서야 한다. 뮤테이션
+    // 대상: page.tsx의 isNeedsCheckGate에서 dead_letter+needsRecheck 절을 걷으면
+    // (또는 failure-action.ts의 needsRecheck 계산을 걷으면) 이 테스트가 RED여야 한다.
+    it('⭐AC2-b(3402 갭) — dead_letter ∧ failure_kind=needs_check도 needs_check 2단계 관문이 선다', async () => {
+      stubFetch({ draftDetail: { command_status: 'dead_letter', failure_kind: 'needs_check', command_id: 'cmd-3' } });
+      await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+      await flush();
+
+      // 배지 문면·CTA 라벨부터 needs_check 것.
+      expect(container.querySelector('[data-testid="channel-post-failure-badge"]')?.textContent)
+        .toContain(koMessages.content.channelPostsFailureNeedsCheck);
+      const retryBtn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement;
+      expect(retryBtn.textContent).toBe(koMessages.content.channelPostsFailureCheckedRetryCta);
+      expect(retryBtn.disabled).toBe(false);
+
+      await act(async () => { retryBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      expect(document.body.querySelector('[data-testid="channel-post-retry-confirm-what"]')?.textContent)
+        .toBe(koMessages.content.channelPostsRetryConfirmWhatNeedsCheck);
+      const checklist = document.body.querySelector('[data-testid="channel-post-retry-confirm-checklist"]') as HTMLInputElement;
+      expect(checklist).not.toBeNull();
+      const confirmBtn = [...document.body.querySelectorAll('button')].filter((b) => b !== retryBtn).find((b) => b.textContent === koMessages.content.channelPostsRetryConfirmAction) as HTMLButtonElement;
+      expect(confirmBtn.disabled).toBe(true);
+
+      await act(async () => { checklist.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(confirmBtn.disabled).toBe(false);
     });
   });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1981,6 +1981,10 @@ export default function ChannelPostEditPage() {
         {failureAction ? (
           <FailureActionBadge
             action={failureAction} displayTimezone={displayTimezone}
+            // story #3402 갭 후속(페드루 PO, 2026-09-10 ②) — 이 화면(상세)엔 아래
+            // ConfirmDialog가 실제 needs_check 관문(체크리스트·확認버튼 disabled)을
+            // 제공한다 — recheckGate=true라 needsRecheck 문면이 「약속을 지키는」 곳.
+            recheckGate
             onRetryClick={() => { setRetryChecklistConfirmed(false); setRetryConfirmOpen(true); }}
           />
         ) : null}

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -1870,6 +1870,12 @@ export default function ChannelPostEditPage() {
     reasonCode: draft.command_reason_code,
     processingKind: draft.processing_kind,
   });
+  // story #3402 갭(PO 채택 ㉡, 2026-09-10) — BE가 needs_check를 즉시 dead_letter로
+  // 접어(publication_command.py:695-698) kind==='needs_check' 갈래가 라이브에서
+  // 도달 불가였다. dead_letter 안에서도 needsRecheck면 같은 2단계 관문(체크 前
+  // 확認 버튼 비활성)을 쓴다 — 아래 ConfirmDialog 세 자리가 이 값 하나로 갈린다.
+  const isNeedsCheckGate = failureAction?.kind === 'needs_check'
+    || (failureAction?.kind === 'dead_letter' && failureAction.needsRecheck);
   const displayTimezone = resolveDisplayTimezone().tz;
 
   // B2(페드루 PO, 2026-09-04 13:27Z·code-review 지적) — 이미지 업로드가 confirm까지
@@ -1986,11 +1992,12 @@ export default function ChannelPostEditPage() {
             // 카디르 QA①·유나 §8과 동형 — 「무엇이·되돌릴 수 있나」는 별도 노드(§17-13).
             <>
               <span className="block" data-testid="channel-post-retry-confirm-what">
-                {failureAction?.kind === 'needs_check' ? t('channelPostsRetryConfirmWhatNeedsCheck') : t('channelPostsRetryConfirmWhatDeadLetter')}
+                {isNeedsCheckGate ? t('channelPostsRetryConfirmWhatNeedsCheck') : t('channelPostsRetryConfirmWhatDeadLetter')}
               </span>
               <span className="block" data-testid="channel-post-retry-confirm-reversible">{t('channelPostsRetryConfirmReversible')}</span>
-              {/* AC2 — needs_check만 2단계: 체크 前엔 확認 버튼 비활성. */}
-              {failureAction?.kind === 'needs_check' ? (
+              {/* AC2 — needs_check(dead_letter 안의 needsRecheck 포함)만 2단계:
+                  체크 前엔 확認 버튼 비활성. */}
+              {isNeedsCheckGate ? (
                 <label className="mt-2 flex items-center gap-2 text-sm text-foreground">
                   <input
                     type="checkbox" checked={retryChecklistConfirmed}
@@ -2004,7 +2011,7 @@ export default function ChannelPostEditPage() {
           )}
           cancelLabel={tc('cancel')}
           confirmLabel={retrying ? t('channelPostsRetryConfirmPendingCta') : t('channelPostsRetryConfirmAction')}
-          confirmDisabled={retrying || (failureAction?.kind === 'needs_check' && !retryChecklistConfirmed)}
+          confirmDisabled={retrying || (isNeedsCheckGate && !retryChecklistConfirmed)}
           destructive={false}
           onConfirm={() => void handleRetry()}
         />

--- a/apps/web/src/components/content/comments-section.test.tsx
+++ b/apps/web/src/components/content/comments-section.test.tsx
@@ -369,7 +369,7 @@ describe('CommentsSection — 행 액션(story #3517 조각②)', () => {
     const face = loadedFace([
       baseComment({
         id: 'c1', replyStatus: 'failed', sentRepliesCount: 2,
-        replyFailureAction: { kind: 'dead_letter' },
+        replyFailureAction: { kind: 'dead_letter', needsRecheck: false },
         replyCommandId: 'cmd-1',
       }),
     ]);

--- a/apps/web/src/components/content/failure-action-badge.test.tsx
+++ b/apps/web/src/components/content/failure-action-badge.test.tsx
@@ -113,23 +113,44 @@ describe('FailureActionBadge — story #3422 ②-c 2/N(doc §17-13 버튼 유무
   // BE가 needs_check를 즉시 dead_letter로 접는(publication_command.py:695-698) 실
   // 라이브 형이다. 문면·CTA 라벨은 needs_check 것을 쓴다(버튼 자체의 존재·활성은
   // command_status=dead_letter라 그대로 有·활성 — 2단계 게이트는 이 버튼이 여는
-  // ConfirmDialog 안, page.test.tsx 몫). 뮤테이션: needsRecheck 분기를 걷으면
-  // (action.needsRecheck ? ... : ...) → 이 두 테스트가 RED여야 한다.
-  it('⭐dead_letter ∧ needsRecheck — 배지 문면이 needs_check 것(채널 확認 필요)으로 뜬다', async () => {
-    await render({ kind: 'dead_letter', needsRecheck: true });
+  // ConfirmDialog 안, page.test.tsx 몫). 이 문면은 recheckGate=true인 소비처(실제
+  // 관문이 있는 channel_posts 상세)에서만 뜬다 — recheckGate=false(기본)면 needs_
+  // check 문면을 안 낸다(바로 아래 별도 테스트, 페드루 PO 지적 2026-09-10 ②: "없는
+  // 관문을 약속" 금지). 뮤테이션: needsRecheck 분기를 걷으면(action.needsRecheck &&
+  // recheckGate ? ... : ...) → 이 두 테스트가 RED여야 한다.
+  it('⭐dead_letter ∧ needsRecheck ∧ recheckGate=true — 배지 문면이 needs_check 것(채널 확認 필요)으로 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <FailureActionBadge action={{ kind: 'dead_letter', needsRecheck: true }} recheckGate displayTimezone="UTC" />,
+      ));
+    });
     expect(container.textContent).toContain(koMessages.content.channelPostsFailureNeedsCheck);
     expect(container.textContent).not.toContain(koMessages.content.channelPostsFailureDeadLetter);
   });
 
-  it('⭐dead_letter ∧ needsRecheck — CTA 라벨이 needs_check 것(「확인했습니다 · 다시 시도」)으로 뜨고 버튼은 有·활성', async () => {
+  it('⭐dead_letter ∧ needsRecheck ∧ recheckGate=true — CTA 라벨이 needs_check 것(「확인했습니다 · 다시 시도」)으로 뜨고 버튼은 有·활성', async () => {
     await act(async () => {
       root.render(wrap(
-        <FailureActionBadge action={{ kind: 'dead_letter', needsRecheck: true }} onRetryClick={() => {}} displayTimezone="UTC" />,
+        <FailureActionBadge action={{ kind: 'dead_letter', needsRecheck: true }} recheckGate onRetryClick={() => {}} displayTimezone="UTC" />,
       ));
     });
     const btn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement | null;
     expect(btn?.textContent).toBe(koMessages.content.channelPostsFailureCheckedRetryCta);
     expect(btn?.disabled).toBe(false);
+  });
+
+  // story #3402 갭 후속(페드루 PO 지적, 2026-09-10 ②) — needs_check는 unmapped
+  // error_code의 fail-closed 기본값이라 site_post 외부 발행 명령에도 실제로
+  // 도달한다. 그 화면엔 확認 다이얼로그·체크리스트 관문 자체가 없어, recheckGate를
+  // 안 넘기면(기본 false) needsRecheck가 true여도 일반 dead_letter 문면·CTA
+  // 그대로여야 한다 — 없는 관문을 약속하지 않는다. 뮤테이션: showRecheckWording
+  // 계산에서 recheckGate를 빼고 needsRecheck만 보면 이 테스트가 RED여야 한다.
+  it('⭐dead_letter ∧ needsRecheck인데 recheckGate 미지정(기본 false) — 일반 dead_letter 문면·CTA 그대로(없는 관문을 약속하지 않는다)', async () => {
+    await render({ kind: 'dead_letter', needsRecheck: true });
+    expect(container.textContent).toContain(koMessages.content.channelPostsFailureDeadLetter);
+    expect(container.textContent).not.toContain(koMessages.content.channelPostsFailureNeedsCheck);
+    const btn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement | null;
+    expect(btn?.textContent).toBe(koMessages.content.channelPostsFailureRetryCta);
   });
 
   // N2(페드루 PO 지적, 2026-09-04) — CONTENT_CHANGED는 실측 BE reason_code(channel_posts.py

--- a/apps/web/src/components/content/failure-action-badge.test.tsx
+++ b/apps/web/src/components/content/failure-action-badge.test.tsx
@@ -87,13 +87,13 @@ describe('FailureActionBadge — story #3422 ②-c 2/N(doc §17-13 버튼 유무
   });
 
   it('⭐dead_letter — 버튼 있음(수동 재시도, 휴먼 전용은 소비부 게이팅 몫)', async () => {
-    await render({ kind: 'dead_letter' });
+    await render({ kind: 'dead_letter', needsRecheck: false });
     expect(container.querySelector('[data-testid="channel-post-failure-retry-button"]')?.textContent)
       .toBe(koMessages.content.channelPostsFailureRetryCta);
   });
 
   it('⭐B3 — dead_letter 재시도 버튼은 onRetryClick 미배선이면 disabled+사유가 버튼 밖 <p>', async () => {
-    await render({ kind: 'dead_letter' });
+    await render({ kind: 'dead_letter', needsRecheck: false });
     const btn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement;
     expect(btn.disabled).toBe(true);
     expect(btn.title).toBe('');
@@ -103,10 +103,33 @@ describe('FailureActionBadge — story #3422 ②-c 2/N(doc §17-13 버튼 유무
 
   it('⭐N3 — compact=true면 dead_letter 재시도 버튼을 아예 안 그린다(라벨만)', async () => {
     await act(async () => {
-      root.render(wrap(<FailureActionBadge action={{ kind: 'dead_letter' }} displayTimezone="UTC" compact />));
+      root.render(wrap(<FailureActionBadge action={{ kind: 'dead_letter', needsRecheck: false }} displayTimezone="UTC" compact />));
     });
     expect(container.querySelector('[data-testid="channel-post-failure-retry-button"]')).toBeNull();
     expect(container.textContent).toBe(koMessages.content.channelPostsFailureDeadLetter);
+  });
+
+  // story #3402 갭(유나 실측·PO 채택 ㉡, 2026-09-10) — dead_letter ∧ needsRecheck는
+  // BE가 needs_check를 즉시 dead_letter로 접는(publication_command.py:695-698) 실
+  // 라이브 형이다. 문면·CTA 라벨은 needs_check 것을 쓴다(버튼 자체의 존재·활성은
+  // command_status=dead_letter라 그대로 有·활성 — 2단계 게이트는 이 버튼이 여는
+  // ConfirmDialog 안, page.test.tsx 몫). 뮤테이션: needsRecheck 분기를 걷으면
+  // (action.needsRecheck ? ... : ...) → 이 두 테스트가 RED여야 한다.
+  it('⭐dead_letter ∧ needsRecheck — 배지 문면이 needs_check 것(채널 확認 필요)으로 뜬다', async () => {
+    await render({ kind: 'dead_letter', needsRecheck: true });
+    expect(container.textContent).toContain(koMessages.content.channelPostsFailureNeedsCheck);
+    expect(container.textContent).not.toContain(koMessages.content.channelPostsFailureDeadLetter);
+  });
+
+  it('⭐dead_letter ∧ needsRecheck — CTA 라벨이 needs_check 것(「확인했습니다 · 다시 시도」)으로 뜨고 버튼은 有·활성', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <FailureActionBadge action={{ kind: 'dead_letter', needsRecheck: true }} onRetryClick={() => {}} displayTimezone="UTC" />,
+      ));
+    });
+    const btn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement | null;
+    expect(btn?.textContent).toBe(koMessages.content.channelPostsFailureCheckedRetryCta);
+    expect(btn?.disabled).toBe(false);
   });
 
   // N2(페드루 PO 지적, 2026-09-04) — CONTENT_CHANGED는 실측 BE reason_code(channel_posts.py
@@ -141,7 +164,7 @@ describe('FailureActionBadge — story #3422 ②-c 2/N(doc §17-13 버튼 유무
   it('onRetryClick이 dead_letter 재시도 버튼 클릭 시 호출된다', async () => {
     let clicked = false;
     await act(async () => {
-      root.render(wrap(<FailureActionBadge action={{ kind: 'dead_letter' }} onRetryClick={() => { clicked = true; }} displayTimezone="UTC" />));
+      root.render(wrap(<FailureActionBadge action={{ kind: 'dead_letter', needsRecheck: false }} onRetryClick={() => { clicked = true; }} displayTimezone="UTC" />));
     });
     const btn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement;
     await act(async () => {

--- a/apps/web/src/components/content/failure-action-badge.tsx
+++ b/apps/web/src/components/content/failure-action-badge.tsx
@@ -25,9 +25,16 @@ export interface FailureActionBadgeProps {
    * `<Button>`을 그대로 넣으면 인터랙티브 요소가 중첩된다(a>button, 무효 HTML). 카드
    * 소비처는 compact=true로 라벨만 받는다 — 재시도는 상세로 들어가서 한다. */
   compact?: boolean;
+  /** story #3402 갭 후속(페드루 PO 지적, 2026-09-10) — needs_check는 unmapped error_code의
+   * fail-closed 기본값이라 site_post 외부 발행 명령(`content/[draftId]/page.tsx`)에도
+   * 실제로 도달한다. 그 화면엔 확認 다이얼로그·체크리스트 관문 자체가 없어, action.
+   * needsRecheck만 보고 배지·CTA를 needs_check 것으로 바꾸면 "없는 관문을 약속"하는
+   * 거짓 문면이 된다. 이 prop이 true인 소비처(channel_posts 상세, 실제 관문이 있음)만
+   * needsRecheck를 반영 — 기본 false(정직한 일반 dead_letter 문면이 거짓 약속보다 낫다). */
+  recheckGate?: boolean;
 }
 
-export function FailureActionBadge({ action, onRetryClick, displayTimezone, compact }: FailureActionBadgeProps) {
+export function FailureActionBadge({ action, onRetryClick, displayTimezone, compact, recheckGate }: FailureActionBadgeProps) {
   const t = useTranslations('content');
 
   if (action.kind === 'blocked') {
@@ -71,14 +78,17 @@ export function FailureActionBadge({ action, onRetryClick, displayTimezone, comp
     );
   }
   if (action.kind === 'dead_letter') {
-    // story #3402 갭(PO 채택 ㉡, 2026-09-10) — needsRecheck면 문면·CTA 라벨만
-    // needs_check 것(채널 확認 관문)을 쓴다. 버튼 자체의 존재·활성 여부(command_
+    // story #3402 갭(PO 채택 ㉡, 2026-09-10) — needsRecheck ∧ recheckGate면 문면·CTA
+    // 라벨만 needs_check 것(채널 확認 관문)을 쓴다. 버튼 자체의 존재·활성 여부(command_
     // status=dead_letter)는 안 바뀐다 — 체크 前 확認 게이트는 이 버튼이 여는
-    // ConfirmDialog 안(page.tsx)에서 이뤄진다.
+    // ConfirmDialog 안(page.tsx)에서 이뤄진다. recheckGate=false(기본, site_post 외부
+    // 발행 등 실제 관문이 없는 소비처)면 needsRecheck가 true여도 일반 dead_letter
+    // 문면 그대로 — 없는 관문을 약속하지 않는다(페드루 PO 지적, 2026-09-10 ②).
+    const showRecheckWording = action.needsRecheck && recheckGate;
     return (
       <div className="space-y-1" data-testid="channel-post-failure-badge">
         <p className="text-xs text-destructive">
-          {action.needsRecheck ? t('channelPostsFailureNeedsCheck') : t('channelPostsFailureDeadLetter')}
+          {showRecheckWording ? t('channelPostsFailureNeedsCheck') : t('channelPostsFailureDeadLetter')}
         </p>
         {compact ? null : (
           <>
@@ -86,7 +96,7 @@ export function FailureActionBadge({ action, onRetryClick, displayTimezone, comp
               variant="outline" size="sm" onClick={onRetryClick} disabled={!onRetryClick}
               data-testid="channel-post-failure-retry-button"
             >
-              {action.needsRecheck ? t('channelPostsFailureCheckedRetryCta') : t('channelPostsFailureRetryCta')}
+              {showRecheckWording ? t('channelPostsFailureCheckedRetryCta') : t('channelPostsFailureRetryCta')}
             </Button>
             {onRetryClick ? null : (
               <p className="text-xs text-muted-foreground" data-testid="channel-post-failure-retry-disabled-reason">

--- a/apps/web/src/components/content/failure-action-badge.tsx
+++ b/apps/web/src/components/content/failure-action-badge.tsx
@@ -71,16 +71,22 @@ export function FailureActionBadge({ action, onRetryClick, displayTimezone, comp
     );
   }
   if (action.kind === 'dead_letter') {
+    // story #3402 갭(PO 채택 ㉡, 2026-09-10) — needsRecheck면 문면·CTA 라벨만
+    // needs_check 것(채널 확認 관문)을 쓴다. 버튼 자체의 존재·활성 여부(command_
+    // status=dead_letter)는 안 바뀐다 — 체크 前 확認 게이트는 이 버튼이 여는
+    // ConfirmDialog 안(page.tsx)에서 이뤄진다.
     return (
       <div className="space-y-1" data-testid="channel-post-failure-badge">
-        <p className="text-xs text-destructive">{t('channelPostsFailureDeadLetter')}</p>
+        <p className="text-xs text-destructive">
+          {action.needsRecheck ? t('channelPostsFailureNeedsCheck') : t('channelPostsFailureDeadLetter')}
+        </p>
         {compact ? null : (
           <>
             <Button
               variant="outline" size="sm" onClick={onRetryClick} disabled={!onRetryClick}
               data-testid="channel-post-failure-retry-button"
             >
-              {t('channelPostsFailureRetryCta')}
+              {action.needsRecheck ? t('channelPostsFailureCheckedRetryCta') : t('channelPostsFailureRetryCta')}
             </Button>
             {onRetryClick ? null : (
               <p className="text-xs text-muted-foreground" data-testid="channel-post-failure-retry-disabled-reason">

--- a/apps/web/src/components/content/failure-action.test.ts
+++ b/apps/web/src/components/content/failure-action.test.ts
@@ -13,8 +13,17 @@ describe('deriveFailureAction', () => {
     expect(deriveFailureAction({ commandStatus: 'voided' })).toEqual({ kind: 'voided', reasonCode: null });
   });
 
-  it('⭐dead_letter — failureKind와 무관하게 dead_letter(자동 재시도 끝남, §17-13 수동 재시도 버튼 대상)', () => {
-    expect(deriveFailureAction({ commandStatus: 'dead_letter', failureKind: 'transient' })).toEqual({ kind: 'dead_letter' });
+  it('⭐dead_letter — 버튼 유무는 failureKind와 무관하게 dead_letter(자동 재시도 끝남, §17-13 수동 재시도 버튼 대상)', () => {
+    expect(deriveFailureAction({ commandStatus: 'dead_letter', failureKind: 'transient' })).toEqual({ kind: 'dead_letter', needsRecheck: false });
+  });
+
+  // story #3402 갭(유나 실측·PO 채택 ㉡, 2026-09-10) — BE가 needs_check를 즉시
+  // dead_letter로 접기(publication_command.py:695-698) 때문에 이 조합이 실제로
+  // 오는 형이다. 뮤테이션: needsRecheck 계산을 지우면(또는 항상 false로 고정하면)
+  // 이 테스트가 RED여야 한다.
+  it('⭐dead_letter ∧ failureKind=needs_check — needsRecheck:true(§17-2 2단계 관문이 dead_letter 안에서도 선다)', () => {
+    expect(deriveFailureAction({ commandStatus: 'dead_letter', failureKind: 'needs_check' }))
+      .toEqual({ kind: 'dead_letter', needsRecheck: true });
   });
 
   it('⭐blocked — failureKind와 무관하게 blocked(연결 문제, §17-13 버튼 없음)', () => {

--- a/apps/web/src/components/content/failure-action.ts
+++ b/apps/web/src/components/content/failure-action.ts
@@ -15,7 +15,14 @@ export type FailureAction =
   | { kind: 'blocked' }
   | { kind: 'needs_check' }
   | { kind: 'auto_retry'; nextRetryAt: string | null }
-  | { kind: 'dead_letter' }
+  // story #3402 갭(유나 실측·PO 채택 ㉡, 2026-09-10) — BE가 needs_check를 즉시
+  // dead_letter로 접어(publication_command.py:695-698) 위 kind:'needs_check' 갈래는
+  // 라이브에서 사실상 도달 불가였다. 층 구분은 유지(command_status=dead_letter가
+  // 버튼 유무·severity를 결정)하되, dead_letter 안에서 failure_kind가 원래
+  // needs_check였는지(needsRecheck)로 문면·체크리스트·CTA만 needs_check 것을 쓴다
+  // — 새 kind를 만들지 않는다(§17-2 두 열 표 그대로: command_status=버튼,
+  // failure_kind=문면).
+  | { kind: 'dead_letter'; needsRecheck: boolean }
   | { kind: 'voided'; reasonCode: string | null }
   // 페드루 PO 정정(2026-09-04 09:49Z, BE #3425/PR#3776) — 이미지 글이 컨테이너 생성→
   // 완료 대기 중일 때. §17-15 "자동으로 이어서 처리 중"(중립·버튼 없음) — transient의
@@ -75,7 +82,10 @@ export interface FailureActionInput {
  */
 export function deriveFailureAction(input: FailureActionInput): FailureAction | undefined {
   if (input.commandStatus === 'voided') return { kind: 'voided', reasonCode: input.reasonCode ?? null };
-  if (input.commandStatus === 'dead_letter') return { kind: 'dead_letter' };
+  // story #3402 갭(2026-09-10) — needsRecheck는 dead_letter로 접히기 直前의 failure_kind가
+  // needs_check였는지만 본다(§17-2 층 구분: command_status가 이미 dead_letter를 확定했으니
+  // 그 안에서 failure_kind는 "무엇을 보여줄지"만 고른다, "보여줄지 말지"는 안 건드린다).
+  if (input.commandStatus === 'dead_letter') return { kind: 'dead_letter', needsRecheck: input.failureKind === 'needs_check' };
   if (input.commandStatus === 'blocked') return { kind: 'blocked' };
   if (input.commandStatus === 'completed' || input.commandStatus === 'cancelled' || !input.commandStatus) return undefined;
   // 페드루 PO 정정(2026-09-04 09:49Z) — pending ∧ processing_kind==='awaiting_container'


### PR DESCRIPTION
## 요약
BE가 `needs_check`를 즉시 `dead_letter`로 접어(`publication_command.py:695-698`) FE `deriveFailureAction`의 `command_status==='dead_letter'` 우선판정(`failure-action.ts:78` vs `:87-90`)이 항상 이겨, needs_check 전용 2단계 관문(체크박스·전용 CTA·전용 배지·전용 다이얼로그 문면)이 **라이브에서 도달 불가**였다(유나 실측, 페드루 PO 처방 ㉡).

## 처방(층 구분 유지)
`command_status`가 버튼 유무를, `failure_kind`가 문면을 정한다는 §17-2 원칙은 안 바꾼다. `FailureAction`의 `dead_letter` variant에 `needsRecheck: boolean`을 실어, `dead_letter` 갈래 **안에서** 문면·CTA 라벨만 needs_check 것으로 갈아 낀다 — 새 `kind`를 만들지 않는다. 버튼 자체의 존재·활성(`command_status=dead_letter`)은 안 바뀐다.

같은 값 하나(`needsRecheck`)로 3곳(`FailureActionBadge` 배지·CTA, `page.tsx`의 `ConfirmDialog` "무엇이"·체크리스트·확認버튼 disabled)이 함께 갈린다.

## 테스트
- `failure-action.test.ts`: `dead_letter ∧ needs_check → needsRecheck:true` 신규.
- `failure-action-badge.test.tsx`: 배지 문면·CTA 라벨 신규 2건.
- `page.test.tsx` 진리표: 「dead_letter ∧ needs_check」 행 신규(배지·CTA·다이얼로그·체크리스트·버튼 disabled 전부 단언) + 기존 「dead_letter(기본값)」 테스트가 「dead_letter ∧ transient」 회귀 무변 역할을 겸함.

뮤테이션(needsRecheck 계산을 항상 false로 고정) → 정확히 2건만 RED, 나머지 253건 GREEN 정합 확認 → 원복 462/462 재GREEN.

## 범위 밖(적기만, 손 안 댐)
`content/[draftId]/page.tsx`(site_post 외부발행 재시도)도 같은 `FailureActionBadge`를 재사용해 `needsRecheck`가 true면 CTA 라벨이 바뀌지만, 이 화면은 애초에 확認 다이얼로그·체크리스트 관문 자체가 없다(`onRetryClick`이 재시도를 바로 호출). 페드루 지시는 channel_posts 화면 요소만 명시(체크박스·CTA·배지·다이얼로그가 전부 이 화면 것과 정확히 일치)해 이 화면은 손 안 댐 — 필요하면 별 스토리.

## 검증
- `pnpm --filter web type-check`: 0 errors
- `pnpm --filter web lint`: 0 errors (무관 pre-existing warning 7개)
- `pnpm --filter web build`: 성공
- `pnpm --filter web exec vitest run`: 738파일/7516테스트 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3515XTWLV62Z117Wx9itQ