### PR TITLE
[SID:3583] fix(FE/BE): 성과 보드 GA4 유입 null 사유가 키 이름 추론이던 결함

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5222,6 +5222,7 @@
     "insightsBoardBucketUnscheduled": "Not scheduled yet",
     "insightsBoardMetricUnavailable": "Metric not provided",
     "insightsBoardGa4NotConnected": "GA4 not connected",
+    "insightsBoardGa4AggregationPending": "Aggregating",
     "errorInvalidWindow": "Unsupported window.",
     "errorInvalidSort": "Unsupported sort.",
     "errorFollowUpHumanOnly": "Only humans can create follow-ups.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -5222,6 +5222,7 @@
     "insightsBoardBucketUnscheduled": "아직 집계 예정 없음",
     "insightsBoardMetricUnavailable": "지표 미제공",
     "insightsBoardGa4NotConnected": "GA4 미연결",
+    "insightsBoardGa4AggregationPending": "집계 대기",
     "errorInvalidWindow": "지원하지 않는 기간입니다.",
     "errorInvalidSort": "지원하지 않는 정렬 기준입니다.",
     "errorFollowUpHumanOnly": "후속 조치 생성은 사람만 할 수 있습니다.",

--- a/apps/web/src/app/(authenticated)/organization/insights-board/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/insights-board/page.tsx
@@ -25,7 +25,7 @@ import { FollowUpDialog } from '@/components/insights-board/follow-up-dialog';
 import { ReconcileResultLine } from '@/components/insights-board/reconcile-result-line';
 import { parseInsightsBoardApiError } from '@/components/insights-board/insights-board-error';
 import { ASSET_LABEL_PREFIX_LENGTH, aggregateGroupBucket, groupInsightsBoardRows, type InsightsBoardGroupBy } from '@/components/insights-board/group-rows';
-import { DEFAULT_METRIC, METRIC_KEYS, type BoardMetric, type InsightsBoardResponse, type InsightsBoardRow, type InsightsBoardWindow } from '@/components/insights-board/types';
+import { DEFAULT_METRIC, METRIC_KEYS, type BoardMetric, type Ga4ConnectionStatus, type InsightsBoardResponse, type InsightsBoardRow, type InsightsBoardWindow } from '@/components/insights-board/types';
 import { PublishingMetricsBand } from '@/components/content/publishing-metrics-band';
 import { deriveFailureAction, type CommandStatus } from '@/components/content/failure-action';
 import { FailureActionBadge } from '@/components/content/failure-action-badge';
@@ -109,6 +109,9 @@ export default function InsightsBoardPage() {
   const searchParams = useSearchParams();
   const t = useTranslations('insightsBoard');
   const tContent = useTranslations('content');
+  // story #3583(정정, 2026-09-10) — GA4 유입 지표 null 사유의 needs_reauth 갈래가
+  // 채널 연결 화면 기존 낱말을 재사용한다(새 낱말 0, PO 確定).
+  const tChannelConnect = useTranslations('channelConnect');
   // story #3656 — 훅 미태깅 묶음 라벨은 새 낱말을 안 만들고 docs 네임스페이스 기존
   // 키(indexCategoryUncategorized, 「미분류」)를 재사용한다(유나 確定).
   const tDocs = useTranslations('docs');
@@ -147,6 +150,10 @@ export default function InsightsBoardPage() {
   // 있다(work_item_id 기준 join, lang은 그 유니크 밖 — site_post.py:20). BE가 그
   // 숨은 수를 셀 수 있을 때만 보낸다(모르면 null — 지어내지 않는다).
   const [hiddenCount, setHiddenCount] = useState<number | null>(null);
+  // story #3583(2026-09-10) — org당 1값(응답 전체에 실림, 행마다가 아니다). 기본값
+  // not_connected는 「아직 안 왔다」 쪽으로 낙관하지 않는다(로딩 中 GA4 셀이 우연히
+  // "집계 대기"를 보이는 것보다 "미연결"이 더 안전한 기본 — 실응답이 곧 덮는다).
+  const [ga4ConnectionStatus, setGa4ConnectionStatus] = useState<Ga4ConnectionStatus>('not_connected');
   // doc a0da40c9 §21-5(유나 2026-09-05) — 제목 기본값(「[재발행] {원문 제목}」 등)을
   // 채워 보이려면 이 행의 원문 title이 필요하다 — publication_id만으론 부족해
   // row 전체를 들고 있는다.
@@ -215,6 +222,7 @@ export default function InsightsBoardPage() {
         setHasMore(json?.data?.has_more ?? false);
         setNextCursor(json?.data?.next_cursor ?? null);
         setHiddenCount(json?.data?.hidden_count ?? null);
+        setGa4ConnectionStatus(json?.data?.ga4_connection_status ?? 'not_connected');
       } else {
         const body = (await res.json().catch(() => null)) as { detail?: unknown; error?: Record<string, unknown> } | null;
         const info = parseInsightsBoardApiError(body);
@@ -538,13 +546,15 @@ export default function InsightsBoardPage() {
                     <td className="px-3 py-2 text-muted-foreground">
                       <InsightsBoardMetricCell
                         bucket={aggregateGroupBucket(group.rows, 'd1')} metric={metricParam}
-                        tContent={tContent} tBoard={t}
+                        tContent={tContent} tBoard={t} tChannelConnect={tChannelConnect}
+                        ga4ConnectionStatus={ga4ConnectionStatus}
                       />
                     </td>
                     <td className="px-3 py-2 text-muted-foreground">
                       <InsightsBoardMetricCell
                         bucket={aggregateGroupBucket(group.rows, 'd7')} metric={metricParam}
-                        tContent={tContent} tBoard={t}
+                        tContent={tContent} tBoard={t} tChannelConnect={tChannelConnect}
+                        ga4ConnectionStatus={ga4ConnectionStatus}
                       />
                     </td>
                     <td colSpan={2} />
@@ -602,10 +612,16 @@ export default function InsightsBoardPage() {
                       {formatScheduledAt(row.published_at, displayTimezone).display}
                     </td>
                     <td className="px-3 py-2.5 text-muted-foreground">
-                      <InsightsBoardMetricCell bucket={row.d1} metric={metricParam} tContent={tContent} tBoard={t} />
+                      <InsightsBoardMetricCell
+                        bucket={row.d1} metric={metricParam} tContent={tContent} tBoard={t}
+                        tChannelConnect={tChannelConnect} ga4ConnectionStatus={ga4ConnectionStatus}
+                      />
                     </td>
                     <td className="px-3 py-2.5 text-muted-foreground">
-                      <InsightsBoardMetricCell bucket={row.d7} metric={metricParam} tContent={tContent} tBoard={t} />
+                      <InsightsBoardMetricCell
+                        bucket={row.d7} metric={metricParam} tContent={tContent} tBoard={t}
+                        tChannelConnect={tChannelConnect} ga4ConnectionStatus={ga4ConnectionStatus}
+                      />
                     </td>
                     <td className="px-3 py-2.5 text-muted-foreground" data-testid="insights-board-comments-cell">
                       <InsightsBoardCommentsCell row={row} t={t} />

--- a/apps/web/src/components/insights-board/insights-board-metric-cell.test.tsx
+++ b/apps/web/src/components/insights-board/insights-board-metric-cell.test.tsx
@@ -4,35 +4,42 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { NextIntlClientProvider, useTranslations } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { InsightsBoardMetricCell } from './insights-board-metric-cell';
-import type { InsightSnapshotBucketView } from './types';
+import type { Ga4ConnectionStatus, InsightSnapshotBucketView } from './types';
 
-function renderCell(bucket: InsightSnapshotBucketView | null, metric: string) {
+function renderCell(bucket: InsightSnapshotBucketView | null, metric: string, ga4ConnectionStatus: Ga4ConnectionStatus = 'not_connected') {
   return renderToStaticMarkup(
     <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
-      <CellHarness bucket={bucket} metric={metric} />
+      <CellHarness bucket={bucket} metric={metric} ga4ConnectionStatus={ga4ConnectionStatus} />
     </NextIntlClientProvider>,
   );
 }
 
 // next-intl 훅(useTranslations)은 컴포넌트 내부에서만 부를 수 있어 얇은 harness로 감싼다 —
-// InsightsBoardMetricCell 자체는 tContent/tBoard를 인자로 받는 순수 프레젠테이션 컴포넌트다.
-function CellHarness({ bucket, metric }: { bucket: InsightSnapshotBucketView | null; metric: string }) {
+// InsightsBoardMetricCell 자체는 tContent/tBoard/tChannelConnect를 인자로 받는 순수
+// 프레젠테이션 컴포넌트다.
+function CellHarness({ bucket, metric, ga4ConnectionStatus }: { bucket: InsightSnapshotBucketView | null; metric: string; ga4ConnectionStatus: Ga4ConnectionStatus }) {
   const tContent = useTranslations('content');
   const tBoard = useTranslations('insightsBoard');
+  const tChannelConnect = useTranslations('channelConnect');
   return (
     <InsightsBoardMetricCell
       bucket={bucket}
       metric={metric as never}
       tContent={tContent}
       tBoard={tBoard}
+      tChannelConnect={tChannelConnect}
+      ga4ConnectionStatus={ga4ConnectionStatus}
     />
   );
 }
 
-// story #3583(페드루 PO 確定 2026-09-06 · 유나 §21-6-1) — captured인데 값이 null인
-// 사유 3갈래 중 GA4 유입 지표(inflow_sessions/inflow_users)만 새 낱말(「GA4 미연결」),
-// 나머지 5지표는 기존 「지표 미제공」 그대로.
-describe('InsightsBoardMetricCell — GA4 유입 지표 null 사유(story #3583)', () => {
+// story #3583(페드루 PO 確定 2026-09-06 · 정정 2026-09-10) — captured인데 값이 null인
+// 사유를 GA4 유입 지표(inflow_sessions/inflow_users)만 「지표 키 이름」이 아니라 org의
+// 실 GA4 연결 상태(ga4_connection_status)로 가른다. 이전 주석("붙었는데 값만 없는
+// 경우는 여기 안 온다")이 거짓으로 밝혀져(insight_snapshots.py의 GA4 처리 지연·일시
+// OAuthError 경로) connected∧null이 실제로 온다 — 그 갈래가 「미연결」로 오판되면
+// 이미 GA4를 붙인 org가 매번 "연결하세요"를 보게 되는 결함이었다.
+describe('InsightsBoardMetricCell — GA4 유입 지표 null 사유 진리표(story #3583)', () => {
   const capturedBucket: InsightSnapshotBucketView = {
     status: 'captured', captured_at: '2026-09-06T00:00:00Z',
     normalized: {
@@ -41,30 +48,50 @@ describe('InsightsBoardMetricCell — GA4 유입 지표 null 사유(story #3583)
     },
   };
 
-  it('기존 5지표(예: impressions) — 값 null이면 「지표 미제공」(회귀 0)', () => {
-    const html = renderCell(capturedBucket, 'impressions');
+  it('행1 — non-GA4 지표(impressions)는 ga4_connection_status와 무관하게 「지표 미제공」(회귀 0)', () => {
+    const html = renderCell(capturedBucket, 'impressions', 'connected');
     expect(html).toContain(koMessages.insightsBoard.insightsBoardMetricUnavailable);
     expect(html).not.toContain(koMessages.insightsBoard.insightsBoardGa4NotConnected);
+    expect(html).not.toContain(koMessages.insightsBoard.insightsBoardGa4AggregationPending);
   });
 
-  it('⭐inflow_sessions — 값 null이면 「GA4 미연결」(「지표 미제공」이 아니다)', () => {
-    const html = renderCell(capturedBucket, 'inflow_sessions');
+  it('행2 — GA4 지표 + not_connected → 「GA4 미연결」', () => {
+    const html = renderCell(capturedBucket, 'inflow_sessions', 'not_connected');
     expect(html).toContain(koMessages.insightsBoard.insightsBoardGa4NotConnected);
+    expect(html).not.toContain(koMessages.insightsBoard.insightsBoardMetricUnavailable);
+    expect(html).not.toContain(koMessages.insightsBoard.insightsBoardGa4AggregationPending);
+  });
+
+  it('행3 — GA4 지표 + needs_reauth → 「다시 연결 필요」(channelStatusReauthRequired 재사용, 새 낱말 0)', () => {
+    const html = renderCell(capturedBucket, 'inflow_sessions', 'needs_reauth');
+    expect(html).toContain(koMessages.channelConnect.channelStatusReauthRequired);
+    expect(html).not.toContain(koMessages.insightsBoard.insightsBoardGa4NotConnected);
+    expect(html).not.toContain(koMessages.insightsBoard.insightsBoardGa4AggregationPending);
+  });
+
+  // ⭐뮤테이션 핀 — 이 결함의 핵심 갈래. 「지표 키 이름」만으로 추론하는 옛 로직으로
+  // 되돌리면(ga4ConnectionStatus를 무시하고 GA4_INFLOW_METRICS만 검사) 이 행이
+  // 「GA4 미연결」을 그리게 되어 RED가 나야 한다.
+  it('행4 — GA4 지표 + connected → 「집계 대기」(미연결이 아니다 — 뮤테이션 핀)', () => {
+    const html = renderCell(capturedBucket, 'inflow_sessions', 'connected');
+    expect(html).toContain(koMessages.insightsBoard.insightsBoardGa4AggregationPending);
+    expect(html).not.toContain(koMessages.insightsBoard.insightsBoardGa4NotConnected);
     expect(html).not.toContain(koMessages.insightsBoard.insightsBoardMetricUnavailable);
   });
 
-  it('⭐inflow_users — 값 null이면 「GA4 미연결」', () => {
-    const html = renderCell(capturedBucket, 'inflow_users');
-    expect(html).toContain(koMessages.insightsBoard.insightsBoardGa4NotConnected);
+  it('inflow_users도 같은 진리표를 탄다(connected∧null → 집계 대기)', () => {
+    const html = renderCell(capturedBucket, 'inflow_users', 'connected');
+    expect(html).toContain(koMessages.insightsBoard.insightsBoardGa4AggregationPending);
   });
 
-  it('inflow_sessions — 값이 있으면(GA4 연결됨) 그 값이 그대로 보인다(사유 문구 없음)', () => {
+  it('값이 있으면(정상 수신) ga4_connection_status와 무관하게 그 값이 그대로 보인다(사유 문구 없음)', () => {
     const bucket: InsightSnapshotBucketView = {
       ...capturedBucket,
       normalized: { ...capturedBucket.normalized!, inflow_sessions: 42 },
     };
-    const html = renderCell(bucket, 'inflow_sessions');
+    const html = renderCell(bucket, 'inflow_sessions', 'connected');
     expect(html).toContain('42');
     expect(html).not.toContain(koMessages.insightsBoard.insightsBoardGa4NotConnected);
+    expect(html).not.toContain(koMessages.insightsBoard.insightsBoardGa4AggregationPending);
   });
 });

--- a/apps/web/src/components/insights-board/insights-board-metric-cell.tsx
+++ b/apps/web/src/components/insights-board/insights-board-metric-cell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { useTranslations } from 'next-intl';
-import type { InsightSnapshotBucketView } from './types';
+import type { Ga4ConnectionStatus, InsightSnapshotBucketView } from './types';
 
 // story #3503 — insight-snapshot-block.tsx(story #3499)의 패턴을 「표 셀 하나」 크기로
 // 축소한 신규 컴포넌트(PO 브리프 — 그 컴포넌트를 통째로 재사용하지 않는다, due_at·source
@@ -51,10 +51,13 @@ const STATUS_LABEL_KEYS: Record<InsightSnapshotBucketView['status'], string> = {
 
 const DESTRUCTIVE_STATUSES: ReadonlySet<InsightSnapshotBucketView['status']> = new Set(['failed']);
 
-// story #3583(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06 · 유나 §21-6-1) — captured인데
-// 값이 null인 사유 3갈래 중 이 하나만 새 낱말(「GA4 미연결」) — 나머지 5지표는 기존
-// insightsBoardMetricUnavailable 그대로. inflow_* 지표가 null인 것은 이 채널·행 자체가
-// GA4를 아직 안 붙였다는 뜻(BE 계약 — 붙었는데 값만 없는 경우는 여기 안 온다).
+// story #3583(Phase2·마케팅운영, 페드루 PO 確定 2026-09-06 정정 2026-09-10) — captured인데
+// 값이 null인 사유 3갈래 중 이 지표 2개만 새 낱말 — 나머지 5지표는 기존
+// insightsBoardMetricUnavailable 그대로. **정정(2026-09-10)**: 이전 주석 "붙었는데 값만
+// 없는 경우는 여기 안 온다"는 거짓이었다 — insight_snapshots.py::_fetch_ga4_inflow_
+// metrics(`if inflow and …`)는 연결이 살아 있어도(GA4 처리 지연으로 rows=[]·해당 창
+// 유입 0·일시 OAuthError) null을 그대로 둔다. 그래서 원인을 지표 키 이름이 아니라
+// 응답의 `ga4_connection_status`(org당 1값)로 가른다 — 아래 참고.
 const GA4_INFLOW_METRICS = new Set(['inflow_sessions', 'inflow_users']);
 
 export interface InsightsBoardMetricCellProps {
@@ -64,9 +67,17 @@ export interface InsightsBoardMetricCellProps {
   tContent: ReturnType<typeof useTranslations>;
   /** insightsBoard 네임스페이스 t — 이 보드 전용 신규 문구(미스케줄 사유)만. */
   tBoard: ReturnType<typeof useTranslations>;
+  /** story #3583(정정, 2026-09-10) — needs_reauth 갈래가 채널 연결 화면의 기존 낱말
+   * `channelStatusReauthRequired`(channelConnect 네임스페이스)를 재사용한다 — 새
+   * 낱말을 만들지 않는다(PO 確定). */
+  tChannelConnect: ReturnType<typeof useTranslations>;
+  /** story #3583(정정, 2026-09-10) — GA4_INFLOW_METRICS가 null일 때 사유를 가르는 축.
+   * org당 1값(InsightsBoardResponse.ga4_connection_status)이라 호출부가 그대로 넘긴다
+   * (이 컴포넌트가 다시 조회하지 않는다). GA4 아닌 지표엔 안 쓰인다. */
+  ga4ConnectionStatus: Ga4ConnectionStatus;
 }
 
-export function InsightsBoardMetricCell({ bucket, metric, tContent, tBoard }: InsightsBoardMetricCellProps) {
+export function InsightsBoardMetricCell({ bucket, metric, tContent, tBoard, tChannelConnect, ga4ConnectionStatus }: InsightsBoardMetricCellProps) {
   // (i) 버킷 자체가 없음 — 아직 스케줄되지 않음/존재하지 않음.
   if (bucket === null) {
     return (
@@ -88,11 +99,22 @@ export function InsightsBoardMetricCell({ bucket, metric, tContent, tBoard }: In
   // (§21-2 — 사유는 명사구 insightsBoardMetricUnavailable, 문장 아님).
   const value = bucket.normalized?.[metric] ?? null;
   if (value === null) {
-    const reasonKey = GA4_INFLOW_METRICS.has(metric) ? 'insightsBoardGa4NotConnected' : 'insightsBoardMetricUnavailable';
+    // story #3583(정정, 2026-09-10) — GA4 두 지표는 이제 「키 이름」이 아니라 org의
+    // 실 연결 상태로 사유를 가른다(위 GA4_INFLOW_METRICS 주석 참고). connected인데
+    // null인 경우는 "미연결"이 아니라 "아직 안 왔다" — 신설 낱말 「집계 대기」로
+    // 구분한다(insightsBoardMetricUnavailable "지표 미제공"과 뜻이 다르다: 저건
+    // 채널 자체가 이 지표를 영원히 안 준다는 뜻, 이건 곧 올 수 있다는 뜻).
+    const reasonNode = GA4_INFLOW_METRICS.has(metric)
+      ? ga4ConnectionStatus === 'not_connected'
+        ? tBoard('insightsBoardGa4NotConnected')
+        : ga4ConnectionStatus === 'needs_reauth'
+          ? tChannelConnect('channelStatusReauthRequired')
+          : tBoard('insightsBoardGa4AggregationPending')
+      : tBoard('insightsBoardMetricUnavailable');
     return (
       <span data-testid="insights-board-cell-value-dash">
         <span>{tContent('insightMetricUnavailableDash')}</span>
-        <span className="ml-1 text-xs text-muted-foreground">{tBoard(reasonKey)}</span>
+        <span className="ml-1 text-xs text-muted-foreground">{reasonNode}</span>
       </span>
     );
   }

--- a/apps/web/src/components/insights-board/story-insights-compare-section.tsx
+++ b/apps/web/src/components/insights-board/story-insights-compare-section.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button';
 import { InsightsBoardMetricCell } from './insights-board-metric-cell';
 import { FollowUpDialog } from './follow-up-dialog';
 import { declaredMetricsForChannel } from './channel-declared-metrics';
-import { METRIC_KEYS, type BoardMetric, type InsightsBoardResponse, type InsightsBoardRow } from './types';
+import { METRIC_KEYS, type BoardMetric, type Ga4ConnectionStatus, type InsightsBoardResponse, type InsightsBoardRow } from './types';
 
 /**
  * story #3697(Phase2·FE, 유나 § 確定 2026-09-08) — 한 story(캠페인)의 발행물을 blog/social
@@ -45,12 +45,14 @@ function isBlogRow(row: InsightsBoardRow): boolean {
 }
 
 function PublicationCard({
-  row, orgId, tBoard, tContent,
+  row, orgId, tBoard, tContent, tChannelConnect, ga4ConnectionStatus,
 }: {
   row: InsightsBoardRow;
   orgId: string;
   tBoard: ReturnType<typeof useTranslations>;
   tContent: ReturnType<typeof useTranslations>;
+  tChannelConnect: ReturnType<typeof useTranslations>;
+  ga4ConnectionStatus: Ga4ConnectionStatus;
 }) {
   const [followUpOpen, setFollowUpOpen] = useState(false);
   const declared = declaredMetricsForChannel(row.channel);
@@ -95,8 +97,18 @@ function PublicationCard({
                     <span className="ml-1 text-[11px] text-muted-foreground">({tBoard(sourceLabelKey)})</span>
                   ) : null}
                 </td>
-                <td className="py-1"><InsightsBoardMetricCell bucket={row.d1} metric={metric} tContent={tContent} tBoard={tBoard} /></td>
-                <td className="py-1"><InsightsBoardMetricCell bucket={row.d7} metric={metric} tContent={tContent} tBoard={tBoard} /></td>
+                <td className="py-1">
+                  <InsightsBoardMetricCell
+                    bucket={row.d1} metric={metric} tContent={tContent} tBoard={tBoard}
+                    tChannelConnect={tChannelConnect} ga4ConnectionStatus={ga4ConnectionStatus}
+                  />
+                </td>
+                <td className="py-1">
+                  <InsightsBoardMetricCell
+                    bucket={row.d7} metric={metric} tContent={tContent} tBoard={tBoard}
+                    tChannelConnect={tChannelConnect} ga4ConnectionStatus={ga4ConnectionStatus}
+                  />
+                </td>
               </tr>
             ))}
           </tbody>
@@ -116,13 +128,15 @@ function PublicationCard({
 }
 
 function AxisGroup({
-  titleKey, rows, orgId, tBoard, tContent,
+  titleKey, rows, orgId, tBoard, tContent, tChannelConnect, ga4ConnectionStatus,
 }: {
   titleKey: string;
   rows: InsightsBoardRow[];
   orgId: string;
   tBoard: ReturnType<typeof useTranslations>;
   tContent: ReturnType<typeof useTranslations>;
+  tChannelConnect: ReturnType<typeof useTranslations>;
+  ga4ConnectionStatus: Ga4ConnectionStatus;
 }) {
   if (rows.length === 0) return null;
   return (
@@ -130,7 +144,10 @@ function AxisGroup({
       <p className="text-xs font-medium text-muted-foreground">{tBoard(titleKey)}</p>
       <div className="space-y-2">
         {rows.map((row) => (
-          <PublicationCard key={row.publication_id} row={row} orgId={orgId} tBoard={tBoard} tContent={tContent} />
+          <PublicationCard
+            key={row.publication_id} row={row} orgId={orgId} tBoard={tBoard} tContent={tContent}
+            tChannelConnect={tChannelConnect} ga4ConnectionStatus={ga4ConnectionStatus}
+          />
         ))}
       </div>
     </div>
@@ -145,6 +162,10 @@ export function StoryInsightsCompareSection({ storyId }: StoryInsightsCompareSec
   const { orgId } = useDashboardContext();
   const tBoard = useTranslations('insightsBoard');
   const tContent = useTranslations('content');
+  // story #3583(2026-09-10) — 이 섹션은 org-wide 보드(page.tsx)와 별도 조회라 값도
+  // 따로 든다(같은 org당 1값이라 결과는 같지만, 조회 자체를 공유하지 않는다).
+  const tChannelConnect = useTranslations('channelConnect');
+  const [ga4ConnectionStatus, setGa4ConnectionStatus] = useState<Ga4ConnectionStatus>('not_connected');
   const [rows, setRows] = useState<InsightsBoardRow[] | null>(null);
   // story #3697(유나 § ②) — has_more는 kind별 상한(BE)에 잘린 게 있는지만 말한다(몇 건인지는
   // 모른다 — 수를 지어내지 않는다). 섹션 수준 한 줄로만 쓴다(어느 축이 잘렸는지는 has_more가
@@ -173,6 +194,7 @@ export function StoryInsightsCompareSection({ storyId }: StoryInsightsCompareSec
         if (cancelled) return;
         setRows(json?.data?.rows ?? []);
         setHasMore(json?.data?.has_more ?? false);
+        setGa4ConnectionStatus(json?.data?.ga4_connection_status ?? 'not_connected');
       } catch {
         if (!cancelled) setRows([]);
       }
@@ -193,8 +215,14 @@ export function StoryInsightsCompareSection({ storyId }: StoryInsightsCompareSec
           {tBoard('storyComparePartialNotice')}
         </p>
       ) : null}
-      <AxisGroup titleKey="storyCompareAxisBlog" rows={blogRows} orgId={orgId} tBoard={tBoard} tContent={tContent} />
-      <AxisGroup titleKey="storyCompareAxisSocial" rows={socialRows} orgId={orgId} tBoard={tBoard} tContent={tContent} />
+      <AxisGroup
+        titleKey="storyCompareAxisBlog" rows={blogRows} orgId={orgId} tBoard={tBoard} tContent={tContent}
+        tChannelConnect={tChannelConnect} ga4ConnectionStatus={ga4ConnectionStatus}
+      />
+      <AxisGroup
+        titleKey="storyCompareAxisSocial" rows={socialRows} orgId={orgId} tBoard={tBoard} tContent={tContent}
+        tChannelConnect={tChannelConnect} ga4ConnectionStatus={ga4ConnectionStatus}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/insights-board/types.ts
+++ b/apps/web/src/components/insights-board/types.ts
@@ -87,6 +87,8 @@ export interface InsightsBoardRow {
   command_status: string | null;
 }
 
+export type Ga4ConnectionStatus = 'not_connected' | 'needs_reauth' | 'connected';
+
 export interface InsightsBoardResponse {
   rows: InsightsBoardRow[];
   has_more: boolean;
@@ -95,6 +97,12 @@ export interface InsightsBoardResponse {
   // 있다(work_item_id 기준 join, lang은 그 유니크 밖). 셀 수 있을 때만 정수, 모르면
   // null(지어내지 않는다) — 기본(include_deleted=false) 뷰에서만 뜻이 있다.
   hidden_count: number | null;
+  // story #3583(2026-09-10, 페드루 PO 確定) — org당 GA4 연결 1값(ga4_connections
+  // unique 제약, 행마다가 아니다). InsightsBoardMetricCell이 inflow_* 지표 null의
+  // 원인을 이 값으로 가른다 — 「지표 키 이름」만으로 «GA4 미연결»을 단정하던 결함의
+  // 처방(insight_snapshots.py::_fetch_ga4_inflow_metrics는 연결이 살아 있어도
+  // 처리 지연·해당 창 유입 0·일시 OAuthError로 null을 그대로 둘 수 있다).
+  ga4_connection_status: Ga4ConnectionStatus;
 }
 
 export type InsightsBoardWindow = '7d' | '30d' | '90d';

--- a/backend/app/routers/insights_board.py
+++ b/backend/app/routers/insights_board.py
@@ -92,6 +92,10 @@ class InsightsBoardResponse(BaseModel):
     # 있다(work_item_id 조인, lang은 그 유니크 밖). include_deleted=True(「보관됨 보기」)
     # 뷰에서는 무의미해 null.
     hidden_count: int | None = None
+    # story #3583(2026-09-10) — org당 GA4 연결 1값(ga4_connections unique 제약, 행마다가
+    # 아니다). FE 셀(insights-board-metric-cell.tsx)이 inflow_* 지표 null의 원인을
+    # 이 값으로 가른다 — 「지표 키 이름」만으로 단정하던 결함의 처방.
+    ga4_connection_status: Literal["not_connected", "needs_reauth", "connected"]
 
 
 class MeasuredMetricValue(BaseModel):

--- a/backend/app/services/insights_board.py
+++ b/backend/app/services/insights_board.py
@@ -38,6 +38,7 @@ from app.core.pagination import decode_cursor, decode_metric_cursor, encode_curs
 from app.models.channel_post_draft import ChannelPostDraft
 from app.models.channel_publication import ChannelPublication
 from app.models.channel_post_version import ChannelPostVersion
+from app.models.ga4_connection import GA4Connection
 from app.models.gate import Gate
 from app.models.insight_snapshot import InsightSnapshot
 from app.models.pm import Story
@@ -53,6 +54,28 @@ from app.services.insight_snapshots import (
 
 _WINDOW_DAYS = {"7d": 7, "30d": 30, "90d": 90}  # story 確定(e) — 3475(7d·30d)에 90d 신규 편입.
 _SNAPSHOT_OFFSET_DAYS = {"d1": 1, "d7": 7}
+
+
+def _derive_board_ga4_connection_status(connection: GA4Connection | None) -> str:
+    """story #3583(Phase2·마케팅운영, 페드루 PO 確定 2026-09-10) — 성과 보드 셀
+    (insights-board-metric-cell.tsx)이 inflow_* 지표 null의 원인을 「지표 키 이름」
+    (GA4_INFLOW_METRICS)만으로 «GA4 미연결»이라 단정하던 결함의 처방. 실제로는
+    _fetch_ga4_inflow_metrics(insight_snapshots.py:~915, `if inflow and …`)가
+    연결이 살아 있어도(GA4 처리 지연으로 rows=[]·그 창 유입 0·일시
+    GA4OAuthError) null을 그대로 둔다 — 「연결 안 됨」과 「연결은 됐는데 아직
+    안 왔다」를 원인축(이 값)으로 갈라야 셀이 문구를 맞게 고른다.
+
+    `GA4Connection.status`(4값: connected·property_pending·disconnected·
+    needs_reauth, ga4_connection.py 계약 보강 3)를 FE가 실제로 구별해야 하는
+    3값으로 접는다 — property_pending(토큰만 있고 속성 미선택)은 fetch 자체가
+    안 되니 "연결 안 됨"과 같은 취급(FE 관점에서 "GA4를 마저 연결하세요"가
+    맞는 안내). disconnected(행이 아예 없을 때와 동형, 실제로는 거의 안 씀)도
+    동일."""
+    if connection is None or connection.status in ("disconnected", "property_pending"):
+        return "not_connected"
+    if connection.status == "needs_reauth":
+        return "needs_reauth"
+    return "connected"
 
 
 class InsightsBoardInvalidWindowError(Exception):
@@ -481,7 +504,17 @@ async def list_insights_board(
         db, org_id=org_id, channel=channel, since=since,
     )
 
-    return {"rows": rows_out, "has_more": has_more, "next_cursor": next_cursor, "hidden_count": hidden_count}
+    # story #3583 — org당 최대 1행(ga4_connection.py unique 제약)이라 행마다가 아니라
+    # 응답 전체에 값 하나.
+    ga4_connection = (await db.execute(
+        select(GA4Connection).where(GA4Connection.org_id == org_id)
+    )).scalar_one_or_none()
+    ga4_connection_status = _derive_board_ga4_connection_status(ga4_connection)
+
+    return {
+        "rows": rows_out, "has_more": has_more, "next_cursor": next_cursor, "hidden_count": hidden_count,
+        "ga4_connection_status": ga4_connection_status,
+    }
 
 
 def _snapshot_view(snap: InsightSnapshot | None) -> dict[str, Any] | None:

--- a/backend/tests/test_3502_insights_board.py
+++ b/backend/tests/test_3502_insights_board.py
@@ -1193,3 +1193,95 @@ async def test_hidden_count_zero_when_nothing_archived():
         assert result["hidden_count"] == 0
     finally:
         await engine.dispose()
+
+
+# story #3583(Phase2·마케팅운영, 페드루 PO 確定 2026-09-10) — 성과 보드 셀이 GA4 유입
+# 지표(inflow_sessions·inflow_users) null의 원인을 「지표 키 이름」만으로 «GA4 미연결»로
+# 단정하던 결함. 실제로는 연결이 살아 있어도(GA4 처리 지연·해당 창 유입 0·일시
+# OAuthError) null일 수 있다(_fetch_ga4_inflow_metrics, insight_snapshots.py:~915 —
+# `if inflow and …`) — 원인은 「연결 상태」가 정한다. 진리표 4행(GA4Connection 행 없음·
+# property_pending·needs_reauth·connected) — 뮤테이션 대상: _derive_board_ga4_
+# connection_status를 「행 존재 여부만」으로 되돌리면(connected/needs_reauth 구별 소실)
+# 아래 needs_reauth·connected 행 2건이 RED여야 한다.
+async def _seed_ga4_connection(session, *, org_id, status, property_id="properties/123"):
+    from app.models.ga4_connection import GA4Connection
+
+    conn = GA4Connection(
+        id=uuid.uuid4(), org_id=org_id,
+        encrypted_access_token="enc-access-token", encrypted_refresh_token="enc-refresh-token",
+        property_id=property_id if status == "connected" else None,
+        status=status,
+    )
+    session.add(conn)
+    await session.commit()
+    return conn
+
+
+@pytest.mark.anyio
+async def test_ga4_connection_status_not_connected_when_no_row():
+    """행1 — GA4Connection 행 자체가 없음(연결한 적 없음) → not_connected."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+
+        assert result["ga4_connection_status"] == "not_connected"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ga4_connection_status_not_connected_when_property_pending():
+    """행2 — 토큰만 있고 속성 미선택(콜백 직후) → not_connected(fetch 자체가 안 됨)."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_ga4_connection(s, org_id=org_id, status="property_pending")
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+
+        assert result["ga4_connection_status"] == "not_connected"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ga4_connection_status_needs_reauth():
+    """행3 — 사람이 다시 연결해야 풀림 → needs_reauth(연결 자체는 있었다)."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_ga4_connection(s, org_id=org_id, status="needs_reauth")
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+
+        assert result["ga4_connection_status"] == "needs_reauth"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ga4_connection_status_connected():
+    """행4 — 토큰+property 둘 다 있음 → connected(이 상태의 inflow null은 "집계 대기")."""
+    from app.services.insights_board import list_insights_board
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_ga4_connection(s, org_id=org_id, status="connected")
+
+            result = await list_insights_board(s, org_id=org_id, window="30d")
+
+        assert result["ga4_connection_status"] == "connected"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 결함

`insights-board-metric-cell.tsx`가 `inflow_sessions`/`inflow_users`(GA4 유입 지표) 값이 null일 때 사유를 **지표 키 이름만으로** 「GA4 미연결」이라 단정했다. 실제로는 `insight_snapshots.py::_fetch_ga4_inflow_metrics`(`if inflow and …`)가 연결이 살아 있어도 다음 네 경로로 null을 그대로 둔다:

- GA4 처리 지연(rows=[])
- 해당 창 유입 실제 0
- 일시 GA4OAuthError
- needs_reauth 승격

1일 창은 발행 당일인데 GA4 지연이 24~48h라, **이미 GA4를 붙인 org가 정상 경로에서 거의 매번 「GA4 미연결」을 보고 연결하러 가는** 실사용 결함(유나 3583 실측).

## 처방

원인을 지표 키 이름 대신 응답의 `ga4_connection_status`(org당 1값, `GA4Connection`에서 파생)로 가른다.

**BE** — `InsightsBoardResponse`에 `ga4_connection_status: Literal["not_connected","needs_reauth","connected"]` additive. `_derive_board_ga4_connection_status`가 `GA4Connection.status`(4값)를 이 3값으로 접는다(`property_pending`은 fetch 자체가 안 되니 `not_connected`와 동일 취급).

**FE 셀 4행 진리표**:
| 지표 | ga4_connection_status | 사유 |
|---|---|---|
| non-GA4 | (무관) | 「지표 미제공」(기존, 무변) |
| GA4 유입 | `not_connected` | 「GA4 미연결」(기존 키) |
| GA4 유입 | `needs_reauth` | 「다시 연결 필요」(`channelStatusReauthRequired` 재사용 — 새 낱말 0) |
| GA4 유입 | `connected` | **「집계 대기」(신설 ko/en)** — 「지표 미제공」과 뜻이 다르다: 채널이 영원히 안 주는 게 아니라 곧 올 수 있다는 뜻 |

`org.insights-board` 페이지와 `story-insights-compare-section`(스토리 상세 비교 섹션) 둘 다 이 값을 자신의 조회 응답에서 읽어 셀에 넘긴다(두 화면이 각자 조회라 값도 각자 든다 — 같은 org라 값은 같다).

## 테스트

- FE: `insights-board-metric-cell.test.tsx` — 4행 진리표 + 뮤테이션 핀(「지표 키 이름」만으로 되돌리면 connected∧null 행이 「GA4 미연결」로 잘못 서서 RED).
- BE: `test_3502_insights_board.py` — `ga4_connection_status` 파생 4행(행 없음·property_pending·needs_reauth·connected).
- 전체 vitest 738파일/7517테스트 GREEN · tsc 통과 · `next build --webpack` 통과 · eslint 0 error(사전 존재 warning 7건은 이 PR 무관 파일) · BE pytest(`test_3502_insights_board.py`) 31/31 GREEN(실 Postgres, throwaway DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn