### PR TITLE
[SID:3806] fix(FE): ads_boost 실행 블록을 needsAction/gate.status와 분리(PR 10)

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -761,3 +761,55 @@ describe('GateDetailPage — story #3128 대상 실물 진입 경로', () => {
     expect(link).toBeTruthy();
   });
 });
+
+// story #3806 PR 10(페드루 PO 실측 2026-09-11 16:18Z 라이브 캡처 — 결함 1) — ads_boost
+// 실행 블록이 gate.status==='approved'로만 게이트돼 있어, 승인 뒤 예산·기간을 바꿔 게이트가
+// pending으로 재오픈(reapproval_required)되면 needsAction=true 분기 전체가 켜지면서 실행
+// 블록(실행 중·중지)이 통째로 사라졌다 — run_status가 실제로 'running'이라도 화면에서
+// 중지 스위치를 잃는다(재승인할 때까지). mount()는 /ads-boosts/.../spend를 커스터마이즈
+// 못 해(기본 폴백 {data:[]}) 이 describe는 자체 fetch mock을 쓴다.
+describe('GateDetailPage — ads_boost 실행 블록은 needsAction/gate.status와 무관(story #3806 PR 10)', () => {
+  const adsBoostGate = (overrides: Partial<GateItem> = {}) => gate({
+    gate_type: 'ads_boost', can_approve: true, risk_grade: 'high',
+    sealed_ads_budget_minor: 50_000, sealed_ads_currency: 'KRW',
+    sealed_ads_starts_at: '2026-09-01T00:00:00Z', sealed_ads_ends_at: '2026-09-19T00:00:00Z',
+    sealed_ads_objective: 'POST_ENGAGEMENT',
+    ...overrides,
+  });
+
+  async function mountWithSpend(gateFixture: GateItem, spend: { run_status: string | null }) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/gates/gate-1') return { ok: true, status: 200, json: async () => ({ data: gateFixture }) };
+      if (url.includes('/ads-boosts/') && url.includes('/spend')) return { ok: true, json: async () => ({ data: spend }) };
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+  }
+
+  it('⭐status=pending·requires_human=true(재승인 대기)여도 run_status=running이면 「중지」 버튼이 그대로 뜬다', async () => {
+    await mountWithSpend(
+      adsBoostGate({ status: 'pending', requires_human: true, reapproval_required: true }),
+      { run_status: 'running' },
+    );
+    expect(document.body.querySelector('[data-testid="boost-pause-trigger"]')).not.toBeNull();
+  });
+
+  it('status=approved(정상 승인 상태)에서도 회귀 없이 그대로 뜬다(기존 동작 pin)', async () => {
+    await mountWithSpend(
+      adsBoostGate({ status: 'approved', requires_human: false }),
+      { run_status: 'running' },
+    );
+    expect(document.body.querySelector('[data-testid="boost-pause-trigger"]')).not.toBeNull();
+  });
+
+  it('run_status=null(진짜 미승인·최초 요청)이면 지어내지 않고 실행 블록 자체가 안 뜬다', async () => {
+    await mountWithSpend(
+      adsBoostGate({ status: 'pending', requires_human: true, sealed_ads_starts_at: null }),
+      { run_status: null },
+    );
+    expect(document.body.querySelector('[data-testid="boost-execution-control"]')).toBeNull();
+  });
+});

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -404,20 +404,6 @@ export default function GateDetailPage() {
                     {isUndoEligible(gate, currentTeamMemberId) ? (
                       <GateUndoButton gateId={gate.id} onUndone={() => void fetchGate()} />
                     ) : null}
-                    {/* story #3806(Phase3·3-2 PR5, 유나 §절 §2) — ads_boost·승인됨 게이트의
-                        시작/중지/재개. 상태 3 중 「승인됨」(approved)일 때만 — 「승인 대기」는
-                        needsAction 분기가 이미 따로 처리(액션 버튼), 「변경됨·재승인 필요」는
-                        isResubmitWaiting류로 별개(gate.status가 다시 pending으로 재오픈됨). */}
-                    {gate.gate_type === 'ads_boost' && gate.status === 'approved' && gate.org_id ? (
-                      <BoostExecutionControl
-                        orgId={gate.org_id} gateId={gate.id}
-                        sealedAdsBudgetMinor={gate.sealed_ads_budget_minor ?? null}
-                        sealedAdsCurrency={gate.sealed_ads_currency ?? null}
-                        sealedAdsStartsAt={gate.sealed_ads_starts_at ?? null}
-                        sealedAdsEndsAt={gate.sealed_ads_ends_at ?? null}
-                        sealedAdsObjective={gate.sealed_ads_objective ?? null}
-                      />
-                    ) : null}
                   </div>
                 ) : !canAct ? (
                   // story #2091(P0) — needsAction=true(게이트 자체는 사람 판단이 필요)이지만
@@ -515,6 +501,27 @@ export default function GateDetailPage() {
                     </Button>
                   </div>
                 )}
+
+                {/* story #3806 PR 10(페드루 PO 실측 2026-09-11 16:18Z — 결함 1) — ads_boost
+                    실행 블록(실행 중/시작·중지)을 gate.status===`'approved'`로 게이트하면
+                    「승인됨→예산·기간 변경→pending 재오픈(reapproval_required)」 도중 실제로는
+                    아직 run_status='running'(집행 中)인데도 화면에서 통째로 사라져 중지 스위치를
+                    잃는다(재승인까지). needsAction/canAct 분기와도 무관하게 항상 마운트해(위
+                    §2902·§2975 AC4와 같은 원칙) `BoostExecutionControl` 자신의 run_status
+                    폴링이 판단한다 — gate.status가 pending이든 approved든 「결재 대기(변경
+                    재승인)」 배지와 「실행 중 · 중지」가 같은 화면에 공존(다른 메커니즘=다른
+                    낱말로, 뭉개지 않는다). sealed_ads_starts_at이 아직 없으면(진짜 미승인·최초
+                    요청) 컴포넌트 자신이 null을 반환해 지어내지 않는다. */}
+                {gate.gate_type === 'ads_boost' && gate.org_id ? (
+                  <BoostExecutionControl
+                    orgId={gate.org_id} gateId={gate.id}
+                    sealedAdsBudgetMinor={gate.sealed_ads_budget_minor ?? null}
+                    sealedAdsCurrency={gate.sealed_ads_currency ?? null}
+                    sealedAdsStartsAt={gate.sealed_ads_starts_at ?? null}
+                    sealedAdsEndsAt={gate.sealed_ads_ends_at ?? null}
+                    sealedAdsObjective={gate.sealed_ads_objective ?? null}
+                  />
+                ) : null}
 
                 {/* story #2902(후보 B, S2h①③ list_entity_backlinks 확장 소비처) — 「이 게이트를
                     언급한 대화」 역참조. 기성 EntityBacklinksSection(3곳 소비 중) 그대로 재사용 —


### PR DESCRIPTION
## 요약
story #3806(PR 10, 페드루 PO 라이브 실측 2026-09-11 16:18Z — 감액 재요청 라이브 검증 中 발견한 결함 1) — 승인된 boost의 예산/기간을 변경해 재요청하면 게이트가 pending으로 재오픈(reapproval_required)되는데, 실행 블록(실행 중/시작·중지)이 `gate.status === 'approved'`로만 게이트돼 있어 통째로 사라졌다 — run_status는 여전히 'running'인데 화면에서 중지 스위치를 잃는다(재승인할 때까지 지출을 막을 방법이 없어짐 — 사고 위험).

## 정정
`BoostExecutionControl`을 needsAction/canAct 분기와 무관하게 항상 마운트 — `EntityBacklinksSection`·`GateActivityHistory`(§2902·§2975 AC4)가 이미 확립한 "감사·안전 표면은 액션 가능 여부와 별개로 항상 선다" 원칙과 동형. 컴포넌트 자신의 run_status 폴링이 렌더 여부를 판단(gate.status는 더 이상 안 봄).

## 테스트
신규 3건 + 뮤테이션 셀프체크(원복 前 조건에서 pending+running 테스트만 RED — 페드루가 라이브에서 본 증상 재현) 전부 GREEN. 전체 FE 7595건 회귀 0·tsc 0에러.

## 캡처
로컬 시드(pending+running) 1장 → 유나 → 카디르.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8