### PR TITLE
[SID:3370] fix(BE): lint_commit_before_validate.py — 스캔 루트/파일 0개 fails-silent 정정

### DIFF
--- a/backend/scripts/lint_commit_before_validate.py
+++ b/backend/scripts/lint_commit_before_validate.py
@@ -32,6 +32,16 @@ AST 스캔으로 최초 3곳 넘어 7곳 추가 발견 후 "10곳 다 고치고 
   ②`getattr`/동적 호출로 commit 또는 model_validate 를 부르는 경우.
   ③trigger 메커니즘 자체가 미상이라, 이 lint를 통과해도 "안전이 증명된 것"은 아니다 —
     다만 "commit 後 refresh 없이 model_validate" 라는 «알려진» 실패 모양은 막는다.
+
+## 완전성 자기 확認(story #3370 후속, 페드루 PO 지시 2026-09-11 — lint_raw_auth_id_into_
+member_field.py 조건부 PASS 조건1과 동형 정정)
+1차본(story #2459)의 `scan_repo()`는 `SCAN_ROOTS` 부재를 `continue`로 삼켜, 스캔 파일이
+0개여도 "위반 0건"을 그대로 OK로 찍는 fails-silent 구멍이 있었다(「추출된 것만 순회」
+클래스 — test_no_team_members_view_dml_in_tests.py 자기 확認 관례·korean_user_strings
+MIN_EXPECTED_FILES 자기 assert와 동형 원칙 위반, lint_raw_auth_id_into_member_field.py
+가 먼저 지적·정정됨). 정정 — `SCAN_ROOTS` 3개 각각 실존을 assert하고, 스캔한 .py 파일
+수가 0이면 `ScanIncompleteError`로 즉시 실패한다(exit 2, "위반 0건"의 exit 1과 종료코드
+로 구분 — 「가드가 헛돌고 있다」와 「가드가 돌았는데 깨끗하다」는 다른 신호).
 """
 from __future__ import annotations
 
@@ -110,32 +120,59 @@ def scan_function(fn: ast.AST) -> list[tuple[int, str]]:
     return findings
 
 
-def scan_file(path: Path) -> list[tuple[str, int, str, str]]:
+def scan_file(path: Path, backend_root: Path | None = None) -> list[tuple[str, int, str, str]]:
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except SyntaxError:
         return []
+    root = backend_root if backend_root is not None else BACKEND_ROOT
     out: list[tuple[str, int, str, str]] = []
     for node in ast.walk(tree):
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
             for lineno, var in scan_function(node):
-                out.append((str(path.relative_to(BACKEND_ROOT)), lineno, node.name, var))
+                out.append((str(path.relative_to(root)), lineno, node.name, var))
     return out
 
 
-def scan_repo() -> list[tuple[str, int, str, str]]:
+class ScanIncompleteError(RuntimeError):
+    """story #3370 후속(페드루 PO 지시 2026-09-11) — scan_repo가 스캔 루트 부재를 `continue`
+    로 삼키면 파일 0개로 조용히 "0건 OK"를 거짓 보고하는 fails-silent 클래스(모듈 docstring
+    "완전성 자기 확認" 절 참고). "위반 0건"과 구분되는 "가드 자체가 헛돌고 있다"는 신호라
+    main()이 별도 종료코드(2)로 뗀다."""
+
+
+def scan_repo(
+    scan_roots: list[str] | None = None, backend_root: Path | None = None,
+) -> list[tuple[str, int, str, str]]:
+    roots = scan_roots if scan_roots is not None else SCAN_ROOTS
+    root = backend_root if backend_root is not None else BACKEND_ROOT
+
     findings: list[tuple[str, int, str, str]] = []
-    for root in SCAN_ROOTS:
-        root_path = BACKEND_ROOT / root
+    scanned_files = 0
+    for r in roots:
+        root_path = root / r
         if not root_path.exists():
-            continue
+            raise ScanIncompleteError(
+                f"스캔 루트가 없다 — {root_path}(SCAN_ROOTS={roots} 중 하나 실종). "
+                "루트 부재를 조용히 건너뛰면 파일 0개로 \"위반 0건\"을 거짓 보고한다 "
+                "— 디렉터리 구조가 바뀌었으면 SCAN_ROOTS를 갱신할 것."
+            )
         for path in sorted(root_path.rglob("*.py")):
-            findings.extend(scan_file(path))
+            scanned_files += 1
+            findings.extend(scan_file(path, backend_root=root))
+    if scanned_files == 0:
+        raise ScanIncompleteError(
+            f"스캔 대상 .py 파일이 0개(SCAN_ROOTS={roots}) — 가드가 헛돌고 있다."
+        )
     return findings
 
 
 def main() -> int:
-    findings = scan_repo()
+    try:
+        findings = scan_repo()
+    except ScanIncompleteError as e:
+        print(f"FAIL(가드 자체 결함, story #3370 후속): {e}")
+        return 2
     if findings:
         print(
             f"FAIL: commit() 後 model_validate() 前 refresh/재대입 없는 자리 {len(findings)}건 "

--- a/backend/tests/test_3370_commit_validate_lint_scan_completeness.py
+++ b/backend/tests/test_3370_commit_validate_lint_scan_completeness.py
@@ -1,0 +1,47 @@
+"""story #3370 후속(페드루 PO 지시 2026-09-11) — `scripts/lint_commit_before_validate.py`
+(story #2459)의 `scan_repo()`가 스캔 루트 부재·파일 0개를 "위반 0건"으로 조용히 흘리던
+fails-silent 구멍을 정정한 뒤, 그 완전성 자기 확認 자체를 pin한다
+(`lint_raw_auth_id_into_member_field.py`의 동형 조건1 정정·테스트와 같은 계약 —
+scripts/lint_commit_before_validate.py 모듈 docstring "완전성 자기 확認" 절 참고).
+
+이 파일은 그 완전성 체크만 다룬다 — commit()/model_validate() 탐지 로직 자체(story #2459
+본체)는 도입 당시 카디르 QA의 AST 스캔+수동 감사로 이미 검증됐고 이 스토리의 관심사가
+아니다."""
+from __future__ import annotations
+
+import pytest
+
+from scripts.lint_commit_before_validate import ScanIncompleteError, scan_repo
+
+
+def test_scan_repo_raises_when_a_root_is_missing(tmp_path):
+    (tmp_path / "app" / "routers").mkdir(parents=True)
+    (tmp_path / "app" / "routers" / "x.py").write_text("async def f(db, obj):\n    pass\n")
+    (tmp_path / "app" / "services").mkdir(parents=True)
+    (tmp_path / "app" / "services" / "y.py").write_text("async def f(db, obj):\n    pass\n")
+    # "ee" 루트를 아예 안 만든다 — 3개 중 하나 실종.
+    with pytest.raises(ScanIncompleteError):
+        scan_repo(scan_roots=["app/routers", "app/services", "ee"], backend_root=tmp_path)
+
+
+def test_scan_repo_raises_when_zero_files_scanned(tmp_path):
+    for root in ("app/routers", "app/services", "ee"):
+        (tmp_path / root).mkdir(parents=True)
+    # 세 루트 다 실존하지만 .py 파일이 하나도 없다.
+    with pytest.raises(ScanIncompleteError):
+        scan_repo(scan_roots=["app/routers", "app/services", "ee"], backend_root=tmp_path)
+
+
+def test_scan_repo_succeeds_when_roots_exist_with_files(tmp_path):
+    for root in ("app/routers", "app/services", "ee"):
+        d = tmp_path / root
+        d.mkdir(parents=True)
+        (d / "x.py").write_text("async def f(db, obj):\n    pass\n")
+    # 예외 없이 정상 반환(빈 리스트 — 위반 0건과 "헛돎" 0건을 구분하는 정상 경로).
+    assert scan_repo(scan_roots=["app/routers", "app/services", "ee"], backend_root=tmp_path) == []
+
+
+def test_repo_has_zero_violations():
+    """실 저장소 scan_repo() 0건 — story #2459 도입 당시 계약(grandfather 없음)이 지금도
+    성립함을 확認(이 파일 자신이 완전성 정정 뒤에도 여전히 유효함을 pin)."""
+    assert scan_repo() == []


### PR DESCRIPTION
[SID:3370] 후속 소형 PR — PR #4169(`lint_raw_auth_id_into_member_field.py`) 조건부 PASS 조건1과 같은 클래스의 구멍이 `scripts/lint_commit_before_validate.py`(story #2459 템플릿)에도 그대로 있었다(페드루 明示, 별건으로 남겨뒀던 것).

## 무엇
`scan_repo()`가 `SCAN_ROOTS` 부재를 `continue`로 삼켜, 스캔 파일이 0개여도 "위반 0건"을 그대로 OK로 찍는 fails-silent 구멍 — 정정: `SCAN_ROOTS` 3개 각각 실존 assert + 스캔 파일 0개면 `ScanIncompleteError`(exit 2, "위반 0건"의 exit 1과 종료코드로 구분). `scan_repo`/`scan_file`에 `scan_roots`/`backend_root` 오버라이드를 추가해 tmp_path 합성 디렉터리로 직접 단위테스트 가능하게 함.

## 테스트
`tests/test_3370_commit_validate_lint_scan_completeness.py` 신설(story #2459 자신은 이 스크립트 전용 테스트가 없었음):
- 루트 하나 부재 → `ScanIncompleteError`
- 루트는 있지만 .py 파일 0개 → 동일
- 정상(루트+파일 존재) → 예외 없이 빈 리스트
- 실 저장소 0건 재확認(grandfather-없음 계약이 지금도 유효함을 pin)

뮤테이션 자체검증 2종(두 `raise`를 각각 되돌림) — 대응하는 신규 테스트만 정확히 RED, 나머지 불변.

## 스코프 밖
commit/model_validate 탐지 로직 자체(story #2459 본체)는 이 PR의 관심사가 아니다 — 완전성 자기 확認만 정정.

로컬: 스크립트 재실행 0건 + `test_2384_scripts_root_image_exclusion_lint.py` 재확인(green). 순수 AST 스크립트라 실 PG 불요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8