### PR TITLE
[SID:3806] feat(BE): Meta Ads boost 첫 출시 PR1 — 광고 계정 연결(meta_ads·ads_sandbox)

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Literal
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -273,6 +273,32 @@ class FacebookSelectRequest(BaseModel):
     page_id: str
 
 
+class AdAccountCandidate(BaseModel):
+    """story #3806 — `PendingSelectionCandidate`(page_id/name)와 같은 계약 형이되
+    필드명이 계정 개념에 맞다(잘못된 이름 재사용 금지 — 광고 계정을 "페이지"로
+    부르면 FE·다음 사람 둘 다 헷갈린다). `account_status`/`disable_reason`은 Meta
+    원값 그대로(정규화 0 — meta_ads_oauth.py::list_ad_accounts 계약과 동일)."""
+    account_id: str
+    name: str
+    account_status: int | None = None
+    disable_reason: int | None = None
+
+
+class AdAccountPendingSelectionResponse(BaseModel):
+    """story #3806 — `PendingSelectionResponse`와 동형(카드 §5 「계정 2개+」 경로).
+    `kind` 판별자 값도 같은 문자열("pending_selection")로 둬 FE가 기존 facebook
+    선택 대기 처리 로직을 재사용할 수 있게(모양은 candidates 필드 타입만 다름)."""
+    kind: Literal["pending_selection"] = "pending_selection"
+    pending_id: uuid.UUID
+    candidates: list[AdAccountCandidate]
+    expires_at: str
+
+
+class MetaAdsSelectRequest(BaseModel):
+    pending_id: uuid.UUID
+    account_id: str
+
+
 class TestConnectionResponse(BaseModel):
     ok: bool
     account: dict | None = None
@@ -321,6 +347,19 @@ def _facebook_oauth_module(channel: str):
     사상(real/sandbox가 정확히 같은 함수 시그니처를 구현, 새 분기 로직 0)."""
     import importlib
     return importlib.import_module(_FACEBOOK_OAUTH_MODULE_PATHS[channel])
+
+
+_META_ADS_OAUTH_MODULE_PATHS = {
+    "meta_ads": "app.services.meta_ads_oauth",
+    "ads_sandbox": "app.services.ads_sandbox_oauth",
+}
+
+
+def _meta_ads_oauth_module(channel: str):
+    """story #3806 — `_facebook_oauth_module`과 동형 dispatch(별도 dict — facebook
+    계열 기존 코드 무변경, 새 채널군은 병렬 등재)."""
+    import importlib
+    return importlib.import_module(_META_ADS_OAUTH_MODULE_PATHS[channel])
 
 
 @router.get("/{org_id}/channel-connections", response_model=list[ChannelConnectionResponse])
@@ -491,6 +530,11 @@ async def authorize_channel_connection(
         # story #3547 — Facebook Login도 PKCE 미지원(facebook_oauth.py 상단 딱지).
         build_facebook_authorize_url = _facebook_oauth_module(channel).build_authorize_url
         url = build_facebook_authorize_url(redirect_uri=_redirect_uri(org_id, channel), state=state, app_id=app_id)
+    elif channel in ("meta_ads", "ads_sandbox"):
+        # story #3806 — Meta Ads도 같은 Graph OAuth 계열이라 PKCE 미지원(facebook과
+        # 동형 판단, meta_ads_oauth.py 상단 딱지).
+        build_meta_ads_authorize_url = _meta_ads_oauth_module(channel).build_authorize_url
+        url = build_meta_ads_authorize_url(redirect_uri=_redirect_uri(org_id, channel), state=state, app_id=app_id)
     else:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
     return AuthorizeResponse(url=url, state=state)
@@ -498,7 +542,11 @@ async def authorize_channel_connection(
 
 @router.post(
     "/{org_id}/channel-connections/{channel}/callback",
-    response_model=ChannelConnectionResponse | PendingSelectionResponse,
+    # story #3806 — AdAccountPendingSelectionResponse(meta_ads/ads_sandbox 2개+ 갈래)
+    # 추가. response_model은 함수 반환 타입 주석과 별개로 FastAPI가 실제 직렬화에
+    # 쓰는 계약이라(라우트 데코레이터 값이 SSOT) 여기서도 같이 넓혀야 한다 —
+    # 안 넓히면 ChannelConnectionResponse 필드 16개 "missing" 검증 에러로 500.
+    response_model=ChannelConnectionResponse | PendingSelectionResponse | AdAccountPendingSelectionResponse,
 )
 async def channel_connection_callback(
     org_id: uuid.UUID,
@@ -507,7 +555,12 @@ async def channel_connection_callback(
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
-) -> ChannelConnectionResponse | PendingSelectionResponse:
+    # story #3806 — additive(다른 채널 분기는 안 씀, meta_ads/ads_sandbox 사용자
+    # 문장 조립에만 필요 — i18n_catalog.py 모듈 docstring 관례, Header() DI는
+    # 이 얇은 엔드포인트에서만 받는다).
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> ChannelConnectionResponse | PendingSelectionResponse | AdAccountPendingSelectionResponse:
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
     resolved = await _require_owner(db, auth, org_id)
@@ -529,7 +582,7 @@ async def channel_connection_callback(
     if adapter is None:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
-    if channel not in ("threads", "instagram", "facebook", "facebook_sandbox"):
+    if channel not in ("threads", "instagram", "facebook", "facebook_sandbox", "meta_ads", "ads_sandbox"):
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
     # authorize 단계와 별도로 다시 조회 — 콜백은 브라우저 왕복(수초~수분) 뒤라 그 사이 owner가
@@ -550,6 +603,15 @@ async def channel_connection_callback(
         return await _facebook_channel_connection_callback(
             db, org_id=org_id, channel=channel, code=body.code, app_id=app_id, app_secret=app_secret,
             requester_member_id=resolved.id, target_connection_id=oauth_state.connection_id,
+        )
+
+    if channel in ("meta_ads", "ads_sandbox"):
+        from app.services.agent_onboarding_config import resolve_locale_from_request
+
+        return await _meta_ads_channel_connection_callback(
+            db, org_id=org_id, channel=channel, code=body.code, app_id=app_id, app_secret=app_secret,
+            requester_member_id=resolved.id, target_connection_id=oauth_state.connection_id,
+            resolved_locale=resolve_locale_from_request(locale, accept_language),
         )
 
     # story #3320 — instagram_oauth.InstagramOAuthError는 ThreadsOAuthError와 같은
@@ -678,6 +740,168 @@ async def _facebook_channel_connection_callback(
         candidates=[PendingSelectionCandidate(**c) for c in candidates],
         expires_at=pending.expires_at.isoformat(),
     )
+
+
+async def _meta_ads_channel_connection_callback(
+    db: AsyncSession, *, org_id: uuid.UUID, channel: str, code: str, app_id: str, app_secret: str,
+    requester_member_id: uuid.UUID, resolved_locale: str, target_connection_id: uuid.UUID | None = None,
+) -> ChannelConnectionResponse | AdAccountPendingSelectionResponse:
+    """story #3806(Phase3·3-2 PR1) — `_facebook_channel_connection_callback`과 동형
+    구조(0/1/2+ 갈래) · 한 가지 진짜 차이: 광고 계정은 Facebook Page와 달리 계정별
+    access_token이 없다(장기 유저 토큰 하나로 `act_<id>` 경로를 스코프해 호출 —
+    meta_ads_oauth.py::list_ad_accounts docstring) — 그래서 1개/2+개 갈래 둘 다
+    **장기 유저 토큰 자체**를 저장 대상(connection.access_token 또는 pending
+    selection의 user_token)으로 쓴다, 페이지별 토큰을 꺼내 쓰지 않는다."""
+    from app.services.meta_ads_oauth import MetaAdsOAuthError
+    from app.services.channel_oauth_pending_selection import create_pending_selection
+    from app.services.i18n_catalog import t
+
+    adapter = get_channel_adapter(channel)
+    oauth_module = _meta_ads_oauth_module(channel)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        try:
+            short_lived_token, _ = await oauth_module.exchange_code_for_short_lived_token(
+                client, code=code, redirect_uri=_redirect_uri(org_id, channel), app_id=app_id, app_secret=app_secret,
+            )
+            long_lived_token, _expires_in = await oauth_module.exchange_for_long_lived_token(
+                client, short_lived_token=short_lived_token, app_id=app_id, app_secret=app_secret,
+            )
+            accounts = await oauth_module.list_ad_accounts(client, user_access_token=long_lived_token)
+        except MetaAdsOAuthError as exc:
+            # story #3806 — code별로 사람 문장이 필요한 것만 i18n_catalog로 갈아 낀다
+            # (review-rejected). 나머지는 real facebook_oauth.py류와 동형으로 provider
+            # 원문 그대로(exc.message, 한글 아님 — #3779 가드 대상 아님).
+            message = (
+                t("ads_sandbox.review_rejected", resolved_locale)
+                if exc.code == "META_ADS_ACCOUNT_REVIEW_REJECTED" else exc.message
+            )
+            raise HTTPException(status_code=400, detail={"code": exc.code, "message": message}) from exc
+        finally:
+            del app_secret  # ⛔즉시 소비 후 폐기 — 더 들고 있지 않는다(기존 규율과 동형).
+
+    if not accounts:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_META_ADS_NO_ACCOUNTS_AVAILABLE",
+                "message": t("channel_connections.meta_ads_no_accounts_available", resolved_locale),
+            },
+        )
+
+    if len(accounts) == 1:
+        account = accounts[0]
+        row = await upsert_channel_connection(
+            db, org_id=org_id, channel=channel, account_id=account["account_id"],
+            account_label=account["name"], credential_kind=adapter.credential_kind,
+            access_token=long_lived_token, refresh_token=None,
+            token_expires_at=None,  # facebook_channel_connection_callback과 동형 — ⚠️미확認.
+            refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(","), connected_by=requester_member_id,
+        )
+        mismatch_target_id = (
+            target_connection_id if target_connection_id is not None and target_connection_id != row.id else None
+        )
+        return _to_response(row, reconnect_mismatch_target_id=mismatch_target_id)
+
+    now = datetime.now(timezone.utc)
+    candidates = [
+        {
+            "account_id": a["account_id"], "name": a["name"],
+            "account_status": a.get("account_status"), "disable_reason": a.get("disable_reason"),
+        }
+        for a in accounts
+    ]
+    pending = await create_pending_selection(
+        db, org_id=org_id, requester_member_id=requester_member_id, channel=channel,
+        user_token=long_lived_token, candidates=candidates, now=now,
+    )
+    return AdAccountPendingSelectionResponse(
+        pending_id=pending.id,
+        candidates=[AdAccountCandidate(**c) for c in candidates],
+        expires_at=pending.expires_at.isoformat(),
+    )
+
+
+@router.post("/{org_id}/channel-connections/meta-ads/select", response_model=ChannelConnectionResponse)
+async def meta_ads_select_account_endpoint(
+    org_id: uuid.UUID,
+    body: MetaAdsSelectRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> ChannelConnectionResponse:
+    """story #3806 — `facebook_select_page_endpoint`와 동형(광고 계정 2개 이상
+    콜백 뒤 사람이 하나를 고르면 이 엔드포인트가 연결 행을 만든다). 광고 계정은
+    페이지와 달리 계정별 토큰이 없어(위 콜백 docstring) `/me/adaccounts` 재호출이
+    불요 — pending에 저장된 **장기 유저 토큰**을 그대로 연결에 쓴다(재호출 없이도
+    안전 — 그 토큰 자체가 이미 이 유저가 광고 계정에 접근 가능함을 증명한다,
+    facebook의 "페이지 토큰은 캐시 불신" 이유와 다른 축)."""
+    from app.services.channel_credential_crypto import decrypt_channel_credential
+    from app.services.channel_oauth_pending_selection import delete_pending_selection, get_pending_selection
+    from app.services.agent_onboarding_config import resolve_locale_from_request
+    from app.services.i18n_catalog import t
+
+    resolved_locale = resolve_locale_from_request(locale, accept_language)
+
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    resolved = await _require_owner(db, auth, org_id)
+
+    pending = await get_pending_selection(db, pending_id=body.pending_id, org_id=org_id)
+    if pending is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_NOT_FOUND",
+                # story #3806 — facebook_select_page_endpoint의 동일 문구를 그대로
+                # 재사용(같은 문자열 내용 — #3779 baseline에 이미 있어 신규 위반 아님).
+                "message": "선택 대기 상태를 찾을 수 없습니다(이미 사용됐거나 존재하지 않습니다).",
+            },
+        )
+    if pending.requester_member_id != resolved.id:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_FORBIDDEN",
+                "message": t("channel_connections.pending_selection_forbidden_ads", resolved_locale),
+            },
+        )
+    if pending.expires_at <= datetime.now(timezone.utc):
+        # 삭제는 스윕 몫(삭제 책임 단일화, facebook_select_page_endpoint와 동형 판단) —
+        # 여기서 안 지운다.
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_EXPIRED",
+                # story #3806 — facebook_select_page_endpoint와 동일 문구 재사용(#3779
+                # baseline에 이미 있음).
+                "message": "15분이 지나 선택 대기 상태가 만료됐습니다. 다시 연결해주세요.",
+            },
+        )
+    if pending.channel not in ("meta_ads", "ads_sandbox"):
+        raise HTTPException(status_code=404, detail=f"unsupported channel: {pending.channel}")
+    if not any(c.get("account_id") == body.account_id for c in pending.candidates):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "CHANNEL_OAUTH_PENDING_SELECTION_INVALID_ACCOUNT",
+                "message": t("channel_connections.pending_selection_invalid_account", resolved_locale),
+            },
+        )
+    candidate = next(c for c in pending.candidates if c["account_id"] == body.account_id)
+
+    adapter = get_channel_adapter(pending.channel)
+    long_lived_token = decrypt_channel_credential(pending.encrypted_user_token)
+    row = await upsert_channel_connection(
+        db, org_id=org_id, channel=pending.channel, account_id=candidate["account_id"],
+        account_label=candidate["name"], credential_kind=adapter.credential_kind,
+        access_token=long_lived_token, refresh_token=None, token_expires_at=None,
+        refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(","), connected_by=resolved.id,
+    )
+    await delete_pending_selection(db, pending_id=pending.id)
+    return _to_response(row)
 
 
 @router.post("/{org_id}/channel-connections/facebook/select", response_model=ChannelConnectionResponse)

--- a/backend/app/services/ads_sandbox_oauth.py
+++ b/backend/app/services/ads_sandbox_oauth.py
@@ -1,0 +1,105 @@
+"""story #3806(Phase3·마케팅운영·3-2 PR1, 페드루 PO 確定 2026-09-11) — Meta Ads 광고
+계정 연결 sandbox. `meta_ads_oauth.py`와 정확히 같은 함수 시그니처(라우터가 채널로
+모듈만 바꿔 끼우는 기존 dispatch 관례 — `facebook_sandbox_oauth.py`/`channel_
+adapters.py::get_publish_client_module`과 동형 사상, 새 분기 로직 0)를 인프로세스
+결정적 응답으로 구현한다(sandbox_publish.py "같은 코드 경로·가짜 데이터" 철학).
+`facebook_sandbox_oauth.py`(story #3547/#3613)와 동형 — authorize가 실 Meta 도메인
+대신 콜백 URL로 곧장 (code, state)를 실어 리다이렉트해, real 없이도 authorize→
+callback→(필요시)select까지 전 구간이 그대로 라이브 왕복으로 실측된다.
+
+**계정 수·상태 마커**(카드 §5 확定) — sandbox 앱 자격(`channel_app_credentials`,
+channel="ads_sandbox")의 `app_id` 접미로 정한다. facebook_sandbox_oauth.py의
+`:pages-0`/`:pages-1` 관례와 동형(개수 축) + 이번 스토리가 추가하는 2종(상태 축,
+연결 단계에서 의미가 있는 것만 — 예산 초과·중지 지연은 boost 요청/실행이 아직
+없어[PR2/PR3] 여기선 못 걺, sandbox_publish.py 카탈로그에 예약만 해 둔다):
+  - `:accounts-0` — 계정 0개(422 CHANNEL_META_ADS_NO_ACCOUNTS_AVAILABLE).
+  - `:accounts-1` — 계정 1개, 정상(즉시 연결).
+  - `:account-unverified` — 계정 1개인데 `account_status=PENDING_RISK_REVIEW`(7,
+    Meta 공식 enum) — `[sandbox:account-unverified]` 마커. 연결 자체는 되지만
+    (Meta도 미인증 계정을 목록엔 보여준다) account_status가 비-ACTIVE로 옴 — 판정은
+    호출부(라우터) 몫, 이 함수는 원값만 정직하게 낸다.
+  - `:review-rejected` — `list_ad_accounts` 단계에서 즉시 예외(`MetaAdsOAuthError`
+    코드 `META_ADS_ACCOUNT_REVIEW_REJECTED`) — 「앱 자체가 ads_management 심사에서
+    거부됨」류, 개별 계정이 아니라 이 앱 자격 전체가 광고 API를 못 쓰는 상태 시뮬
+    (Meta 공식 API 응답 형은 ⚠️미확認 — sandbox가 라이브에서 이 실패 모양을 먼저
+    노출해 두는 것 자체가 이 마커의 존재 이유, threads_publish.py류 「미확認 딱지」
+    관례와 동형).
+  - 접미 없음(기본) — 계정 2개(선택 대기 경로 실측)."""
+from __future__ import annotations
+
+import httpx
+
+from app.services.meta_ads_oauth import MetaAdsOAuthError
+
+_ACCOUNTS_0_SUFFIX = ":accounts-0"
+_ACCOUNTS_1_SUFFIX = ":accounts-1"
+_ACCOUNT_UNVERIFIED_SUFFIX = ":account-unverified"
+_REVIEW_REJECTED_SUFFIX = ":review-rejected"
+_FAKE_TOKEN_PREFIX = "sandbox-meta-ads-user-token"
+
+_SANDBOX_FAKE_CODE = "sandbox-oauth-code"
+
+# Meta 공식 account_status enum(developers.facebook.com/docs/marketing-api/reference/
+# ad-account/, 2026-09-11 fetch 확認) — 7=PENDING_RISK_REVIEW를 그대로 재사용(지어낸
+# 값 0).
+_ACCOUNT_STATUS_ACTIVE = 1
+_ACCOUNT_STATUS_PENDING_RISK_REVIEW = 7
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, app_id: str) -> str:
+    """meta_ads_oauth.py 시그니처 동형 — real Meta 없이 콜백 URL로 곧장 리다이렉트
+    (facebook_sandbox_oauth.py `build_authorize_url` docstring 원칙 그대로)."""
+    from urllib.parse import urlencode
+
+    return f"{redirect_uri}?{urlencode({'code': _SANDBOX_FAKE_CODE, 'state': state})}"
+
+
+async def exchange_code_for_short_lived_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, app_id: str, app_secret: str,
+) -> tuple[str, str]:
+    return f"{_FAKE_TOKEN_PREFIX}:{app_id}", ""
+
+
+async def exchange_for_long_lived_token(
+    client: httpx.AsyncClient, *, short_lived_token: str, app_id: str, app_secret: str,
+) -> tuple[str, int]:
+    # 장기 토큰에 app_id를 그대로 옮겨 싣는다 — list_ad_accounts가 이 값에서
+    # 마커를 읽는다(facebook_sandbox_oauth.py와 동형).
+    return short_lived_token, 5_184_000  # 60일(초).
+
+
+async def list_ad_accounts(client: httpx.AsyncClient, *, user_access_token: str) -> list[dict]:
+    """결정적 고정 후보 — 이름·id는 절대 안 바뀐다(facebook_sandbox_oauth.py
+    `list_pages`와 동형 원칙, 라이브 판정이 이름을 대조한다)."""
+    if user_access_token.endswith(_REVIEW_REJECTED_SUFFIX):
+        # story #3806(BE 한글 사용자 문장 가드, #3779) — .message는 실 provider
+        # 응답 텍스트를 그대로 옮기는 축(facebook_oauth.py 등 다른 *OAuthError와
+        # 동형 — 로그·디버그용 영문 기술 문구)이지 사람에게 보이는 최종 문장이
+        # 아니다. 사용자 문장은 라우터가 이 code를 잡을 때 i18n_catalog
+        # "ads_sandbox.review_rejected"로 조립한다(캐치 지점만 locale을 안다).
+        raise MetaAdsOAuthError(
+            "META_ADS_ACCOUNT_REVIEW_REJECTED",
+            "sandbox: [sandbox:review-rejected] marker simulation — ads_management review rejected",
+        )
+    if user_access_token.endswith(_ACCOUNTS_0_SUFFIX):
+        return []
+    if user_access_token.endswith(_ACCOUNTS_1_SUFFIX):
+        return [{
+            "account_id": "sandbox-ads-account-1", "name": "Sandbox Ads Account 1",
+            "account_status": _ACCOUNT_STATUS_ACTIVE, "disable_reason": 0,
+        }]
+    if user_access_token.endswith(_ACCOUNT_UNVERIFIED_SUFFIX):
+        return [{
+            "account_id": "sandbox-ads-account-1", "name": "Sandbox Ads Account 1",
+            "account_status": _ACCOUNT_STATUS_PENDING_RISK_REVIEW, "disable_reason": 0,
+        }]
+    return [
+        {
+            "account_id": "sandbox-ads-account-1", "name": "Sandbox Ads Account 1",
+            "account_status": _ACCOUNT_STATUS_ACTIVE, "disable_reason": 0,
+        },
+        {
+            "account_id": "sandbox-ads-account-2", "name": "Sandbox Ads Account 2",
+            "account_status": _ACCOUNT_STATUS_ACTIVE, "disable_reason": 0,
+        },
+    ]

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -37,7 +37,11 @@ class ChannelAdapterConfig:
     # (channel_post·Threads류)인지 블로그(site_post·hosted_site/wordpress/webhook류)
     # 인지. available-channels가 이 값을 그대로 노출해 FE가 "채널 연결"과 "블로그 목적지"
     # 화면을 분기한다(kind 자체가 SSOT — 문자열 목록을 어디서도 하드코딩하지 않는다).
-    kind: Literal["social", "blog"] = "social"
+    # story #3806(Phase3·3-2) — "ads"는 콘텐츠 발행 목적지가 아니라 기존 발행물을
+    # boost하는 실행 채널이라 "social"/"blog" 어느 쪽도 부정확하다(available-channels
+    # 화면이 이 값으로 묶어 보일 수 있어 FE 오분류 방지 목적, hosted_site 도입 때
+    # "blog"를 추가한 것과 같은 판단).
+    kind: Literal["social", "blog", "ads"] = "social"
     # story e4fc29fa(페드루 PO 리뷰 B1, 2026-09-04) — available-channels는 "연결 만들기"
     # 버튼 목록이다(그 엔드포인트 자체 목적). credential_kind="none"을 FE(#3435 AC2)가
     # 곧바로 "샌드박스 연결 만들기 버튼"으로 읽는다 — hosted_site도 credential_kind="none"
@@ -437,6 +441,39 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # unpublish=webhook_publish.unpublish()(event:"unpublish" 신호 POST) — webhook
         # 도 스코프 개념이 없다(공유 비밀 하나가 전권).
         supports_unpublish=True,
+    ),
+    # story #3806(Phase3·3-2 PR1, 페드루 PO 確定 2026-09-11) — Meta Ads boost 첫 출시.
+    # 콘텐츠 필드(image_*/video_*/max_text_length 등)는 전부 미선언(0/빈값 기본) —
+    # 이 채널은 새 콘텐츠를 만들지 않고 기존 발행물을 참조만 한다(그라운딩① object_
+    # story_id, PR2 몫). insight_metrics도 미선언 — spend는 InsightSnapshot.source=
+    # "paid" 축(PR4)으로 별도 수집, 이 어댑터의 organic insight_metrics 선언과는
+    # 다른 파이프라인.
+    "meta_ads": ChannelAdapterConfig(
+        authorize_url="https://www.facebook.com/v21.0/dialog/oauth",
+        token_url="https://graph.facebook.com/v21.0/oauth/access_token",
+        # ⚠️미확認 — ads_management 하나로 boost(기존 페이지 게시물 참조)까지 충분한지,
+        # 페이지 자체 권한(pages_read_engagement류)도 같이 필요한지는 App Review 신청
+        # 시점에 재확認 필요(카드 그라운딩① 미확認 항목과 같은 축).
+        scope="ads_management",
+        refresh_mode="reissue_from_access_token",
+        credential_kind="oauth",
+        display_name="Meta Ads",
+        kind="ads",
+        requires_connection=True,
+    ),
+    "ads_sandbox": ChannelAdapterConfig(
+        authorize_url="https://www.facebook.com/v21.0/dialog/oauth",
+        token_url="https://graph.facebook.com/v21.0/oauth/access_token",
+        scope="ads_management",
+        refresh_mode="reissue_from_access_token",
+        # facebook_sandbox와 동형 이유(channel_adapters.py:328 근방 주석 참고) —
+        # 계정 수·상태 마커를 sandbox 앱 자격의 app_id 접미로 나르므로 credential_
+        # kind="none"(범용 `/sandbox` 엔드포인트)이 아니라 진짜 authorize→callback
+        # 라우터를 태워야 한다(ads_sandbox_oauth.py가 Meta 호출부만 페이크로 스왑).
+        credential_kind="oauth",
+        display_name="Meta Ads Sandbox",
+        kind="ads",
+        requires_connection=True,
     ),
 }
 

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -176,6 +176,28 @@ _CATALOG: dict[str, dict[str, str]] = {
         "ko": "이 조직에 없는 발행물입니다",
         "en": "Publication not found in this organization",
     },
+    # story #3806(Phase3·3-2 PR1, 페드루 PO 確定 2026-09-11) — Meta Ads 광고 계정
+    # 연결. channel_connections.py는 이 스토리 前엔 i18n_catalog을 안 쓰던 파일(기존
+    # 문구는 story #3779 baseline에 grandfather) — 새로 추가하는 4개만 카탈로그로
+    # (freeze 가드가 신규 0건을 요구, 파일 전체 이관은 이 PR 범위 밖).
+    "channel_connections.meta_ads_no_accounts_available": {
+        "ko": "연결할 수 있는 광고 계정이 없습니다 — 이 계정이 접근 가능한 Meta 광고 계정이 없거나, "
+              "광고 계정 권한을 허용하지 않았습니다.",
+        "en": "No ad accounts available to connect — this account has no accessible Meta ad accounts, "
+              "or ad account permissions were not granted.",
+    },
+    "channel_connections.pending_selection_forbidden_ads": {
+        "ko": "이 선택 대기 상태를 시작한 사람만 광고 계정을 고를 수 있습니다.",
+        "en": "Only the person who started this pending selection can choose an ad account.",
+    },
+    "channel_connections.pending_selection_invalid_account": {
+        "ko": "선택한 광고 계정이 이 선택 대기 상태의 후보 목록에 없습니다.",
+        "en": "The selected ad account is not in this pending selection's candidate list.",
+    },
+    "ads_sandbox.review_rejected": {
+        "ko": "이 앱 자격의 ads_management 권한 심사가 거부됐습니다 — Meta 앱 검수를 다시 신청해주세요.",
+        "en": "This app credential's ads_management permission review was rejected — please reapply for Meta App Review.",
+    },
     # story #3369(BE, 페드루 PO 確定 2026-09-11) — events.py::_render_gate_verdict_
     # message의 external_publish 승인 「다음 행동」 2갈래(site_post 발행 명령 자동 생성
     # vs 휴먼 화면 발행). BE 한글 사용자 문장 가드 baseline에서 이 2줄을 걷고 카탈로그로

--- a/backend/app/services/meta_ads_oauth.py
+++ b/backend/app/services/meta_ads_oauth.py
@@ -1,0 +1,123 @@
+"""story #3806(Phase3·마케팅운영·3-2 PR1, 페드루 PO 確定 2026-09-11) — Meta Ads(광고
+계정) 연결 서버 OAuth 교환 + 계정 목록 조회. `facebook_oauth.py`(story #3547)와 동형
+구조 — app_id/secret은 호출부(`channel_app_credentials.py` 3단 우선순위)가 해석해
+넘긴다. Facebook Login과 같은 Graph OAuth 계열이라(Marketing API도 Graph API 위에
+얹힌다) authorize/token 엔드포인트는 facebook_oauth.py와 동일 base — scope만
+`ads_management`로 갈린다.
+
+⚠️미확認 딱지(facebook_oauth.py/instagram_oauth.py 상단 관례와 동형) — `/me/
+adaccounts` 엔드포인트 자체(공식 문서 fetch로 정확한 URL 문자열까지는 재확認 못함,
+2026-09-11)와 응답 필드 shape은 디디의 일반 Meta Marketing API 지식이다. `account_
+status`/`disable_reason` 정수 enum(1=ACTIVE·2=DISABLED 등)은 공식 문서 fetch로
+확認(developers.facebook.com/docs/marketing-api/reference/ad-account/, 2026-09-11).
+**이 모듈은 PR1(계정 연결 자리만) 시점에 App Review(`ads_management` 권한)·Business
+Verification·실 앱 자격이 전혀 없어 라이브 왕복 자체가 불가능** — 코드는 구조만
+갖춘다(카드 「코드는 어댑터 자리만·자격 값 0」 그대로). 출시 前 재확認 필수.
+
+흐름: authorize(코드 부여) → callback(단기 유저 토큰) → 단기→장기(≈60일) 유저 토큰
+교환(facebook_oauth.py와 동일 `fb_exchange_token` grant) → `list_ad_accounts`
+(`/me/adaccounts`)로 이 유저가 접근 가능한 광고 계정 목록을 받는다. `account_status
+!= 1`(ACTIVE 아님)인 계정은 목록에서 제외하지 않고 그대로 반환 — 「계정 미인증」
+류 판정은 연결 단계가 아니라 boost 요청 시점(PR2)에서 하는 것이 더 정확할 수
+있으나, 카드 §5가 이 마커를 connection 플로우 마커로 명시해 여기서도 상태를 실어
+둔다(`account_status`/`disable_reason` 원값 그대로 candidate dict에 포함 — FE/후속
+PR이 판정)."""
+from __future__ import annotations
+
+import httpx
+
+_AUTHORIZE_BASE = "https://www.facebook.com/v21.0/dialog/oauth"
+_GRAPH_BASE = "https://graph.facebook.com/v21.0"
+_TOKEN_URL = _GRAPH_BASE + "/oauth/access_token"
+_AD_ACCOUNTS_URL = _GRAPH_BASE + "/me/adaccounts"
+
+
+class MetaAdsOAuthError(Exception):
+    """code→token/장기교환/계정목록 실패. .code/.message가 FacebookOAuthError·
+    ThreadsOAuthError·InstagramOAuthError와 동형 속성(라우터가 같은 except 튜플로
+    묶어 처리)."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, app_id: str) -> str:
+    from urllib.parse import urlencode
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    cfg = CHANNEL_ADAPTERS["meta_ads"]
+    params = {
+        "client_id": app_id, "redirect_uri": redirect_uri, "scope": cfg.scope,
+        "response_type": "code", "state": state,
+    }
+    return f"{_AUTHORIZE_BASE}?{urlencode(params)}"
+
+
+async def exchange_code_for_short_lived_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, app_id: str, app_secret: str,
+) -> tuple[str, str]:
+    """authorization code → (access_token, "") — facebook_oauth.py와 동형 시그니처
+    (두 번째 원소는 list_ad_accounts가 계정 식별을 대신하므로 빈 문자열)."""
+    resp = await client.get(
+        _TOKEN_URL,
+        params={"client_id": app_id, "client_secret": app_secret, "redirect_uri": redirect_uri, "code": code},
+    )
+    if resp.status_code != 200:
+        raise MetaAdsOAuthError("META_ADS_TOKEN_EXCHANGE_FAILED", resp.text[:500])
+    body = resp.json()
+    access_token = body.get("access_token")
+    if not access_token:
+        raise MetaAdsOAuthError("META_ADS_TOKEN_EXCHANGE_MISSING_FIELDS", "access_token missing")
+    return access_token, ""
+
+
+async def exchange_for_long_lived_token(
+    client: httpx.AsyncClient, *, short_lived_token: str, app_id: str, app_secret: str,
+) -> tuple[str, int]:
+    resp = await client.get(
+        _TOKEN_URL,
+        params={
+            "grant_type": "fb_exchange_token", "client_id": app_id, "client_secret": app_secret,
+            "fb_exchange_token": short_lived_token,
+        },
+    )
+    if resp.status_code != 200:
+        raise MetaAdsOAuthError("META_ADS_LONG_LIVED_EXCHANGE_FAILED", resp.text[:500])
+    body = resp.json()
+    access_token = body.get("access_token")
+    expires_in = body.get("expires_in")
+    if not access_token or not expires_in:
+        raise MetaAdsOAuthError("META_ADS_LONG_LIVED_EXCHANGE_MISSING_FIELDS", "access_token/expires_in missing")
+    return access_token, int(expires_in)
+
+
+async def list_ad_accounts(client: httpx.AsyncClient, *, user_access_token: str) -> list[dict]:
+    """`GET /me/adaccounts` — 장기 유저 토큰으로 이 유저가 접근 가능한 광고 계정
+    목록을 받는다. 반환은 `[{"account_id": str, "name": str, "account_status": int,
+    "disable_reason": int}, ...]`(원본 `id`가 `act_<id>` 접두를 갖는 축과 `account_id`
+    필드가 접두 없는 원본 축, 둘 중 어느 쪽인지는 ⚠️미확認 — 라이브 확認 전 접두
+    유무 확定 필요). `account_status`/`disable_reason` 판정(활성/미인증/심사거부
+    분류)은 이 함수가 하지 않는다 — 원값 그대로 넘기고 호출부(라우터/PR2)가 판정
+    (같은 값이 다른 뜻으로 오해석되면 안 되므로 정규화는 최대한 늦게)."""
+    resp = await client.get(
+        _AD_ACCOUNTS_URL,
+        params={"access_token": user_access_token, "fields": "account_id,name,account_status,disable_reason"},
+    )
+    if resp.status_code != 200:
+        raise MetaAdsOAuthError("META_ADS_LIST_ACCOUNTS_FAILED", resp.text[:500])
+    body = resp.json()
+    entries = body.get("data")
+    if entries is None:
+        raise MetaAdsOAuthError("META_ADS_LIST_ACCOUNTS_MISSING_FIELD", "data missing in response")
+    accounts = []
+    for entry in entries:
+        account_id, name = entry.get("account_id") or entry.get("id"), entry.get("name")
+        if not account_id:
+            continue
+        accounts.append({
+            "account_id": str(account_id), "name": name or str(account_id),
+            "account_status": entry.get("account_status"), "disable_reason": entry.get("disable_reason"),
+        })
+    return accounts

--- a/backend/app/services/sandbox_publish.py
+++ b/backend/app/services/sandbox_publish.py
@@ -77,6 +77,24 @@
   캡처 자체가 그 창을 훨씬 지나 도는 실 스케줄(_SNAPSHOT_OFFSETS=1일·7일)이라
   라이브에서 stored>live를 절대 못 만들어 기각됐다.
 
+- `[sandbox:account-unverified]`(story #3806 §5, ads_sandbox 전용, 라이브 런북용) —
+  ⚠️이 파일이 읽는 마커가 아니다(카탈로그 완전성을 위해 여기 등재만 함). 실제
+  소비처는 `ads_sandbox_oauth.py::list_ad_accounts` — `create_container`의 text
+  인자가 아니라 sandbox 앱 자격(`channel_app_credentials`, channel="ads_sandbox")의
+  `app_id` 접미(`:account-unverified`)로 읽는다(facebook_sandbox_oauth.py의 페이지
+  수 마커 관례와 동형 — 발행물 텍스트가 아니라 OAuth 콜백 단계 마커라 이 축이
+  자연스럽다). 계정 1개가 그대로 반환되지만 `account_status=7`(Meta 공식
+  PENDING_RISK_REVIEW enum)이 실린다.
+- `[sandbox:review-rejected]`(story #3806 §5, ads_sandbox 전용, 라이브 런북용) —
+  ⚠️위와 동일 축(app_id 접미 `:review-rejected`) — `list_ad_accounts` 자체가
+  `MetaAdsOAuthError("META_ADS_ACCOUNT_REVIEW_REJECTED", ...)`로 즉시 실패한다
+  (개별 계정이 아니라 앱 자격 전체가 광고 API를 못 쓰는 상태 시뮬 — 「계정 0개」
+  와는 다른 사실이라 다른 코드로 구분).
+- `[sandbox:budget-exceeded]`·`[sandbox:pause-delayed]`(story #3806 §5) — **예약만,
+  미구현**. boost 요청(PR2)·중지 명령(PR3) 자체가 아직 없어 걸 자리가 없다 — 그
+  PR에서 마커 소비처를 신설할 때 이 카탈로그도 갱신할 것(카드 §5가 지정한 4마커
+  중 나머지 둘, 「정직하게 적어둔다」 house 관례 — 지어낸 완료 표시 금지).
+
 마커는 서로 배타적으로 다루지 않는다(먼저 매치되는 것을 그대로 적용) — 실패 마커 3종은
 텍스트 안 어디에든, 컨테이너 마커 2종과 자유롭게 조합 가능(단, 컨테이너 마커 2종은
 이미지 첨부 초안에서만 의미 있음, 위 참고)."""

--- a/backend/scripts/lint_channel_insight_metrics_drift.py
+++ b/backend/scripts/lint_channel_insight_metrics_drift.py
@@ -58,6 +58,11 @@ _CHANNEL_BLOCK_START_RE = re.compile(
 EXPECTED_BACKEND_CHANNELS = frozenset({
     "threads", "instagram", "facebook", "facebook_sandbox", "hosted_site",
     "wordpress", "webhook", "sandbox", "instagram_sandbox",
+    # story #3806(Phase3·3-2 PR1) — meta_ads/ads_sandbox 둘 다 insight_metrics
+    # 미선언(빈 튜플 기본값·콘텐츠 발행 채널이 아니라 이 지표 축 자체가 안 맞음,
+    # channel_adapters.py 항목 주석 참고) — extract_backend_declared_metrics가
+    # []로 등재하고 find_drift도 FE 부재=[] 폴백이라 drift 0(신규 FE 등재 불요).
+    "meta_ads", "ads_sandbox",
 })
 
 

--- a/backend/tests/test_3806_meta_ads_account_connection.py
+++ b/backend/tests/test_3806_meta_ads_account_connection.py
@@ -1,0 +1,408 @@
+"""story #3806(Phase3·3-2 PR1, 페드루 PO 確定 2026-09-11) — Meta Ads 광고 계정 연결.
+`test_3547_facebook_page_connection.py`(story #3547/#3613)와 동형 세팅 헬퍼 재사용
+(중복 재발명 0) — 이 파일은 그 파일의 정확한 계약 사본이 아니라 **진짜 차이가
+있는 자리만** 새로 검증한다: 계정별 토큰이 없다(장기 유저 토큰 하나로 select까지
+재사용) · account_status/disable_reason 원값 투과 · review-rejected가 목록 조회
+자체를 예외로 죽인다(0개 반환이 아니라).
+
+ads_sandbox_oauth.py도 facebook_sandbox_oauth.py와 동형으로 실 HTTP 없이 인프로세스
+결정적으로 답한다 — authorize→callback→select 라우터 코드를 그대로 태운다."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_3373_channel_connections_auth import (
+    _seed_org, _seed_human, _session_factory, _client_for, _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+    monkeypatch.setattr(config_module.settings, "channel_oauth_state_secret", "test-channel-oauth-state-secret")
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _register_ads_sandbox_app_credentials(session, *, org_id, updated_by, app_id="sandbox-app-id"):
+    """ads_sandbox도 facebook_sandbox와 동형 이유로 platform fallback이 없다(org가
+    직접 등록해야 authorize가 진입)."""
+    from app.services.channel_app_credentials import upsert_channel_app_credentials
+
+    return await upsert_channel_app_credentials(
+        session, org_id=org_id, channel="ads_sandbox", app_id=app_id, app_secret="sandbox-secret",
+        updated_by=updated_by,
+    )
+
+
+async def _authorize_and_callback(client, org_id: str, *, channel="ads_sandbox", code="auth-code"):
+    r_auth = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/{channel}/authorize")
+    assert r_auth.status_code == 200, r_auth.text
+    state = r_auth.json()["state"]
+    return await client.post(
+        f"/api/v2/organizations/{org_id}/channel-connections/{channel}/callback",
+        json={"code": code, "state": state},
+    )
+
+
+# ─── 어댑터 등재 ──────────────────────────────────────────────────────────────
+
+
+def test_meta_ads_and_ads_sandbox_registered_with_ads_kind():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    assert CHANNEL_ADAPTERS["meta_ads"].kind == "ads"
+    assert CHANNEL_ADAPTERS["ads_sandbox"].kind == "ads"
+    assert CHANNEL_ADAPTERS["meta_ads"].credential_kind == "oauth"
+    assert CHANNEL_ADAPTERS["ads_sandbox"].credential_kind == "oauth"
+    # 콘텐츠 필드 전부 미선언(그라운딩 — 이 채널은 콘텐츠를 만들지 않는다).
+    assert CHANNEL_ADAPTERS["meta_ads"].image_max_count == 0
+    assert CHANNEL_ADAPTERS["meta_ads"].max_text_length == 0
+
+
+# ─── ads_sandbox_oauth.py 단위 — 계정 수·상태 마커 ────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_ads_sandbox_list_ad_accounts_marker_branches():
+    from app.services.ads_sandbox_oauth import list_ad_accounts
+
+    zero = await list_ad_accounts(None, user_access_token="sandbox-meta-ads-user-token:app:accounts-0")
+    one = await list_ad_accounts(None, user_access_token="sandbox-meta-ads-user-token:app:accounts-1")
+    default_two = await list_ad_accounts(None, user_access_token="sandbox-meta-ads-user-token:app")
+    unverified = await list_ad_accounts(None, user_access_token="sandbox-meta-ads-user-token:app:account-unverified")
+
+    assert zero == []
+    assert [a["account_id"] for a in one] == ["sandbox-ads-account-1"]
+    assert [a["account_id"] for a in default_two] == ["sandbox-ads-account-1", "sandbox-ads-account-2"]
+    assert default_two[0]["name"] == "Sandbox Ads Account 1"
+    assert default_two[1]["name"] == "Sandbox Ads Account 2"
+    # account_status 원값 투과 — 1(ACTIVE) 기본.
+    assert one[0]["account_status"] == 1
+    # 미인증 마커 — 7(PENDING_RISK_REVIEW, Meta 공식 enum), 계정은 여전히 1개 반환.
+    assert len(unverified) == 1
+    assert unverified[0]["account_status"] == 7
+
+
+@pytest.mark.anyio
+async def test_ads_sandbox_review_rejected_marker_raises_not_empty_list():
+    """review-rejected는 «계정 0개»(빈 목록)가 아니라 목록 조회 자체가 실패한다 —
+    「이 앱 자격이 광고 API 접근을 아예 못 받음」과 「계정을 하나도 못 찾음」은
+    다른 사실이다(0개로 뭉치면 콜백이 CHANNEL_META_ADS_NO_ACCOUNTS_AVAILABLE로
+    오분류해 실제 원인 — 앱 심사 거부 — 이 사람에게 안 닿는다)."""
+    from app.services.ads_sandbox_oauth import list_ad_accounts
+    from app.services.meta_ads_oauth import MetaAdsOAuthError
+
+    with pytest.raises(MetaAdsOAuthError) as exc_info:
+        await list_ad_accounts(None, user_access_token="sandbox-meta-ads-user-token:app:review-rejected")
+    assert exc_info.value.code == "META_ADS_ACCOUNT_REVIEW_REJECTED"
+
+
+# ─── 콜백 3갈래(0/1/2+) — 실 authorize→callback 라우터 코드, HTTP 왕복 ────────
+
+
+@pytest.mark.anyio
+async def test_callback_zero_accounts_returns_422_no_pending_row():
+    from app.main import app
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _register_ads_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id, app_id="app:accounts-0")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await _authorize_and_callback(client, org_id)
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_META_ADS_NO_ACCOUNTS_AVAILABLE"
+
+        async with Session() as s:
+            rows = (await s.execute(select(ChannelOAuthPendingSelection))).scalars().all()
+            assert rows == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_callback_review_rejected_returns_400_not_422():
+    """META_ADS_ACCOUNT_REVIEW_REJECTED는 MetaAdsOAuthError로 전파돼 400(다른
+    OAuth 교환 실패류와 동형 — no-accounts의 422와 다른 축, 콜백 코드에서 두
+    except 경로가 다른 status를 내는 게 의도다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _register_ads_sandbox_app_credentials(
+                s, org_id=org_id, updated_by=owner_id, app_id="app:review-rejected",
+            )
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await _authorize_and_callback(client, org_id)
+        assert r.status_code == 400, r.text
+        assert r.json()["error"]["code"] == "META_ADS_ACCOUNT_REVIEW_REJECTED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_callback_one_account_connects_immediately_no_pending_row():
+    from app.main import app
+    from app.models.channel_connection import ChannelConnection
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _register_ads_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id, app_id="app:accounts-1")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await _authorize_and_callback(client, org_id)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["kind"] == "connected"
+        assert body["account_id"] == "sandbox-ads-account-1"
+        assert body["account_label"] == "Sandbox Ads Account 1"
+
+        async with Session() as s:
+            conn = (await s.execute(select(ChannelConnection).where(ChannelConnection.org_id == org_id))).scalar_one()
+            assert conn.encrypted_access_token is not None
+            pending_rows = (await s.execute(select(ChannelOAuthPendingSelection))).scalars().all()
+            assert pending_rows == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_callback_two_accounts_returns_pending_selection_no_connection_row():
+    from app.main import app
+    from app.models.channel_connection import ChannelConnection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _register_ads_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await _authorize_and_callback(client, org_id)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["kind"] == "pending_selection"
+        assert {c["account_id"] for c in body["candidates"]} == {"sandbox-ads-account-1", "sandbox-ads-account-2"}
+        assert body["pending_id"]
+        assert body["expires_at"]
+
+        async with Session() as s:
+            conns = (await s.execute(select(ChannelConnection).where(ChannelConnection.org_id == org_id))).scalars().all()
+            assert conns == [], "2개+ 갈래는 콜백에서 연결 행을 만들면 안 된다(select가 만든다)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── select — 성공(토큰 재사용, /me/adaccounts 재호출 없음) + 실패코드 ────────
+
+
+async def _setup_pending_two_accounts(app, Session, *, org_id, owner_id):
+    async with Session() as s:
+        await _register_ads_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id)
+    _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+    async with _client_for(app) as client:
+        r = await _authorize_and_callback(client, org_id)
+    assert r.status_code == 200, r.text
+    return r.json()["pending_id"]
+
+
+@pytest.mark.anyio
+async def test_select_success_creates_connection_and_deletes_pending_row():
+    from app.main import app
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_accounts(app, Session, org_id=org_id, owner_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/meta-ads/select",
+                json={"pending_id": pending_id, "account_id": "sandbox-ads-account-2"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["kind"] == "connected"
+        assert body["account_id"] == "sandbox-ads-account-2"
+        assert body["account_label"] == "Sandbox Ads Account 2"
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.id == uuid.UUID(pending_id))
+            )).scalar_one_or_none()
+            assert row is None, "성공했는데 pending 행이 안 지워졌다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_unknown_account_id_returns_400():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_accounts(app, Session, org_id=org_id, owner_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/meta-ads/select",
+                json={"pending_id": pending_id, "account_id": "not-a-real-account"},
+            )
+        assert r.status_code == 400, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_OAUTH_PENDING_SELECTION_INVALID_ACCOUNT"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_wrong_requester_returns_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            other_owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_accounts(app, Session, org_id=org_id, owner_id=owner_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=other_owner_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/meta-ads/select",
+                json={"pending_id": pending_id, "account_id": "sandbox-ads-account-1"},
+            )
+        assert r.status_code == 403, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_OAUTH_PENDING_SELECTION_FORBIDDEN"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_select_expired_pending_returns_404_row_not_deleted():
+    from app.main import app
+    from app.models.channel_oauth_pending_selection import ChannelOAuthPendingSelection
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        pending_id = await _setup_pending_two_accounts(app, Session, org_id=org_id, owner_id=owner_id)
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.id == uuid.UUID(pending_id))
+            )).scalar_one()
+            row.expires_at = datetime.now(timezone.utc).replace(year=2020)
+            s.add(row)
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/meta-ads/select",
+                json={"pending_id": pending_id, "account_id": "sandbox-ads-account-1"},
+            )
+        assert r.status_code == 404, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_OAUTH_PENDING_SELECTION_EXPIRED"
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(ChannelOAuthPendingSelection).where(ChannelOAuthPendingSelection.id == uuid.UUID(pending_id))
+            )).scalar_one_or_none()
+            assert row is not None, "만료 실패 경로는 삭제 책임이 없다(스윕 몫) — 여기서 지우면 회귀"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ads_sandbox는 credential_kind="oauth"라 범용 /sandbox 엔드포인트가 거부해야 함 ──
+
+
+@pytest.mark.anyio
+async def test_generic_sandbox_endpoint_rejects_ads_sandbox_422():
+    """facebook_sandbox와 동형 가드(story #3523 판정 로직) — credential_kind가
+    "none"이 아니면 범용 /sandbox 엔드포인트가 422로 막는다. ads_sandbox는 authorize
+    →callback 진짜 라우터를 태워야 한다(위 테스트들)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/ads_sandbox/sandbox")
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "CHANNEL_SANDBOX_UNSUPPORTED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1587,6 +1587,11 @@
       "file": "tests/test_3370_workflow_line_and_visual_artifacts_member_id.py",
       "sec": 3.0,
       "source": "story-3370(카디르 QA 재발견 후속, 2026-09-10) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 7건 합계 약 3.0s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3806_meta_ads_account_connection.py",
+      "sec": 7.5,
+      "source": "story-3806(Phase3·3-2 PR1, Meta Ads 광고 계정 연결, 2026-09-11) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 12건 전체 wall time 7.53s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
Phase3 3-2(Meta Ads boost) 첫 조각 — **광고 계정 연결(계정 0/1/2+ 갈래)만**. boost 요청·예산 봉인 게이트(PR2)·실행/중지(PR3)·지출 수집(PR4)은 범위 밖(같은 카드 안 PR 순서, PO 確定 그대로). 실 Meta 토큰 경로(App Review·Business Verification)는 이 PR 스코프 밖 — 코드는 어댑터 자리만, 자격 값 0.

## 처방
- `meta_ads_oauth.py`(신규) — facebook_oauth.py 동형(같은 Graph OAuth 계열). `/me/adaccounts` 목록 조회 — Meta 공식 account_status/disable_reason enum은 문서 fetch로 확認, 엔드포인트·전체 필드 스펙은 ⚠️미확認 딱지(App Review 뒤 재확認).
- `ads_sandbox_oauth.py`(신규) — facebook_sandbox_oauth.py 동형 인프로세스 결정적 미러. 계정 수 마커(`:accounts-0/-1`, 기본 2개) + connection-time 마커 2종(`:account-unverified`·`:review-rejected`, 카드 §5). 나머지 2마커(budget-exceeded·pause-delayed)는 boost/pause 명령이 없어[PR2/PR3] 미구현 — 카탈로그에 예약만(정직하게 적어둠).
- `channel_adapters.py` — `kind` Literal에 `"ads"` 추가(콘텐츠 목적지가 아니라 boost 실행 채널) + `meta_ads`/`ads_sandbox` 등재.
- `channel_connections.py` — 병렬 dispatch(기존 facebook 무변경) + `_meta_ads_channel_connection_callback`(0/1/2+ 갈래, facebook과 동형이되 진짜 차이: 광고 계정은 페이지와 달리 계정별 토큰이 없어 select 단계 재호출 불요) + `POST .../meta-ads/select` 신규.
- i18n_catalog.py — 신규 사용자 문장 4개 카탈로그 이관(#3779 가드 신규 0건).
- `lint_channel_insight_metrics_drift.py` — EXPECTED_BACKEND_CHANNELS 완전성 자기 확認에 2채널 추가.

## 테스트
신규 12건(계정 0/1/2+ 갈래·2마커·select 성공+3실패코드·범용 /sandbox 거부) — 전부 실 HTTP 왕복(목 없음, facebook_sandbox 스위트와 동형 철학).

뮤테이션(review-rejected 체크 제거) → 정확히 2건만 RED, 원복 재GREEN.

기존 회귀 79건 GREEN(facebook/instagram/threads 연결 스위트 무변경).

라이브 도중 실 버그 1건 발견·수정: `/callback`의 `response_model` 유니온이 새 응답 타입을 몰라 500(데코레이터 값이 SSOT).

가드 전부 통과: verify_no_new_korean_user_strings·lint_raw_auth_id_into_member_field·lint_model_registration_completeness·test_3697(drift lint self-check).

## 스코프 밖
boost 요청·`ads_boost` gate_type(PR2) · 실행/중지(PR3) · 지출 수집·분리 표시(PR4) · FE(유나 §절 뒤 별도 카드).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8