### PR TITLE
[SID:3369] fix(BE): events.py 게이트 판정 「다음 행동」 2문장 i18n_catalog 이관

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -41,6 +41,8 @@ from app.core import shutdown as _shutdown_module
 from app.dependencies.database import get_db
 from app.dependencies.ownership import _is_org_admin
 from app.models.event import Event
+from app.services.agent_onboarding_config import resolve_locale_from_request
+from app.services.i18n_catalog import t
 from app.services.member_resolver import assert_caller_is_member, resolve_member_identity
 
 router = APIRouter(prefix="/api/v2/events", tags=["events", "Organization"])
@@ -1267,7 +1269,9 @@ async def _tokenize_embedded_entity_refs(db: AsyncSession, *, org_id: uuid.UUID,
     return await _async_regex_sub(_EMBEDDED_HEX8_RE, _replace_prefix, text)
 
 
-async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, payload: dict) -> str:
+async def _render_gate_verdict_message(
+    db: AsyncSession, *, org_id: uuid.UUID, payload: dict, resolved_locale: str = "ko",
+) -> str:
     """story #3330 — `preset.gate.verdict` 전용 렌더. 승인/반려 대상 work item·게이트
     종류·판정·(반려 시) 사유·대상 산출물 doc 클릭 토큰·다음 행동을 담는다(AC2, #3323이
     stage 알림에 한 것과 같은 규격). `preset.gate.verdict`는 `stage_metadata`가 없는
@@ -1441,13 +1445,9 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
                     select(PublicationCommand.id).where(PublicationCommand.gate_id == gate_row.id)
                 )).first() is not None
             if is_site_post and site_post_command_exists:
-                lines.append(
-                    "- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 "
-                    "tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 "
-                    "확認합니다."
-                )
+                lines.append(f"- {t('events.gate_verdict_next_action_publish_command_created', resolved_locale)}")
             else:
-                lines.append("- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.")
+                lines.append(f"- {t('events.gate_verdict_next_action_publish_human_only', resolved_locale)}")
         elif verdict == "rejected":
             # AC3 — 사유에 «폐기/중단» 신호가 있으면 다음 행동 자체를 비운다(침묵도
             # 문구다). 재상신을 권하면 카드가 사람의 결정과 정면으로 반대되는 행동을
@@ -1495,7 +1495,7 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
 
 
 async def _render_event_message_content(
-    db: AsyncSession, *, org_id: uuid.UUID, definition, payload: dict,
+    db: AsyncSession, *, org_id: uuid.UUID, definition, payload: dict, resolved_locale: str = "ko",
 ) -> str:
     """story #3313(마케팅자동화·온보딩 결함) — `block_template`가 없는 사이클형 정의(stage
     이벤트)의 알림 본문이 "stage/work_item_id뿐"이라 수신 에이전트가 `list_event_definitions`
@@ -1514,7 +1514,7 @@ async def _render_event_message_content(
     ②로 떨어져 여태 제네릭 폴백뿐이었다(반려 사유·산출물 링크·다음 행동이 전혀 안
     실림). 그 키만 전용 렌더(`_render_gate_verdict_message`)로 먼저 갈라낸다."""
     if definition.key == "preset.gate.verdict":
-        return await _render_gate_verdict_message(db, org_id=org_id, payload=payload)
+        return await _render_gate_verdict_message(db, org_id=org_id, payload=payload, resolved_locale=resolved_locale)
     if definition.block_template is not None or not definition.stage_metadata:
         return "\n".join(_generic_event_message_lines(definition.key, payload))
 
@@ -1605,6 +1605,7 @@ async def publish_registry_event(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    locale: str | None = None,
 ) -> dict:
     """POST /api/v2/events/publish — story #2633 AC1~AC3.
 
@@ -1619,11 +1620,21 @@ async def publish_registry_event(
 
     실 로직은 `_publish_registry_event_core`(story #2791 P0 추출) — 서버 자동발행
     (`publish_preset_event`)도 HTTP 요청 컨텍스트 없이 같은 core를 호출해 단일 파이프
-    원칙(#2633 AC2)을 유지한다. 이 엔드포인트는 auth 의존성 해석만 하고 넘긴다."""
+    원칙(#2633 AC2)을 유지한다. 이 엔드포인트는 auth 의존성 해석만 하고 넘긴다.
+
+    story #3369(BE, 페드루 PO 確定 2026-09-11) — `_render_gate_verdict_message`의
+    i18n_catalog 이관분이 쓸 locale. `#3796`/`#3614`와 같은 우선순위(explicit locale
+    → Accept-Language → 기본 "ko")이되, 이 함수는 이미 `request: Request`(plain
+    파라미터, `Header()` DI 마커가 아니다)를 받고 있어 그걸로 헤더를 직접 읽는다 —
+    별도 `Header()` 진입점/직접-호출 분리가 불필요하다(이 레포 realdb 테스트
+    10여 곳이 이 함수를 HTTP 경유 없이 직접 호출하는데, `request`는 이미 실
+    Starlette Request라 `.headers`가 항상 안전하게 동작한다 — `Header()` 마커였다면
+    그 호출부 전부가 깨졌을 것)."""
+    resolved_locale = resolve_locale_from_request(locale, request.headers.get("accept-language"))
     return await _publish_registry_event_core(
         db, org_id, auth, body.definition_key, body.payload, background_tasks,
         request=request, extra_broadcast_member_ids=body.extra_broadcast_member_ids,
-        conversation_id=body.conversation_id,
+        conversation_id=body.conversation_id, resolved_locale=resolved_locale,
     )
 
 
@@ -1638,6 +1649,12 @@ async def _publish_registry_event_core(
     request: Request | None = None,
     extra_broadcast_member_ids: "list[uuid.UUID] | None" = None,
     conversation_id: uuid.UUID | None = None,
+    # story #3369(BE, 페드루 PO 確定 2026-09-11) — `_render_gate_verdict_message`의
+    # i18n_catalog 이관분(#3796/#3614와 같은 형)이 쓸 locale. 서버 자동발행(publish_
+    # preset_event, HTTP 요청 컨텍스트 없음 — 이 함수 docstring 참조)은 이 인자를
+    # 안 넘겨 기본값 "ko"로 떨어진다(회귀 0) — HTTP 진입점(publish_registry_event)만
+    # Header()로 실제 값을 풀어 넘긴다.
+    resolved_locale: str = "ko",
 ) -> dict:
     """`publish_registry_event`(HTTP)·`publish_preset_event`(서버 자동발행, story #2791 P0)의
     공유 core — definition_key+payload를 검증하고 routing(상신선·전파선)을 실 member_id로
@@ -1890,7 +1907,9 @@ async def _publish_registry_event_core(
     # "이벤트 발행분"으로 인지하고 event_key로 event_definitions를 조회해 block_template
     # 렌더러를 태울 근거. 렌더러 자체는 #2637 FE 레인(이 커밋은 스키마 배선만).
     send_body = SendMessageRequest(
-        content=await _render_event_message_content(db, org_id=org_id, definition=definition, payload=payload),
+        content=await _render_event_message_content(
+            db, org_id=org_id, definition=definition, payload=payload, resolved_locale=resolved_locale,
+        ),
         mentioned_ids=list(escalation_ids),
         event_context={"event_key": definition.key, "payload": payload, "refs": refs},
     )

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -176,6 +176,18 @@ _CATALOG: dict[str, dict[str, str]] = {
         "ko": "이 조직에 없는 발행물입니다",
         "en": "Publication not found in this organization",
     },
+    # story #3369(BE, 페드루 PO 確定 2026-09-11) — events.py::_render_gate_verdict_
+    # message의 external_publish 승인 「다음 행동」 2갈래(site_post 발행 명령 자동 생성
+    # vs 휴먼 화면 발행). BE 한글 사용자 문장 가드 baseline에서 이 2줄을 걷고 카탈로그로
+    # 이관(#3796/#3614와 같은 형).
+    "events.gate_verdict_next_action_publish_command_created": {
+        "ko": "다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 확認합니다.",
+        "en": "Next action: none — approval created the publish command, and it will publish on the next worker tick (within 1 minute). Check the result in the \"Publish result\" line on the source detail page.",
+    },
+    "events.gate_verdict_next_action_publish_human_only": {
+        "ko": "다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.",
+        "en": "Next action: nothing to do — a human publishes this from the screen.",
+    },
 }
 
 

--- a/backend/scripts/korean_user_strings_baseline.txt
+++ b/backend/scripts/korean_user_strings_baseline.txt
@@ -194,10 +194,8 @@ app/routers/events.py::- 다음 단계로 넘기는 발행 예시: publish_event
 app/routers/events.py::- 다음 행동:
 app/routers/events.py::- 다음 행동: channel=
 app/routers/events.py::- 다음 행동: 산출물을 수정한 뒤, 같은 레시피 정의의 approve stage 이벤트를 다시 발행하세요(payload.previous_output_doc_id=수정본 id) — 게이트는 그 발행으로 자동 재오픈됩니다.
-app/routers/events.py::- 다음 행동: 없음 — 승인으로 발행 명령이 만들어졌고 다음 워커 tick(최대 1분)에 발행됩니다. 결과는 원문 상세 «발행 결과» 줄에서 확認합니다.
 app/routers/events.py::- 다음 행동: 이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 이 승인 게이트를 확인하는 발행 도구를 쓰세요).
 app/routers/events.py::- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다.
-app/routers/events.py::- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.
 app/routers/events.py::- 단계 `
 app/routers/events.py::- 대상 산출물:
 app/routers/events.py::- 사유:

--- a/backend/tests/test_3387_gate_verdict_agent_next_action.py
+++ b/backend/tests/test_3387_gate_verdict_agent_next_action.py
@@ -101,7 +101,7 @@ def _stub_work_item_ref(monkeypatch):
 
 async def _render(
     payload: dict, gate_row=None, *, site_post_draft_exists: bool = False,
-    site_post_command_exists: bool = False,
+    site_post_command_exists: bool = False, resolved_locale: str = "ko",
 ) -> str:
     from app.routers.events import _render_gate_verdict_message
 
@@ -110,7 +110,7 @@ async def _render(
             gate_row, site_post_draft_exists=site_post_draft_exists,
             site_post_command_exists=site_post_command_exists,
         ),
-        org_id=uuid.uuid4(), payload=payload,
+        org_id=uuid.uuid4(), payload=payload, resolved_locale=resolved_locale,
     )
 
 
@@ -273,3 +273,55 @@ class TestOtherGateTypesUnchanged:
         text = await _render(_payload(gate_type="qa", verdict="rejected", resolution_note="폐기 대상"))
         assert "다시 발행하세요" in text
         assert "자동 재오픈됩니다" in text
+
+
+class TestNextActionI18nCatalogMigration:
+    """story #3369(BE, 페드루 PO 確定 2026-09-11) — BE 한글 사용자 문장 가드(story #3779)가
+    이 두 「다음 행동」 문장을 신규 위반으로 잡아, baseline이 아니라 i18n_catalog로
+    이관했다(#3796/#3614와 같은 형). 여기서는 그 배선(render → t(key, resolved_locale))
+    자체를 카탈로그 값과 대조해 고정한다 — 값 자체는 위 TestExternalPublishAgentNextAction/
+    TestSitePostExternalDestination류가 이미 KO 리터럴로 pin하고 있다(회귀 0 확認 済)."""
+
+    async def test_human_only_branch_renders_en_from_catalog(self):
+        from app.services.i18n_catalog import t
+
+        text = await _render(
+            _payload(gate_type="external_publish", verdict="approved"), resolved_locale="en",
+        )
+        assert t("events.gate_verdict_next_action_publish_human_only", "en") in text
+        assert "할 일 없음" not in text  # ko 리터럴이 안 새어 들어온다.
+
+    async def test_publish_command_created_branch_renders_en_from_catalog(self):
+        from app.services.i18n_catalog import t
+
+        draft_id = str(uuid.uuid4())
+        gate_row = _FakeGateRow({"draft_id": draft_id})
+        text = await _render(
+            _payload(gate_type="external_publish", verdict="approved"),
+            gate_row=gate_row, site_post_draft_exists=True, site_post_command_exists=True,
+            resolved_locale="en",
+        )
+        assert t("events.gate_verdict_next_action_publish_command_created", "en") in text
+        assert "워커 tick" not in text
+
+    async def test_ko_default_matches_catalog_value_exactly(self):
+        """뮤테이션 표적 — 카탈로그 값과 렌더 결과가 문자 그대로 같은지(직접 비교, 부분
+        일치가 아니라)로 배선을 고정한다. 카탈로그 값이 바뀌었는데 렌더가 옛 하드코딩
+        문자열로 계속 새면(즉 t() 호출이 죽은 코드로 남으면) 이 단언이 RED다."""
+        from app.services.i18n_catalog import t
+
+        text = await _render(_payload(gate_type="external_publish", verdict="approved"))
+        expected = t("events.gate_verdict_next_action_publish_human_only", "ko")
+        assert f"- {expected}" in text
+
+    async def test_missing_catalog_key_raises_instead_of_silent_fallback(self, monkeypatch):
+        """⭐뮤테이션 — 카탈로그에서 키를 지우면(오타·삭제 등) 조용한 폴백 대신 즉시
+        UnknownMessageKeyError로 죽어야 한다(i18n_catalog.py 가드 2, story #3786).
+        _render_gate_verdict_message가 여전히 옛 하드코딩 문자열로 폴백하도록 되돌리면
+        이 테스트가 RED(예외가 안 남)여야 한다."""
+        import app.services.i18n_catalog as catalog_module
+        from app.services.i18n_catalog import UnknownMessageKeyError
+
+        monkeypatch.delitem(catalog_module._CATALOG, "events.gate_verdict_next_action_publish_human_only")
+        with pytest.raises(UnknownMessageKeyError):
+            await _render(_payload(gate_type="external_publish", verdict="approved"))


### PR DESCRIPTION
## 배경

BE 한글 사용자 문장 재발 가드(story #3779)가 `_render_gate_verdict_message`(external_publish 승인 카드의 「다음 행동」 렌더)의 기존 2줄 편집을 신규 위반으로 잡았다(SID:3369 작업 중 발견). PO 確定: baseline에 추가하는 대신 #3796/#3614와 같은 메커니즘으로 i18n_catalog 이관.

## 처방

- `events.gate_verdict_next_action_publish_command_created` / `events.gate_verdict_next_action_publish_human_only` 2키 등록(ko 값은 원문과 문자 그대로 동일 — 회귀 0).
- `_render_gate_verdict_message`·`_render_event_message_content`·`_publish_registry_event_core`에 `resolved_locale: str = "ko"`를 additive로 통과.
- **구현 세부(디디 #4167 템플릿에서 한 가지 조정)**: `publish_registry_event`는 이미 `Header()` DI가 아니라 plain `Request`를 받고 있어(`request.headers.get("accept-language")`로 직접 읽으면 충분), 별도 얇은 진입점/직접-호출 분리 없이 그 자리에서 바로 `resolve_locale_from_request(locale, request.headers.get("accept-language"))`를 계산해 넘긴다. 이 함수를 HTTP 없이 직접 호출하는 realdb 테스트가 10여 개 있는데(`Header()` 마커였다면 전부 깨졌을 것) `Request`는 실제 객체라 안전 — 새 `locale` kwarg는 기본값 `None`이라 기존 호출부 전부 무변.
- 서버 자동발행(`publish_preset_event`, HTTP 컨텍스트 없음)도 `resolved_locale` 인자를 안 넘겨 기본값 "ko"로 회귀 0.
- baseline에서 이관된 2줄 제거(stale 방지).

## 테스트

- `test_3387_gate_verdict_agent_next_action.py`에 4건 추가: human-only/command-created 두 갈래 EN 렌더가 카탈로그 값과 정확히 일치·ko 기본 렌더가 카탈로그 값과 문자 그대로 대조(뮤테이션: 옛 하드코딩으로 되돌리면 RED)·카탈로그 키 삭제 시 `UnknownMessageKeyError`(뮤테이션: 조용한 폴백으로 되돌리면 RED).
- 기존 `test_3387`(14건)·`test_3330_gate_verdict_notification.py`(5건, realdb)·`test_2633_event_publish.py`(13건, realdb)·`test_3786_i18n_catalog.py`(5건) + `publish_registry_event` 직접-호출 회귀 파일 5개(29건, realdb) 전부 무변 GREEN — `locale` kwarg 추가가 기존 시그니처를 안 깬다는 것의 실증.
- `verify_no_new_korean_user_strings.py` 신규 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn