### PR TITLE
[SID:3807] 데스크톱 업데이트 매니페스트 공개 중계(/desktop/updates/macos.json)

### DIFF
--- a/apps/web/src/app/desktop/updates/macos.json/route.test.ts
+++ b/apps/web/src/app/desktop/updates/macos.json/route.test.ts
@@ -1,0 +1,33 @@
+// [SID:3807] 슬라이스12 AC2 — 리다이렉트 0·Content-Type application/json 정확히(no-store)·
+// 원문 그대로 중계(재조립 0)·업스트림 실패 시 502(깨진 200 아님) 회귀가드.
+import { describe, expect, it, vi } from 'vitest';
+
+const { fetchDesktopUpdateManifestMock } = vi.hoisted(() => ({
+  fetchDesktopUpdateManifestMock: vi.fn(),
+}));
+vi.mock('@/lib/desktop-updates', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/desktop-updates')>();
+  return { ...actual, fetchDesktopUpdateManifest: fetchDesktopUpdateManifestMock };
+});
+
+import { GET } from './route';
+import { DesktopManifestUnavailableError } from '@/lib/desktop-updates';
+
+describe('GET /desktop/updates/macos.json', () => {
+  it('relays the GCS manifest verbatim with 200 + application/json + no-store, no redirect', async () => {
+    fetchDesktopUpdateManifestMock.mockResolvedValue('{"version":"9.9.9"}');
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    expect(res.headers.get('Location')).toBeNull();
+    const body = await res.text();
+    expect(body).toBe('{"version":"9.9.9"}');
+  });
+
+  it('fails loud (502, not a broken 200) when the GCS manifest is unavailable', async () => {
+    fetchDesktopUpdateManifestMock.mockRejectedValue(new DesktopManifestUnavailableError('boom'));
+    const res = await GET();
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/src/app/desktop/updates/macos.json/route.test.ts
+++ b/apps/web/src/app/desktop/updates/macos.json/route.test.ts
@@ -13,16 +13,21 @@ vi.mock('@/lib/desktop-updates', async (importOriginal) => {
 import { GET } from './route';
 import { DesktopManifestUnavailableError } from '@/lib/desktop-updates';
 
+// [SID:3807] 카디르 QA #4187 발견 ③ — 압축형 픽스처는 parse→stringify 재조립 뮤테이션이
+// 공허통과한다(우연히 바이트 동일). mobile CI의 실 macos.json 모양(jq 2칸 들여쓰기)을 그대로
+// 써서 재조립이 일어나면 반드시 바이트가 달라지게 한다.
+const FIXTURE_MANIFEST = '{\n  "version": "9.9.9",\n  "platforms": {\n    "darwin-aarch64": {\n      "signature": "abc",\n      "url": "https://example/x"\n    }\n  }\n}\n';
+
 describe('GET /desktop/updates/macos.json', () => {
   it('relays the GCS manifest verbatim with 200 + application/json + no-store, no redirect', async () => {
-    fetchDesktopUpdateManifestMock.mockResolvedValue('{"version":"9.9.9"}');
+    fetchDesktopUpdateManifestMock.mockResolvedValue(FIXTURE_MANIFEST);
     const res = await GET();
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toBe('application/json');
     expect(res.headers.get('Cache-Control')).toBe('no-store');
     expect(res.headers.get('Location')).toBeNull();
     const body = await res.text();
-    expect(body).toBe('{"version":"9.9.9"}');
+    expect(body).toBe(FIXTURE_MANIFEST);
   });
 
   it('fails loud (502, not a broken 200) when the GCS manifest is unavailable', async () => {

--- a/apps/web/src/app/desktop/updates/macos.json/route.ts
+++ b/apps/web/src/app/desktop/updates/macos.json/route.ts
@@ -1,0 +1,21 @@
+// §10.2류 공개 경로 — 데스크톱 컴패니언이 인증 쿠키 없이 업데이트를 확인하는 자리
+// (proxy.ts PUBLIC_PREFIX '/desktop/updates/'). 본문은 desktop-updates.ts 단일 출처
+// (mobile 레포 CI가 만든 GCS 매니페스트를 그대로 중계, 이 파일은 손으로 안 지음).
+import { NextResponse } from 'next/server';
+import { DesktopManifestUnavailableError, fetchDesktopUpdateManifest } from '@/lib/desktop-updates';
+
+export async function GET() {
+  try {
+    const body = await fetchDesktopUpdateManifest();
+    return new NextResponse(body, {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+  } catch (err) {
+    if (err instanceof DesktopManifestUnavailableError) {
+      console.error('desktop_updates.manifest_unavailable', err);
+      return NextResponse.json({ error: 'manifest_unavailable' }, { status: 502 });
+    }
+    throw err;
+  }
+}

--- a/apps/web/src/lib/desktop-updates.test.ts
+++ b/apps/web/src/lib/desktop-updates.test.ts
@@ -2,14 +2,20 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DesktopManifestUnavailableError, fetchDesktopUpdateManifest } from './desktop-updates';
 
+// [SID:3807] 카디르 QA #4187 발견 ③ — 압축형 2키 JSON은 parse→stringify 재조립을 해도
+// 바이트가 우연히 같아 "원문 그대로" 뮤테이션가드가 공허통과한다. mobile CI의 실 macos.json은
+// jq가 2칸 들여쓰기로 찍는다(pretty-print) — 그 실제 모양을 픽스처로 써서 재조립이 일어나면
+// (들여쓰기 손실) 반드시 바이트가 달라지게 한다.
+const FIXTURE_MANIFEST = '{\n  "version": "0.1.0",\n  "pub_date": "2026-09-11T00:00:00Z",\n  "platforms": {\n    "darwin-aarch64": {\n      "signature": "abc",\n      "url": "https://example/x"\n    }\n  }\n}\n';
+
 describe('fetchDesktopUpdateManifest', () => {
   it('returns the GCS manifest body verbatim on success — no reparsing/reassembly', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
-      text: async () => '{"version":"0.1.0","pub_date":"2026-09-11T00:00:00Z"}',
+      text: async () => FIXTURE_MANIFEST,
     });
     const body = await fetchDesktopUpdateManifest(mockFetch as unknown as typeof fetch);
-    expect(body).toBe('{"version":"0.1.0","pub_date":"2026-09-11T00:00:00Z"}');
+    expect(body).toBe(FIXTURE_MANIFEST);
     expect(mockFetch).toHaveBeenCalledWith(
       'https://storage.googleapis.com/sprintable-desktop-releases-dev/macos/latest/macos.json',
       { cache: 'no-store' },

--- a/apps/web/src/lib/desktop-updates.test.ts
+++ b/apps/web/src/lib/desktop-updates.test.ts
@@ -1,0 +1,25 @@
+// [SID:3807] 슬라이스12 AC2 — GCS 공개읽기 버킷(mobile 레포 CI가 채움) 중계 순수 로직.
+import { describe, expect, it, vi } from 'vitest';
+import { DesktopManifestUnavailableError, fetchDesktopUpdateManifest } from './desktop-updates';
+
+describe('fetchDesktopUpdateManifest', () => {
+  it('returns the GCS manifest body verbatim on success — no reparsing/reassembly', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => '{"version":"0.1.0","pub_date":"2026-09-11T00:00:00Z"}',
+    });
+    const body = await fetchDesktopUpdateManifest(mockFetch as unknown as typeof fetch);
+    expect(body).toBe('{"version":"0.1.0","pub_date":"2026-09-11T00:00:00Z"}');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://storage.googleapis.com/sprintable-desktop-releases-dev/macos/latest/macos.json',
+      { cache: 'no-store' },
+    );
+  });
+
+  it('throws DesktopManifestUnavailableError when GCS returns non-2xx — mutation guard: bucket object missing/gone must not surface as a broken 200', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+    await expect(
+      fetchDesktopUpdateManifest(mockFetch as unknown as typeof fetch),
+    ).rejects.toThrow(DesktopManifestUnavailableError);
+  });
+});

--- a/apps/web/src/lib/desktop-updates.ts
+++ b/apps/web/src/lib/desktop-updates.ts
@@ -1,0 +1,23 @@
+// [SID:3807] 슬라이스12 AC2(PO 確定 2026-09-11) — 데스크톱 컴패니언(sprintable-mobile)의
+// check_for_updates가 WEB_ORIGIN에서 파생하는 경로({WEB_ORIGIN}/desktop/updates/macos.json)를
+// 여기서 받는다. 매니페스트 원본은 이 레포가 손으로 안 짓는다 — mobile 레포 CI(PR #95)가
+// 실 빌드·실 서명해서 공개읽기 GCS 버킷(gs://sprintable-desktop-releases-dev)의
+// macos/latest/macos.json에 올려둔 걸 그대로 중계만 한다.
+
+const GCS_MANIFEST_URL =
+  'https://storage.googleapis.com/sprintable-desktop-releases-dev/macos/latest/macos.json';
+
+export class DesktopManifestUnavailableError extends Error {}
+
+/** GCS의 실 매니페스트를 그대로 가져온다(파싱·재조립 0 — 원문 그대로 중계). */
+export async function fetchDesktopUpdateManifest(
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  const res = await fetchImpl(GCS_MANIFEST_URL, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new DesktopManifestUnavailableError(
+      `GCS manifest fetch failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  return res.text();
+}

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -66,6 +66,10 @@ export const RESERVED_FIRST_SEGMENTS = new Set([
   // 라우트. `scripts/verify-reserved-first-segments-sync.ts`가 어긋남을 CI에서 잡는다.
   '.well-known', 'activity', 'api', 'apple-app-site-association', 'apple-icon.png', 'auth',
   'channel', 'chats', 'dashboard',
+  // [SID:3807] 슬라이스12 AC2 — 새 최상위 app/desktop/updates/macos.json(공개 업데이트
+  // 매니페스트 중계) 신설. 미등재 시 '/desktop/...'가 워크스페이스 slug로 오인될 수 있다
+  // (카디르 QA #4187 발견).
+  'desktop',
   'favicon.ico', 'forgot-password', 'gates', 'icon.svg', 'inbox', 'internal-dogfood',
   'invite', 'login', 'loop-queue', 'manifest.webmanifest', 'meetings', 'mfa', 'more',
   // [P1] iOS TestFlight 구글 로그인 후 404 인시던트 — AASA(.well-known/apple-app-site-association)

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -109,6 +109,11 @@ describe('proxy', () => {
     expect(response.status).toBe(200);
   });
 
+  it('treats /desktop/updates/macos.json as public — [SID:3807] 데스크톱 컴패니언이 로그인 세션 없이 업데이트를 확인하는 자리, 누락 시 /login 307로 튕겨 check_for_updates가 항상 실패한다', async () => {
+    const response = await middleware(makeRequest('/desktop/updates/macos.json'));
+    expect(response.status).toBe(200);
+  });
+
   it('treats /native/oauth-return as public (no cookie) — [P1] 실측(next start+curl)으로 발견: 누락 시 307-to-login으로 폴백 페이지가 렌더되지 않았다', async () => {
     // native 핸드오프 콜백은 이 응답에 웹 세션 쿠키를 세팅하지 않으므로(격리 rail) 쿠키 없는
     // 요청이 정상 케이스 — /auth/native와 동일 결함 클래스.

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -110,6 +110,11 @@ const PUBLIC_PREFIX = [
   // 놓치면(위 두 개와 별개 가드 — route-resolve.ts RESERVED_FIRST_SEGMENTS와는 다른 축)
   // 방문자가 보호 라우트로 오인돼 /login 307로 튕긴다.
   '/refund-policy',
+  // [SID:3807] 슬라이스12 AC2(PO 確定 2026-09-11) — 데스크톱 컴패니언(sprintable-mobile)의
+  // check_for_updates가 인증 세션 없이 호출하는 업데이트 매니페스트 자리. 실 파일은 mobile
+  // 레포 CI(PR #95)가 만들어 GCS 공개읽기 버킷에 올린 걸 이 경로가 그대로 중계만 한다
+  // (route.ts §desktop/updates/macos.json, 본문 desktop-updates.ts).
+  '/desktop/updates/',
 ];
 
 export const SP_AT_COOKIE = 'sp_at';


### PR DESCRIPTION
## 무엇

슬라이스12(다운로드·설치·업데이트 매니페스트 호스팅) AC2. sprintable-mobile 데스크톱 컴패니언의 `check_for_updates`가 인증 세션 없이 조회하는 `{WEB_ORIGIN}/desktop/updates/macos.json`을 공개 경로로 연다.

- `apps/web/src/lib/desktop-updates.ts` — 실 매니페스트 원본은 이 레포가 손으로 안 짓는다. mobile 레포 CI([PR #95](https://github.com/moonklabs/sprintable-mobile/pull/95))가 실 빌드·실 서명해서 공개읽기 GCS 버킷(`gs://sprintable-desktop-releases-dev`)의 `macos/latest/macos.json`에 올린 걸 그대로 중계만 한다(파싱·재조립 0).
- `apps/web/src/app/desktop/updates/macos.json/route.ts` — `.well-known/apple-app-site-association` 선례와 동일 패턴(얇은 GET → lib 위임 → `NextResponse` + 명시 헤더 + 타입드 에러로 502).
- `apps/web/src/proxy.ts` — `PUBLIC_PREFIX`에 `/desktop/updates/` 추가. 누락 시 인증 리다이렉트(307 `/login`)로 튕겨 `check_for_updates`가 항상 실패한다.

## 증거

**단위 테스트 — 실행 결과(신규/수정 3파일)**:
```
$ pnpm exec vitest run src/lib/desktop-updates.test.ts src/app/desktop/updates/macos.json/route.test.ts src/proxy.test.ts
 Test Files  3 passed (3)
      Tests  84 passed (84)
```
- `desktop-updates.test.ts`: GCS 200 → 원문 그대로 반환 검증 + GCS non-2xx → `DesktopManifestUnavailableError`(뮤테이션가드: 깨진 200 아님)
- `route.test.ts`: 200/`application/json`/`no-store`/`Location` null/원문 body 검증 + 업스트림 실패 시 502
- `proxy.test.ts`: `/desktop/updates/macos.json`이 미들웨어에서 200 통과(로그인 리다이렉트 안 걸림)

**AC1(mobile CI, 이 PR의 전제) 실측 — 오늘 실 러너 재트리거 결과**:
- GHA 실행: https://github.com/moonklabs/sprintable-mobile/actions/runs/34618554342 (conclusion: success)
- GCS 실 경로: `gs://sprintable-desktop-releases-dev/macos/0.1.0/Sprintable.app.tar.gz{,.sig}` + `macos/latest/macos.json`
- 비로그인 curl 실측(방금):
  - `GET https://storage.googleapis.com/sprintable-desktop-releases-dev/macos/latest/macos.json` → `200 application/json`, `version:"0.1.0"`, `platforms.darwin-aarch64.{url,signature}` 채워짐
  - `HEAD .../macos/0.1.0/Sprintable.app.tar.gz` → `200 application/gzip`
  - `HEAD .../macos/0.1.0/Sprintable.app.tar.gz.sig` → `200 text/plain`

이 PR이 머지되면 dev-app 배포 후 같은 매니페스트를 `{WEB_ORIGIN}/desktop/updates/macos.json`으로 비로그인 200 재검증 예정(AC4 왕복 실측의 전제 조건).

## 다음

- AC3(다운로드 자리, dev-app 화면)은 디디군 담당 — 이 PR 머지 후 route 계약(`version`/`pub_date`/`platforms.darwin-aarch64.{url,signature}`) 그대로 전달.
- AC4(이 머신 설치 왕복 실측 + 매니페스트 버전 올린 양성대조)는 이 PR 머지 후 착수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xkNnQ4d69Wg1HZGm3WoYM