### PR TITLE
[SID:3369] fix(FE): site_post 외부발행 상세 needs_check 2단계 관문 이식

### DIFF
--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -1710,14 +1710,109 @@ describe('ContentPostEditPage — 외부 목적지 발행 결과(story #3479, �
     expect(container.querySelector('[data-testid="content-external-publication-info"]')).toBeNull();
   });
 
-  it('⭐command dead_letter — FailureActionBadge 재시도 버튼 클릭 → 공용 BFF(publication-commands/{id}/retry) 호출', async () => {
+  // story #3369(Phase2·FE, 페드루 PO 確定 2026-09-11) — channel_posts 상세의 needs_check
+  // 2단계 관문을 site_post 외부발행 상세에도 이식(recheckGate=true, 새 컴포넌트·새
+  // 낱말 0). ConfirmDialog는 Portal이라 document.body에 뜬다(unpublish 다이얼로그
+  // 테스트와 동형).
+  describe('⭐3369 — needs_check 2단계 관문(dead_letter ∧ failure_kind=needs_check)', () => {
+    it('⭐배지·CTA부터 needs_check 것 — recheckGate=true라 「밖에 나갔는지 모르는 실패」 문면이 선다', async () => {
+      stubFetchWithVersions([VERSION_1], undefined, undefined, {
+        publication: {
+          published_at: null, url: null, published_by_member_id: null, published_body_sha256: null,
+          destination: 'webhook',
+          channel_publication: null,
+          command: { id: 'cmd-1', command_status: 'dead_letter', attempt_count: 5, failure_kind: 'needs_check', next_retry_at: null, dead_letter_at: '2026-09-05T00:00:00Z', command_reason_code: null, last_error: 'timeout' },
+        },
+      });
+      await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+      await flush();
+      await flush();
+
+      // ⭐뮤테이션 핀 1 — recheckGate를 안 넘기면(또는 지우면) FailureActionBadge가
+      // 일반 dead_letter 문면(channelPostsFailureDeadLetter)+CTA(channelPostsFailureRetryCta)를
+      // 그린다 — 이 두 단언이 RED가 되어야 그 회귀를 잡는다.
+      expect(container.querySelector('[data-testid="channel-post-failure-badge"]')?.textContent)
+        .toContain(koMessages.content.channelPostsFailureNeedsCheck);
+      const retryBtn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement;
+      expect(retryBtn.textContent).toBe(koMessages.content.channelPostsFailureCheckedRetryCta);
+      expect(retryBtn.disabled).toBe(false);
+    });
+
+    it('⭐체크 前엔 확認 버튼 비활성 · 체크 後 활성 · 확認 시 공용 BFF(publication-commands/{id}/retry) 1회', async () => {
+      let retried: string | null = null;
+      let retryCallCount = 0;
+      stubFetchWithVersions([VERSION_1], undefined, undefined, {
+        publication: {
+          published_at: null, url: null, published_by_member_id: null, published_body_sha256: null,
+          destination: 'webhook',
+          channel_publication: null,
+          command: { id: 'cmd-1', command_status: 'dead_letter', attempt_count: 5, failure_kind: 'needs_check', next_retry_at: null, dead_letter_at: '2026-09-05T00:00:00Z', command_reason_code: null, last_error: 'timeout' },
+        },
+        onRetryPublicationCommand: (commandId) => { retried = commandId; retryCallCount += 1; return { status: 200, body: { id: commandId, status: 'pending' } }; },
+      });
+      await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+      await flush();
+      await flush();
+
+      const retryBtn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement;
+      await act(async () => { retryBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      expect(document.body.querySelector('[data-testid="content-retry-confirm-what"]')?.textContent)
+        .toBe(koMessages.content.channelPostsRetryConfirmWhatNeedsCheck);
+      const checklist = document.body.querySelector('[data-testid="content-retry-confirm-checklist"]') as HTMLInputElement;
+      expect(checklist).not.toBeNull();
+      const confirmBtn = [...document.body.querySelectorAll('button')].filter((b) => b !== retryBtn)
+        .find((b) => b.textContent === koMessages.content.channelPostsRetryConfirmAction) as HTMLButtonElement;
+      // ⭐뮤테이션 핀 2 — confirmDisabled 조건에서 체크리스트 항을 걷으면(체크 없이도
+      // 확認 가능해지면) 이 단언이 RED다.
+      expect(confirmBtn.disabled).toBe(true);
+      expect(retried).toBeNull();
+
+      await act(async () => { checklist.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(confirmBtn.disabled).toBe(false);
+
+      await act(async () => { confirmBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      expect(retried).toBe('cmd-1');
+      expect(retryCallCount).toBe(1);
+    });
+
+    it('취소를 누르면 호출 0 — 체크리스트도 리셋된다(다음에 다시 열면 미체크 상태)', async () => {
+      let retryCallCount = 0;
+      stubFetchWithVersions([VERSION_1], undefined, undefined, {
+        publication: {
+          published_at: null, url: null, published_by_member_id: null, published_body_sha256: null,
+          destination: 'webhook',
+          channel_publication: null,
+          command: { id: 'cmd-1', command_status: 'dead_letter', attempt_count: 5, failure_kind: 'needs_check', next_retry_at: null, dead_letter_at: '2026-09-05T00:00:00Z', command_reason_code: null, last_error: 'timeout' },
+        },
+        onRetryPublicationCommand: () => { retryCallCount += 1; return { status: 200, body: { id: 'cmd-1', status: 'pending' } }; },
+      });
+      await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+      await flush();
+      await flush();
+
+      const retryBtn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement;
+      await act(async () => { retryBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const cancelBtn = [...document.body.querySelectorAll('button')].filter((b) => b !== retryBtn).find((b) => b.textContent === koMessages.common.cancel);
+      expect(cancelBtn).toBeDefined();
+      await act(async () => { cancelBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(retryCallCount).toBe(0);
+    });
+  });
+
+  it('command dead_letter(needs_check 아님) — 확認 다이얼로그엔 체크리스트가 없고 확認 즉시 재시도된다(회귀 0)', async () => {
     let retried: string | null = null;
     stubFetchWithVersions([VERSION_1], undefined, undefined, {
       publication: {
         published_at: null, url: null, published_by_member_id: null, published_body_sha256: null,
         destination: 'webhook',
         channel_publication: null,
-        command: { id: 'cmd-1', command_status: 'dead_letter', attempt_count: 5, failure_kind: 'needs_check', next_retry_at: null, dead_letter_at: '2026-09-05T00:00:00Z', command_reason_code: null, last_error: 'timeout' },
+        command: { id: 'cmd-1', command_status: 'dead_letter', attempt_count: 5, failure_kind: null, next_retry_at: null, dead_letter_at: '2026-09-05T00:00:00Z', command_reason_code: null, last_error: 'timeout' },
       },
       onRetryPublicationCommand: (commandId) => { retried = commandId; return { status: 200, body: { id: commandId, status: 'pending' } }; },
     });
@@ -1728,7 +1823,14 @@ describe('ContentPostEditPage — 외부 목적지 발행 결과(story #3479, �
     const retryBtn = container.querySelector('[data-testid="channel-post-failure-retry-button"]') as HTMLButtonElement;
     expect(retryBtn).not.toBeNull();
     expect(retryBtn.disabled).toBe(false);
-    await act(async () => { retryBtn.click(); });
+    await act(async () => { retryBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(document.body.querySelector('[data-testid="content-retry-confirm-checklist"]')).toBeNull();
+    const confirmBtn = [...document.body.querySelectorAll('button')].filter((b) => b !== retryBtn)
+      .find((b) => b.textContent === koMessages.content.channelPostsRetryConfirmAction) as HTMLButtonElement;
+    expect(confirmBtn.disabled).toBe(false);
+    await act(async () => { confirmBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
     expect(retried).toBe('cmd-1');

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -303,6 +303,12 @@ export default function ContentPostEditPage() {
   // story #3479(BE #3476) — 외부 목적지 발행 재시도. 공용 BFF(publication-commands/
   // {id}/retry) — content_kind 무관, command_id 하나로 서버가 대상을 안다.
   const [retryingCommand, setRetryingCommand] = useState(false);
+  // story #3369(Phase2·FE, 페드루 PO 確定 2026-09-11) — channel_posts 상세
+  // (content/channel-posts/[draftId]/page.tsx)의 needs_check 2단계 관문을 그대로
+  // 이식한다 — 「밖에 나갔는지 모르는 실패」를 곧바로 재시도로 넘기지 않고, 채널에서
+  // 확認했다는 체크가 끝나야 확認 버튼이 열린다(recheckGate 이 화면에서 켬).
+  const [retryConfirmOpen, setRetryConfirmOpen] = useState(false);
+  const [retryChecklistConfirmed, setRetryChecklistConfirmed] = useState(false);
 
   // story 15e481ce(#3453 AC1) — 「Threads 변형 만들기」. 활성 연결 목록·이미 만든 변형
   // 목록은 서로 다른 조회(연결=channel-connections, 변형=variants) — 같이 로드한다.
@@ -998,7 +1004,13 @@ export default function ContentPostEditPage() {
     setRetryingCommand(true);
     try {
       const res = await fetchWithAuth(`/api/organizations/${orgId}/publication-commands/${commandId}/retry`, { method: 'POST' });
-      if (res.ok) void loadPublication();
+      if (res.ok) {
+        // story #3369 — channel_posts 상세 handleRetry와 동형(성공 시 다이얼로그 닫고
+        // 체크 상태 리셋).
+        setRetryConfirmOpen(false);
+        setRetryChecklistConfirmed(false);
+        void loadPublication();
+      }
     } finally {
       setRetryingCommand(false);
     }
@@ -1076,6 +1088,11 @@ export default function ContentPostEditPage() {
         reasonCode: publication.command.command_reason_code,
       })
     : undefined;
+  // story #3369(channel_posts 상세 isNeedsCheckGate와 동형) — dead_letter 안에서도
+  // needsRecheck면 「밖에 나갔는지 모르는 실패」다. ConfirmDialog 세 자리(문면·체크박스·
+  // confirmDisabled)가 이 값 하나로 갈린다.
+  const isExternalNeedsCheckGate = externalFailureAction?.kind === 'needs_check'
+    || (externalFailureAction?.kind === 'dead_letter' && externalFailureAction.needsRecheck);
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-6 p-6">
@@ -1292,10 +1309,42 @@ export default function ContentPostEditPage() {
           {publication.command && externalFailureAction ? (
             <FailureActionBadge
               action={externalFailureAction}
-              onRetryClick={() => void handleRetryPublicationCommand(publication.command!.id)}
               displayTimezone={displayTimezone}
+              // story #3369 — 아래 ConfirmDialog가 실제 needs_check 관문(체크리스트·
+              // 확認버튼 disabled)을 제공한다 — recheckGate=true라 needsRecheck
+              // 문면이 「약속을 지키는」 곳(channel_posts 상세와 동형).
+              recheckGate
+              onRetryClick={() => { setRetryChecklistConfirmed(false); setRetryConfirmOpen(true); }}
             />
           ) : null}
+          <ConfirmDialog
+            open={retryConfirmOpen}
+            onOpenChange={(next) => { setRetryConfirmOpen(next); if (!next) setRetryChecklistConfirmed(false); }}
+            title={t('channelPostsRetryConfirmTitle')}
+            description={(
+              <>
+                <span className="block" data-testid="content-retry-confirm-what">
+                  {isExternalNeedsCheckGate ? t('channelPostsRetryConfirmWhatNeedsCheck') : t('channelPostsRetryConfirmWhatDeadLetter')}
+                </span>
+                <span className="block" data-testid="content-retry-confirm-reversible">{t('channelPostsRetryConfirmReversible')}</span>
+                {isExternalNeedsCheckGate ? (
+                  <label className="mt-2 flex items-center gap-2 text-sm text-foreground">
+                    <input
+                      type="checkbox" checked={retryChecklistConfirmed}
+                      onChange={(e) => setRetryChecklistConfirmed(e.target.checked)}
+                      data-testid="content-retry-confirm-checklist"
+                    />
+                    {t('channelPostsRetryConfirmChecklist')}
+                  </label>
+                ) : null}
+              </>
+            )}
+            cancelLabel={tc('cancel')}
+            confirmLabel={retryingCommand ? t('channelPostsRetryConfirmPendingCta') : t('channelPostsRetryConfirmAction')}
+            confirmDisabled={retryingCommand || (isExternalNeedsCheckGate && !retryChecklistConfirmed)}
+            destructive={false}
+            onConfirm={() => void handleRetryPublicationCommand(publication.command!.id)}
+          />
         </div>
       ) : null}
 


### PR DESCRIPTION
**Stacked on #4163** — `fix/3402-needs-check-gate-dead-letter`(head `d09b36a487`) 위. #4163 머지 즉시 base를 develop으로 rebase(head 한 번만).

## 그라운딩 결론(코드 0, 채팅 보고 완료)

site_post 외부발행(`content/[draftId]/page.tsx`)도 channel_post와 **같은 분류 표**(`classify_failure_kind`, `publication_command.py:117`)로 needs_check가 이미 도달한다(`_process_one_site_post_command` → `apply_command_failure`). 다만 화면엔 needs_check 인지 자체가 0 — `deriveFailureAction`은 이미 `failureKind`를 넘겨받지만(`recheckGate` prop이 없어) `FailureActionBadge`가 일반 dead_letter 문구+바로 재시도 버튼만 그리고, 확認 다이얼로그·체크리스트·`confirmDisabled` 같은 관문 인프라 자체가 이 페이지엔 없었다.

## 처방

channel_posts 상세의 `isNeedsCheckGate` 구조(다이얼로그 "무엇이" 문면·체크박스·`confirmDisabled` 셋을 한 값이 묶는 것, `content/channel-posts/[draftId]/page.tsx:1877~2018`)를 그대로 이식:

- `isExternalNeedsCheckGate` 파생(`externalFailureAction.kind === 'needs_check' || (kind === 'dead_letter' && needsRecheck)`)
- `FailureActionBadge`에 `recheckGate` 켬 — 아래 ConfirmDialog가 실제 관문을 제공하므로 needsRecheck 문면이 "약속을 지키는" 자리가 됨
- `onRetryClick`이 직접 재시도 대신 확認 다이얼로그를 열게 변경, 체크 前엔 확認 버튼 비활성

**새 컴포넌트 0 · 새 낱말 0** — channel_posts와 site_post 둘 다 이미 같은 `t = useTranslations('content')` / `tc = useTranslations('common')`를 쓰므로 `channelPostsRetryConfirm*` 키를 그대로 재사용.

## 테스트

- 기존 "dead_letter 재시도 버튼 클릭 → 즉시 호출" 테스트를 다이얼로그 경유 흐름으로 갱신 + `needs_check` 진리표 3건(배지/CTA 문면, 체크 前後 confirmDisabled, 확認 시 BFF 1회 호출, 취소 시 호출 0) + 회귀 1건(`failure_kind=null`인 dead_letter는 체크리스트 없이 즉시 확認 가능).
- 뮤테이션 핀 2: recheckGate 걷으면 배지가 일반 문구로 RED / `confirmDisabled`에서 체크리스트 조건 걷으면 "체크 前 비활성" 단언이 RED.
- FE 전체 vitest 738파일/7520테스트 GREEN · tsc 통과 · `next build --webpack` 통과 · eslint 0(터치 파일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn