### PR TITLE
[SID:3806] fix(FE): 게이트 상세 해소자·상태 날것 표기 정정(PR 9 ①)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4780,6 +4780,8 @@
     "boostExecutionStartConfirmTitle": "Start boost",
     "boostExecutionStartConfirmDescription": "This starts the boost under the conditions below. Once started, the sealed budget and schedule run as-is.",
     "boostExecutionStartBeforeSchedule": "Before start date ({date})",
+    "boostExecutionInitiatedByScheduler": "Started: scheduled (automatic) {date}",
+    "boostExecutionInitiatedByHuman": "Started: manual click",
     "commentReplyAlreadySentCount": "{count} replies already sent to this comment",
     "commentReplyTargetLabel": "Target comment",
     "commentReplyTargetTextLabel": "Target comment body",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4780,6 +4780,8 @@
     "boostExecutionStartConfirmTitle": "홍보 시작",
     "boostExecutionStartConfirmDescription": "아래 조건으로 홍보를 시작합니다. 시작 뒤에는 예산·기간이 봉인된 그대로 집행됩니다.",
     "boostExecutionStartBeforeSchedule": "시작일 전입니다({date})",
+    "boostExecutionInitiatedByScheduler": "시작: 예약 실행(자동) {date}",
+    "boostExecutionInitiatedByHuman": "시작: 사람 클릭",
     "commentReplyAlreadySentCount": "이 댓글에 이미 보낸 답변 {count}건",
     "commentReplyTargetLabel": "대상 댓글",
     "commentReplyTargetTextLabel": "대상 댓글 본문",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -466,6 +466,58 @@ describe('GateDetailPage — gate_type 사람 낱말(story #3565)', () => {
   });
 });
 
+// story #3806 PR 9(페드루 PO 리뷰 2026-09-11 — 「{member id}님이 처리 — 상태: approved」
+// 처럼 member id·상태 enum 원문이 그대로 뜨던 결함) — mount()는 /api/team-members를
+// 커스터마이즈 못 해(기본 폴백 {data:[]}) 이 describe는 자체 fetch mock을 쓴다.
+describe('GateDetailPage — 해소자·상태 낱말 원문 노출 금지(story #3806 PR 9)', () => {
+  async function mountWithTeamMembers(gateFixture: GateItem, teamMembers: { id: string; name: string }[]) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/gates/gate-1') return { ok: true, status: 200, json: async () => ({ data: gateFixture }) };
+      if (url === '/api/team-members') return { ok: true, json: async () => ({ data: teamMembers }) };
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    // team-members fetch가 비동기로 한 텀 더 걸린다 — memberNames state 반영까지 대기.
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+  }
+
+  it('⭐resolver_id가 team-members에 있으면 이름·번역된 상태 낱말이 뜨고 원시 id·enum은 0', async () => {
+    await mountWithTeamMembers(
+      gate({ status: 'approved', resolver_id: 'd823926d-aaaa-bbbb-cccc-000000000001', resolved_at: new Date().toISOString() }),
+      [{ id: 'd823926d-aaaa-bbbb-cccc-000000000001', name: '페드루 올리베이라' }],
+    );
+    expect(container.textContent).toContain('페드루 올리베이라님이 처리');
+    expect(container.textContent).toContain(koMessages.cage.gateStatusApproved);
+    expect(container.textContent).not.toContain('approved');
+    expect(container.textContent).not.toContain('d823926d');
+  });
+
+  // 정정 前엔 이 경우 `d823926d`(id 앞 8자)가 화면에 그대로 떴다 — 지금은 이름을
+  // 모르면 「누가」 자체를 말하지 않고 상태만 말한다(raw id 노출 경로 자체 제거).
+  it('⭐resolver_id가 team-members에 없으면(비동기 경합·조직 밖 등) raw id 대신 이름 없는 문장으로 물러난다', async () => {
+    await mountWithTeamMembers(
+      gate({ status: 'approved', resolver_id: 'd823926d-aaaa-bbbb-cccc-000000000001', resolved_at: new Date().toISOString() }),
+      [], // team-members 응답에 이 resolver가 없음
+    );
+    expect(container.textContent).toContain(koMessages.cage.gateDetailResolvedStatus.replace('{status}', koMessages.cage.gateStatusApproved));
+    expect(container.textContent).not.toContain('d823926d');
+    expect(container.textContent).not.toContain('approved');
+  });
+
+  it('status=rejected도 번역된 낱말(반려됨)로 뜬다(승인됨 하나만 대조하면 앞뒤 안 맞음)', async () => {
+    await mountWithTeamMembers(
+      gate({ status: 'rejected', resolver_id: 'm-1', resolved_at: new Date().toISOString() }),
+      [{ id: 'm-1', name: '카디르' }],
+    );
+    expect(container.textContent).toContain('카디르님이 처리');
+    expect(container.textContent).toContain(koMessages.cage.gateStatusRejected);
+    expect(container.textContent).not.toContain('rejected');
+  });
+});
+
 describe('GateDetailPage — 실시간 해소 반영(story #2985 AC2)', () => {
   it('mux가 conversation.gate_resolved(같은 gate_id)를 쏘면 재조회된다', async () => {
     let getCount = 0;

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -15,6 +15,7 @@ import { GateUndoButton, isUndoEligible } from '@/components/cage/gate-undo-butt
 import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
 import { deriveRiskLevel, usesSignatureFlow, deriveGateProofState, isDecisionGate, deriveDecisionFacts } from '@/components/cage/gate-risk';
 import { gateTypeLabel } from '@/lib/gate-type-label';
+import { gateStatusLabel } from '@/lib/gate-status-label';
 import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
@@ -387,9 +388,14 @@ export default function GateDetailPage() {
                           Auto로 단정하던 게 자기모순의 절반이었다). */}
                     <p className="text-[11px] text-muted-foreground">
                       {gate.status !== 'pending'
-                        ? (gate.resolver_id
-                            ? t('gateDetailResolvedByStatus', { name: memberNames[gate.resolver_id] ?? gate.resolver_id.slice(0, 8), status: gate.status })
-                            : t('gateDetailResolvedStatus', { status: gate.status }))
+                        ? (gate.resolver_id && memberNames[gate.resolver_id]
+                            // story #3806 PR 9(페드루 PO 리뷰 2026-09-11 실측) — 이름을 아직
+                            // 모르면(비동기 조회 경합·조직 밖 등) id 스니펫을 날것으로 보여주던
+                            // 자리를 없앴다 — 이름을 확실히 알 때만 「{name}님이 처리」, 모르면
+                            // 그냥 「이미 처리됨」(gateDetailResolvedStatus)으로 조용히 물러난다
+                            // (raw id 노출 경로 자체를 제거 — 타이밍이든 진짜 미스든 둘 다 막힘).
+                            ? t('gateDetailResolvedByStatus', { name: memberNames[gate.resolver_id], status: gateStatusLabel(gate.status, t) })
+                            : t('gateDetailResolvedStatus', { status: gateStatusLabel(gate.status, t) }))
                         : gateDecision(gate) === 'block' ? t('gateReadonlyBlock')
                         : gateDecision(gate) === 'auto_merge' ? t('gateReadonlyAuto')
                         : t('gateReadonlyNoVerdict')}

--- a/apps/web/src/components/cage/boost-execution-control.test.tsx
+++ b/apps/web/src/components/cage/boost-execution-control.test.tsx
@@ -62,6 +62,49 @@ describe('BoostExecutionControl — story #3806(Phase3·3-2 PR5, 유나 §절 §
     expect(document.body.querySelector('[data-testid="boost-start-trigger"]')).toBeNull();
   });
 
+  // story #3806 PR 9②(PR8 #4185, 페드루 PO 確定 2026-09-11) — /spend가 신규
+  // initiated_by를 실으면 「시작: ...」 한 줄이 뜬다. PR8 착지 前엔 이 필드가
+  // 응답에 없어(undefined) 항상 숨어야 한다 — falsy-safe 회귀 가드.
+  it('⭐initiated_by="human" — 「시작: 사람 클릭」이 뜬다', async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse({ data: { run_status: 'running', initiated_by: 'human' } }));
+    await act(async () => {
+      root.render(wrap(
+        <BoostExecutionControl orgId="org-1" gateId="gate-1" {...SEALED} sealedAdsStartsAt="2026-09-01T00:00:00Z" />,
+      ));
+    });
+    await flush();
+
+    expect(document.body.querySelector('[data-testid="boost-execution-initiated-by"]')?.textContent)
+      .toBe(koMessages.cage.boostExecutionInitiatedByHuman);
+  });
+
+  it('⭐initiated_by="scheduler" — 「시작: 예약 실행(자동) {date}」가 봉인 starts_at으로 뜬다', async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse({ data: { run_status: 'running', initiated_by: 'scheduler' } }));
+    await act(async () => {
+      root.render(wrap(
+        <BoostExecutionControl orgId="org-1" gateId="gate-1" {...SEALED} sealedAdsStartsAt="2026-09-01T09:00:00Z" />,
+      ));
+    });
+    await flush();
+
+    const text = document.body.querySelector('[data-testid="boost-execution-initiated-by"]')?.textContent ?? '';
+    expect(text).toContain('예약 실행(자동)');
+    expect(text).toContain('09-01');
+    expect(text).not.toContain('사람 클릭');
+  });
+
+  it('initiated_by가 응답에 없으면(PR8 미착지·구 데이터) 「시작: ...」 줄 자체가 안 뜬다(falsy-safe)', async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse({ data: { run_status: 'running' } }));
+    await act(async () => {
+      root.render(wrap(
+        <BoostExecutionControl orgId="org-1" gateId="gate-1" {...SEALED} sealedAdsStartsAt="2026-09-01T00:00:00Z" />,
+      ));
+    });
+    await flush();
+
+    expect(document.body.querySelector('[data-testid="boost-execution-initiated-by"]')).toBeNull();
+  });
+
   it('⭐run_status="paused" — 「중지됨」 표시 + 「재개」 버튼만 뜬다', async () => {
     mockedFetch.mockResolvedValueOnce(jsonResponse({ data: { run_status: 'paused' } }));
     await act(async () => {

--- a/apps/web/src/components/cage/boost-execution-control.tsx
+++ b/apps/web/src/components/cage/boost-execution-control.tsx
@@ -33,6 +33,11 @@ export interface BoostExecutionControlProps {
 }
 
 type RunStatus = 'pending' | 'running' | 'paused' | 'failed';
+// story #3806 PR 9②(PR8 #4185, 페드루 PO 確定 2026-09-11) — boost_start 커맨드의
+// initiated_by. /spend(SpendSummaryResponse)에 실린다 — POST /start 응답
+// (CommandResponse)에도 있지만 scheduler 기동분은 이 화면이 그 POST를 절대 안
+// 거치므로(PR6 워커가 직접 실행) /spend가 유일한 관측 축(PR8 diff 확認).
+type InitiatedBy = 'scheduler' | 'human';
 
 export function BoostExecutionControl({
   orgId, gateId, sealedAdsBudgetMinor, sealedAdsCurrency, sealedAdsStartsAt, sealedAdsEndsAt, sealedAdsObjective,
@@ -42,6 +47,7 @@ export function BoostExecutionControl({
   const locale = useLocale();
   const displayTimezone = resolveDisplayTimezone().tz;
   const [runStatus, setRunStatus] = useState<RunStatus | null>(null);
+  const [initiatedBy, setInitiatedBy] = useState<InitiatedBy | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [startConfirmOpen, setStartConfirmOpen] = useState(false);
   const [pauseConfirmOpen, setPauseConfirmOpen] = useState(false);
@@ -51,8 +57,11 @@ export function BoostExecutionControl({
   const load = () => {
     fetchWithAuth(`/api/organizations/${orgId}/ads-boosts/${gateId}/spend`)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`status ${r.status}`))))
-      .then((json: { data?: { run_status: RunStatus | null } }) => {
+      .then((json: { data?: { run_status: RunStatus | null; initiated_by?: InitiatedBy | null } }) => {
         setRunStatus(json.data?.run_status ?? null);
+        // story #3806 PR 9② — PR8(#4185) 착지 前엔 이 필드가 응답에 없어 항상
+        // undefined→null로 떨어진다(falsy-safe, 아래 렌더가 자동으로 숨는다).
+        setInitiatedBy(json.data?.initiated_by ?? null);
         setLoaded(true);
       })
       .catch(() => setLoaded(true));
@@ -161,6 +170,20 @@ export function BoostExecutionControl({
           {runStatus === 'running' ? t('boostExecutionStatusRunning') : t('boostExecutionStatusPaused')}
         </span>
       </p>
+      {/* story #3806 PR 9②(PR8 #4185) — initiated_by 없으면(PR8 미착지·boost_start
+          커맨드 자체가 없는 과거 데이터 등) 조용히 숨는다(지어내지 않는다). scheduler는
+          봉인 starts_at(이미 아는 값, 새 타임스탬프 필드 0)을 그대로 보여준다. */}
+      {initiatedBy === 'human' ? (
+        <p className="text-xs text-muted-foreground" data-testid="boost-execution-initiated-by">
+          {t('boostExecutionInitiatedByHuman')}
+        </p>
+      ) : initiatedBy === 'scheduler' ? (
+        <p className="text-xs text-muted-foreground" data-testid="boost-execution-initiated-by">
+          {t('boostExecutionInitiatedByScheduler', {
+            date: sealedAdsStartsAt ? formatScheduledAt(sealedAdsStartsAt, displayTimezone).display : '',
+          })}
+        </p>
+      ) : null}
       {actionError ? <p className="text-xs text-destructive" data-testid="boost-execution-error">{actionError}</p> : null}
       {runStatus === 'running' ? (
         <Button variant="outline" size="sm" onClick={() => setPauseConfirmOpen(true)} data-testid="boost-pause-trigger">

--- a/apps/web/src/lib/gate-status-label.test.ts
+++ b/apps/web/src/lib/gate-status-label.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { gateStatusLabel } from './gate-status-label';
+import koMessages from '../../messages/ko.json';
+
+// story #3806 PR 9(카디르 QA 실측 2026-09-11 — 테스트 갭) — 기존 렌더 테스트 3건은
+// approved·rejected 2종만 대조해, held·voided 엔트리를 GATE_STATUS_LABEL_KEYS에서
+// 빼도 RED 0이었다(단방향 검사 공허통과 — feedback_one_directional_check_vacuous_
+// pass와 동형 함정). 여기서 쓰는 목록은 GATE_STATUS_LABEL_KEYS를 거꾸로 읽지 않고
+// 독립적으로 하드코딩(backend Gate.status 실 쓰임 5종, gate-status-label.ts 주석
+// 참고) — 매핑에서 엔트리를 빼면 그 값이 raw-fallback으로 떨어져 이 루프가 즉시
+// 잡는다(맵을 거울처럼 읽는 루프였다면 엔트리 삭제 자체가 검사 대상에서도 같이
+// 빠져 아무 것도 못 잡았을 것).
+const KNOWN_GATE_STATUSES = ['pending', 'approved', 'rejected', 'held', 'voided'];
+
+describe('gateStatusLabel — story #3806 PR 9(카디르 QA 실측 2026-09-11)', () => {
+  const t = (key: string) => (koMessages.cage as Record<string, string>)[key] ?? key;
+
+  it('⭐등재된 5종 status 전부 원시 문자열과 다른 낱말로 뜬다(엔트리 하나만 빠져도 이 루프가 그 값에서 RED)', () => {
+    for (const status of KNOWN_GATE_STATUSES) {
+      expect(gateStatusLabel(status, t)).not.toBe(status);
+    }
+  });
+
+  it('미등재 값(미래 확장·오타 등)은 지어내지 않고 원문 그대로 폴백한다', () => {
+    const identity = (key: string) => key;
+    expect(gateStatusLabel('some_future_status', identity)).toBe('some_future_status');
+  });
+});

--- a/apps/web/src/lib/gate-status-label.ts
+++ b/apps/web/src/lib/gate-status-label.ts
@@ -1,0 +1,19 @@
+// story #3806 PR 9(페드루 PO 리뷰 2026-09-11 — 「{member id}님이 처리 — 상태: approved」
+// 처럼 gate.status 원시 enum이 그대로 새던 결함) — gate-type-label.ts와 동형 패턴.
+// Gate.status는 backend/app/models/gate.py(String(20), server_default="pending")이며
+// 실제 쓰이는 값은 app/services/gate_service.py 등에 흩어진 리터럴 grep으로 확認한
+// 5종(pending·approved·rejected·held·voided) — 이 화면(gates/[id]/page.tsx)은 그중
+// «status !== 'pending'»만 이 표를 탄다.
+export const GATE_STATUS_LABEL_KEYS: Record<string, string> = {
+  pending: 'gateStatusPending',
+  approved: 'gateStatusApproved',
+  rejected: 'gateStatusRejected',
+  held: 'gateStatusHeld',
+  voided: 'gateStatusVoided',
+};
+
+/** gate.status → 사람 낱말. 미등재 값(지어내지 않는다, channelLabel과 동형 폴백)은 원문 그대로. */
+export function gateStatusLabel(status: string, t: (key: string) => string): string {
+  const key = GATE_STATUS_LABEL_KEYS[status];
+  return key ? t(key) : status;
+}


### PR DESCRIPTION
## 요약
story #3806(PR 9①, 페드루 PO 리뷰) — 게이트 상세(`gates/[id]/page.tsx`)에서 「{member id}님이 처리 — 상태: approved」처럼 member id·상태 enum 원문이 그대로 뜨던 결함.

- `gate.status` 원시 enum을 새 헬퍼 `gateStatusLabel()`(gate-type-label.ts 동형 패턴)로 교체 — 이미 등재된 cage 네임스페이스 키(gateStatusPending/Approved/Rejected/Held/Voided) 재사용(새 낱말 0).
- resolver 이름을 아직 모를 때 id 조각을 날것으로 보여주던 폴백 제거 — 이름을 확실히 알 때만 「{name}님이 처리」, 모르면 이름 언급 없이 「이미 처리됨」으로 물러난다(raw id 노출 경로 자체 제거).

## 테스트
신규 3건 + 뮤테이션 셀프체크(원복 전 정확히 이 3건만 RED, 페드루가 실측한 문구를 그대로 재현) 전부 GREEN. 기존 GateDetailPage 스위트 40건 회귀 0·전체 FE 7587건 회귀 0·tsc 0에러.

## 남은 조각
PR 9②(PR8 `initiated_by` 필드 착지 전제 — 「시작: 예약 실행(자동) HH:MM」/「시작: 사람 클릭」)는 미르코 PR8이 실제로 착지해 정확한 필드 위치·형을 확認한 뒤 별도 커밋으로 진행(추측 배선 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8