### PR TITLE
[SID:3370] feat(BE): AST 린트 — raw auth.user_id → member-id kwarg 원천봉쇄

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,6 +712,22 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_commit_before_validate.py
 
+  # story #3370 회귀(페드루 PO 지시 2026-09-11) — raw auth.user_id(JWT는 users.id·API키는
+  # team_member.id 그대로)가 영속 멤버-id kwarg(*_member_id·resolver_id·actor_id)에 그대로
+  # 흘러드는 클래스를 원천봉쇄. 스크립트 docstring(scripts/lint_raw_auth_id_into_member_field.py)
+  # 참조 — baseline 없음(도입 시점 사후감사로 발견된 14건 전부 정정 또는 인라인
+  # `# member-id-lint: user-id-field` 예외 처리 완료, app/routers·app/services·ee 전 스윕 후 확認).
+  raw-auth-id-into-member-field-lint:
+    name: raw auth.user_id → member-id kwarg lint (guard, story #3370)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan for raw auth.user_id flowing into *_member_id/resolver_id/actor_id kwargs
+        working-directory: backend
+        run: python3 scripts/lint_raw_auth_id_into_member_field.py
+
   # story #2786(2026-08-19, PR#3088 DROP SCHEMA 906건 연쇄·PR#3217 DELETE FROM 26건 연쇄
   # — 같은 클래스 3일 내 2회) — 공유 실PG를 부수는 테스트 SQL 리터럴(WHERE 없는 DELETE FROM·
   # DROP SCHEMA·DROP TABLE·TRUNCATE)을 커밋 시점에 잡는다. 스크립트 docstring(scripts/

--- a/backend/app/routers/agent_deployments.py
+++ b/backend/app/routers/agent_deployments.py
@@ -12,6 +12,7 @@ from app.schemas.agent_deployment import (
     PatchDeploymentRequest,
 )
 from app.services.deployment_lifecycle import DeploymentLifecycleError, DeploymentLifecycleService
+from app.services.member_resolver import resolve_member_db_verified
 
 router = APIRouter(prefix="/api/v2/agent-deployments", tags=["agent-deployments", "Organization"])
 
@@ -62,11 +63,15 @@ async def create_deployment(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     try:
+        # story #3370 회귀 클래스(페드루 PO 지시 2026-09-11) — actor_id는
+        # AgentDeployment.created_by로 영속된다(휴먼 JWT의 auth.user_id는 users.id,
+        # org 멤버 id가 아니다). resolve_member_db_verified()의 영속 멤버 id로 정정.
+        resolved = await resolve_member_db_verified(auth, org_id, svc.session)
         result = await svc.create_deployment(
             org_id=org_id,
             project_id=project_id,
             agent_id=body.agent_id,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=resolved.id,
             name=body.name,
             runtime=body.runtime,
             model=body.model,
@@ -89,6 +94,8 @@ async def run_preflight(
     org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    # story #3370 회귀 클래스 — create_deployment와 같은 actor_id 축(위 주석 참고).
+    resolved = await resolve_member_db_verified(auth, org_id, svc.session)
     preflight = await svc.run_deployment_preflight(
         org_id=org_id,
         project_id=project_id,
@@ -100,7 +107,7 @@ async def run_preflight(
         persona_id=body.persona_id,
         config=body.config,
         overwrite_routing_rules=body.overwrite_routing_rules,
-        actor_id=uuid.UUID(auth.user_id),
+        actor_id=resolved.id,
     )
     return _ok({"preflight": preflight.model_dump(mode="json")})
 
@@ -132,10 +139,13 @@ async def patch_deployment(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     try:
+        # story #3370 회귀 클래스 — actor_id는 AgentAuditLog.payload·AgentDeployment
+        # 감사기록에 "누가 이 전이를 했는지"로 실린다(create_deployment와 동형 축).
+        resolved = await resolve_member_db_verified(auth, org_id, svc.session)
         result = await svc.transition_deployment(
             org_id=org_id,
             project_id=project_id,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=resolved.id,
             deployment_id=id,
             status=body.status,
             failure=body.failure,
@@ -155,10 +165,12 @@ async def delete_deployment(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     try:
+        # story #3370 회귀 클래스 — actor_id 축(위 patch_deployment와 동형).
+        resolved = await resolve_member_db_verified(auth, org_id, svc.session)
         result = await svc.terminate_deployment(
             org_id=org_id,
             project_id=project_id,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=resolved.id,
             deployment_id=id,
         )
         return _ok(result.model_dump(mode="json"))
@@ -176,10 +188,13 @@ async def complete_verification(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     try:
+        # story #3370 회귀 클래스 — actor_id는 config.verification.completed_by로
+        # 영속된다("완료자" 표시 필드, create_deployment와 동형 축).
+        resolved = await resolve_member_db_verified(auth, org_id, svc.session)
         dep = await svc.complete_verification(
             org_id=org_id,
             project_id=project_id,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=resolved.id,
             deployment_id=id,
         )
         return _ok({"deployment": dep.model_dump(mode="json")})

--- a/backend/app/routers/agent_personas.py
+++ b/backend/app/routers/agent_personas.py
@@ -10,6 +10,7 @@ from app.dependencies.database import get_db
 from app.models.member import Member
 from app.repositories.agent_persona import AgentPersonaRepository
 from app.schemas.agent_persona import CreatePersonaRequest, UpdatePersonaRequest
+from app.services.member_resolver import resolve_member_db_verified
 from app.services.project_auth import assert_target_in_caller_org
 
 router = APIRouter(prefix="/api/v2/agent-personas", tags=["agent-personas", "Organization"])
@@ -72,11 +73,15 @@ async def create_persona(
         return _err("FORBIDDEN", "org_id required", 403)
     await _assert_agent_in_caller_org(repo.session, org_id, body.agent_id)
     try:
+        # story #3370 회귀 클래스(페드루 PO 지시 2026-09-11) — actor_id는
+        # AgentPersona.created_by로 영속된다. resolve_member_db_verified()의 영속
+        # 멤버 id로 정정(휴먼 JWT의 auth.user_id는 users.id, org 멤버 id가 아니다).
+        resolved = await resolve_member_db_verified(auth, org_id, repo.session)
         persona = await repo.create(
             org_id=org_id,
             project_id=project_id,
             agent_id=body.agent_id,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=resolved.id,
             name=body.name,
             slug=body.slug,
             description=body.description,
@@ -134,9 +139,11 @@ async def update_persona(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     try:
+        # story #3370 회귀 클래스 — create_persona와 같은 actor_id 축(위 참고).
+        resolved = await resolve_member_db_verified(auth, org_id, repo.session)
         persona = await repo.update(
             id, org_id, project_id,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=resolved.id,
             **{k: v for k, v in body.model_dump().items() if v is not None},
         )
         if persona is None:

--- a/backend/app/routers/agent_routing_rules.py
+++ b/backend/app/routers/agent_routing_rules.py
@@ -9,6 +9,7 @@ from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.dependencies.project_scope import enforce_write_scope, resolve_required_project_id
 from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+from app.services.member_resolver import resolve_member_db_verified
 from app.schemas.agent_routing_rule import (
     CreateRoutingRuleRequest,
     DisableAllRequest,
@@ -74,10 +75,14 @@ async def create_rule(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     try:
+        # story #3370 회귀 클래스(페드루 PO 지시 2026-09-11) — actor_id는
+        # AgentRoutingRule.created_by로 영속된다. resolve_member_db_verified()의
+        # 영속 멤버 id로 정정(휴먼 JWT의 auth.user_id는 users.id, org 멤버 id가 아니다).
+        resolved = await resolve_member_db_verified(auth, org_id, repo.session)
         rule = await repo.create(
             org_id=org_id,
             project_id=project_id,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=resolved.id,
             agent_id=body.agent_id,
             name=body.name,
             priority=body.priority or 100,

--- a/backend/app/routers/agent_sessions.py
+++ b/backend/app/routers/agent_sessions.py
@@ -63,7 +63,7 @@ async def transition_session(
             session_id=id,
             org_id=org_id,
             project_id=project_id,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=uuid.UUID(auth.user_id),  # member-id-lint: user-id-field — session_metadata JSON 감사 블롭 문자열용(FK 아님, 사람 이름 해소 소비처 없음, story #3370 2026-09-11 확認)
             status=body.status,
             reason=body.reason,
         )

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -22,6 +22,7 @@ from app.models.project import Project
 from app.models.team import TeamMember
 from app.repositories.agent_persona import AgentPersonaRepository
 from app.schemas.recruit import RecruitRequest
+from app.services.member_resolver import resolve_member_db_verified
 from app.schemas.team_member import OrgAgentCreate, TeamMemberResponse
 from app.services.agent_onboarding_config import (
     DEFAULT_RUNTIME,
@@ -412,13 +413,18 @@ async def _recruit_agent_endpoint(
 
     resolved_locale = resolve_locale_from_request(body.locale, accept_language)
     try:
+        # story #3370 회귀 클래스(페드루 PO 지시 2026-09-11) — actor_id는
+        # recruit_agent()를 거쳐 AgentPersona.created_by로 영속된다(휴먼 JWT의
+        # auth.user_id는 users.id, org 멤버 id가 아니다). resolve_member_db_verified()
+        # 의 영속 멤버 id로 정정.
+        resolved = await resolve_member_db_verified(auth, org_id, session)
         result = await recruit_agent(
             session,
             agent_member=member,
             org_id=org_id,
             role_template=role_template,
             runtime=body.runtime,
-            actor_id=uuid.UUID(auth.user_id),
+            actor_id=resolved.id,
             locale=resolved_locale,
         )
     except ValueError as exc:

--- a/backend/app/routers/billing_keys.py
+++ b/backend/app/routers/billing_keys.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id_no_project_gate
 from app.dependencies.database import get_db
 from app.models.org_billing_key import OrgBillingKey
+from app.services.member_resolver import resolve_member_db_verified
 from app.services.org_billing_key import ActiveSubscriptionBlocksRevoke, ensure_customer_key, issue_billing_key, revoke_billing_key
 
 router = APIRouter(prefix="/api/v2/org-billing-keys", tags=["billing", "Organization"])
@@ -127,7 +128,13 @@ async def delete_billing_key(
     if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
         raise HTTPException(status_code=403, detail="org admin/owner role required")
 
-    resolved_actor_id = uuid.UUID(auth.user_id)
+    # story #3370 회귀 클래스(페드루 PO 지시 2026-09-11, prod-live) — revoke_billing_key()
+    # 가 이 값을 그대로 ActivityLogService.record(actor_id=...)로 넘겨 ActivityLog.actor_id
+    # 로 영속한다. 이 컬럼은 activity_logs.py가 이미 「resolve_member().id(영속 멤버 id)
+    # 여야 「본인 actor_id만」 필터 축과 정합한다」고 확定한 바로 그 슬롯이다(app/routers/
+    # activity_logs.py 2026-09-10 주석 참고) — 거기서 읽기축(필터)만 고쳐졌고 이 쓰기축은
+    # 그대로 raw auth.user_id(휴먼 JWT면 users.id, org 멤버 id가 아니다)를 흘리고 있었다.
+    resolved_actor_id = (await resolve_member_db_verified(auth, org_id, session)).id
     try:
         result = await revoke_billing_key(
             session, org_id=org_id, actor_id=resolved_actor_id, actor_type="human",

--- a/backend/app/routers/dependencies.py
+++ b/backend/app/routers/dependencies.py
@@ -151,7 +151,8 @@ async def _create_dependency(
         from app.services.trust_pipeline import maybe_emit_trust_stage_changed
 
         await maybe_emit_trust_stage_changed(
-            session, org_id, body.to_id, _trust_before, actor_id=user_id
+            session, org_id, body.to_id, _trust_before,
+            actor_id=user_id,  # member-id-lint: user-id-field — SSE 이벤트 payload용(비영속, 사람 이름 해소 소비처 없음, story #3370 2026-09-11 확認)
         )
 
     # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — «attention.changed»는 FE가 수신
@@ -260,7 +261,8 @@ async def _update_dependency(
         from app.services.trust_pipeline import maybe_emit_trust_stage_changed
 
         await maybe_emit_trust_stage_changed(
-            repo.session, repo.org_id, dep.to_id, _trust_before, actor_id=user_id
+            repo.session, repo.org_id, dep.to_id, _trust_before,
+            actor_id=user_id,  # member-id-lint: user-id-field — SSE 이벤트 payload용(비영속, 사람 이름 해소 소비처 없음, story #3370 2026-09-11 확認)
         )
 
     # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — commit-then-publish로 정렬(create_
@@ -324,7 +326,8 @@ async def _delete_dependency(
         from app.services.trust_pipeline import maybe_emit_trust_stage_changed
 
         await maybe_emit_trust_stage_changed(
-            repo.session, repo.org_id, dep.to_id, _trust_before, actor_id=user_id
+            repo.session, repo.org_id, dep.to_id, _trust_before,
+            actor_id=user_id,  # member-id-lint: user-id-field — SSE 이벤트 payload용(비영속, 사람 이름 해소 소비처 없음, story #3370 2026-09-11 확認)
         )
 
     # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — commit-then-publish로 정렬(위

--- a/backend/scripts/lint_raw_auth_id_into_member_field.py
+++ b/backend/scripts/lint_raw_auth_id_into_member_field.py
@@ -23,6 +23,17 @@ API키는 team_member.id 그대로)를 영속 멤버-id 칼럼/kwarg 자리에 �
 자신이 발견한 자리를 전부 고친 결과) — lint_commit_before_validate.py(story #2459)와 동일
 계약: 처음부터 0건이라 grandfather 관용이 불필요, 위반이 하나라도 있으면 즉시 FAIL한다.
 
+## 완전성 자기 확認(페드루 PO 조건부 PASS 조건1, 2026-09-11)
+1차본은 `scan_repo()`가 스캔 루트 부재를 `continue`로 삼켜, 파일 0개여도 "위반 0건"을
+그대로 OK로 찍는 fails-silent 구멍이 있었다(「추출된 것만 순회」 클래스 —
+test_no_team_members_view_dml_in_tests.py의 자기 확認 관례·korean_user_strings
+MIN_EXPECTED_FILES 자기 assert와 동형 원칙 위반). 정정 — `SCAN_ROOTS` 3개 각각 실존을
+assert하고, 스캔한 .py 파일 수가 0이면 `ScanIncompleteError`로 즉시 실패한다. 이 실패는
+"위반 0건"(exit 1이 아니라 별도 종료코드 2)과 구분한다 — 「가드가 헛돌고 있다」와
+「가드가 돌았는데 깨끗하다」는 다른 신호라 CI 로그에서도 갈라 보여야 한다.
+⚠️`lint_commit_before_validate.py` 템플릿도 같은 구멍을 그대로 갖고 있다 — 그건 이
+PR 스코프 밖(페드루 PO 明示, 적기만·후속 별건).
+
 ## 인라인 예외(페드루 PO 지시 2026-09-11 — 「칸의 뜻」이 원래 users.id인 자리)
 2026-09-11 사후 감사에서 도입 시점 baseline이 실제로는 14건이었다(agent_deployments 5·
 agent_personas 2·agent_routing_rules 1·agents 1·billing_keys 1은 칸이 org 멤버 id를
@@ -162,29 +173,56 @@ def findings_for_source(source: str) -> list[tuple[int, str, str, str]]:
     return out
 
 
-def scan_file(path: Path) -> list[tuple[str, int, str, str, str]]:
+def scan_file(path: Path, backend_root: Path | None = None) -> list[tuple[str, int, str, str, str]]:
     try:
         source = path.read_text(encoding="utf-8")
         findings = findings_for_source(source)
     except SyntaxError:
         return []
-    rel = str(path.relative_to(BACKEND_ROOT))
+    rel = str(path.relative_to(backend_root if backend_root is not None else BACKEND_ROOT))
     return [(rel, lineno, func, kwarg, reason) for lineno, func, kwarg, reason in findings]
 
 
-def scan_repo() -> list[tuple[str, int, str, str, str]]:
+class ScanIncompleteError(RuntimeError):
+    """story #3370(페드루 PO 조건부 PASS 2026-09-11) — scan_repo가 스캔 루트 부재를
+    `continue`로 삼키면 파일 0개로 조용히 "0건 OK"를 거짓 보고하는 fails-silent 클래스
+    (「추출된 것만 순회」— test_no_team_members_view_dml_in_tests.py의 자기 확認 관례,
+    korean_user_strings MIN_EXPECTED_FILES 자기 assert와 동형 원칙). 이 예외는 "위반
+    0건"과 구분되는 "가드 자체가 헛돌고 있다"는 신호라 main()이 별도 종료코드(2)로 뗀다."""
+
+
+def scan_repo(
+    scan_roots: list[str] | None = None, backend_root: Path | None = None,
+) -> list[tuple[str, int, str, str, str]]:
+    roots = scan_roots if scan_roots is not None else SCAN_ROOTS
+    root = backend_root if backend_root is not None else BACKEND_ROOT
+
     findings: list[tuple[str, int, str, str, str]] = []
-    for root in SCAN_ROOTS:
-        root_path = BACKEND_ROOT / root
+    scanned_files = 0
+    for r in roots:
+        root_path = root / r
         if not root_path.exists():
-            continue
+            raise ScanIncompleteError(
+                f"스캔 루트가 없다 — {root_path}(SCAN_ROOTS={roots} 중 하나 실종). "
+                "루트 부재를 조용히 건너뛰면 파일 0개로 \"위반 0건\"을 거짓 보고한다 "
+                "— 디렉터리 구조가 바뀌었으면 SCAN_ROOTS를 갱신할 것."
+            )
         for path in sorted(root_path.rglob("*.py")):
-            findings.extend(scan_file(path))
+            scanned_files += 1
+            findings.extend(scan_file(path, backend_root=root))
+    if scanned_files == 0:
+        raise ScanIncompleteError(
+            f"스캔 대상 .py 파일이 0개(SCAN_ROOTS={roots}) — 가드가 헛돌고 있다."
+        )
     return findings
 
 
 def main() -> int:
-    findings = scan_repo()
+    try:
+        findings = scan_repo()
+    except ScanIncompleteError as e:
+        print(f"FAIL(가드 자체 결함, story #3370 조건부 PASS 조건1): {e}")
+        return 2
     if findings:
         print(
             f"FAIL: raw auth.user_id가 영속 멤버-id kwarg에 그대로 흘러든 자리 {len(findings)}건 "

--- a/backend/scripts/lint_raw_auth_id_into_member_field.py
+++ b/backend/scripts/lint_raw_auth_id_into_member_field.py
@@ -1,0 +1,210 @@
+"""story #3370 회귀 원천봉쇄(페드루 PO 지시 2026-09-11) — 「auth.user_id(JWT는 users.id·
+API키는 team_member.id 그대로)를 영속 멤버-id 칼럼/kwarg 자리에 원시로 쓰던」 결함 클래스가
+#3370 정정 커밋들(583c2bd1c·bcf9bed0c·3e337a938·e2d5b3569)로 10여 곳 고쳐졌다 — 그 클래스가
+「고치고 나면 끝」이 아니라 새 코드가 같은 실수를 반복할 수 있는 자리라 CI로 원천봉쇄한다
+(verify_no_new_korean_user_strings.py와 동형 AST·정규식 아님 기전, 이유 주석 관례 — 새 기전
+발명 금지).
+
+## 잡는 패턴
+`*_member_id=`·`resolver_id=`·`actor_id=` kwarg의 값이:
+  ①직접 `uuid.UUID(<expr>.user_id)` 호출이거나(`uuid.UUID(...)` 또는 `from uuid import UUID`
+    형 `UUID(...)` 둘 다 인식),
+  ②같은 함수 안에서 그 호출로 대입된 변수를 그대로 경유(1단계, 예: `raw = uuid.UUID(auth.
+    user_id); foo(created_by_member_id=raw)`)
+하는 경우 — `resolve_member()`/`resolve_member_db_verified()`가 반환하는 영속 멤버 id
+(`resolved.id`)를 거치지 않고 raw auth 클레임을 그대로 영속 필드에 흘려보내는 자리다.
+
+## 스캔 범위
+`app/routers`·`app/services`·`ee`(lint_commit_before_validate.py와 동일 3디렉터리 — 같은
+층위의 결함 클래스).
+
+## grandfather 베이스라인 없음
+2026-09-11 도입 시점(#3370 정정 e2d5b3569 위) 스캔 대상 3디렉터리에 위반 0건 확認(#3370
+자신이 발견한 자리를 전부 고친 결과) — lint_commit_before_validate.py(story #2459)와 동일
+계약: 처음부터 0건이라 grandfather 관용이 불필요, 위반이 하나라도 있으면 즉시 FAIL한다.
+
+## 인라인 예외(페드루 PO 지시 2026-09-11 — 「칸의 뜻」이 원래 users.id인 자리)
+2026-09-11 사후 감사에서 도입 시점 baseline이 실제로는 14건이었다(agent_deployments 5·
+agent_personas 2·agent_routing_rules 1·agents 1·billing_keys 1은 칸이 org 멤버 id를
+기대해(FK/소비처가 member로 이름 해소) genuine으로 판정돼 이 PR에서 함께 고쳤다 —
+dependencies.py 3·agent_sessions.py 1은 칸 자체가 SSE 이벤트 payload/JSON 감사 블롭처럼
+"이 값으로 사람 이름을 해소하는 소비처가 없는" 자리라 코드는 그대로 두고, 그 줄에
+정확히 `# member-id-lint: user-id-field — <이유>` 트레일링 주석을 달아 이 가드를 지나가게
+한다(중앙 allowlist 파일 없음 — 이유가 그 코드 옆에 그대로 붙어야 다음 사람이 맥락 없이
+읽을 수 있다). 마커 문자열 자체(`_EXEMPTION_MARKER`)만 찾고 `<이유>` 내용은 검증하지
+않는다 — 리뷰가 그 이유의 타당성을 본다.
+
+## 이 lint가 «못 잡는» 것(정직하게 적어둔다 — story #2335/#2459 AC5와 같은 원칙)
+  ①간접 호출 — 헬퍼 함수나 classmethod 뒤에 숨어 `uuid.UUID(auth.user_id)`를 계산해 돌려주면
+    (`def _raw_actor(auth): return uuid.UUID(auth.user_id)`) 이 함수는 호출부만 보므로 못 잡는다.
+  ②2단 이상 변수 경유(`raw = uuid.UUID(auth.user_id); tmp = raw; foo(actor_id=tmp)`) — 1단
+    alias까지만 추적한다.
+  ③다른 이름의 "member 칸"(예: `assignee_id=`·`owner_member_id=`처럼 목표 kwarg 3종 접미사/
+    이름과 다른 이름으로 선언된 영속 멤버-id 필드) — 카드에 명시된 3종(`*_member_id`·
+    `resolver_id`·`actor_id`)만 목표로 한다, 새 필드명이 생기면 이 목록에 추가해야 한다.
+  ④`.user_id` 말고 다른 속성명으로 같은 raw 값을 얻는 자리(레포 관례상 전부 `auth.user_id`
+    이지만, 변수명이 `auth`가 아니어도 속성명 `.user_id`이기만 하면 잡는다 — 반대로 속성명
+    자체가 `user_id`가 아니면 못 잡는다).
+  ⑤`str(uuid.UUID(auth.user_id))`처럼 한 겹 더 감싼 표현식 — kwarg 값이 정확히 그 Call
+    노드이거나 그 Call로 대입된 단순 Name이어야 매치한다.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+SCAN_ROOTS = ["app/routers", "app/services", "ee"]
+
+# story #3370 카드 明示 3종 — 새 필드명이 생기면 여기 추가.
+_EXACT_KWARGS = {"resolver_id", "actor_id"}
+
+# story #3370(페드루 PO 지시 2026-09-11) — 칸의 뜻이 애초에 users.id인 자리(사람 이름을
+# 해소하는 소비처가 없음)의 인라인 예외. 그 줄(트레일링 주석)에 이 마커+이유가 있으면
+# 조용히 넘긴다 — 중앙 allowlist 파일 없음(모듈 docstring 참고).
+_EXEMPTION_MARKER = "# member-id-lint: user-id-field"
+
+
+def _is_target_kwarg(name: str) -> bool:
+    return name.endswith("_member_id") or name in _EXACT_KWARGS
+
+
+def _is_uuid_ctor(func: ast.expr) -> bool:
+    if isinstance(func, ast.Attribute):
+        return func.attr == "UUID"
+    if isinstance(func, ast.Name):
+        return func.id == "UUID"
+    return False
+
+
+def _is_user_id_attr(node: ast.expr) -> bool:
+    return isinstance(node, ast.Attribute) and node.attr == "user_id"
+
+
+def _is_tainted_call(node: ast.expr | None) -> bool:
+    """`uuid.UUID(<expr>.user_id)`(또는 bare `UUID(...)`) 형 호출인지."""
+    return (
+        isinstance(node, ast.Call)
+        and _is_uuid_ctor(node.func)
+        and len(node.args) == 1
+        and not node.keywords
+        and _is_user_id_attr(node.args[0])
+    )
+
+
+class _Event:
+    __slots__ = ("lineno", "kind", "payload")
+
+    def __init__(self, lineno: int, kind: str, payload: str) -> None:
+        self.lineno = lineno
+        self.kind = kind  # "taint" | "violation_direct" | "check_var"
+        self.payload = payload
+
+
+def scan_function(fn: ast.AST) -> list[tuple[int, str, str]]:
+    """(lineno, kwarg, 사유) 목록. lint_commit_before_validate.py(story #2459)와 동일하게
+    이벤트를 모아 lineno로 정렬한 뒤 순서대로 재생 — 트리 순회 순서가 아니라 소스 순서로
+    "assign이 use보다 먼저" 판정을 안정화한다."""
+    events: list[_Event] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Assign(self, node: ast.Assign) -> None:
+            if _is_tainted_call(node.value):
+                for t in node.targets:
+                    if isinstance(t, ast.Name):
+                        events.append(_Event(node.lineno, "taint", t.id))
+            self.generic_visit(node)
+
+        def visit_Call(self, node: ast.Call) -> None:
+            for kw in node.keywords:
+                if kw.arg is None or not _is_target_kwarg(kw.arg):
+                    continue
+                if _is_tainted_call(kw.value):
+                    events.append(_Event(kw.value.lineno, "violation_direct", kw.arg))
+                elif isinstance(kw.value, ast.Name):
+                    events.append(_Event(kw.value.lineno, "check_var", f"{kw.arg}::{kw.value.id}"))
+            self.generic_visit(node)
+
+    Visitor().visit(fn)
+    events.sort(key=lambda e: e.lineno)
+
+    findings: list[tuple[int, str, str]] = []
+    tainted_vars: set[str] = set()
+    for e in events:
+        if e.kind == "taint":
+            tainted_vars.add(e.payload)
+        elif e.kind == "violation_direct":
+            findings.append((e.lineno, e.payload, "직접 uuid.UUID(<expr>.user_id)"))
+        elif e.kind == "check_var":
+            kwarg, varname = e.payload.split("::", 1)
+            if varname in tainted_vars:
+                findings.append((e.lineno, kwarg, f"변수 `{varname}` 경유(1단계)"))
+    return findings
+
+
+def _is_exempted_line(line: str) -> bool:
+    return _EXEMPTION_MARKER in line
+
+
+def findings_for_source(source: str) -> list[tuple[int, str, str, str]]:
+    """(lineno, func, kwarg, reason) — 파일 경로 없이 소스 문자열만으로 스캔+예외적용까지
+    끝내는 축(단위테스트가 실 파일 I/O·BACKEND_ROOT 상대경로 없이 이 마커 로직을 직접
+    검증할 수 있게 scan_file에서 분리)."""
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    out: list[tuple[int, str, str, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            for lineno, kwarg, reason in scan_function(node):
+                if 1 <= lineno <= len(lines) and _is_exempted_line(lines[lineno - 1]):
+                    continue
+                out.append((lineno, node.name, kwarg, reason))
+    return out
+
+
+def scan_file(path: Path) -> list[tuple[str, int, str, str, str]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+        findings = findings_for_source(source)
+    except SyntaxError:
+        return []
+    rel = str(path.relative_to(BACKEND_ROOT))
+    return [(rel, lineno, func, kwarg, reason) for lineno, func, kwarg, reason in findings]
+
+
+def scan_repo() -> list[tuple[str, int, str, str, str]]:
+    findings: list[tuple[str, int, str, str, str]] = []
+    for root in SCAN_ROOTS:
+        root_path = BACKEND_ROOT / root
+        if not root_path.exists():
+            continue
+        for path in sorted(root_path.rglob("*.py")):
+            findings.extend(scan_file(path))
+    return findings
+
+
+def main() -> int:
+    findings = scan_repo()
+    if findings:
+        print(
+            f"FAIL: raw auth.user_id가 영속 멤버-id kwarg에 그대로 흘러든 자리 {len(findings)}건 "
+            "발견(story #3370 회귀 클래스):"
+        )
+        for file, lineno, func, kwarg, reason in findings:
+            print(f"  {file}:{lineno} in {func}() — {kwarg}=... ({reason})")
+        print(
+            "\n고치는 법: resolve_member() 또는 resolve_member_db_verified()(agent 판정을 DB 실측"
+            "으로 하는 축이 필요하면)를 먼저 불러 그 결과의 `.id`(영속 멤버 id)를 대신 쓸 것 — "
+            "member_resolver.py 기존 호출부 참고. 간접 호출·2단 이상 변수 경유·다른 이름의 "
+            "member 칸은 이 lint의 알려진 사각지대(스크립트 docstring 참조) — 새로 짤 때 직접 "
+            "주의할 것."
+        )
+        return 1
+    print("OK: raw auth.user_id → 영속 멤버-id kwarg 직접/1단계 대입 0건")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -44,6 +44,9 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "lint_model_registration_completeness.py",    # story #2255 — CI lint 게이트(app/models AST 정적 스캔, 운영 DB 무접속)
     "lint_project_access_403.py",                 # story #2342 AC7 — CI lint 게이트
     "lint_query_sentinel_direct_calls.py",        # story #2335 — CI lint 게이트
+    "lint_raw_auth_id_into_member_field.py",      # story #3370 — CI lint 게이트(app/routers·
+                                                   # app/services·ee AST 정적 스캔, 운영 DB 무접속 —
+                                                   # lint_project_access_403.py와 동형 관례).
     "lint_no_script_output_artifacts.py",         # story #3008 — CI lint 게이트(scripts/ 파일명·내용 정적 스캔, 운영 DB 무접속)
     "lint_org_today_direct_call.py",              # story #3674 — CI lint 게이트(app/**/*.py 정적
                                                    # 정규식 스캔, 운영 DB 무접속).

--- a/backend/tests/test_2486_agents_router_project_gate.py
+++ b/backend/tests/test_2486_agents_router_project_gate.py
@@ -177,6 +177,15 @@ async def test_recruit_ignores_inaccessible_x_project_id_when_owner(
     monkeypatch.setattr(agents_router, "emit_onboarding_event", AsyncMock(return_value=None))
     mock_session.commit = AsyncMock(return_value=None)
 
+    # story #3370 회귀 클래스 정정(페드루 PO 지시 2026-09-11) — _recruit_agent_endpoint가
+    # 이제 actor_id를 쓰기 前 resolve_member_db_verified()로 실측한다(test_s41.py 등과 동형
+    # 사유). 이 파일의 순수 AsyncMock 세션은 그 조회를 감당 못 한다.
+    resolved_caller = MagicMock()
+    resolved_caller.id = uuid.uuid4()
+    monkeypatch.setattr(
+        agents_router, "resolve_member_db_verified", AsyncMock(return_value=resolved_caller)
+    )
+
     inaccessible_project_id = str(uuid.uuid4())
     resp = await test_client.post(
         f"/api/v2/agents/{agent_id}/recruit",

--- a/backend/tests/test_2989_billing_key_endpoints.py
+++ b/backend/tests/test_2989_billing_key_endpoints.py
@@ -58,6 +58,13 @@ async def test_delete_billing_key_endpoint_success(test_client, mock_session, mo
     import app.services.project_auth as project_auth
 
     monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+    # story #3370 회귀 클래스 정정(페드루 PO 지시 2026-09-11) — delete_billing_key가 이제
+    # actor_id를 쓰기 前 resolve_member_db_verified()로 영속 멤버 id를 실측한다(진짜 DB
+    # 조회). mock_session은 순수 AsyncMock(실 PG 아님)이라 이 파일 관례(서비스 계층
+    # monkeypatch)와 동형으로 그 심볼만 목으로 갈아 우회한다.
+    resolved_member = MagicMock()
+    resolved_member.id = uuid.uuid4()
+    monkeypatch.setattr(router_module, "resolve_member_db_verified", AsyncMock(return_value=resolved_member))
     monkeypatch.setattr(
         router_module, "revoke_billing_key",
         AsyncMock(return_value={"deleted": True, "toss_revoked": True, "card_number_masked": "1234********5678"}),
@@ -82,6 +89,10 @@ async def test_delete_billing_key_endpoint_409_when_active_subscription_blocks(
     from app.services.org_billing_key import ActiveSubscriptionBlocksRevoke
 
     monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+    # story #3370 회귀 클래스 정정(페드루 PO 지시 2026-09-11) — 위 success 테스트와 동형 사유.
+    resolved_member = MagicMock()
+    resolved_member.id = uuid.uuid4()
+    monkeypatch.setattr(router_module, "resolve_member_db_verified", AsyncMock(return_value=resolved_member))
     period_end = datetime(2026, 9, 24, tzinfo=timezone.utc)
     monkeypatch.setattr(
         router_module, "revoke_billing_key",

--- a/backend/tests/test_3370_raw_auth_id_into_member_field_lint.py
+++ b/backend/tests/test_3370_raw_auth_id_into_member_field_lint.py
@@ -1,0 +1,312 @@
+"""story #3370 회귀 원천봉쇄 — `scripts/lint_raw_auth_id_into_member_field.py`의 검출/미검출
+범위를 코드 자체가 아니라 합성 소스 문자열로 pin한다(test_no_team_members_view_dml_in_tests.py
+의 #2523 스캐너 자체검증 관례와 동형 — 단발 probe가 아니라 CI가 계속 지키게 하는 것).
+
+실 저장소 상태(0건 여부)를 검증하는 통합 테스트는 이 파일이 아니라 별도(스코프 판단 대기 —
+2026-09-11 실측: E-AGENT-* 도메인(agent_deployments.py 등)에서 이 규칙과 정확히 같은 클래스의
+기존 위반 14건이 발견돼, #3370 원 스윕 범위(channel_posts/visual_artifacts/workflow_line_
+config 축) 밖의 별건인지 페드루 PO 판단 대기 中 — 이 파일은 스캐너의 판정 로직 자체만 고정)."""
+from __future__ import annotations
+
+import ast
+
+from scripts.lint_raw_auth_id_into_member_field import findings_for_source, scan_function, scan_repo
+
+
+def _findings_in(source: str) -> list[tuple[int, str, str]]:
+    tree = ast.parse(source)
+    out: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            out.extend(scan_function(node))
+    return out
+
+
+# ─── 잡아야 하는 것 ────────────────────────────────────────────────────────────
+
+
+def test_direct_call_into_member_id_suffix_kwarg_is_caught():
+    src = "async def f(auth, db):\n    await create(created_by_member_id=uuid.UUID(auth.user_id))\n"
+    findings = _findings_in(src)
+    assert len(findings) == 1
+    assert findings[0][1] == "created_by_member_id"
+    assert "직접" in findings[0][2]
+
+
+def test_direct_call_into_resolver_id_kwarg_is_caught():
+    src = "async def f(auth, session, gate):\n    await transition_gate(session, gate, resolver_id=uuid.UUID(auth.user_id))\n"
+    findings = _findings_in(src)
+    assert len(findings) == 1
+    assert findings[0][1] == "resolver_id"
+
+
+def test_direct_call_into_actor_id_kwarg_is_caught():
+    src = "async def f(auth, repo):\n    await repo.create(actor_id=uuid.UUID(auth.user_id))\n"
+    findings = _findings_in(src)
+    assert len(findings) == 1
+    assert findings[0][1] == "actor_id"
+
+
+def test_one_level_variable_indirection_is_caught():
+    """카드 明示 축 — 직접 호출뿐 아니라 1단계 변수 경유도 잡는다."""
+    src = (
+        "async def f(auth, repo):\n"
+        "    raw = uuid.UUID(auth.user_id)\n"
+        "    await repo.create(actor_id=raw)\n"
+    )
+    findings = _findings_in(src)
+    assert len(findings) == 1
+    assert findings[0][1] == "actor_id"
+    assert "변수" in findings[0][2] and "raw" in findings[0][2]
+
+
+def test_bare_uuid_ctor_form_is_also_caught():
+    """`from uuid import UUID` 형(bare Name 호출)도 `uuid.UUID(...)`(Attribute 호출)와
+    동형으로 잡는다 — 이 레포 실제 관례는 전자뿐이지만(2026-09-11 실측, app/ 0건) 가드
+    자신은 두 형 다 지원한다."""
+    src = "async def f(auth, repo):\n    await repo.create(actor_id=UUID(auth.user_id))\n"
+    findings = _findings_in(src)
+    assert len(findings) == 1
+
+
+# ─── 양성대조 — 정정 前/後 실제 형(story #3370, app/routers/workflow_line_config.py:290
+# `approve_publish_endpoint`, transition_gate(resolver_id=resolved.id) 호출) ───────────────
+
+
+def test_positive_control_workflow_line_config_pre_fix_shape_is_caught():
+    """workflow_line_config.py:290의 **정정 前** 형을 되돌린 것과 동형 — 이 형이면 반드시
+    잡혀야 한다(양성대조, 페드루 지시 2026-09-11 "10곳 중 1곳을 되돌리면 그 줄 이름 대고
+    RED")."""
+    src = (
+        "async def approve_publish_endpoint(auth, session, version):\n"
+        "    gate = await transition_gate(session, org_id, version.review_gate_id, "
+        "\"approved\", resolver_id=uuid.UUID(auth.user_id))\n"
+    )
+    findings = _findings_in(src)
+    assert len(findings) == 1
+    assert findings[0][1] == "resolver_id"
+
+
+def test_fixed_shape_using_resolved_member_id_is_not_flagged():
+    """workflow_line_config.py:290의 **정정 後**(실 코드) 형 — resolve_member_db_verified()가
+    반환한 영속 멤버 id(`resolved.id`)를 쓰면 이 가드가 조용해야 한다(false positive 0)."""
+    src = (
+        "async def approve_publish_endpoint(auth, session, version):\n"
+        "    resolved = await resolve_member_db_verified(auth, org_id, session)\n"
+        "    gate = await transition_gate(session, org_id, version.review_gate_id, "
+        "\"approved\", resolver_id=resolved.id)\n"
+    )
+    findings = _findings_in(src)
+    assert findings == []
+
+
+# ─── 잡지 말아야 하는 것(오탐 방지 + 스크립트 docstring이 선언한 사각지대 pin) ──────────────
+
+
+def test_non_target_kwarg_is_not_flagged():
+    """대상 3종(`*_member_id`·`resolver_id`·`actor_id`) 밖의 kwarg(예: `assignee_id`)는
+    같은 raw 패턴이어도 이 가드의 대상이 아니다(스크립트 docstring 사각지대③)."""
+    src = "async def f(auth, repo):\n    await repo.create(assignee_id=uuid.UUID(auth.user_id))\n"
+    assert _findings_in(src) == []
+
+
+def test_attribute_access_value_is_not_flagged():
+    """request body 필드처럼 값이 `<name>.attr` 형(Call도 tainted-Name도 아님)이면 오탐 0
+    (실측: app/routers/workflow_line_config.py의 `actor_id=body.actor_id` 자리가 정확히
+    이 형 — dry-run 검증용 파라미터일 뿐 auth 클레임이 아니다)."""
+    src = "async def f(auth, body, repo):\n    await repo.create(actor_id=body.actor_id)\n"
+    assert _findings_in(src) == []
+
+
+def test_two_level_variable_chain_is_not_flagged():
+    """2단 이상 alias 체인은 이 가드의 알려진 사각지대②(1단만 보장)."""
+    src = (
+        "async def f(auth, repo):\n"
+        "    raw = uuid.UUID(auth.user_id)\n"
+        "    tmp = raw\n"
+        "    await repo.create(actor_id=tmp)\n"
+    )
+    assert _findings_in(src) == []
+
+
+def test_wrapped_in_another_call_is_not_flagged():
+    """`str(uuid.UUID(auth.user_id))`처럼 한 겹 더 감싼 표현식은 사각지대⑤ — kwarg 값이
+    정확히 tainted Call 노드이거나 그 Call로 대입된 단순 Name이어야 매치한다."""
+    src = "async def f(auth, repo):\n    await repo.create(actor_id=str(uuid.UUID(auth.user_id)))\n"
+    assert _findings_in(src) == []
+
+
+def test_different_attribute_than_user_id_is_not_flagged():
+    """`.user_id`가 아닌 다른 속성(예: `.id`)에서 온 uuid.UUID(...)는 애초에 이 결함
+    클래스(auth 클레임 원시값)가 아니므로 대상 밖."""
+    src = "async def f(auth, repo):\n    await repo.create(actor_id=uuid.UUID(auth.id))\n"
+    assert _findings_in(src) == []
+
+
+# ─── 인라인 예외 마커(페드루 PO 지시 2026-09-11) ───────────────────────────────────
+
+
+def test_exemption_marker_silences_direct_call():
+    src = (
+        "async def f(auth, repo):\n"
+        "    await repo.create(actor_id=uuid.UUID(auth.user_id))  # member-id-lint: user-id-field — SSE payload\n"
+    )
+    assert findings_for_source(src) == []
+
+
+def test_exemption_marker_silences_variable_indirection():
+    src = (
+        "async def f(auth, repo):\n"
+        "    raw = uuid.UUID(auth.user_id)\n"
+        "    await repo.create(\n"
+        "        actor_id=raw,  # member-id-lint: user-id-field — audit blob\n"
+        "    )\n"
+    )
+    assert findings_for_source(src) == []
+
+
+def test_without_marker_same_shape_is_still_flagged():
+    """마커가 없으면 그대로 잡힌다 — 마커 자체가 검사를 무력화하는 게 아니라 그 한 줄만
+    지나가게 한다는 것을 대조로 확인."""
+    src = "async def f(auth, repo):\n    await repo.create(actor_id=uuid.UUID(auth.user_id))\n"
+    assert len(findings_for_source(src)) == 1
+
+
+def test_marker_only_silences_its_own_line_not_sibling_violations():
+    """한 함수 안에 마커 있는 줄과 없는 줄이 섞이면 마커 없는 쪽만 잡혀야 한다(마커가
+    함수 전체를 꺼버리는 전역 스위치가 아님을 확인)."""
+    src = (
+        "async def f(auth, repo):\n"
+        "    await repo.create(actor_id=uuid.UUID(auth.user_id))  # member-id-lint: user-id-field — ok\n"
+        "    await repo.update(resolver_id=uuid.UUID(auth.user_id))\n"
+    )
+    findings = findings_for_source(src)
+    assert len(findings) == 1
+    assert findings[0][2] == "resolver_id"
+
+
+# ─── story #3370 2차 CHANGES(페드루 2026-09-11) — 실 저장소 0건 통합 검증 ────────────
+# 2026-09-11 사후 감사에서 baseline이 실제로는 14건이었다(agent_deployments 5·
+# agent_personas 2·agent_routing_rules 1·agents 1·billing_keys 1은 genuine으로 판정돼
+# resolve_member_db_verified()로 정정·dependencies.py 3·agent_sessions.py 1은 SSE
+# payload/JSON 감사 블롭이라 인라인 마커로 처리) — 이 테스트는 그 정정이 실제로 반영된
+# 뒤의 최종 상태(0건)를 고정한다.
+
+
+def test_repo_has_zero_violations():
+    findings = scan_repo()
+    assert findings == [], (
+        f"story #3370 회귀 클래스 위반 {len(findings)}건 — 각 자리를 resolve_member_db_verified()"
+        "로 정정하거나(칸이 member id를 뜻하면) `# member-id-lint: user-id-field — <이유>` "
+        "인라인 주석을 달 것(칸이 users.id를 뜻하면): " + repr(findings)
+    )
+
+
+# ─── 인스턴스 핀(페드루 지시 2026-09-11 — 고친 (a)마다 1개) ─────────────────────────
+# 실 소스 파일을 import해 정정 後 실제 시그니처/값 축이 살아있는지 고정한다(합성 스니펫이
+# 아니라 실 코드 대상 — "이 자리를 다시 되돌리면 잡힌다"가 아니라 "이 자리가 실제로
+# resolve_member_db_verified를 거친다"는 것 자체를 pin).
+
+
+def test_agent_deployments_create_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agent_deployments
+
+    src = inspect.getsource(agent_deployments.create_deployment)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_agent_deployments_preflight_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agent_deployments
+
+    src = inspect.getsource(agent_deployments.run_preflight)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_agent_deployments_patch_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agent_deployments
+
+    src = inspect.getsource(agent_deployments.patch_deployment)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_agent_deployments_delete_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agent_deployments
+
+    src = inspect.getsource(agent_deployments.delete_deployment)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_agent_deployments_complete_verification_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agent_deployments
+
+    src = inspect.getsource(agent_deployments.complete_verification)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_agent_personas_create_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agent_personas
+
+    src = inspect.getsource(agent_personas.create_persona)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_agent_personas_update_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agent_personas
+
+    src = inspect.getsource(agent_personas.update_persona)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_agent_routing_rules_create_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agent_routing_rules
+
+    src = inspect.getsource(agent_routing_rules.create_rule)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_agents_recruit_endpoint_uses_resolved_member_id():
+    import inspect
+
+    from app.routers import agents
+
+    src = inspect.getsource(agents._recruit_agent_endpoint)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved.id" in src
+
+
+def test_billing_keys_delete_uses_resolved_member_id():
+    """prod-live 성립 자리(페드루 지시 2026-09-11) — revoke_billing_key()가 이 값을
+    ActivityLogService.record(actor_id=...)로 넘겨 ActivityLog.actor_id로 영속한다.
+    activity_logs.py가 이미 확定한 "그 칸=resolve_member().id" 계약과 같은 축(별도
+    회귀 pin — 상세 사유는 라우터 인라인 주석 참고)."""
+    import inspect
+
+    from app.routers import billing_keys
+
+    src = inspect.getsource(billing_keys.delete_billing_key)
+    assert "resolve_member_db_verified" in src
+    assert "actor_id=resolved_actor_id" in src

--- a/backend/tests/test_3370_raw_auth_id_into_member_field_lint.py
+++ b/backend/tests/test_3370_raw_auth_id_into_member_field_lint.py
@@ -2,15 +2,23 @@
 범위를 코드 자체가 아니라 합성 소스 문자열로 pin한다(test_no_team_members_view_dml_in_tests.py
 의 #2523 스캐너 자체검증 관례와 동형 — 단발 probe가 아니라 CI가 계속 지키게 하는 것).
 
-실 저장소 상태(0건 여부)를 검증하는 통합 테스트는 이 파일이 아니라 별도(스코프 판단 대기 —
-2026-09-11 실측: E-AGENT-* 도메인(agent_deployments.py 등)에서 이 규칙과 정확히 같은 클래스의
-기존 위반 14건이 발견돼, #3370 원 스윕 범위(channel_posts/visual_artifacts/workflow_line_
-config 축) 밖의 별건인지 페드루 PO 판단 대기 中 — 이 파일은 스캐너의 판정 로직 자체만 고정)."""
+2026-09-11 실측: 도입 시점 E-AGENT-* 도메인(agent_deployments.py 등)에서 이 규칙과 정확히
+같은 클래스의 기존 위반 14건이 발견됐다 — 페드루 PO 판단②'(칸의 뜻으로 가름)에 따라 10건은
+resolve_member_db_verified()로 정정(이 파일 하단 인스턴스 핀 참고), 4건(dependencies.py 3·
+agent_sessions.py 1)은 소비처가 없는 users.id 자리라 인라인 `# member-id-lint: user-id-field`
+마커로 처리 — `test_repo_has_zero_violations`가 그 최종 상태(0건)를 고정한다."""
 from __future__ import annotations
 
 import ast
 
-from scripts.lint_raw_auth_id_into_member_field import findings_for_source, scan_function, scan_repo
+import pytest
+
+from scripts.lint_raw_auth_id_into_member_field import (
+    ScanIncompleteError,
+    findings_for_source,
+    scan_function,
+    scan_repo,
+)
 
 
 def _findings_in(source: str) -> list[tuple[int, str, str]]:
@@ -191,6 +199,38 @@ def test_marker_only_silences_its_own_line_not_sibling_violations():
 # resolve_member_db_verified()로 정정·dependencies.py 3·agent_sessions.py 1은 SSE
 # payload/JSON 감사 블롭이라 인라인 마커로 처리) — 이 테스트는 그 정정이 실제로 반영된
 # 뒤의 최종 상태(0건)를 고정한다.
+
+
+# ─── 완전성 자기 확認(페드루 PO 조건부 PASS 조건1, 2026-09-11) ────────────────────
+# scan_repo가 스캔 루트 부재·파일 0개를 "위반 0건"으로 조용히 흘리지 않고 ScanIncompleteError
+# 로 즉시 실패하는지 고정한다(fails-silent 클래스 원천봉쇄 자체를 pin).
+
+
+def test_scan_repo_raises_when_a_root_is_missing(tmp_path):
+    (tmp_path / "app" / "routers").mkdir(parents=True)
+    (tmp_path / "app" / "routers" / "x.py").write_text("async def f(auth, repo):\n    pass\n")
+    (tmp_path / "app" / "services").mkdir(parents=True)
+    (tmp_path / "app" / "services" / "y.py").write_text("async def f(auth, repo):\n    pass\n")
+    # "ee" 루트를 아예 안 만든다 — 3개 중 하나 실종.
+    with pytest.raises(ScanIncompleteError):
+        scan_repo(scan_roots=["app/routers", "app/services", "ee"], backend_root=tmp_path)
+
+
+def test_scan_repo_raises_when_zero_files_scanned(tmp_path):
+    for root in ("app/routers", "app/services", "ee"):
+        (tmp_path / root).mkdir(parents=True)
+    # 세 루트 다 실존하지만 .py 파일이 하나도 없다.
+    with pytest.raises(ScanIncompleteError):
+        scan_repo(scan_roots=["app/routers", "app/services", "ee"], backend_root=tmp_path)
+
+
+def test_scan_repo_succeeds_when_roots_exist_with_files(tmp_path):
+    for root in ("app/routers", "app/services", "ee"):
+        d = tmp_path / root
+        d.mkdir(parents=True)
+        (d / "x.py").write_text("async def f(auth, repo):\n    pass\n")
+    # 예외 없이 정상 반환(빈 리스트 — 위반 0건과 "헛돎" 0건을 구분하는 정상 경로).
+    assert scan_repo(scan_roots=["app/routers", "app/services", "ee"], backend_root=tmp_path) == []
 
 
 def test_repo_has_zero_violations():

--- a/backend/tests/test_e_recruit_s3_recruit_endpoint.py
+++ b/backend/tests/test_e_recruit_s3_recruit_endpoint.py
@@ -18,6 +18,17 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _mock_resolve_member_db_verified(monkeypatch):
+    """story #3370 회귀 클래스 정정(페드루 PO 지시 2026-09-11) — _recruit_agent_endpoint가
+    이제 actor_id를 쓰기 前 resolve_member_db_verified()로 영속 멤버 id를 실측한다(진짜 DB
+    조회). 이 파일의 session은 순수 MagicMock/AsyncMock(실 PG 아님)이라 그 조회를 감당
+    못 한다 — 라우터 모듈에 import된 그 심볼만 목으로 갈아 우회."""
+    resolved = MagicMock()
+    resolved.id = uuid.uuid4()
+    monkeypatch.setattr("app.routers.agents.resolve_member_db_verified", AsyncMock(return_value=resolved))
+
+
 def _auth_ctx():
     return SimpleNamespace(user_id=str(uuid.uuid4()))
 

--- a/backend/tests/test_e_security_sec_s7_persona_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s7_persona_org_scope_realdb.py
@@ -63,9 +63,24 @@ async def _seed_two_orgs(session):
     session.add_all([agent_a, agent_b])
     await session.commit()
 
+    # story #3370 회귀 클래스(페드루 PO 지시 2026-09-11) — create_persona가 이제
+    # resolve_member_db_verified()로 caller를 실측한다(fail-closed). 201까지 가는 유일한
+    # 테스트(test_create_persona_same_org_agent_still_free)를 위해 실 org_a 휴먼 caller를
+    # 심는다(다른 테스트는 org_a agent_id로 못 도달하는 가드에서 먼저 막혀 무관).
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    caller_user = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller_user)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=caller_user.id, role="member")
+    session.add(caller_om)
+    await session.commit()
+
     return {
         "org_a_id": org_a.id, "org_b_id": org_b.id,
         "project_a_id": project_a.id, "agent_a_id": agent_a.id, "agent_b_id": agent_b.id,
+        "caller_user_id": caller_user.id,
     }
 
 
@@ -74,7 +89,7 @@ def _client_for(app):
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
-async def _setup_app(app, Session, org_id, project_id):
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
     from app.dependencies.auth import AuthContext, get_current_user
     from app.dependencies.database import get_db
 
@@ -89,7 +104,7 @@ async def _setup_app(app, Session, org_id, project_id):
 
     async def _auth():
         return AuthContext(
-            user_id=str(uuid.uuid4()), email="caller@test",
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
             claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
         )
 
@@ -141,7 +156,7 @@ async def test_create_persona_same_org_agent_still_free():
         async with Session() as s:
             seeded = await _seed_two_orgs(s)
 
-        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"], user_id=seeded["caller_user_id"])
         client = _client_for(app)
         try:
             resp = await client.post(

--- a/backend/tests/test_s41.py
+++ b/backend/tests/test_s41.py
@@ -18,6 +18,23 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _mock_resolve_member_db_verified(monkeypatch):
+    """story #3370 회귀 클래스 정정(페드루 PO 지시 2026-09-11) — 라우터가 이제 actor_id를
+    쓰기 前 resolve_member_db_verified()로 영속 멤버 id를 실측한다(진짜 DB 조회). 이 파일의
+    세션은 순수 AsyncMock(실 PG 아님)이라 그 조회가 그대로 통과하면 응답 파싱이 깨진다 —
+    라우터 모듈에 import된 그 심볼만 목으로 갈아 이 파일의 서비스-계층 목킹 계약(create_
+    deployment 등 자체는 그대로 목)을 그대로 유지한다."""
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    resolved = MagicMock()
+    resolved.id = uuid.uuid4()
+    monkeypatch.setattr(
+        "app.routers.agent_deployments.resolve_member_db_verified",
+        _AsyncMock(return_value=resolved),
+    )
+
+
 async def _client():
     from app.main import app
     ctx = MagicMock()

--- a/backend/tests/test_s42.py
+++ b/backend/tests/test_s42.py
@@ -18,6 +18,19 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _mock_resolve_member_db_verified(monkeypatch):
+    """story #3370 회귀 클래스 정정(페드루 PO 지시 2026-09-11) — test_s41.py와 동형 사유
+    (create_persona/update_persona가 이제 actor_id를 쓰기 前 resolve_member_db_verified()
+    로 실측한다 — 이 파일의 순수 AsyncMock 세션은 그 조회를 감당 못 한다)."""
+    resolved = MagicMock()
+    resolved.id = uuid.uuid4()
+    monkeypatch.setattr(
+        "app.routers.agent_personas.resolve_member_db_verified",
+        AsyncMock(return_value=resolved),
+    )
+
+
 async def _client():
     from app.main import app
     ctx = MagicMock()

--- a/backend/tests/test_s43.py
+++ b/backend/tests/test_s43.py
@@ -18,6 +18,19 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _mock_resolve_member_db_verified(monkeypatch):
+    """story #3370 회귀 클래스 정정(페드루 PO 지시 2026-09-11) — test_s41.py와 동형 사유
+    (create_rule이 이제 actor_id를 쓰기 前 resolve_member_db_verified()로 실측한다 —
+    이 파일의 순수 AsyncMock 세션은 그 조회를 감당 못 한다)."""
+    resolved = MagicMock()
+    resolved.id = uuid.uuid4()
+    monkeypatch.setattr(
+        "app.routers.agent_routing_rules.resolve_member_db_verified",
+        AsyncMock(return_value=resolved),
+    )
+
+
 async def _client():
     from app.main import app
     ctx = MagicMock()


### PR DESCRIPTION
스택 대상: #4156 (fix/3370-requester-member-id-resolve) 위 stacked — #4156 develop 착지 뒤 base를 develop으로 재지정 예정.

## 무엇
`*_member_id=`·`resolver_id=`·`actor_id=` kwarg에 `uuid.UUID(auth.user_id)`(직접·1단계 변수 경유)가 그대로 흘러드는 자리를 CI로 원천봉쇄(`verify_no_new_korean_user_strings.py`·`lint_commit_before_validate.py` 형 — AST·정규식 아님·baseline 없음).

## 사후감사 — baseline이 실제로는 14건이었다(E-AGENT-* 도메인, #3370 원 스윕 범위 밖)
가름선 = 「이 값으로 사람 이름을 해소하는 소비처가 있나」(페드루 PO 판단②').

| 파일:줄(함수) | 칸 | 소비처 | 판정 | 처방 |
|---|---|---|---|---|
| agent_deployments.py:65 create_deployment | actor_id | `AgentDeployment.created_by`(실 컬럼) | a | resolve_member_db_verified |
| agent_deployments.py:92 run_preflight | actor_id | (미사용·자매 함수와 동형 시그니처) | a | 동일 정정(일관성) |
| agent_deployments.py:135 patch_deployment→transition_deployment | actor_id | `AgentAuditLog.payload["actor_id"]`+webhook payload | a | resolve_member_db_verified |
| agent_deployments.py:158 delete_deployment→terminate_deployment | actor_id | 동일(AgentAuditLog.payload) | a | 동일 |
| agent_deployments.py:179 complete_verification | actor_id | `config.verification.completed_by`+AgentAuditLog.payload | a | 동일 |
| agent_personas.py:75 create_persona | actor_id | `AgentPersona.created_by`(실 컬럼) | a | resolve_member_db_verified |
| agent_personas.py:137 update_persona | actor_id | (현재 미사용·create와 동형 시그니처) | a | 동일 정정(일관성) |
| agent_routing_rules.py:77 create_rule | actor_id | `AgentRoutingRule.created_by`(실 컬럼) | a | resolve_member_db_verified |
| agents.py:415 _recruit_agent_endpoint | actor_id | recruit_service→AgentPersona.created_by(위와 같은 sink) | a | resolve_member_db_verified |
| **billing_keys.py:132 delete_billing_key** | actor_id | **`ActivityLog.actor_id`** — activity_logs.py가 이미 "칸=resolve_member().id" 계약을 확定한 그 슬롯(2026-09-10). 그 스토리는 읽기축(RBAC 필터)만 고쳤고 이 쓰기축은 그대로 raw auth.user_id를 흘리고 있었다 — **prod-live 성립** | a(별도 계급) | resolve_member_db_verified |
| dependencies.py:153 _create_dependency | actor_id | `maybe_emit_trust_stage_changed`→SSE event_data(비영속) | b | 인라인 `# member-id-lint: user-id-field` |
| dependencies.py:262 _update_dependency | actor_id | 동일 | b | 인라인 마커 |
| dependencies.py:326 _delete_dependency | actor_id | 동일 | b | 인라인 마커 |
| agent_sessions.py:62 transition_session | actor_id | `session_metadata["transition_actor_id"]`(JSON 블롭, FK 아님) | b | 인라인 마커 |

`resolver_id`·`*_member_id`는 0건(이미 #3370 원 스윕이 정리) — 발견된 14건 전부 `actor_id`.

## 인라인 예외 기전(신규)
칸이 users.id를 뜻하는 자리는 코드를 그대로 두고 그 줄에 `# member-id-lint: user-id-field — <이유>` 트레일링 주석으로 지나가게 한다 — 중앙 allowlist 파일 없음, 이유가 코드 옆에 그대로 남아야 다음 사람이 맥락 없이 읽을 수 있다.

## 이 lint가 못 잡는 것
간접 호출(헬퍼 뒤에 숨은 uuid.UUID(auth.user_id))·2단 이상 변수 경유·카드 明示 3종 밖의 다른 이름의 member 칸·`.user_id` 아닌 다른 속성명 경유·한 겹 더 감싼 표현식(`str(uuid.UUID(...))`). 스크립트 docstring에 정직하게 명시.

## 테스트
- 합성 스니펫 12종 + 예외마커 4종.
- 고친 (a) 10곳마다 실 소스 기반 인스턴스 핀 1개.
- `test_repo_has_zero_violations` — 실 저장소 0건 통합 확認.
- 뮤테이션 자체검증 2종(실 정정 라인 되돌림·실 예외마커 제거) — 각각 정확히 예상 테스트만 RED.

## 회귀 스윕
(a) 10곳 정정이 라우터에 새 DB 조회를 추가해 순수 AsyncMock 세션 기반 기존 단위테스트(test_s41/s42/s43·billing_key_endpoints·recruit_endpoint)가 깨졌다 — 각 파일에 그 심볼만 목으로 갈아 우회. `test_e_security_sec_s7_persona_org_scope_realdb.py`(실 PG)는 실 caller를 심어 정정(#4156과 동일 클래스).

로컬 실 PG(alembic head)로 관련 파일 전수 253건 + 가드/한글 lint 전수 재확인(green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8