### PR TITLE
[SID:3806] feat: 봉인 starts_at 자동 실행 워커(PR 6) — 홍보 시작 자동화

### DIFF
--- a/backend/alembic/versions/0367_publication_command_initiated_by.py
+++ b/backend/alembic/versions/0367_publication_command_initiated_by.py
@@ -1,0 +1,41 @@
+"""story #3806(Phase3·3-2 PR 6 정정, 페드루 PO 定 2026-09-11 13:42Z) — 「누가
+시작했나」 두 세계 처방. 자동 워커(`process_due_ads_boost_starts`)와 사람의
+「홍보 시작」 버튼이 같은 `boost_start` command 행으로 수렴하는데(멱등 upsert),
+`requested_by_member_id`만으로는 구분이 안 된다 — 승인자 본인이 직접 클릭하면
+자동 워커가 채운 값(`gate.resolver_id`)과 똑같아진다.
+
+`initiated_by`: 'scheduler'|'human', nullable(기존 행은 이 정보를 몰라 null —
+지어내지 않는다, 이 스토리 이전 데이터 없음이라 실질 영향 0이지만 원칙은 유지).
+`publication_commands`에 얹는다(`AdsBoostRun`이 아니라) — «이 요청이 어떻게
+왔나»는 요청 원장(command)의 속성이지, 실행 결과 상태(run)의 속성이 아니다.
+
+Revision ID: 0367
+Revises: 0366
+Create Date: 2026-09-11
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0367"
+down_revision = "0366"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "publication_commands",
+        sa.Column("initiated_by", sa.Text(), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_publication_commands_initiated_by",
+        "publication_commands",
+        "initiated_by IS NULL OR initiated_by IN ('scheduler', 'human')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_publication_commands_initiated_by", "publication_commands", type_="check")
+    op.drop_column("publication_commands", "initiated_by")

--- a/backend/app/models/publication_command.py
+++ b/backend/app/models/publication_command.py
@@ -52,6 +52,14 @@ class PublicationCommand(Base):
             "content_kind IN ('channel_post', 'site_post', 'comment_reply', 'ads_boost')",
             name="ck_publication_commands_content_kind",
         ),
+        # story #3806(Phase3·3-2 PR 6 정정, 페드루 PO 定 2026-09-11 13:42Z) — 0367
+        # 마이그의 정본 미러(위 content_kind 관례와 동형 — 이름 `ck_publication_
+        # commands_initiated_by` 반드시 일치 유지, create_all() 기반 로컬 테스트가
+        # 이 제약을 보게 하는 목적).
+        CheckConstraint(
+            "initiated_by IS NULL OR initiated_by IN ('scheduler', 'human')",
+            name="ck_publication_commands_initiated_by",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -83,6 +91,12 @@ class PublicationCommand(Base):
     failure_kind: Mapped[str | None] = mapped_column(Text, nullable=True)
     dead_letter_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     requested_by_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    # story #3806(Phase3·3-2 PR 6 정정, 페드루 PO 定 2026-09-11 13:42Z) — 「누가
+    # 시작했나」 두 세계 처방(0367). `requested_by_member_id`만으로는 자동 워커와
+    # 사람 클릭을 구분 못 한다(승인자 본인이 직접 누르면 둘 다 같은 member_id).
+    # null=이 정보를 모르는 기존 행(이 컬럼 도입 전 데이터·다른 content_kind는
+    # 채울 이유가 없어 계속 null로 둔다 — ads_boost의 boost_start만 채움).
+    initiated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False,

--- a/backend/app/routers/ads_boost_execution.py
+++ b/backend/app/routers/ads_boost_execution.py
@@ -105,7 +105,7 @@ async def _start_ads_boost_endpoint(
     resolved = await _require_human(db, auth, org_id, resolved_locale)
     try:
         command = await request_ads_boost_start(
-            db, org_id=org_id, gate_id=gate_id, requester_member_id=resolved.id,
+            db, org_id=org_id, gate_id=gate_id, requester_member_id=resolved.id, initiated_by="human",
         )
     except (AdsBoostGateNotFoundError, AdsBoostGateNotApprovedError) as exc:
         _raise_common_error(exc, resolved_locale)

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1316,6 +1316,15 @@ async def publication_commands_tick(
         except Exception as exc:
             logger.exception("agent-run-tool-calls sweep tick error: %s", exc)
             counts["agent_run_tool_calls_swept"] = {"error": "unhandled"}
+        # story #3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z) — 봉인
+        # sealed_ads_starts_at 도래 게이트 자동 실행. 위 축들과 같은 피기백 사상
+        # (새 Cloud Scheduler 잡 0) — 독립 try.
+        try:
+            from app.services.ads_boost_execution import process_due_ads_boost_starts
+            counts["ads_boost_starts"] = await process_due_ads_boost_starts(session)
+        except Exception as exc:
+            logger.exception("ads-boost-starts tick error: %s", exc)
+            counts["ads_boost_starts"] = {"error": "unhandled"}
         return _ok(counts)
     except Exception as exc:
         logger.exception("publication-commands cron error: %s", exc)

--- a/backend/app/services/ads_boost_execution.py
+++ b/backend/app/services/ads_boost_execution.py
@@ -44,6 +44,11 @@ OP_BOOST_START = "boost_start"
 OP_PAUSE = "pause"
 OP_RESUME = "resume"
 
+# publication_command.py::BATCH_SIZE·channel_post_comments.py::BATCH_SIZE와 동형 값
+# (신규 상수 발명 0 — 그 둘을 import하면 이 모듈의 gate_type 무관 워커 배치와
+# 우연히 같은 상수를 공유하게 돼 오히려 결합이 생긴다, 여기선 리터럴로 동형만).
+_DUE_STARTS_BATCH_SIZE = 50
+
 
 class AdsBoostGateNotFoundError(Exception):
     """존재 자체 비노출(publication_id 404와 동형 원칙) — 미존재·타 org 소유·
