### PR TITLE
[SID:3806] feat: initiated_by 응답 직렬화(PR 8) — scheduler/human 구분값 API 노출

### DIFF
--- a/backend/app/routers/ads_boost_execution.py
+++ b/backend/app/routers/ads_boost_execution.py
@@ -54,12 +54,18 @@ class CommandResponse(BaseModel):
     operation: str
     toggle_seq: int
     status: str
+    # story #3806(Phase3·3-2 PR 8, 페드루 PO 確定 2026-09-11) — 0367이 만든 컬럼을
+    # 여기 직렬화하지 않아 "있어도 못 읽으면 안 닫힌 것"이었다(PR6 정정 배경).
+    # boost_start의 human 경로(이 파일 `_start_ads_boost_endpoint`)만 채우고
+    # pause/resume 커맨드는 이 축 구분이 없어(scheduler가 안 건드리는 operation)
+    # null 그대로 — 지어내지 않는다.
+    initiated_by: str | None
 
 
 def _to_response(command) -> CommandResponse:
     return CommandResponse(
         command_id=command.id, operation=command.operation, toggle_seq=command.toggle_seq,
-        status=command.status,
+        status=command.status, initiated_by=command.initiated_by,
     )
 
 
@@ -209,6 +215,11 @@ class SpendSummaryResponse(BaseModel):
     # 'running'|'paused'|'failed') 실 관측값. run 행이 아직 없으면 None(gate 승인
     # 직후·실행 요청 前 — "미실행"을 지어낸 상태값으로 가리지 않는다).
     run_status: str | None
+    # story #3806(Phase3·3-2 PR 8, 페드루 PO 確定 2026-09-11) — boost_start 커맨드의
+    # `initiated_by`('scheduler'|'human'). run_status와 동형 판단(디디 3자기점검
+    # 정신 재사용) — 이 GET이 이미 gate_id 단건 조회 자리라 3번째 GET 신설 안 함.
+    # boost_start 커맨드 자체가 없으면(gate 승인 직후·실행 前) None.
+    initiated_by: str | None
     snapshots: list[SpendSnapshotView]
 
 
@@ -245,6 +256,7 @@ async def _get_ads_boost_spend_endpoint(
         gate_id=summary["gate_id"], sealed_ads_budget_minor=summary["sealed_ads_budget_minor"],
         sealed_ads_currency=summary["sealed_ads_currency"], captured_spend_minor=summary["captured_spend_minor"],
         remaining_minor=summary["remaining_minor"], run_status=summary["run_status"],
+        initiated_by=summary["initiated_by"],
         snapshots=[
             SpendSnapshotView(
                 due_at=s["due_at"].isoformat(), captured_at=s["captured_at"].isoformat() if s["captured_at"] else None,

--- a/backend/app/services/ads_spend_snapshots.py
+++ b/backend/app/services/ads_spend_snapshots.py
@@ -211,11 +211,27 @@ async def get_ads_boost_spend_summary(db: AsyncSession, *, org_id: uuid.UUID, ga
         select(AdsBoostRun).where(AdsBoostRun.org_id == org_id, AdsBoostRun.gate_id == gate_id)
     )).scalar_one_or_none()
 
+    # story #3806(Phase3·3-2 PR 8, 페드루 PO 確定 2026-09-11) — 「있어도 못 읽으면 안
+    # 닫힌 것」 처방. boost_start는 그 승인주기당 toggle_seq=0 고정 1행(이 파일 상단
+    # 참조 모듈 docstring)이라 gate_id+operation만으로 단건 확정 — run_status와
+    # 동형으로 이 GET에 얹는다(2개 모듈 순환import 회피를 위해 지연 import,
+    # ads_boost_execution.py도 이 파일을 함수 내부에서만 부르는 동형 관례).
+    from app.models.publication_command import PublicationCommand
+    from app.services.ads_boost_execution import OP_BOOST_START
+
+    boost_start_command = (await db.execute(
+        select(PublicationCommand).where(
+            PublicationCommand.org_id == org_id, PublicationCommand.gate_id == gate_id,
+            PublicationCommand.operation == OP_BOOST_START,
+        )
+    )).scalar_one_or_none()
+
     captured_spend_minor = sum(
         (s.normalized or {}).get("spend") or 0 for s in snapshots if s.status == "captured"
     )
     return {
         "gate_id": gate.id,
+        "initiated_by": boost_start_command.initiated_by if boost_start_command is not None else None,
         "sealed_ads_budget_minor": gate.sealed_ads_budget_minor,
         "sealed_ads_currency": gate.sealed_ads_currency,
         "captured_spend_minor": captured_spend_minor,

--- a/backend/tests/test_3806_ads_boost_execution.py
+++ b/backend/tests/test_3806_ads_boost_execution.py
@@ -141,6 +141,29 @@ async def test_start_creates_boost_start_command():
 
 
 @pytest.mark.anyio
+async def test_start_response_serializes_initiated_by_human():
+    """story #3806(Phase3·3-2 PR 8, 페드루 PO 確定 2026-09-11) — 0367 컬럼은 PR6이
+    이미 DB에 채웠지만(`test_3806_ads_boost_starts_worker.py::
+    test_human_triggered_start_is_marked_initiated_by_human`가 DB 모델 값으로
+    확認) 이 파일의 `CommandResponse`가 그 필드를 직렬화 안 해 API 축만으론 못
+    읽었다(양성대조 실측 중 자체발견 — PO 지적). 뮤테이션 대상: `_to_response`에서
+    `initiated_by=command.initiated_by` kwarg를 걷으면 이 단언이 KeyError/실패로
+    RED."""
+    from app.main import app
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/start")
+        assert r.status_code == 201, r.text
+        assert r.json()["initiated_by"] == "human"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_start_resubmit_is_idempotent_same_command():
     from app.main import app
 

--- a/backend/tests/test_3806_ads_boost_spend.py
+++ b/backend/tests/test_3806_ads_boost_spend.py
@@ -187,6 +187,52 @@ async def test_spend_endpoint_returns_budget_and_captured_sum():
 
 
 @pytest.mark.anyio
+async def test_spend_endpoint_serializes_initiated_by_scheduler():
+    """story #3806(Phase3·3-2 PR 8, 페드루 PO 確定 2026-09-11) — 「게이트 상세 등
+    명령을 돌려주는 GET 전부」축. scheduler 경로(`process_due_ads_boost_starts`)는
+    `/start`를 절대 안 거치므로(사람 클릭 0) `CommandResponse` 직렬화만으론
+    이 값을 절대 못 본다 — /spend가 이 gate의 유일한 GET 관측 자리(run_status와
+    동형 판단, 이 파일 상단 서비스 docstring). 뮤테이션 대상: `get_ads_boost_
+    spend_summary`가 `initiated_by` 키를 안 넣거나 `_get_ads_boost_spend_endpoint`가
+    그걸 응답에 안 실으면 이 단언이 실패한다."""
+    from app.main import app
+    from app.services.ads_boost_execution import process_due_ads_boost_starts
+    from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        # starts_at을 「이미 도래」로 직접 봉인해 스케줄러 픽업 대상으로 만든다
+        # (test_3806_ads_boost_starts_worker.py::_setup_gate와 동형 조작 — 이
+        # 파일은 그 헬퍼를 안 쓰므로 Gate 컬럼을 직접 민다).
+        from datetime import datetime, timedelta, timezone
+
+        from app.models.gate import Gate
+        from sqlalchemy import update
+
+        async with Session() as s:
+            await s.execute(
+                update(Gate).where(Gate.id == gate_id).values(
+                    sealed_ads_starts_at=datetime.now(timezone.utc) - timedelta(hours=1),
+                )
+            )
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_ads_boost_starts(s)
+        assert counts["started"] == 1, counts
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/spend")
+        assert r.status_code == 200, r.text
+        assert r.json()["initiated_by"] == "scheduler"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_spend_endpoint_run_status_null_before_boost_started():
     """gate는 approved인데 boost_start를 아직 요청 안 한 상태(AdsBoostRun 행 자체가
     없음) — run_status는 "미실행"을 뜻하는 None이지 "pending" 등 지어낸 값이 아니다."""


### PR DESCRIPTION
## 배경
PR6(#4184)이 `publication_commands.initiated_by`(0367 컬럼, 'scheduler'|'human')를 채웠지만 어느 응답에도 직렬화하지 않았다 — "있어도 못 읽으면 안 닫힌 것"(페드루 PO). story #3805 배포 72 라이브 API 축 검증 도중 다음 큐(#3806 BE 축 라이브 실측)를 준비하며 자체발견했고, PO가 즉시 처방(③=이 작은 PR)을 정함.

## 변경
- `CommandResponse.initiated_by`: `/start`·`/pause`·`/resume` 공통 응답에 노출(human 경로만 값 있음, pause/resume은 이 축 구분 없어 null).
- `SpendSummaryResponse.initiated_by`: `GET /ads-boosts/{gate_id}/spend`에 노출 — 이 GET이 gate 단건조회 유일 자리라는 PR5의 `run_status` 선례를 그대로 재사용(2번째 GET 신설 안 함). scheduler 경로(`process_due_ads_boost_starts`)는 `/start`를 절대 안 거치므로 **이 GET이 scheduler 귀속을 관측할 유일한 축**.
- `get_ads_boost_spend_summary`: gate_id + operation="boost_start"로 `PublicationCommand` 단건조회(toggle_seq=0 고정이라 그 승인주기당 유일 1행) 후 `initiated_by` 반환. 순환import 회피 위해 함수 내부 지연 import(기존 관례 동형).

## 테스트
- `test_start_response_serializes_initiated_by_human`(human, POST /start 응답)
- `test_spend_endpoint_serializes_initiated_by_scheduler`(scheduler, GET /spend 응답 — starts_at을 직접 과거로 봉인해 워커 픽업 유도)
- 뮤테이션 셀프체크: 두 직렬화 지점을 `initiated_by=None`으로 강제 → 정확히 이 2건만 RED, 나머지 51건 그대로 GREEN 확인 후 원복.
- 회귀: ads_boost 관련 전 스위트(execution/spend/starts_worker/starts_cron_wiring/worker/gate) 53/53 GREEN.

## 범위 밖
- 마이그레이션 0건(0367 컬럼 재사용, 직렬화만).
- 유나(design) 스킵 — 화면 없음(BE 전용).
- FE 「예약 실행(자동)」 표기는 #3806 카드에 적기만(디디 후속, 화면 재편 때).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn