### PR TITLE
[SID:3796] fix(BE): 타 org publication_id → 404 거부(존재 비노출)

### DIFF
--- a/backend/app/routers/insight_snapshots.py
+++ b/backend/app/routers/insight_snapshots.py
@@ -18,6 +18,7 @@ from app.dependencies.database import get_db
 from app.services.insight_snapshots import (
     label_snapshot_offset,
     list_insight_snapshots_for_publication,
+    resolve_publication_org_id,
     resolve_publication_published_at,
 )
 
@@ -52,13 +53,26 @@ async def list_publication_insights_endpoint(
     _auth=Depends(get_current_user),
 ) -> list[InsightSnapshotView]:
     """AC6 — 스냅샷 목록(raw_payload 제외 — 원본은 디버그 전용, 이 조회 축에 실을
-    필요가 없다). 존재하지 않는 publication_id는 빈 목록으로 응답한다(그 자체가
-    "이 발행엔 아직 스냅샷이 없다"는 정직한 사실 — 404로 지어내지 않는다, org
-    경계는 org_id mismatch일 때만 403)."""
+    필요가 없다). 애초에 존재하지 않는 publication_id는 빈 목록으로 응답한다(그
+    자체가 "이 발행엔 아직 스냅샷이 없다"는 정직한 사실 — 404로 지어내지 않는다).
+
+    story #3796(페드루 PO 確定 2026-09-10, 유나 실측) — 그러나 publication_id가
+    **타 org 소유**로 실존하면 얘기가 다르다. 쿼리 자체는 org_id+publication_id를
+    이미 WHERE에 걸어 데이터를 새기지 않지만(row 0건), 응답은 "애초에 없음"과
+    "있는데 남의 것"을 구분 안 해 똑같이 빈 목록으로 조용히 넘겼다 — MCP 소비부
+    (sprintable_mcp/tools/channel_posts.py::get_publication_insights)가 그 빈 목록을
+    delta_unavailable_reason="스냅샷이 2건 미만…"으로 번역해 "기다리면 된다"로
+    읽히는 거짓 사유가 나갔다(진실은 "네 org 것이 아니다"). 스냅샷 0건일 때만
+    (비용 최소화) 실 소유 org를 추가로 확인해 타 org 소유면 404로 존재 자체를
+    비노출한다."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
     rows = await list_insight_snapshots_for_publication(db, org_id=org_id, publication_id=publication_id)
+    if not rows:
+        owner_org_id = await resolve_publication_org_id(db, publication_id=publication_id)
+        if owner_org_id is not None and owner_org_id != org_id:
+            raise HTTPException(status_code=404, detail="이 조직에 없는 발행물입니다")
     # story #3651 CHANGES — 이 publication의 «지금» published_at 1회 조회(행마다 반복
     # 조회 0, 어차피 폴리모픽 publication_id 하나당 kind는 하나다 — rows[0]에서 그대로
     # 읽는다). 스냅샷이 없으면 조회 자체를 스킵(빈 목록 반환은 그대로 유지).

--- a/backend/app/routers/insight_snapshots.py
+++ b/backend/app/routers/insight_snapshots.py
@@ -8,13 +8,15 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import get_current_user
 from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
+from app.services.agent_onboarding_config import resolve_locale_from_request
+from app.services.i18n_catalog import t
 from app.services.insight_snapshots import (
     label_snapshot_offset,
     list_insight_snapshots_for_publication,
@@ -51,28 +53,52 @@ async def list_publication_insights_endpoint(
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth=Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> list[InsightSnapshotView]:
+    """story #3796 — 라우트 진입점, `Header()` DI 마커는 여기서만 받는다(까심 QA CI FAILURE
+    원칙, i18n_catalog.py 모듈 docstring 참조). 직접-호출(realdb·유닛) 테스트는
+    `_list_publication_insights_endpoint`를 불러야 한다."""
+    return await _list_publication_insights_endpoint(
+        org_id, publication_id, db=db, verified_org_id=verified_org_id, _auth=_auth,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _list_publication_insights_endpoint(
+    org_id: uuid.UUID,
+    publication_id: uuid.UUID,
+    *,
+    db: AsyncSession,
+    verified_org_id: uuid.UUID,
+    _auth,
+    resolved_locale: str,
 ) -> list[InsightSnapshotView]:
     """AC6 — 스냅샷 목록(raw_payload 제외 — 원본은 디버그 전용, 이 조회 축에 실을
-    필요가 없다). 애초에 존재하지 않는 publication_id는 빈 목록으로 응답한다(그
-    자체가 "이 발행엔 아직 스냅샷이 없다"는 정직한 사실 — 404로 지어내지 않는다).
+    필요가 없다).
 
-    story #3796(페드루 PO 確定 2026-09-10, 유나 실측) — 그러나 publication_id가
-    **타 org 소유**로 실존하면 얘기가 다르다. 쿼리 자체는 org_id+publication_id를
-    이미 WHERE에 걸어 데이터를 새기지 않지만(row 0건), 응답은 "애초에 없음"과
-    "있는데 남의 것"을 구분 안 해 똑같이 빈 목록으로 조용히 넘겼다 — MCP 소비부
-    (sprintable_mcp/tools/channel_posts.py::get_publication_insights)가 그 빈 목록을
-    delta_unavailable_reason="스냅샷이 2건 미만…"으로 번역해 "기다리면 된다"로
-    읽히는 거짓 사유가 나갔다(진실은 "네 org 것이 아니다"). 스냅샷 0건일 때만
-    (비용 최소화) 실 소유 org를 추가로 확인해 타 org 소유면 404로 존재 자체를
-    비노출한다."""
+    story #3796(페드루 PO 確定 2026-09-10, 유나 실측 — 2차 CHANGES 2026-09-11) —
+    **계약 변경**: "애초에 존재하지 않는 publication_id"와 "타 org 소유로 실존"을
+    가르는 축을 404/200으로 노출하면(1차 처방이 그랬다) 호출자가 그 둘을 구분해
+    "이 id가 실존하는지"를 org 경계 밖에서 열거(enumerate)할 수 있다 — docstring의
+    "존재 자체를 비노출"과 응답이 실제로는 어긋나는 자기모순(같은 화면 두 문장이
+    다른 세계를 말하는 것). 가름선을 **소유**로 다시 긋는다 — `owner_org_id`가
+    `None`(애초에 미존재)이든 caller org와 다른 실제 org든, 어느 쪽이든 "내 org
+    것이 아니다"는 사실은 같으므로 **둘 다 404**로 동일하게 응답한다(응답 바디·
+    status 완전히 구분 불가). "내 org 소유인데 스냅샷만 0건"일 때만 빈 목록(그
+    자체가 "이 발행엔 아직 스냅샷이 없다"는 정직한 사실 — 지어내지 않는다). 3497의
+    옛 계약("애초에 미존재=빈 목록")은 이 스토리로 폐기·404로 갱신됐다(해당 테스트도
+    같이 고쳤다)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
     rows = await list_insight_snapshots_for_publication(db, org_id=org_id, publication_id=publication_id)
     if not rows:
         owner_org_id = await resolve_publication_org_id(db, publication_id=publication_id)
-        if owner_org_id is not None and owner_org_id != org_id:
-            raise HTTPException(status_code=404, detail="이 조직에 없는 발행물입니다")
+        if owner_org_id != org_id:
+            raise HTTPException(
+                status_code=404, detail=t("insight_snapshots.publication_not_found_in_org", resolved_locale),
+            )
     # story #3651 CHANGES — 이 publication의 «지금» published_at 1회 조회(행마다 반복
     # 조회 0, 어차피 폴리모픽 publication_id 하나당 kind는 하나다 — rows[0]에서 그대로
     # 읽는다). 스냅샷이 없으면 조회 자체를 스킵(빈 목록 반환은 그대로 유지).

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -169,6 +169,13 @@ _CATALOG: dict[str, dict[str, str]] = {
         "ko": "이 액션은 org owner 만 가능합니다.",
         "en": "This action requires org owner",
     },
+    # story #3796(페드루 PO 確定 2026-09-10 — 2차 CHANGES 2026-09-11, 3779 가드 발견) —
+    # 애초에 미존재·타 org 소유 둘 다 이 문구로 404(존재 자체 비노출, 응답 완전 동일
+    # — insight_snapshots.py 라우터 docstring 참조).
+    "insight_snapshots.publication_not_found_in_org": {
+        "ko": "이 조직에 없는 발행물입니다",
+        "en": "Publication not found in this organization",
+    },
 }
 
 

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -118,9 +118,10 @@ async def list_insight_snapshots_for_publication(
 
 
 async def resolve_publication_org_id(db: AsyncSession, *, publication_id: uuid.UUID) -> uuid.UUID | None:
-    """story #3796(페드루 PO 確定 2026-09-10, 유나 실측) — 폴리모픽 publication_id의
-    실 소유 org. 라우터가 스냅샷 0건일 때만 부른다(존재+타 org인지 vs 애초에 미존재인지
-    구분하기 위함 — 전자만 404, 후자는 기존 "빈 목록" 계약 그대로 유지). resolve_
+    """story #3796(페드루 PO 確定 2026-09-10, 2차 CHANGES 2026-09-11) — 폴리모픽
+    publication_id의 실 소유 org. 라우터가 스냅샷 0건일 때만 부른다 — 반환값이
+    caller org와 다르면(None 포함, 애초에 미존재도 여기 해당) 404, 같으면(내 org
+    소유+스냅샷만 0건) 빈 목록(가름선=소유, 라우터 docstring 참고). resolve_
     publication_published_at과 같은 두 테이블(ChannelPublication·SitePost)을 보되,
     이쪽은 kind를 모르는 채로 호출되므로(스냅샷 행 자체가 없어 kind를 읽을 자리가
     없다) 순서대로 둘 다 시도 — 어느 쪽도 없으면 None(지어내지 않는다)."""

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -117,6 +117,26 @@ async def list_insight_snapshots_for_publication(
     return list(rows)
 
 
+async def resolve_publication_org_id(db: AsyncSession, *, publication_id: uuid.UUID) -> uuid.UUID | None:
+    """story #3796(페드루 PO 確定 2026-09-10, 유나 실측) — 폴리모픽 publication_id의
+    실 소유 org. 라우터가 스냅샷 0건일 때만 부른다(존재+타 org인지 vs 애초에 미존재인지
+    구분하기 위함 — 전자만 404, 후자는 기존 "빈 목록" 계약 그대로 유지). resolve_
+    publication_published_at과 같은 두 테이블(ChannelPublication·SitePost)을 보되,
+    이쪽은 kind를 모르는 채로 호출되므로(스냅샷 행 자체가 없어 kind를 읽을 자리가
+    없다) 순서대로 둘 다 시도 — 어느 쪽도 없으면 None(지어내지 않는다)."""
+    from app.models.channel_publication import ChannelPublication
+    from app.models.site_post import SitePost
+
+    org_id = (await db.execute(
+        select(ChannelPublication.org_id).where(ChannelPublication.id == publication_id)
+    )).scalar_one_or_none()
+    if org_id is not None:
+        return org_id
+    return (await db.execute(
+        select(SitePost.org_id).where(SitePost.id == publication_id)
+    )).scalar_one_or_none()
+
+
 async def resolve_publication_published_at(
     db: AsyncSession, *, publication_kind: str, publication_id: uuid.UUID,
 ) -> datetime | None:

--- a/backend/tests/test_3497_insight_snapshots.py
+++ b/backend/tests/test_3497_insight_snapshots.py
@@ -852,7 +852,46 @@ async def test_insights_list_endpoint_returns_captured_snapshot():
 
 
 @pytest.mark.anyio
-async def test_insights_list_endpoint_empty_list_for_unknown_publication():
+async def test_insights_list_endpoint_own_org_publication_zero_snapshots_is_empty_list():
+    """story #3796(페드루 PO 確定 2026-09-10, 2차 CHANGES 2026-09-11) — 계약 변경 뒤
+    빈 목록이 남는 유일한 경우: publication_id가 **내 org 소유가 맞는데** 스냅샷이
+    아직 0건인 것(그 자체가 정직한 사실 — 지어내지 않는다). 애초에 미존재·타 org
+    소유는 이제 둘 다 404(아래 두 테스트)."""
+    from app.main import app
+    from app.models.site_post import SitePost
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+            own_post = SitePost(
+                id=uuid.uuid4(), org_id=org_id, lang="ko", slug=f"own-post-{uuid.uuid4().hex[:8]}",
+                title="제목", summary="요약", tags=[], body_md="본문",
+                published_at=datetime.now(timezone.utc), source_story_id=uuid.uuid4(), gate_id=uuid.uuid4(),
+            )
+            s.add(own_post)
+            await s.commit()
+            own_post_id = own_post.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/publications/{own_post_id}/insights")
+        assert r.status_code == 200, r.text
+        assert r.json() == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_insights_list_endpoint_unknown_publication_returns_404():
+    """story #3796 2차 CHANGES(페드루 2026-09-11) — 계약 변경: 애초에 미존재인
+    publication_id는 더 이상 200/[]가 아니라 404다. 옛 계약("미존재=빈 목록")은
+    이 스토리로 폐기됐다 — 존재 여부를 200/404로 노출하면(가름선이 "존재"였을 때)
+    호출자가 org 경계 밖에서 존재를 열거할 수 있어(아래
+    test_unknown_and_cross_org_return_identical_404_no_existence_oracle이 그 축을
+    직접 검증), 이제 가름선은 "소유"뿐이다."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -864,8 +903,7 @@ async def test_insights_list_endpoint_empty_list_for_unknown_publication():
         _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
         async with _client_for(app) as client:
             r = await client.get(f"/api/v2/organizations/{org_id}/publications/{uuid.uuid4()}/insights")
-        assert r.status_code == 200, r.text
-        assert r.json() == [], "존재하지 않는 publication_id는 404가 아니라 빈 목록(지어내지 않는다)"
+        assert r.status_code == 404, r.text
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -874,9 +912,7 @@ async def test_insights_list_endpoint_empty_list_for_unknown_publication():
 @pytest.mark.anyio
 async def test_insights_list_endpoint_cross_org_site_post_returns_404():
     """story #3796(페드루 PO 確定 2026-09-10, 유나 실측) — publication_id가 실존하되
-    **타 org 소유**면 빈 목록이 아니라 404(존재 자체 비노출). 위
-    test_insights_list_endpoint_empty_list_for_unknown_publication(애초에 미존재)과는
-    다른 축 — 그쪽은 지금도 그대로 200/[]가 맞다(지어내지 않는다), 이쪽만 404."""
+    **타 org 소유**면 404(존재 자체 비노출)."""
     from app.main import app
     from app.models.site_post import SitePost
 
@@ -900,6 +936,42 @@ async def test_insights_list_endpoint_cross_org_site_post_returns_404():
         async with _client_for(app) as client:
             r = await client.get(f"/api/v2/organizations/{org_id}/publications/{other_post_id}/insights")
         assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unknown_and_cross_org_return_identical_404_no_existence_oracle():
+    """story #3796 2차 CHANGES(페드루 2026-09-11) — 핵심 요구: "애초에 미존재"와
+    "타 org 실존"이 응답으로 구분 불가능해야 한다(구분되면 그 자체가 존재-열거
+    오라클). status·JSON 바디를 완전히 diff해 동일함을 직접 단언."""
+    from app.main import app
+    from app.models.site_post import SitePost
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+
+            other_org_id, _ = await _seed_org(s)
+            other_post = SitePost(
+                id=uuid.uuid4(), org_id=other_org_id, lang="ko", slug=f"other-org-post-{uuid.uuid4().hex[:8]}",
+                title="제목", summary="요약", tags=[], body_md="본문",
+                published_at=datetime.now(timezone.utc), source_story_id=uuid.uuid4(), gate_id=uuid.uuid4(),
+            )
+            s.add(other_post)
+            await s.commit()
+            other_post_id = other_post.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_unknown = await client.get(f"/api/v2/organizations/{org_id}/publications/{uuid.uuid4()}/insights")
+            r_cross_org = await client.get(f"/api/v2/organizations/{org_id}/publications/{other_post_id}/insights")
+
+        assert r_unknown.status_code == r_cross_org.status_code == 404
+        assert r_unknown.json() == r_cross_org.json(), "존재-열거 오라클 — 두 응답이 구분되면 안 된다"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3497_insight_snapshots.py
+++ b/backend/tests/test_3497_insight_snapshots.py
@@ -872,6 +872,67 @@ async def test_insights_list_endpoint_empty_list_for_unknown_publication():
 
 
 @pytest.mark.anyio
+async def test_insights_list_endpoint_cross_org_site_post_returns_404():
+    """story #3796(페드루 PO 確定 2026-09-10, 유나 실측) — publication_id가 실존하되
+    **타 org 소유**면 빈 목록이 아니라 404(존재 자체 비노출). 위
+    test_insights_list_endpoint_empty_list_for_unknown_publication(애초에 미존재)과는
+    다른 축 — 그쪽은 지금도 그대로 200/[]가 맞다(지어내지 않는다), 이쪽만 404."""
+    from app.main import app
+    from app.models.site_post import SitePost
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+
+            other_org_id, _ = await _seed_org(s)
+            other_post = SitePost(
+                id=uuid.uuid4(), org_id=other_org_id, lang="ko", slug=f"other-org-post-{uuid.uuid4().hex[:8]}",
+                title="제목", summary="요약", tags=[], body_md="본문",
+                published_at=datetime.now(timezone.utc), source_story_id=uuid.uuid4(), gate_id=uuid.uuid4(),
+            )
+            s.add(other_post)
+            await s.commit()
+            other_post_id = other_post.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/publications/{other_post_id}/insights")
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_insights_list_endpoint_cross_org_channel_publication_returns_404():
+    """위 site_post 케이스의 짝 — 폴리모픽 publication_id의 다른 쪽(ChannelPublication)도
+    같은 축으로 404여야 한다(resolve_publication_org_id가 두 테이블 다 본다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+
+            other_org_id, _ = await _seed_org(s)
+            other_conn = await _seed_channel_connection(s, other_org_id, channel="sandbox")
+            other_pub = await _seed_channel_publication(
+                s, org_id=other_org_id, connection_id=other_conn.id, channel="sandbox",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/publications/{other_pub.id}/insights")
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_insights_list_endpoint_org_mismatch_403():
     from app.main import app
 

--- a/backend/tests/test_3651_mcp_get_publication_insights.py
+++ b/backend/tests/test_3651_mcp_get_publication_insights.py
@@ -134,11 +134,38 @@ async def test_float_metrics_get_real_delta_not_null(monkeypatch):
     assert body["delta_1d_to_7d"]["ctr"] is None  # 1일값이 null(미제공)이라 여전히 null
 
 
+async def test_direct_publication_id_cross_org_surfaces_404_not_fake_reason(monkeypatch):
+    """story #3796(페드루 PO 確定 2026-09-10, 유나 실측) — 3651 원래 설계는 publication_id
+    직접 조회 경로에서 org WHERE절 불일치를 빈 목록으로 떨어뜨려(아래
+    test_draft_id_without_publication_surfaces_be_error_as_text의 예전 docstring이 그
+    갭을 그대로 명시했었다), 이 계층이 그 빈 목록을 "스냅샷이 2건 미만…"이라는 거짓
+    delta_unavailable_reason으로 번역해 냈다(데이터는 안 새지만 "기다리면 된다"로
+    읽히는 오도 — 진실은 "네 org 것이 아니다"). BE(insight_snapshots.py 라우터)가
+    이제 이 경우 404를 낸다 — SprintableApiError를 삼키지 않고 그대로 err()로 전파돼야
+    한다(거짓 사유 조합 0)."""
+    from sprintable_mcp.tools import channel_posts
+    from sprintable_mcp.api_client import SprintableApiError
+
+    async def _raise(path: str, **_kwargs):
+        raise SprintableApiError(404, "이 조직에 없는 발행물입니다", None)
+
+    monkeypatch.setattr(channel_posts.client, "get", _raise)
+    monkeypatch.setattr(type(channel_posts.client), "org_id", property(lambda self: "org-1"))
+
+    result = await channel_posts.get_publication_insights(
+        channel_posts.GetPublicationInsightsInput(publication_id="pub-foreign-org"),
+    )
+    assert result[0].text.startswith("Error:")
+    assert "이 조직에 없는 발행물" in result[0].text
+    assert "delta_unavailable_reason" not in result[0].text
+    assert "스냅샷이 2건 미만" not in result[0].text
+
+
 async def test_draft_id_without_publication_surfaces_be_error_as_text(monkeypatch):
     """다른 org의 draft_id(또는 존재하지 않는 draft_id)를 주면 draft 상세 조회 자체가
-    BE에서 404로 거부된다 — SprintableApiError를 삼키지 않고 그대로 err()로 낸다(3651
-    AC1 「다른 org publication → 404/403」의 실제 발생 지점: publication_id 직접 조회는
-    org WHERE절 불일치가 빈 목록으로 떨어지는 기존 설계라, 거부는 draft_id 경로에서 난다)."""
+    BE에서 404로 거부된다 — SprintableApiError를 삼키지 않고 그대로 err()로 낸다(draft_id
+    편의 축 자신의 org 경계 — publication_id 직접 조회 축의 경계 정정은 위
+    test_direct_publication_id_cross_org_surfaces_404_not_fake_reason·story #3796)."""
     from sprintable_mcp.tools import channel_posts
     from sprintable_mcp.api_client import SprintableApiError
 


### PR DESCRIPTION
## 그라운딩(페드루 지시 2026-09-10 17:41Z, 유나 실측)
MCP `get_publication_insights`가 래핑하는 REST `GET /publications/{publication_id}/insights`는 org_id+publication_id를 WHERE에 걸어 데이터를 새기지는 않지만, "애초에 없음"과 "있는데 남의 것"을 구분 안 해 둘 다 조용히 빈 목록으로 넘겼다 — MCP 소비부가 그 빈 목록을 `delta_unavailable_reason="스냅샷이 2건 미만…"`으로 번역해 "기다리면 된다"로 읽히는 거짓 사유가 나갔다. 실측: 뭉클랩 키로 PO Test Org 발행물 c547fa6d 조회.

## ⚠️계약 변경(PO CHANGES 2026-09-11)
1차 처방은 "애초에 미존재"(200/`[]`)와 "타 org 실존"(404)을 구분해 응답했는데, 그 구분 자체가 호출자에게 publication_id의 실존 여부를 org 경계 밖에서 열거(enumerate)하게 하는 오라클이었다. **가름선을 소유로 재정의** — `owner_org_id != org_id`(None 포함 단일 조건): 애초에 미존재든 타 org 소유든 둘 다 동일하게 404("이 조직에 없는 발행물입니다", status·바디 완전 동일). "내 org 소유+스냅샷 0건"만 빈 목록. 기존 `test_insights_list_endpoint_empty_list_for_unknown_publication`(미존재=200/[])은 이 스토리로 폐기·404 기대로 교체됨.

## AC4 — 계열 도구 전수 감사
판별 기준: 「org_id로 거르지 않고 빈 목록/거짓 사유를 돌려주나」.
- `channel_post_comments.py`(list/refresh) — 이미 404로 정확히 거부.
- `insights_board.py`(follow-ups·reconcile) — 이미 404/409로 정확히 거부.
- 위반은 `insight_snapshots.py` 라우터 하나뿐이었다.

## i18n
CI가 새 한글 사용자 문장을 "BE 한글 사용자 문장 재발 가드"로 잡아, baseline 추가 대신 `gates.py`와 같은 형으로 `i18n_catalog`에 이관(`insight_snapshots.publication_not_found_in_org` 키) — 라우트를 얇은 Header-DI 래퍼 + `_list_publication_insights_endpoint`(직접-호출용) 두 함수로 분리.

## 테스트
- REST: 미존재 → 404, 타 org(SitePost·ChannelPublication 양쪽) → 404, 내 org+스냅샷0 → `[]`.
- **오라클 제거 직접 검증**: 미존재 응답과 타org 응답을 diff해 status·JSON 바디 완전 동일 단언.
- MCP: `SprintableApiError`가 거짓 사유 조합 없이 그대로 전파.
- 뮤테이션(None 분기 되돌림) → 미존재 케이스 테스트 2건만 정확히 RED, 나머지 25건 불변.

로컬 실 PG(alembic head)로 destructive 27건 + i18n/한글 가드 21건 + MCP non-destructive 10건 전수 재확인(green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8