### PR TITLE
[SID:3806] feat(BE): ads_boost paid 지출 수집(PR4) — source=paid 분리·승인예산 대비 지출

### DIFF
--- a/backend/app/routers/ads_boost_execution.py
+++ b/backend/app/routers/ads_boost_execution.py
@@ -1,7 +1,13 @@
 """story #3806(Phase3·3-2 PR3, 페드루 PO 確定 2026-09-11) — 승인된 ads_boost 게이트
 실행·중지·재개 API. `_require_human`은 PR 2 router(app/routers/ads_boost.py)와
 동형(호출부마다 로컬 복제 관례) — 휴먼 전용(그라운딩 AC4). i18n_catalog 스레딩
-패턴도 PR 2 router와 동형(Header() DI는 라우트 진입점에서만)."""
+패턴도 PR 2 router와 동형(Header() DI는 라우트 진입점에서만).
+
+story #3806 PR4(페드루 PO 確定 2026-09-11) — 지출 요약 GET 엔드포인트도 이 파일에
+동봉(같은 `/ads-boosts/{gate_id}/...` prefix 아래 자연 위치). 읽기 전용이라
+insight_snapshots.py::list_publication_insights_endpoint와 동형 권한 축(휴먼·
+에이전트 모두, human-only 아님 — start/pause/resume과 다른 판단, 조회는 실행이
+아니다)."""
 from __future__ import annotations
 
 import uuid
@@ -23,6 +29,7 @@ from app.services.ads_boost_execution import (
     request_ads_boost_resume,
     request_ads_boost_start,
 )
+from app.services.ads_spend_snapshots import AdsBoostGateNotFoundForSpendError, get_ads_boost_spend_summary
 from app.services.i18n_catalog import t
 from app.services.member_resolver import resolve_member
 
@@ -183,3 +190,62 @@ async def _resume_ads_boost_endpoint(
             detail={"code": "ADS_BOOST_ALREADY_RUNNING", "message": t("ads_boost.already_running", resolved_locale)},
         ) from exc
     return _to_response(command)
+
+
+class SpendSnapshotView(BaseModel):
+    due_at: str
+    captured_at: str | None
+    status: str
+    spend_minor: int | None
+
+
+class SpendSummaryResponse(BaseModel):
+    gate_id: uuid.UUID
+    sealed_ads_budget_minor: int
+    sealed_ads_currency: str
+    captured_spend_minor: int
+    remaining_minor: int
+    snapshots: list[SpendSnapshotView]
+
+
+@router.get("/{org_id}/ads-boosts/{gate_id}/spend", response_model=SpendSummaryResponse)
+async def get_ads_boost_spend_endpoint(
+    org_id: uuid.UUID, gate_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db), verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
+) -> SpendSummaryResponse:
+    """story #3806 PR4 — 「승인 예산 대비 지출」(paid 축만, source=="paid" 분리 표시).
+    읽기 전용이라 조회 자체는 human-only가 아니다(insight_snapshots.py 동형 판단,
+    이 파일 상단 모듈 docstring 참고)."""
+    return await _get_ads_boost_spend_endpoint(
+        org_id, gate_id, db=db, verified_org_id=verified_org_id,
+        resolved_locale=resolve_locale_from_request(locale, accept_language),
+    )
+
+
+async def _get_ads_boost_spend_endpoint(
+    org_id: uuid.UUID, gate_id: uuid.UUID, *, db: AsyncSession, verified_org_id: uuid.UUID, resolved_locale: str,
+) -> SpendSummaryResponse:
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    try:
+        summary = await get_ads_boost_spend_summary(db, org_id=org_id, gate_id=gate_id)
+    except AdsBoostGateNotFoundForSpendError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "ADS_BOOST_GATE_NOT_FOUND", "message": t("ads_boost.gate_not_found", resolved_locale)},
+        ) from exc
+    return SpendSummaryResponse(
+        gate_id=summary["gate_id"], sealed_ads_budget_minor=summary["sealed_ads_budget_minor"],
+        sealed_ads_currency=summary["sealed_ads_currency"], captured_spend_minor=summary["captured_spend_minor"],
+        remaining_minor=summary["remaining_minor"],
+        snapshots=[
+            SpendSnapshotView(
+                due_at=s["due_at"].isoformat(), captured_at=s["captured_at"].isoformat() if s["captured_at"] else None,
+                status=s["status"], spend_minor=s["spend_minor"],
+            )
+            for s in summary["snapshots"]
+        ],
+    )

--- a/backend/app/services/ads_boost_execution.py
+++ b/backend/app/services/ads_boost_execution.py
@@ -256,6 +256,7 @@ async def _resolve_execution_context(db: AsyncSession, command: PublicationComma
         "gate": gate, "module": module,
         "ad_account_id": conn.account_id, "access_token": decrypt_channel_credential(conn.encrypted_access_token),
         "object_story_id": f"{origin_conn.account_id}_{publication.external_id}",
+        "publication_id": publication.id, "ad_channel": conn.channel,
     }
 
 
@@ -303,6 +304,15 @@ async def process_one_ads_boost_command(db: AsyncSession, command: PublicationCo
                 )
                 run.status = "running"
                 run.started_at = now
+                # story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — boost_start
+                # 성공 즉시 paid 지출 +1d/+7d 스냅샷 예약(insight_snapshots.py의
+                # publish 성공 시 스케줄링과 동형 시점 — "그 사건이 확정된 순간").
+                from app.services.ads_spend_snapshots import schedule_ads_spend_snapshots
+
+                await schedule_ads_spend_snapshots(
+                    db, org_id=command.org_id, work_item_id=gate.work_item_id,
+                    publication_id=ctx["publication_id"], channel=ctx["ad_channel"], anchor_at=now,
+                )
             elif command.operation == OP_PAUSE:
                 if run.campaign_id is None:
                     raise AdsBoostAdapterUnavailableError(

--- a/backend/app/services/ads_sandbox_campaign.py
+++ b/backend/app/services/ads_sandbox_campaign.py
@@ -55,3 +55,16 @@ async def set_campaign_status(
     client: httpx.AsyncClient, *, campaign_id: str, access_token: str, status: str,
 ) -> None:
     return  # sandbox — 항상 성공. pause-delayed 판정은 호출부 몫(위 모듈 docstring).
+
+
+# story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — 결정적 고정값(ads_sandbox_
+# oauth.py::list_ad_accounts의 「이름·id는 절대 안 바뀐다」 원칙과 동형) — 해시 유도
+# 대신 고정 상수를 쓴 이유는 테스트가 정확한 값을 assert할 수 있게(해시면 테스트가
+# 같은 계산을 재구현해야 한다, 취약).
+_FIXED_SPEND_MINOR = 12_345
+
+
+async def get_campaign_spend_minor(
+    client: httpx.AsyncClient, *, campaign_id: str, access_token: str,
+) -> int:
+    return _FIXED_SPEND_MINOR

--- a/backend/app/services/ads_spend_snapshots.py
+++ b/backend/app/services/ads_spend_snapshots.py
@@ -1,0 +1,195 @@
+"""story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — 승인된 ads_boost의 paid
+지출 수집. `insight_snapshots.py`의 +1d/+7d 스케줄링·SKIP LOCKED 배치 패턴을 그대로
+재사용하되(새 기전 발명 금지) **다른 파이프라인**으로 둔다(channel_adapters.py::
+"meta_ads"/"ads_sandbox" 어댑터 docstring이 PR1 시점에 이미 이렇게 明示) — 그
+어댑터들은 `insight_metrics=()`(organic 콘텐츠 지표 0선언)라 `process_due_insight_
+snapshots`의 「선언 0=unsupported 즉시 종결」 게이트에 걸려 거기선 절대 못 나간다.
+그래서 이 파일이 같은 `InsightSnapshot` 테이블(재사용 — 새 테이블 0)을 별도
+scheduling+capture 경로로 돌린다.
+
+`InsightSnapshot.source`는 organic 행처럼 `snapshot.channel`을 그대로 옮기지 않고
+**리터럴 "paid"**로 고정한다(카드 PO 確定③ "source=paid 재사용" 그대로) — 향후
+Meta 외 다른 ad 채널이 추가돼도 대시보드가 채널명 나열 없이 `source=="paid"` 한
+축으로 organic/paid를 가른다.
+
+`publication_id`는 boost 대상 원 발행물(`ChannelPublication.id`, gate.scope_key가
+이미 그 값 — PR2)을 그대로 재사용한다 — 같은 발행물의 organic 행과 paid 행이
+`due_at`으로만 갈린다(publish 시각 anchor vs boost 시작 시각 anchor라 실사용에서
+거의 항상 다르다, UNIQUE(publication_id, due_at) 충돌 사실상 0)."""
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+from app.models.insight_snapshot import InsightSnapshot
+
+_ADS_BOOST_GATE_TYPE = "ads_boost"
+_PAID_CHANNELS = ("meta_ads", "ads_sandbox")
+_PAID_SOURCE = "paid"
+_SNAPSHOT_OFFSETS = (timedelta(days=1), timedelta(days=7))
+BATCH_SIZE = 50
+
+
+async def schedule_ads_spend_snapshots(
+    db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, publication_id: uuid.UUID,
+    channel: str, anchor_at: datetime,
+) -> None:
+    """boost_start 성공 직후(같은 트랜잭션, commit은 호출자 몫 — insight_snapshots.py
+    ::schedule_insight_snapshots와 동형 계약) +1d·+7d 두 행을 연다. `anchor_at`은
+    호출자가 이미 확정한 시각(run.started_at)을 그대로 넘긴다 — 재처리마다 새로
+    재면 UNIQUE(publication_id, due_at) 멱등이 무력화되는 것도 동형(그 함수 docstring
+    그대로)."""
+    for due_at in (anchor_at + offset for offset in _SNAPSHOT_OFFSETS):
+        stmt = pg_insert(InsightSnapshot).values(
+            id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, publication_id=publication_id,
+            publication_kind="channel_publication", channel=channel, external_id=None, due_at=due_at,
+            status="pending",
+        ).on_conflict_do_nothing(constraint="uq_insight_snapshots_publication_due_at")
+        await db.execute(stmt)
+
+
+class AdsSpendFetchError(Exception):
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+async def _resolve_spend_context(db: AsyncSession, snapshot: InsightSnapshot) -> dict:
+    from app.models.ads_boost_run import AdsBoostRun
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import decrypt_channel_credential
+
+    gate = (await db.execute(
+        select(Gate).where(
+            Gate.org_id == snapshot.org_id, Gate.gate_type == _ADS_BOOST_GATE_TYPE,
+            Gate.scope_key == str(snapshot.publication_id),
+        )
+    )).scalar_one_or_none()
+    if gate is None:
+        raise AdsSpendFetchError("ADS_SPEND_GATE_MISSING", f"no ads_boost gate for publication: {snapshot.publication_id}")
+
+    run = (await db.execute(select(AdsBoostRun).where(AdsBoostRun.gate_id == gate.id))).scalar_one_or_none()
+    if run is None or run.campaign_id is None:
+        raise AdsSpendFetchError("ADS_SPEND_NOT_STARTED", f"boost not started at provider yet: {gate.id}")
+
+    conn = (await db.execute(
+        select(ChannelConnection).where(ChannelConnection.id == gate.sealed_ads_connection_id)
+    )).scalar_one_or_none()
+    if conn is None:
+        raise AdsSpendFetchError("ADS_SPEND_CONNECTION_MISSING", f"ad connection missing: {gate.sealed_ads_connection_id}")
+
+    module_path = "app.services.ads_sandbox_campaign" if conn.channel == "ads_sandbox" else "app.services.meta_ads_campaign"
+    module = importlib.import_module(module_path)
+    return {
+        "module": module, "campaign_id": run.campaign_id,
+        "access_token": decrypt_channel_credential(conn.encrypted_access_token),
+    }
+
+
+async def process_due_ads_spend_snapshots(db: AsyncSession, *, now: datetime | None = None) -> dict[str, int]:
+    """`insight_snapshots.py::process_due_insight_snapshots`와 동형 SKIP LOCKED
+    2단계 커밋 — 단 WHERE에 `channel IN ('meta_ads','ads_sandbox')`를 명시해 그
+    함수와 겹쳐 같은 행을 경합하지 않는다(그 함수 쪽도 이 두 채널을 제외하도록
+    같이 고쳤다 — insight_snapshots.py::process_due_insight_snapshots 참고,
+    안 그러면 두 워커 tick이 같은 pending 행을 서로 다르게 처리하려는 경합이
+    생긴다)."""
+    import httpx
+
+    now = now or datetime.now(timezone.utc)
+    rows = (await db.execute(
+        select(InsightSnapshot).where(
+            InsightSnapshot.status == "pending", InsightSnapshot.due_at <= now,
+            InsightSnapshot.channel.in_(_PAID_CHANNELS),
+        ).order_by(InsightSnapshot.due_at.asc())
+        .limit(BATCH_SIZE)
+        .with_for_update(skip_locked=True)
+    )).scalars().all()
+
+    for snapshot in rows:
+        snapshot.status = "in_progress"
+    await db.commit()
+
+    counts = {"captured": 0, "failed": 0, "error": 0}
+    for snapshot in rows:
+        try:
+            ctx = await _resolve_spend_context(db, snapshot)
+            async with httpx.AsyncClient(timeout=20) as client:
+                spend_minor = await ctx["module"].get_campaign_spend_minor(
+                    client, campaign_id=ctx["campaign_id"], access_token=ctx["access_token"],
+                )
+            from app.services.insight_snapshots import NORMALIZED_KEYS
+
+            # NORMALIZED_KEYS를 그대로 재사용(드리프트 금지) — spend만 채우고
+            # 나머지 전부 None(insight_snapshots.py::_normalize와 같은 계약: paid
+            # 어댑터는 spend 외 organic 지표를 아예 선언 안 하므로 "미선언"과 같은
+            # null, 지어내지 않는다).
+            snapshot.normalized = {key: (spend_minor if key == "spend" else None) for key in NORMALIZED_KEYS}
+            snapshot.source = _PAID_SOURCE
+            snapshot.captured_at = now
+            snapshot.status = "captured"
+            snapshot.error_code = None
+            await db.commit()
+            counts["captured"] += 1
+        except AdsSpendFetchError as exc:
+            snapshot.error_code = exc.code
+            snapshot.status = "failed"
+            snapshot.captured_at = now
+            await db.commit()
+            counts["failed"] += 1
+        except Exception:  # noqa: BLE001 — publication_command.py와 동형 2중 방어.
+            await db.rollback()
+            counts["error"] += 1
+    return counts
+
+
+class AdsBoostGateNotFoundForSpendError(Exception):
+    def __init__(self, gate_id: uuid.UUID):
+        self.gate_id = gate_id
+        super().__init__(f"ads_boost gate not found: {gate_id}")
+
+
+async def get_ads_boost_spend_summary(db: AsyncSession, *, org_id: uuid.UUID, gate_id: uuid.UUID) -> dict:
+    """story #3806(Phase3·3-2 PR4) — 「승인 예산 대비 지출」. 승인 게이트가 봉인한
+    예산(`gate.sealed_ads_budget_minor`, 불변)과 이 gate의 발행물에 걸린 `source==
+    "paid"` 행 중 `status="captured"` 스냅샷의 `normalized.spend` 합을 대조한다.
+    `remaining_minor`는 음수를 0으로 바닥 처리하지 않는다 — 실제로 봉인 예산을
+    넘겨 지출됐다면(Meta 쪽 집행 지연·초과 가능성, 이 레포가 막는 건 "요청 시점
+    증액"뿐이지 "이미 집행된 뒤 provider 측 실제 지출"까지 봉인이 통제하진 못한다)
+    그 사실을 화면이 그대로 봐야 한다 — 지어낸 하한으로 가리지 않는다."""
+    gate = (await db.execute(
+        select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id, Gate.gate_type == _ADS_BOOST_GATE_TYPE)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise AdsBoostGateNotFoundForSpendError(gate_id)
+
+    snapshots = (await db.execute(
+        select(InsightSnapshot).where(
+            InsightSnapshot.org_id == org_id, InsightSnapshot.publication_id == uuid.UUID(gate.scope_key),
+            InsightSnapshot.source == _PAID_SOURCE,
+        ).order_by(InsightSnapshot.due_at.asc())
+    )).scalars().all()
+
+    captured_spend_minor = sum(
+        (s.normalized or {}).get("spend") or 0 for s in snapshots if s.status == "captured"
+    )
+    return {
+        "gate_id": gate.id,
+        "sealed_ads_budget_minor": gate.sealed_ads_budget_minor,
+        "sealed_ads_currency": gate.sealed_ads_currency,
+        "captured_spend_minor": captured_spend_minor,
+        "remaining_minor": (gate.sealed_ads_budget_minor or 0) - captured_spend_minor,
+        "snapshots": [
+            {
+                "due_at": s.due_at, "captured_at": s.captured_at, "status": s.status,
+                "spend_minor": (s.normalized or {}).get("spend") if s.status == "captured" else None,
+            }
+            for s in snapshots
+        ],
+    }

--- a/backend/app/services/ads_spend_snapshots.py
+++ b/backend/app/services/ads_spend_snapshots.py
@@ -36,6 +36,18 @@ _SNAPSHOT_OFFSETS = (timedelta(days=1), timedelta(days=7))
 BATCH_SIZE = 50
 
 
+def organic_snapshots_only(stmt):
+    """story #3806(Phase3·3-2 PR4, 페드루 PO 追加 確定 2026-09-11) — paid 채널
+    제외를 쓰는 **유일한** 자리. `insight_snapshots.py`의 두 소비처(캡처 루프·조회
+    목록)가 각자 `.where(channel.notin_(_PAID_CHANNELS))`를 따로 적었을 때 실측
+    결함(조회 목록이 그 절을 빠뜨려 paid 행이 섞여 나옴)이 실제로 났다 — 상수 하나
+    공유로는 "적용을 잊는" 클래스 자체를 못 막는다(_PAID_CHANNELS는 이미 공유였다,
+    깜빡한 건 «호출» 쪽). 이 술어 함수 하나로 모아 앞으로의 세 번째·네 번째
+    소비처도 이 함수를 부르는 것만으로 자동으로 막히게 한다 — `.where()`를 손으로
+    다시 쓰지 않는 것 자체가 강제다."""
+    return stmt.where(InsightSnapshot.channel.notin_(_PAID_CHANNELS))
+
+
 async def schedule_ads_spend_snapshots(
     db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, publication_id: uuid.UUID,
     channel: str, anchor_at: datetime,

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -688,7 +688,15 @@ async def _finalize_snapshot_write(db: AsyncSession, snapshot: InsightSnapshot, 
 async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | None = None) -> dict[str, int]:
     """story #3497 그라운딩④ — `process_due_publication_commands`와 동형 SKIP LOCKED
     2단계 커밋(클레임 commit → 개별 처리 commit/rollback 격리). due_at이 도래한
-    status='pending' 스냅샷을 배치로 집어 처리한다."""
+    status='pending' 스냅샷을 배치로 집어 처리한다.
+
+    story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — `channel IN ('meta_ads',
+    'ads_sandbox')`는 이 루프 밖(ads_spend_snapshots.py::process_due_ads_spend_
+    snapshots가 전담, 「다른 파이프라인」— channel_adapters.py 그 두 어댑터
+    docstring 참고). 제외 안 하면 이 루프가 먼저 집어 insight_metrics=() 게이트에
+    걸려 즉시 'unsupported'로 종결시켜 버린다(두 워커 tick이 같은 pending 행을
+    경합하는 것도 별개 문제)."""
+    from app.services.ads_spend_snapshots import _PAID_CHANNELS
     from app.services.channel_adapters import CHANNEL_ADAPTERS
     from app.services.publication_command import classify_failure_kind, FAILURE_KIND_CONNECTION, FAILURE_KIND_TRANSIENT
 
@@ -696,6 +704,7 @@ async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | Non
     rows = (await db.execute(
         select(InsightSnapshot).where(
             InsightSnapshot.status == "pending", InsightSnapshot.due_at <= now,
+            InsightSnapshot.channel.notin_(_PAID_CHANNELS),
         ).order_by(InsightSnapshot.due_at.asc())
         .limit(BATCH_SIZE)
         .with_for_update(skip_locked=True)

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -110,23 +110,29 @@ async def list_insight_snapshots_for_publication(
     격리는 호출자(라우터)가 이미 검증한 뒤 이 함수를 부른다는 전제(다른 서비스
     함수들과 동형 — org_id는 여기서도 WHERE에 걸어 이중 방어).
 
-    story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — `channel NOT IN
-    ('meta_ads','ads_sandbox')` 제외. paid 행이 이 목록에 섞이면 두 가지가
-    깨진다: ① `label_snapshot_offset`이 `due_at - published_at`으로 라벨을
-    내는데 paid의 due_at anchor는 boost 시작 시각(publish 시각 아님)이라 그
-    계산이 의미를 잃는다(대개 None으로 떨어지긴 하나, boost가 발행 직후
-    시작되면 우연히 1d/7d에 근접해 오라벨될 수 있다) ② 이 엔드포인트의 계약
-    자체가 organic 인사이트 조회다 — paid는 `GET .../ads-boosts/{gate_id}/
-    spend`(PR4 신규)가 전담. 그 엔드포인트가 이 목록과 겹치지 않도록 가른다."""
-    from app.services.ads_spend_snapshots import _PAID_CHANNELS
+    story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — paid 채널 제외.
+    paid 행이 이 목록에 섞이면 두 가지가 깨진다: ① `label_snapshot_offset`이
+    `due_at - published_at`으로 라벨을 내는데 paid의 due_at anchor는 boost
+    시작 시각(publish 시각 아님)이라 그 계산이 의미를 잃는다(대개 None으로
+    떨어지긴 하나, boost가 발행 직후 시작되면 우연히 1d/7d에 근접해 오라벨될
+    수 있다) ② 이 엔드포인트의 계약 자체가 organic 인사이트 조회다 — paid는
+    `GET .../ads-boosts/{gate_id}/spend`(PR4 신규)가 전담. 그 엔드포인트가
+    이 목록과 겹치지 않도록 가른다.
+
+    story #3806 페드루 PO 追加 確定(2026-09-11, 정정1) — 제외 조건 자체를
+    `ads_spend_snapshots.py::organic_snapshots_only()` 술어 하나로 모은다(이
+    함수와 `process_due_insight_snapshots` 둘 다 각자 `.where(channel.notin_(
+    _PAID_CHANNELS))`를 따로 적었을 때 조회 목록 쪽이 실제로 빠뜨린 실사고가
+    났다 — 상수 공유만으론 "적용 자체를 잊는" 클래스를 못 막는다, 술어 함수를
+    부르는 것 자체가 강제)."""
+    from app.services.ads_spend_snapshots import organic_snapshots_only
 
     rows = (await db.execute(
-        select(InsightSnapshot)
-        .where(
-            InsightSnapshot.org_id == org_id, InsightSnapshot.publication_id == publication_id,
-            InsightSnapshot.channel.notin_(_PAID_CHANNELS),
-        )
-        .order_by(InsightSnapshot.due_at.asc())
+        organic_snapshots_only(
+            select(InsightSnapshot).where(
+                InsightSnapshot.org_id == org_id, InsightSnapshot.publication_id == publication_id,
+            )
+        ).order_by(InsightSnapshot.due_at.asc())
     )).scalars().all()
     return list(rows)
 
@@ -704,21 +710,27 @@ async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | Non
     2단계 커밋(클레임 commit → 개별 처리 commit/rollback 격리). due_at이 도래한
     status='pending' 스냅샷을 배치로 집어 처리한다.
 
-    story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — `channel IN ('meta_ads',
-    'ads_sandbox')`는 이 루프 밖(ads_spend_snapshots.py::process_due_ads_spend_
-    snapshots가 전담, 「다른 파이프라인」— channel_adapters.py 그 두 어댑터
-    docstring 참고). 제외 안 하면 이 루프가 먼저 집어 insight_metrics=() 게이트에
-    걸려 즉시 'unsupported'로 종결시켜 버린다(두 워커 tick이 같은 pending 행을
-    경합하는 것도 별개 문제)."""
-    from app.services.ads_spend_snapshots import _PAID_CHANNELS
+    story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — paid 채널은 이
+    루프 밖(ads_spend_snapshots.py::process_due_ads_spend_snapshots가 전담,
+    「다른 파이프라인」 — channel_adapters.py 그 두 어댑터 docstring 참고).
+    제외 안 하면 이 루프가 먼저 집어 insight_metrics=() 게이트에 걸려 즉시
+    'unsupported'로 종결시켜 버린다(두 워커 tick이 같은 pending 행을 경합하는
+    것도 별개 문제).
+
+    story #3806 페드루 PO 追加 確定(2026-09-11, 정정1) — 이 제외도 `organic_
+    snapshots_only()` 같은 술어 하나를 `list_insight_snapshots_for_publication`
+    과 공유한다(그 함수 docstring 참고 — 상수 공유만으론 "적용 자체를 잊는"
+    클래스를 못 막는다는 실사고 교훈)."""
+    from app.services.ads_spend_snapshots import organic_snapshots_only
     from app.services.channel_adapters import CHANNEL_ADAPTERS
     from app.services.publication_command import classify_failure_kind, FAILURE_KIND_CONNECTION, FAILURE_KIND_TRANSIENT
 
     now = now or datetime.now(timezone.utc)
     rows = (await db.execute(
-        select(InsightSnapshot).where(
-            InsightSnapshot.status == "pending", InsightSnapshot.due_at <= now,
-            InsightSnapshot.channel.notin_(_PAID_CHANNELS),
+        organic_snapshots_only(
+            select(InsightSnapshot).where(
+                InsightSnapshot.status == "pending", InsightSnapshot.due_at <= now,
+            )
         ).order_by(InsightSnapshot.due_at.asc())
         .limit(BATCH_SIZE)
         .with_for_update(skip_locked=True)

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -108,10 +108,24 @@ async def list_insight_snapshots_for_publication(
 ) -> list[InsightSnapshot]:
     """story #3497 조각3(조회 API) — 스냅샷 목록(due_at 오름차순, +1d 먼저). org
     격리는 호출자(라우터)가 이미 검증한 뒤 이 함수를 부른다는 전제(다른 서비스
-    함수들과 동형 — org_id는 여기서도 WHERE에 걸어 이중 방어)."""
+    함수들과 동형 — org_id는 여기서도 WHERE에 걸어 이중 방어).
+
+    story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — `channel NOT IN
+    ('meta_ads','ads_sandbox')` 제외. paid 행이 이 목록에 섞이면 두 가지가
+    깨진다: ① `label_snapshot_offset`이 `due_at - published_at`으로 라벨을
+    내는데 paid의 due_at anchor는 boost 시작 시각(publish 시각 아님)이라 그
+    계산이 의미를 잃는다(대개 None으로 떨어지긴 하나, boost가 발행 직후
+    시작되면 우연히 1d/7d에 근접해 오라벨될 수 있다) ② 이 엔드포인트의 계약
+    자체가 organic 인사이트 조회다 — paid는 `GET .../ads-boosts/{gate_id}/
+    spend`(PR4 신규)가 전담. 그 엔드포인트가 이 목록과 겹치지 않도록 가른다."""
+    from app.services.ads_spend_snapshots import _PAID_CHANNELS
+
     rows = (await db.execute(
         select(InsightSnapshot)
-        .where(InsightSnapshot.org_id == org_id, InsightSnapshot.publication_id == publication_id)
+        .where(
+            InsightSnapshot.org_id == org_id, InsightSnapshot.publication_id == publication_id,
+            InsightSnapshot.channel.notin_(_PAID_CHANNELS),
+        )
         .order_by(InsightSnapshot.due_at.asc())
     )).scalars().all()
     return list(rows)

--- a/backend/app/services/meta_ads_campaign.py
+++ b/backend/app/services/meta_ads_campaign.py
@@ -94,3 +94,28 @@ async def set_campaign_status(
     )
     if resp.status_code != 200:
         raise MetaAdsCampaignError("META_ADS_CAMPAIGN_STATUS_UPDATE_FAILED", resp.text[:500])
+
+
+async def get_campaign_spend_minor(
+    client: httpx.AsyncClient, *, campaign_id: str, access_token: str,
+) -> int:
+    """story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — 캠페인 누적 지출(그
+    캠페인 전체 lifetime, `date_preset` 미지정 시 Meta 기본값 — ⚠️미확認: Insights
+    API가 기본으로 lifetime을 주는지 별도 date_preset이 필요한지는 공식 문서 fetch로
+    재확認 못함, meta_ads_oauth.py 상단과 동일 딱지). `spend` 필드는 Meta가 통화
+    소수점 문자열("12.34")로 낸다 — 이 레포 관례(minor unit int, gate.sealed_ads_
+    budget_minor와 같은 단위)로 맞추려 100을 곱해 반올림한다(⚠️미확認: 모든 통화가
+    2자리 소수인지는 통화별로 다를 수 있어 재확認 필요 — KRW는 소수점이 없는 통화라
+    이 가정이 깨질 수 있는 자리, 출시 前 재확認)."""
+    resp = await client.get(
+        f"{_GRAPH_BASE}/{campaign_id}/insights", params={"access_token": access_token, "fields": "spend"},
+    )
+    if resp.status_code != 200:
+        raise MetaAdsCampaignError("META_ADS_SPEND_FETCH_FAILED", resp.text[:500])
+    data = resp.json().get("data") or []
+    if not data:
+        return 0  # 아직 노출/지출 이력 0 — "미제공"이 아니라 "0"으로 정직하게 낸다.
+    spend_str = data[0].get("spend")
+    if spend_str is None:
+        raise MetaAdsCampaignError("META_ADS_SPEND_MISSING_FIELD", "spend missing in insights response")
+    return round(float(spend_str) * 100)

--- a/backend/tests/test_3806_ads_boost_spend.py
+++ b/backend/tests/test_3806_ads_boost_spend.py
@@ -1,0 +1,237 @@
+"""story #3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — ads_boost paid 지출 수집
+(+1d/+7d 스케줄링·source="paid" 분리·승인예산 대비 지출 API) 회귀. 세팅 헬퍼는
+test_3806_ads_boost_execution.py/test_3806_ads_boost_worker.py 재사용(중복 재발명
+금지) — 새 마이그 0건(InsightSnapshot 테이블 그대로 재사용, source는 원래도 free
+Text라 스키마 변경 불요)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_3806_ads_boost_execution import _setup_approved_gate, _mark_command_status
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _start_boost(session_maker, org_id, gate_id, owner_id):
+    from app.services.ads_boost_execution import request_ads_boost_start
+    from app.services.publication_command import process_due_publication_commands
+
+    async with session_maker() as s:
+        await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id)
+    async with session_maker() as s:
+        counts = await process_due_publication_commands(s)
+    assert counts["completed"] == 1, counts
+
+
+async def _make_spend_snapshots_due(session, org_id, gate_id):
+    """UNIQUE(publication_id, due_at) 위반 없이 두 행을 각자 다른 과거 시각으로
+    민다(한 값으로 일괄 UPDATE하면 둘이 같은 due_at을 가져 그 제약을 위반한다)."""
+    rows = await _get_spend_snapshots(session, org_id, gate_id)
+    now = datetime.now(timezone.utc)
+    for i, row in enumerate(rows):
+        row.due_at = now - timedelta(minutes=len(rows) - i)
+    await session.commit()
+
+
+async def _get_spend_snapshots(session, org_id, gate_id):
+    from app.models.gate import Gate
+    from app.models.insight_snapshot import InsightSnapshot
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    rows = (await session.execute(
+        select(InsightSnapshot).where(
+            InsightSnapshot.publication_id == uuid.UUID(gate.scope_key),
+            InsightSnapshot.channel == "ads_sandbox",
+        ).order_by(InsightSnapshot.due_at.asc())
+    )).scalars().all()
+    return rows
+
+
+@pytest.mark.anyio
+async def test_boost_start_schedules_two_spend_snapshots():
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        async with Session() as s:
+            rows = await _get_spend_snapshots(s, org_id, gate_id)
+        assert len(rows) == 2, rows
+        assert all(r.status == "pending" for r in rows)
+        # +1d·+7d 두 행 — 정확한 오프셋보다 "짧은 것 하나·긴 것 하나"만 pin(6일差
+        # 이상이면 1d/7d 조합이 맞다는 뜻, anchor_at 자체의 정밀 초 단위는 비관심사).
+        assert (rows[1].due_at - rows[0].due_at) > timedelta(days=5)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_process_due_ads_spend_snapshots_captures_with_source_paid():
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+
+        async with Session() as s:
+            counts = await process_due_ads_spend_snapshots(s)
+        assert counts["captured"] == 2, counts
+
+        async with Session() as s:
+            rows = await _get_spend_snapshots(s, org_id, gate_id)
+        assert all(r.status == "captured" for r in rows)
+        assert all(r.source == "paid" for r in rows), [r.source for r in rows]
+        assert all(r.normalized["spend"] == 12_345 for r in rows), [r.normalized for r in rows]
+        assert all(r.normalized["impressions"] is None for r in rows), "organic 지표는 미선언과 같은 null이어야 한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_organic_loop_skips_paid_channel_snapshots():
+    """process_due_insight_snapshots(organic 루프)가 paid 채널 행을 안 건드려야
+    한다 — 안 그러면 insight_metrics=() 게이트에 걸려 즉시 'unsupported'로
+    오염된다(두 워커 경합 방지의 핵심 pin)."""
+    from app.services.insight_snapshots import process_due_insight_snapshots
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+
+        async with Session() as s:
+            counts = await process_due_insight_snapshots(s)
+        assert counts == {"captured": 0, "unsupported": 0, "failed": 0, "pending_retry": 0, "error": 0}, counts
+
+        async with Session() as s:
+            rows = await _get_spend_snapshots(s, org_id, gate_id)
+        assert all(r.status == "pending" for r in rows), "organic 루프가 paid 행을 건드리면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_spend_endpoint_returns_budget_and_captured_sum():
+    from app.main import app
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+        async with Session() as s:
+            await process_due_ads_spend_snapshots(s)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/spend")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["sealed_ads_budget_minor"] == 100_000
+        assert body["captured_spend_minor"] == 12_345 * 2
+        assert body["remaining_minor"] == 100_000 - 12_345 * 2
+        assert len(body["snapshots"]) == 2
+        assert all(s["spend_minor"] == 12_345 for s in body["snapshots"])
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_spend_endpoint_unknown_gate_returns_404():
+    from app.main import app
+    from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, _gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/ads-boosts/{uuid.uuid4()}/spend")
+        assert r.status_code == 404, r.text
+        assert r.json()["error"]["code"] == "ADS_BOOST_GATE_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_spend_fetch_fails_gracefully_without_run():
+    """boost_start를 아예 안 돌린(run.campaign_id 없음) 상태에서 스냅샷이 존재하면
+    (정상 흐름에선 스케줄링 자체가 boost_start 성공 뒤에만 일어나 도달 불가 — 방어
+    로직 자체의 견고성만 직접 확인, 워커 테스트의 같은 클래스 방어 표본과 동형)."""
+    from app.models.gate import Gate
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from sqlalchemy import select
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            snap = InsightSnapshot(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=gate.work_item_id,
+                publication_id=uuid.UUID(gate.scope_key), publication_kind="channel_publication",
+                channel="ads_sandbox", due_at=datetime.now(timezone.utc) - timedelta(minutes=1), status="pending",
+            )
+            s.add(snap)
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_ads_spend_snapshots(s)
+        assert counts["failed"] == 1, counts
+
+        async with Session() as s:
+            row = (await s.execute(select(InsightSnapshot).where(InsightSnapshot.id == snap.id))).scalar_one()
+            assert row.status == "failed"
+            assert row.error_code == "ADS_SPEND_NOT_STARTED"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3806_ads_boost_spend.py
+++ b/backend/tests/test_3806_ads_boost_spend.py
@@ -235,3 +235,37 @@ async def test_spend_fetch_fails_gracefully_without_run():
             assert row.error_code == "ADS_SPEND_NOT_STARTED"
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_organic_insights_list_endpoint_excludes_paid_rows():
+    """페드루 PO 確定(2026-09-11, 판단 콜② 답) — 기존 GET .../insights(organic 조회
+    축)가 paid 행을 섞어 돌려주면 실측 결함(offset_label이 boost 시작 시각 anchor를
+    publish 시각 기준으로 잘못 대조할 수 있고, 이 엔드포인트의 계약 자체가 organic
+    전용이라 paid는 GET .../ads-boosts/{gate_id}/spend가 전담해야 한다). 이 테스트가
+    바로 그 「반환 0」을 실측으로 고정한다."""
+    from app.main import app
+    from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        from app.models.gate import Gate
+        from sqlalchemy import select
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            publication_id = uuid.UUID(gate.scope_key)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/publications/{publication_id}/insights")
+        assert r.status_code == 200, r.text
+        channels = {row["channel"] for row in r.json()}
+        assert "ads_sandbox" not in channels, f"paid 행이 organic 목록에 섞였다: {channels}"
+        assert "meta_ads" not in channels
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1612,6 +1612,11 @@
       "file": "tests/test_3806_ads_boost_worker.py",
       "sec": 4.9,
       "source": "story-3806(Phase3·3-2 PR3 워커 fix, 페드루 PO 確定 2026-09-11) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 6건 wall time 약 4.9s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3806_ads_boost_spend.py",
+      "sec": 6.3,
+      "source": "story-3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 6건 wall time 약 6.3s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1615,8 +1615,8 @@
     },
     {
       "file": "tests/test_3806_ads_boost_spend.py",
-      "sec": 6.3,
-      "source": "story-3806(Phase3·3-2 PR4, 페드루 PO 確定 2026-09-11) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 6건 wall time 약 6.3s — test_3766 등재 선례와 동일 방법론)"
+      "sec": 6.4,
+      "source": "story-3806(Phase3·3-2 PR4, 페드루 PO 追加 確定 2026-09-11 — offset_label 판단 콜② 답으로 organic 목록 필터 테스트 1건 추가) — 재측(로컬, uv run pytest --durations=0 직접 1회 실행, 7건 wall time 약 6.4s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
story #3806(Phase3·3-2) PR4 — 승인된 ads_boost의 paid 지출 수집. `boost_start` 성공 즉시 `insight_snapshots` 테이블에 +1d/+7d 지출 스냅샷을 예약하고(새 테이블 0, 기존 스케줄링 패턴 재사용), `source="paid"`로 organic 인사이트와 분리 표시하며, 승인 예산 대비 실 지출을 보여주는 API를 신설합니다.

**base=`fix/3806-ads-boost-execute`(PR3, #4176)** — `ads_boost_runs`(campaign_id)에 직접 의존하는 스택 PR입니다. PR3가 develop에 머지되면 base를 재지정하겠습니다.

## 핵심 설계 — 「다른 파이프라인」(PR1이 이미 明示해 둔 설계, 이 PR이 실제로 구현)
PR1의 `channel_adapters.py`가 `meta_ads`/`ads_sandbox` 어댑터를 만들며 이미 이렇게 적어 뒀습니다: *"insight_metrics도 미선언 — spend는 InsightSnapshot.source="paid" 축(PR4)으로 별도 수집, 이 어댑터의 organic insight_metrics 선언과는 다른 파이프라인."* 실측으로 확인: `process_due_insight_snapshots`(organic 루프)는 `insight_metrics=()`인 채널을 즉시 `'unsupported'`로 종결시키는 게이트가 있어, paid 행이 그 루프에 섞이면 절대 캡처되지 못하고 오염됩니다.

그래서:
- `app/services/ads_spend_snapshots.py`(신규) — `schedule_ads_spend_snapshots`(`schedule_insight_snapshots`와 동형 +1d/+7d upsert)·`process_due_ads_spend_snapshots`(SKIP LOCKED 2단계 커밋 동형, `channel IN ('meta_ads','ads_sandbox')`만 집음)·`get_ads_boost_spend_summary`(승인예산 대비 지출).
- `insight_snapshots.py::process_due_insight_snapshots`에 `channel NOT IN ('meta_ads','ads_sandbox')` 제외를 추가 — 안 하면 두 워커 tick이 같은 pending 행을 경합하며 organic 루프가 먼저 집어 오염시킬 수 있습니다(mutation self-check로 재현·확認, 아래).
- `source`는 organic 행처럼 `channel`을 그대로 echo하지 않고 **리터럴 `"paid"`**로 고정합니다(카드 PO 確定③ "source=paid 재사용" 그대로) — 향후 Meta 외 다른 ad 채널이 추가돼도 대시보드가 채널명 나열 없이 `source=="paid"` 한 축으로 organic/paid를 가릅니다.

## 지출 조회
- `meta_ads_campaign.py::get_campaign_spend_minor`(신규, 실 Meta Insights API — PR1/PR3와 같은 「자격 값 0·코드 경로는 완전」) + `ads_sandbox_campaign.py` 동형(결정적 고정값 `12_345` — 해시 유도 대신 상수를 쓴 이유는 테스트가 정확한 값을 assert할 수 있게).
- `GET /{org}/ads-boosts/{gate_id}/spend`(신규) — `sealed_ads_budget_minor`·`captured_spend_minor`(합)·`remaining_minor`·스냅샷 목록. 읽기 전용이라 `insights_snapshot.py` GET과 동형 권한 축(휴먼·에이전트 모두, human-only 아님 — 조회는 실행이 아니라는 판단).

## 판단 콜 답변(페드루 PO 判定 2026-09-11)
- **remaining_minor 음수 바닥처리 안 함 — 채택**: 실지출이 봉인을 넘긴 사실을 숨기지 않습니다. FE가 「초과」 낱말로 표시.
- **offset_label — 실측 결과 결함으로 확定, 이 PR 안에서 처리 완료**: 기존 `GET .../publications/{id}/insights`(`list_insight_snapshots_for_publication`)가 `org_id`+`publication_id`로만 걸러 channel 축을 전혀 구분하지 않았습니다 — paid 스냅샷이 organic과 같은 `publication_id`를 공유하는 이 PR의 설계상, 그 목록에 paid 행이 그대로 섞여 나왔습니다(「반환 0=결함 아님」이 아니라 「반환함=결함」으로 실측). 후속 커밋으로 같은 `channel NOT IN ('meta_ads','ads_sandbox')` 필터를 그 목록 함수에도 적용, 신규 테스트 1건(organic 목록에 paid 채널이 안 섞임 pin) + mutation self-check로 고정했습니다.

## 검증
- 새 마이그 0건(`InsightSnapshot.source`가 원래도 free Text — 스키마 변경 불요).
- 신규 테스트 7건 — boost_start 성공 시 2행 스케줄링·capture 시 source="paid"+정확한 spend 값·organic 캡처 루프가 paid 행을 안 건드림(핵심 pin)·**organic 조회 목록(`/insights`)이 paid 채널을 안 섞음(판단 콜② 답으로 추가)**·`/spend` API 응답(budget·captured·remaining 정합)·404(미존재 gate)·run 미생성 방어 — 전부 GREEN.
- mutation self-check 3건 — organic 캡처 루프 제외 비활성화 → `unsupported` 오염 재현으로 정확히 그 1건만 RED 확認 → 복원. `source="paid"` 대입 비활성화 → 저장 단언·API 조회(필터가 그 값에 의존) 양쪽 정확히 2건만 RED 확認 → 복원. organic 조회 목록 필터 비활성화 → 정확히 그 1건만 RED 확認 → 복원.
- 기존 `insight_snapshots` 소비 회귀 스위트(3320·3414·3497·3571·3603·3620·3645·3696·3497_channel_post_publication_id_exposure·3651_mcp) 103건 재통과 — WHERE 절 추가 2곳(캡처 루프+조회 목록)이 회귀 0.
- 한글 사용자 문장 가드 신규 0건(기존 `ads_boost.gate_not_found` 카탈로그 키 재사용, 신규 키 0).
- 정적 가드(model registration·dependency override·destructive test SQL·raw auth id·shard-weights) 전부 0건.

## 다음
이 PR이 story #3806의 PR1~4(BE)를 전부 마무리합니다. 다음은 **PR5(FE)** — 카드 「유나 §절」 SSOT로 같은 카드 안 새 스택(범위: 결재 카드 봉인 표시·boost 요청 폼·중지/재개 버튼·성과 보드 「광고비」 분리 칸).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8