@@ -187,6 +192,73 @@ async def request_ads_boost_resume(
     return await _request_toggle(
         db, org_id=org_id, gate_id=gate_id, requester_member_id=requester_member_id, operation=OP_RESUME,
     )
+
+
+# story #3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z) — 봉인 starts_at 자동
+# 실행 워커. AC2 "[제품] 상한 내 실행"의 원래 뜻은 승인 뒤 `sealed_ads_starts_at`에
+# 도달하면 제품이 자동으로 `request_ads_boost_start`를 부르는 것인데, PR3엔 그
+# 자동발화 지점이 0건이었다(디디 실측·PO 콜①) — PR5가 사람이 누르는 「홍보 시작」
+# 버튼(`start_ads_boost_endpoint`)으로 루프를 닫은 임시 지름길이었고, 이 워커가
+# "안 눌렀을 때의 안전망"으로 겹쳐 놓는 진짜 자동화다.
+#
+# 멱등: `request_ads_boost_start`→`create_or_get_publication_command`가 이미 그
+# 자체로 (org_id, destination, approved_version, operation="boost_start",
+# toggle_seq=0) 키의 upsert라 두 번 불러도 새 command가 안 생긴다(먼저 된 사람
+# 클릭과 겹쳐도 안전). 아래 SQL 필터(`ads_boost_runs` 행 부재)는 그 위에 얹는 효율
+# 축 — `AdsBoostRun`은 실행 단계(`_process_one_command`의 ads_boost 분기)에서야
+# 지연 생성되므로, 이미 실행까지 끝난 gate를 매 tick 재선택하지 않게 거른다(아직
+# enqueue만 되고 실행 전인 gate는 이 필터를 통과해도 위 멱등 upsert가 안전망).
+#
+# requester_member_id = `gate.resolver_id`(그 게이트를 승인한 휴먼) — 이 코드베이스에
+# "시스템/스케줄러 행위자" sentinel 관례가 없고 `PublicationCommand.requested_by_
+# member_id`가 NOT NULL이라, "승인이 이미 이 실행을 허가했다"는 뜻으로 승인자
+# 귀속이 유일하게 지어내지 않는 선택지다(worker는 승인된 gate만 골라 status=
+# "approved" 조건상 resolver_id가 항상 채워져 있다).
+async def process_due_ads_boost_starts(db: AsyncSession, *, now=None) -> dict[str, int]:
+    """`sealed_ads_starts_at`이 도래한 승인 게이트를 찾아 `request_ads_boost_start`를
+    자동 호출한다. `process_due_publication_commands`류 기존 due-date 워커와 동형
+    패턴(SKIP LOCKED 배치)이나, 클레임 대상이 PublicationCommand가 아니라 Gate라
+    "처리 중" 표시 컬럼이 없다 — 대신 각 건을 개별 트랜잭션(gate별 committed 여부가
+    `request_ads_boost_start`의 자체 upsert로 이미 안전)으로 처리해 겹친 tick이
+    있어도 중복 command가 안 생긴다(멱등이 배치 락 대신 이 축의 안전망)."""
+    from datetime import datetime, timezone
+
+    from app.models.ads_boost_run import AdsBoostRun
+
+    now = now or datetime.now(timezone.utc)
+    rows = (await db.execute(
+        select(Gate.id, Gate.org_id, Gate.resolver_id)
+        .where(
+            Gate.gate_type == _ADS_BOOST_GATE_TYPE,
+            Gate.status == "approved",
+            Gate.sealed_ads_starts_at.isnot(None),
+            Gate.sealed_ads_starts_at <= now,
+            ~select(AdsBoostRun.id).where(AdsBoostRun.gate_id == Gate.id).exists(),
+        )
+        .order_by(Gate.sealed_ads_starts_at.asc())
+        .limit(_DUE_STARTS_BATCH_SIZE)
+    )).all()
+
+    counts = {"started": 0, "error": 0}
+    for gate_id, org_id, resolver_id in rows:
+        if resolver_id is None:
+            # 승인됐는데 resolver_id가 없는 상태는 이론상 불가(approve 경로가 항상
+            # 채운다) — 지어내지 않고 이 건만 건너뛴다(카운트로 드러남, 침묵 금지).
+            counts["error"] += 1
+            continue
+        try:
+            await request_ads_boost_start(
+                db, org_id=org_id, gate_id=gate_id, requester_member_id=resolver_id,
+            )
+            counts["started"] += 1
+        except (AdsBoostGateNotFoundError, AdsBoostGateNotApprovedError):
+            # 이 tick과 다른 tick(또는 사람 클릭)이 경합해 그 사이 상태가 바뀐 경우
+            # (예: 재봉인으로 pending 재오픈) — 그 자체가 이 워커의 실패가 아니다.
+            counts["error"] += 1
+        except Exception:  # noqa: BLE001 — publication_command.py의 배치 격리와 동형.
+            await db.rollback()
+            counts["error"] += 1
+    return counts
 
 
 class AdsBoostAdapterUnavailableError(Exception):

--- a/backend/app/services/ads_boost_execution.py
+++ b/backend/app/services/ads_boost_execution.py
@@ -123,12 +123,17 @@ async def _latest_toggle(
 
 async def request_ads_boost_start(
     db: AsyncSession, *, org_id: uuid.UUID, gate_id: uuid.UUID, requester_member_id: uuid.UUID,
+    initiated_by: str,
 ) -> PublicationCommand:
+    """`initiated_by` ∈ {"human", "scheduler"} — 페드루 PO 定(2026-09-11 13:42Z,
+    「누가 시작했나」 두 세계 처방). 필수 kwarg(기본값 0)로 둬 새 호출부가 이 축을
+    빠뜨리면 즉시 TypeError로 드러나게 한다(조용히 None으로 새는 것을 막는다)."""
     gate = await _resolve_gate(db, org_id=org_id, gate_id=gate_id)
     command, _ = await create_or_get_publication_command(
         db, org_id=org_id, gate_id=gate.id, destination=gate.sealed_ads_connection_id,
         approved_version=gate.sealed_ads_boost_version_id, requested_by_member_id=requester_member_id,
         scheduled_at=None, operation=OP_BOOST_START, content_kind=_ADS_BOOST_CONTENT_KIND, toggle_seq=0,
+        initiated_by=initiated_by,
     )
     await db.commit()
     return command
@@ -249,6 +254,7 @@ async def process_due_ads_boost_starts(db: AsyncSession, *, now=None) -> dict[st
         try:
             await request_ads_boost_start(
                 db, org_id=org_id, gate_id=gate_id, requester_member_id=resolver_id,
+                initiated_by="scheduler",
             )
             counts["started"] += 1
         except (AdsBoostGateNotFoundError, AdsBoostGateNotApprovedError):

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -132,7 +132,7 @@ async def create_or_get_publication_command(
     db: AsyncSession, *, org_id: uuid.UUID, gate_id: uuid.UUID, destination: uuid.UUID,
     approved_version: uuid.UUID, requested_by_member_id: uuid.UUID,
     scheduled_at: datetime | None, operation: str = "publish", content_kind: str = "channel_post",
-    toggle_seq: int = 0,
+    toggle_seq: int = 0, initiated_by: str | None = None,
 ) -> tuple[PublicationCommand, bool]:
     """멱등 upsert(블루프린트 §3 키: org_id+destination+approved_version+operation+
     toggle_seq — story #3806 PR3가 toggle_seq를 추가, 그 전까지는 항상 0이라
@@ -149,7 +149,13 @@ async def create_or_get_publication_command(
     롤백하고(바깥 트랜잭션은 오염 안 됨), constraint 이름을 확인한 뒤(다른 원인까지
     "경합"으로 오판하지 않도록 — approval_delivery.py QA 교훈) 진 쪽은 이긴 쪽이 커밋한
     행을 재조회해 그대로 반환한다(완료 대기 불요 — #3757과 다른 점, 여기 command는
-    "완결된 발행 결과"가 아니라 감사 원장이라 어느 상태든 반환해도 무방)."""
+    "완결된 발행 결과"가 아니라 감사 원장이라 어느 상태든 반환해도 무방).
+
+    story #3806(Phase3·3-2 PR 6 정정, 페드루 PO 定 2026-09-11 13:42Z) — `initiated_by`
+    ('scheduler'|'human'|None, 0367)는 기존 행이 있으면(위 "그대로 반환") 안 덮어쓴다
+    — 먼저 만든 쪽의 값이 그대로 남는다(이 함수의 멱등 원칙과 동형: 「먼저 된 쪽이
+    이김」이 상태뿐 아니라 이 축에도 적용). 대부분 호출부는 None(기존 의미 불변) —
+    ads_boost_execution.py만 명시로 채운다."""
     existing = (await db.execute(
         select(PublicationCommand).where(
             PublicationCommand.org_id == org_id,
@@ -166,7 +172,7 @@ async def create_or_get_publication_command(
         id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=destination,
         approved_version=approved_version, operation=operation, scheduled_at=scheduled_at,
         status="pending", requested_by_member_id=requested_by_member_id, content_kind=content_kind,
-        toggle_seq=toggle_seq,
+        toggle_seq=toggle_seq, initiated_by=initiated_by,
     )
     try:
         async with db.begin_nested():

--- a/backend/tests/test_3806_ads_boost_spend.py
+++ b/backend/tests/test_3806_ads_boost_spend.py
@@ -52,7 +52,7 @@ async def _start_boost(session_maker, org_id, gate_id, owner_id):
     from app.services.publication_command import process_due_publication_commands
 
     async with session_maker() as s:
-        await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id)
+        await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id, initiated_by="human")
     async with session_maker() as s:
         counts = await process_due_publication_commands(s)
     assert counts["completed"] == 1, counts

--- a/backend/tests/test_3806_ads_boost_starts_cron_wiring.py
+++ b/backend/tests/test_3806_ads_boost_starts_cron_wiring.py
@@ -1,0 +1,158 @@
+"""story #3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z) —
+`ads_boost_execution.py::process_due_ads_boost_starts`가 실제로 `/publication-
+commands` cron tick에 배선됐는지(신규 엔드포인트 0, 피기백)와 그 축의 예외가
+다른 축 카운트를 오염시키지 않는지(3527 comment_collections 선례와 동형 격리).
+
+세팅 헬퍼는 test_3806_ads_boost_gate.py·test_3527_comment_collection_cron_wiring.py
+와 동형 재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.mark.anyio
+async def test_cron_tick_starts_due_ads_boost_via_worker_db(monkeypatch):
+    """AC — tick 호출 → due 지난 승인 ads_boost 게이트가 boost_start command를
+    받는다(카운트로 확認, 되돌리면 test_3806_ads_boost_starts_worker.py의 단위
+    테스트들이 이미 RED — 여기선 "cron 엔드포인트가 이 함수를 실제로 부르는가"
+    배선만 겨눈다)."""
+    import app.routers.cron as cron_module
+    from app.dependencies.database import get_worker_db
+    from app.main import app
+    from httpx import AsyncClient, ASGITransport
+    from sqlalchemy import select
+    from app.models.publication_command import PublicationCommand
+
+    from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+    from tests.test_3475_publishing_metrics import _seed_human, _client_for, _setup_org_scoped_app
+    from tests.test_3497_insight_snapshots import _seed_channel_connection
+    from tests.test_3806_ads_boost_gate import _seed_publication, _boost_body, _approve_gate, _seed_default_role
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "test-cron-secret")
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            conn = await _seed_channel_connection(s, org_id, channel="threads")
+            ad_conn = await _seed_channel_connection(s, org_id, channel="ads_sandbox")
+            await _seed_default_role(s, org_id)
+            pub, _ = await _seed_publication(s, org_id=org_id, connection_id=conn.id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/publications/{pub.id}/boosts",
+                json=_boost_body(ad_connection_id=ad_conn.id, hours_from_now=-1),
+            )
+        assert r.status_code == 201, r.text
+        gate_id = uuid.UUID(r.json()["gate_id"])
+        app.dependency_overrides.clear()
+
+        async with Session() as s:
+            await _approve_gate(s, gate_id, owner_id)
+
+        async def _worker_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_worker_db] = _worker_db
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/v2/internal/cron/publication-commands",
+                headers={"Authorization": "Bearer test-cron-secret"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()["data"]
+        assert body["ads_boost_starts"]["started"] == 1, body
+
+        async with Session() as s:
+            command = (await s.execute(
+                select(PublicationCommand).where(
+                    PublicationCommand.gate_id == gate_id, PublicationCommand.operation == "boost_start",
+                )
+            )).scalar_one_or_none()
+        assert command is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_ads_boost_starts_exception_does_not_corrupt_other_axes_counts(monkeypatch):
+    """test_3527_comment_collection_cron_wiring.py::test_cron_comment_collection_
+    exception_does_not_corrupt_other_axes_counts와 동형 — ads_boost_starts 축
+    예외가 publication_commands 카운트를 오염시키지 않는다(독립 try 격리 확認)."""
+    import app.routers.cron as cron_module
+    import app.services.ads_boost_execution as ads_boost_execution_module
+    from app.dependencies.database import get_worker_db
+    from app.main import app
+    from httpx import AsyncClient, ASGITransport
+
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "test-cron-secret")
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("ads boost starts boom(테스트 주입)")
+
+    monkeypatch.setattr(ads_boost_execution_module, "process_due_ads_boost_starts", _boom)
+
+    engine, Session = await _session_factory()
+    try:
+        async def _worker_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_worker_db] = _worker_db
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/v2/internal/cron/publication-commands",
+                headers={"Authorization": "Bearer test-cron-secret"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()["data"]
+        assert body["ads_boost_starts"] == {"error": "unhandled"}
+        assert body["completed"] == 0 and body["error"] == 0, (
+            "ads_boost_starts 축 예외가 publication_commands 카운트 필드까지 오염시켰다"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3806_ads_boost_starts_worker.py
+++ b/backend/tests/test_3806_ads_boost_starts_worker.py
@@ -1,0 +1,288 @@
+"""story #3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z) — 봉인
+`sealed_ads_starts_at` 자동 실행 워커(`process_due_ads_boost_starts`). AC2
+"[제품] 상한 내 실행"의 원래 뜻(승인 뒤 시작 시점 도달 시 제품이 자동으로
+`request_ads_boost_start`를 부름)을 채운다 — PR5의 「홍보 시작」 사람 클릭은
+지름길로 유지되고(먼저 된 쪽이 이김), 이 워커는 "안 눌렀을 때의 안전망".
+
+세팅은 test_3806_ads_boost_gate.py(PR 2)·test_3806_ads_boost_execution.py(PR 3)
+와 동형 재사용(중복 재발명 금지) — `_setup_approved_gate`는 starts_at을 항상
+미래(+1h)로 고정해 둬(그 파일의 관심사가 아님) 이 파일은 `hours_from_now`를
+과거로 넘기는 자체 세팅 함수를 둔다."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory, _seed_default_role
+from tests.test_3475_publishing_metrics import _seed_human, _client_for, _setup_org_scoped_app
+from tests.test_3497_insight_snapshots import _seed_channel_connection
+from tests.test_3806_ads_boost_gate import _seed_publication, _boost_body, _approve_gate
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _setup_gate(session_factory_result, *, hours_from_now: float, approve: bool = True):
+    """test_3806_ads_boost_execution.py::_setup_approved_gate와 동형이나
+    `hours_from_now`를 그대로 `_boost_body`에 흘려 starts_at을 과거/미래로 고른다."""
+    from app.main import app
+
+    engine, Session = session_factory_result
+    async with Session() as s:
+        org_id, project_id = await _seed_org(s)
+        owner_id = await _seed_human(s, org_id, role="owner")
+        conn = await _seed_channel_connection(s, org_id, channel="threads")
+        ad_conn = await _seed_channel_connection(s, org_id, channel="ads_sandbox")
+        await _seed_default_role(s, org_id)
+        pub, _ = await _seed_publication(s, org_id=org_id, connection_id=conn.id)
+
+    _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+    async with _client_for(app) as client:
+        r = await client.post(
+            f"/api/v2/organizations/{org_id}/publications/{pub.id}/boosts",
+            json=_boost_body(ad_connection_id=ad_conn.id, hours_from_now=hours_from_now),
+        )
+    assert r.status_code == 201, r.text
+    gate_id = uuid.UUID(r.json()["gate_id"])
+    app.dependency_overrides.clear()
+
+    if approve:
+        async with Session() as s:
+            await _approve_gate(s, gate_id, owner_id)
+
+    return engine, Session, org_id, owner_id, gate_id
+
+
+async def _get_boost_start_command(session, org_id: uuid.UUID, gate_id: uuid.UUID):
+    from app.models.publication_command import PublicationCommand
+    from sqlalchemy import select
+
+    return (await session.execute(
+        select(PublicationCommand).where(
+            PublicationCommand.org_id == org_id, PublicationCommand.gate_id == gate_id,
+            PublicationCommand.operation == "boost_start",
+        )
+    )).scalar_one_or_none()
+
+
+@pytest.mark.anyio
+async def test_due_approved_gate_gets_boost_start_command():
+    from app.services.ads_boost_execution import process_due_ads_boost_starts
+
+    engine, Session, org_id, owner_id, gate_id = await _setup_gate(
+        await _session_factory(), hours_from_now=-1,  # 1시간 前 — 이미 도래
+    )
+    try:
+        async with Session() as s:
+            counts = await process_due_ads_boost_starts(s, now=datetime.now(timezone.utc))
+        assert counts["started"] == 1, counts
+
+        async with Session() as s:
+            command = await _get_boost_start_command(s, org_id, gate_id)
+        assert command is not None
+        assert command.requested_by_member_id == owner_id  # gate.resolver_id 귀속
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_not_yet_due_gate_is_skipped():
+    """뮤테이션 대상: `Gate.sealed_ads_starts_at <= now` 조건을 걷으면 미래 gate도
+    잡혀 이 테스트가 실패한다."""
+    from app.services.ads_boost_execution import process_due_ads_boost_starts
+
+    engine, Session, org_id, owner_id, gate_id = await _setup_gate(
+        await _session_factory(), hours_from_now=1,  # 1시간 뒤 — 아직 안 도래
+    )
+    try:
+        async with Session() as s:
+            counts = await process_due_ads_boost_starts(s, now=datetime.now(timezone.utc))
+        assert counts["started"] == 0, counts
+
+        async with Session() as s:
+            command = await _get_boost_start_command(s, org_id, gate_id)
+        assert command is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pending_gate_not_yet_approved_is_skipped():
+    """뮤테이션 대상: `Gate.status == "approved"` 조건을 걷으면 미승인 gate도
+    잡힌다 — «승인=실행 허가» 원칙(ads_boost_execution.py 모듈 관례) 위반. 이 시나리오
+    는 실 데이터로도 일어난다(요청 시점에 이미 starts_at이 봉인되고, 승인 전에
+    시간이 지나 그 값이 과거가 될 수 있다 — PR 2 「pending 중 재봉인」 관례). 필터가
+    없으면 내부 `_resolve_gate`가 재검사해 `AdsBoostGateNotApprovedError`로 막지만
+    (started는 0 유지) 그 경로를 타면 `counts["error"]`가 늘어난다 — 그 차이로 검산
+    (test_wrong_gate_type_is_skipped와 동형 이중 방어 구조)."""
+    from app.services.ads_boost_execution import process_due_ads_boost_starts
+
+    engine, Session, org_id, owner_id, gate_id = await _setup_gate(
+        await _session_factory(), hours_from_now=-1, approve=False,
+    )
+    try:
+        async with Session() as s:
+            counts = await process_due_ads_boost_starts(s, now=datetime.now(timezone.utc))
+        assert counts["started"] == 0, counts
+        assert counts["error"] == 0, counts  # 필터가 살아있으면 이 gate는 시도조차 안 됨
+
+        async with Session() as s:
+            command = await _get_boost_start_command(s, org_id, gate_id)
+        assert command is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_wrong_gate_type_is_skipped():
+    """뮤테이션 대상: `Gate.gate_type == "ads_boost"` 조건을 걷으면 다른 gate_type도
+    잡힌다. 실 데이터에선 `sealed_ads_starts_at`이 ads_boost 전용 nullable 컬럼이라
+    다른 gate_type 행은 애초에 값이 없어(구조적으로 이 SQL필터가 못 걸릴 일이
+    없다) — 그 방어를 직접 검산하려고 **인위적으로**(실 애플리케이션 플로우로는
+    못 만드는 상태) concept_approval 게이트에 그 컬럼을 채워 넣는다. 그래도 이
+    필터가 없으면 `request_ads_boost_start`의 내부 `_resolve_gate`가 재검사해
+    `AdsBoostGateNotFoundError`로 막긴 하나(started 카운트는 0 유지) — 그 경로를
+    타면 `counts["error"]`가 늘어난다(필터가 있으면 애초에 시도 자체를 안 해 0).
+    그 차이로 이 SQL필터가 실제로 도는지 검산한다(`_resolve_gate`와의 이중 방어
+    구조 — 어느 한쪽만 봐선 「하나는 죽은 코드」로 오독하기 쉬워 여기 기록)."""
+    from sqlalchemy import select, update
+    from app.models.gate import Gate
+    from app.services.ads_boost_execution import process_due_ads_boost_starts
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            role_id = await _seed_default_role(s, org_id)
+            other_gate = await create_gate(
+                s, org_id, uuid.uuid4(), "story", "concept_approval", owner_id, role_id,
+                scope_key=str(uuid.uuid4()),
+            )
+            other_gate.status = "approved"
+            other_gate.resolver_id = owner_id
+            await s.commit()
+            other_gate_id = other_gate.id
+            # 인위적 상태 주입 — 위 docstring 참고.
+            await s.execute(
+                update(Gate).where(Gate.id == other_gate_id).values(
+                    sealed_ads_starts_at=datetime.now(timezone.utc) - timedelta(hours=1),
+                )
+            )
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_ads_boost_starts(s, now=datetime.now(timezone.utc))
+        assert counts["started"] == 0, counts
+        assert counts["error"] == 0, counts  # 필터가 살아있으면 이 gate는 시도조차 안 됨
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+
+            command = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == other_gate_id)
+            )).scalar_one_or_none()
+        assert command is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_already_started_gate_is_not_reprocessed():
+    """뮤테이션 대상: `~exists(AdsBoostRun...)` 필터를 걷으면 이미 run 행이 생긴
+    gate도 매 tick 재선택된다 — «이미 시작된 게이트 재실행 0»(카드 §4)."""
+    from app.models.ads_boost_run import AdsBoostRun
+    from app.services.ads_boost_execution import process_due_ads_boost_starts
+
+    engine, Session, org_id, owner_id, gate_id = await _setup_gate(
+        await _session_factory(), hours_from_now=-1,
+    )
+    try:
+        async with Session() as s:
+            run = AdsBoostRun(id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, status="running")
+            s.add(run)
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_ads_boost_starts(s, now=datetime.now(timezone.utc))
+        assert counts["started"] == 0, counts
+
+        async with Session() as s:
+            command = await _get_boost_start_command(s, org_id, gate_id)
+        # boost_start command 자체가 아예 없다(사람도 워커도 이 gate를 아직 건드린
+        # 적 없이 run만 직접 심은 인위적 상태) — 워커가 이 gate를 건드리지 않았다는
+        # 증거로 충분.
+        assert command is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_calling_worker_twice_does_not_duplicate_command():
+    """겹친 tick(또는 워커+사람 클릭 경합) 멱등 — 두 번째 호출은 no-op(create_or_get
+    upsert가 안전망)."""
+    from app.services.ads_boost_execution import process_due_ads_boost_starts
+
+    engine, Session, org_id, owner_id, gate_id = await _setup_gate(
+        await _session_factory(), hours_from_now=-1,
+    )
+    try:
+        async with Session() as s:
+            counts1 = await process_due_ads_boost_starts(s, now=datetime.now(timezone.utc))
+        assert counts1["started"] == 1
+
+        # 두 번째 tick — AdsBoostRun이 아직 안 생겼으므로(실행은 process_due_
+        # publication_commands가 별도로 함) 필터를 다시 통과하지만, 아래에서
+        # create_or_get_publication_command의 자체 멱등이 새 행을 안 만든다는
+        # 것을 확認한다(카운트는 그래도 "started"로 집힘 — 그 자체가 no-op라는
+        # 사실은 command 개수로 검증).
+        async with Session() as s:
+            await process_due_ads_boost_starts(s, now=datetime.now(timezone.utc))
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.publication_command import PublicationCommand
+
+            commands = (await s.execute(
+                select(PublicationCommand).where(
+                    PublicationCommand.org_id == org_id, PublicationCommand.gate_id == gate_id,
+                    PublicationCommand.operation == "boost_start",
+                )
+            )).scalars().all()
+        assert len(commands) == 1, "두 번째 tick이 새 command를 만들면 멱등이 깨진 것"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3806_ads_boost_starts_worker.py
+++ b/backend/tests/test_3806_ads_boost_starts_worker.py
@@ -114,7 +114,39 @@ async def test_due_approved_gate_gets_boost_start_command():
             command = await _get_boost_start_command(s, org_id, gate_id)
         assert command is not None
         assert command.requested_by_member_id == owner_id  # gate.resolver_id 귀속
+        # story #3806 PR 6 정정(페드루 PO 定 2026-09-11 13:42Z) — 「누가 시작했나」
+        # 두 세계 처방. 뮤테이션 대상: process_due_ads_boost_starts의
+        # request_ads_boost_start 호출에서 initiated_by="scheduler"를 걷으면(또는
+        # publication_command.py::create_or_get_publication_command가 그 값을
+        # 안 저장하면) 이 단언이 실패한다.
+        assert command.initiated_by == "scheduler"
     finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_triggered_start_is_marked_initiated_by_human():
+    """뮤테이션 대상: `start_ads_boost_endpoint`(사람 경로)가 initiated_by="human"을
+    안 넘기면 이 단언이 실패한다 — 워커 경로(scheduler)와의 구분이 이 값 하나에
+    달려 있다."""
+    from app.main import app
+
+    engine, Session, org_id, owner_id, gate_id = await _setup_gate(
+        await _session_factory(), hours_from_now=1, approve=True,
+    )
+    try:
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/start")
+        assert r.status_code == 201, r.text
+        app.dependency_overrides.clear()
+
+        async with Session() as s:
+            command = await _get_boost_start_command(s, org_id, gate_id)
+        assert command is not None
+        assert command.initiated_by == "human"
+    finally:
+        app.dependency_overrides.clear()
         await engine.dispose()
 
 

--- a/backend/tests/test_3806_ads_boost_worker.py
+++ b/backend/tests/test_3806_ads_boost_worker.py
@@ -67,7 +67,7 @@ async def test_boost_start_command_completes_and_creates_run():
     engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
     try:
         async with Session() as s:
-            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id)
+            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id, initiated_by="human")
 
         async with Session() as s:
             counts = await process_due_publication_commands(s)
@@ -94,7 +94,7 @@ async def test_pause_then_resume_updates_run_status():
     engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
     try:
         async with Session() as s:
-            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id)
+            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id, initiated_by="human")
         async with Session() as s:
             counts = await process_due_publication_commands(s)
         assert counts["completed"] == 1, counts
@@ -133,7 +133,7 @@ async def test_pause_delayed_marker_leaves_run_pause_pending():
     )
     try:
         async with Session() as s:
-            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id)
+            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id, initiated_by="human")
         async with Session() as s:
             await process_due_publication_commands(s)
 
@@ -162,7 +162,7 @@ async def test_budget_exceeded_marker_fails_without_creating_run_ids():
     )
     try:
         async with Session() as s:
-            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id)
+            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id, initiated_by="human")
         async with Session() as s:
             counts = await process_due_publication_commands(s)
         assert counts["completed"] == 0, counts
@@ -240,7 +240,7 @@ async def test_gate_reopened_before_worker_pickup_blocks_execution():
     engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
     try:
         async with Session() as s:
-            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id)
+            await request_ads_boost_start(s, org_id=org_id, gate_id=gate_id, requester_member_id=owner_id, initiated_by="human")
 
         async with Session() as s:
             gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1627,6 +1627,16 @@
       "file": "tests/test_3805_pr4_reply_collection.py",
       "sec": 6.5,
       "source": "story-3805(Phase3·3-1 PR 4, 페드루 PO 確定 2026-09-11 12:12Z·12:29Z 후속 — 인바운드 중첩 답글 수집·kind 열 복귀·「조용히 0」 처방 reply_detection_unavailable 3건 추가) — 재측(로컬, uv run pytest --durations=0 직접 1회 실행, 11건 call+setup 합산 약 6.5s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3806_ads_boost_starts_worker.py",
+      "sec": 4.6,
+      "source": "story-3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z — 봉인 starts_at 자동 실행 워커) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 6건 call+setup 합산 약 4.6s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3806_ads_boost_starts_cron_wiring.py",
+      "sec": 1.8,
+      "source": "story-3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z — cron 배선 회귀, test_3527_comment_collection_cron_wiring.py 선례와 동형) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 2건 call+setup 합산 약 1.8s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1630,8 +1630,8 @@
     },
     {
       "file": "tests/test_3806_ads_boost_starts_worker.py",
-      "sec": 4.6,
-      "source": "story-3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z — 봉인 starts_at 자동 실행 워커) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 6건 call+setup 합산 약 4.6s — test_3766 등재 선례와 동일 방법론)"
+      "sec": 5.5,
+      "source": "story-3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z·13:42Z 정정(initiated_by 테스트 1건 추가) — 봉인 starts_at 자동 실행 워커) — 재측(로컬, uv run pytest --durations=0 직접 1회 실행, 7건 call+setup 합산 약 5.5s — test_3766 등재 선례와 동일 방법론)"
     },
     {
       "file": "tests/test_3806_ads_boost_starts_cron_wiring.py",


### PR DESCRIPTION
## Summary
- PO 確定(2026-09-11 13:27Z) — AC2 "[제품] 상한 내 실행"의 원래 뜻(승인 뒤 봉인 `sealed_ads_starts_at` 도달 시 제품이 자동으로 `request_ads_boost_start`를 실행)을 채운다. PR3엔 그 자동발화 지점이 0건이었고(디디 실측·PO 콜①), PR5가 사람이 누르는 「홍보 시작」 버튼으로 루프를 닫은 임시 지름길이었다 — 이 워커가 "안 눌렀을 때의 안전망"으로 겹쳐 놓는 진짜 자동화.
- `process_due_ads_boost_starts`(`ads_boost_execution.py`): `gate_type="ads_boost" ∧ status="approved" ∧ sealed_ads_starts_at<=now ∧ (ads_boost_runs 행 없음)` 조건의 게이트를 찾아 `request_ads_boost_start`를 자동 호출.
- 멱등은 `create_or_get_publication_command`의 기존 upsert가 안전망(사람 클릭과 겹쳐도 먼저 된 쪽이 이김) — SQL 필터(`ads_boost_runs` 행 부재)는 효율 축(실행까지 끝난 gate를 매 tick 재선택 안 함).
- `requester_member_id = gate.resolver_id`(그 게이트를 승인한 휴먼) — 이 코드베이스에 시스템/스케줄러 행위자 sentinel 관례가 없고 `PublicationCommand.requested_by_member_id`가 NOT NULL이라, "승인이 이미 이 실행을 허가했다"는 뜻으로 유일하게 지어내지 않는 선택.
- `cron.py`: 기존 `/publication-commands` tick에 피기백(새 Cloud Scheduler 잡 0 — `insight_snapshots`·`comment_collections`·`oauth_pending_selections`·`unhandled_error_events`·`agent_run_tool_calls` 등 기존 축과 동형 사상).

## Test plan
- [x] 신규 `test_3806_ads_boost_starts_worker.py` 6건 — 뮤테이션 킬 확인(4개 SQL 필터 각각 개별 제거 후 재현): `gate_type`·`status` 필터는 `request_ads_boost_start` 내부 `_resolve_gate`와 이중 방어 구조라 `error` 카운트 증가로 검산, `starts_at`·`run-exists` 필터는 `started` 카운트 직접 변화로 검산.
- [x] 신규 `test_3806_ads_boost_starts_cron_wiring.py` 2건 — cron 엔드포인트 실배선 확인 + 예외 축 격리(다른 축 카운트 오염 0, `test_3527_comment_collection_cron_wiring.py` 선례와 동형).
- [x] 기존 ads_boost 계열(gate/execution/worker/spend) 39건 + cron 계열(3414/3527/2072/3605) 회귀 0.
- [x] i18n 한글 사용자 문장 가드·authz/org-scoped-rest 가드 0건 신규.
- [x] shard-weights 신규 2건 등재+lint 통과.

## 남은 것
- Cloud Scheduler 잡 등록: 불필요(기존 `/publication-commands` 잡에 피기백해 새 잡 0) — PO가 당초 예상한 "PO가 등록" 액션 자체가 사라짐(사양 변경 아님, 기존 코드베이스 관례를 따른 결과).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn