### PR TITLE
[SID:3806] feat: paid 지출 캡처 cron 배선 + 상한 내 실행 자동 중지(PR 11)

### DIFF
--- a/backend/alembic/versions/0368_ads_boost_runs_cap_reached_at.py
+++ b/backend/alembic/versions/0368_ads_boost_runs_cap_reached_at.py
@@ -1,0 +1,26 @@
+"""story #3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z) — 「상한 내 실행」
+실물 처방(§7 실측 열 「상한 초과 0건」의 장치). `ads_boost_runs.cap_reached_at`:
+캡처된 paid 지출 합이 `gate.sealed_ads_budget_minor`에 도달/초과한 순간을 1회
+기록(nullable — 미도달이면 null, 지어내지 않는다). 이 시각을 찍은 뒤에만
+자동 중지(scheduler pause)를 시도해 같은 게이트를 매 tick 재-중지 요청하지
+않는다(멱등 게이트 역할)."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0368"
+down_revision = "0367"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ads_boost_runs",
+        sa.Column("cap_reached_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ads_boost_runs", "cap_reached_at")

--- a/backend/app/models/ads_boost_run.py
+++ b/backend/app/models/ads_boost_run.py
@@ -41,6 +41,11 @@ class AdsBoostRun(Base):
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default="pending")
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     paused_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z) — 캡처된 paid
+    # 지출 합이 gate.sealed_ads_budget_minor에 도달/초과한 순간(1회, 0368 마이그).
+    # null=미도달 — 지어내지 않는다. 이 값이 찍힌 뒤에만 자동 중지를 시도해 매 tick
+    # 재-중지 요청을 안 보내는 멱등 게이트(ads_spend_snapshots.py::_enforce_spend_cap).
+    cap_reached_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/routers/ads_boost_execution.py
+++ b/backend/app/routers/ads_boost_execution.py
@@ -220,6 +220,11 @@ class SpendSummaryResponse(BaseModel):
     # 정신 재사용) — 이 GET이 이미 gate_id 단건 조회 자리라 3번째 GET 신설 안 함.
     # boost_start 커맨드 자체가 없으면(gate 승인 직후·실행 前) None.
     initiated_by: str | None
+    # story #3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z) — §7 실측 열
+    # 「상한 초과 0건」의 장치. 캡처 spend 합이 sealed_ads_budget_minor에 도달한
+    # 시각(ads_boost_runs.cap_reached_at, 0368) — run 자체가 없거나 미도달이면
+    # null(지어내지 않는다).
+    cap_reached_at: str | None
     snapshots: list[SpendSnapshotView]
 
 
@@ -257,6 +262,7 @@ async def _get_ads_boost_spend_endpoint(
         sealed_ads_currency=summary["sealed_ads_currency"], captured_spend_minor=summary["captured_spend_minor"],
         remaining_minor=summary["remaining_minor"], run_status=summary["run_status"],
         initiated_by=summary["initiated_by"],
+        cap_reached_at=summary["cap_reached_at"].isoformat() if summary["cap_reached_at"] else None,
         snapshots=[
             SpendSnapshotView(
                 due_at=s["due_at"].isoformat(), captured_at=s["captured_at"].isoformat() if s["captured_at"] else None,

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1325,6 +1325,17 @@ async def publication_commands_tick(
         except Exception as exc:
             logger.exception("ads-boost-starts tick error: %s", exc)
             counts["ads_boost_starts"] = {"error": "unhandled"}
+        # story #3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z) — 「만들어졌는데
+        # 도는 자리 없음」 처방: `process_due_ads_spend_snapshots`가 PR4에서 만들어진
+        # 뒤 어떤 cron 축에도 피기백되지 않아(3-7 그라운딩 도중 자체발견) paid 지출이
+        # 실제로는 한 번도 자동 수집되지 않고 있었다 — 위 축들과 같은 피기백 사상
+        # (새 Cloud Scheduler 잡 0)·독립 try.
+        try:
+            from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+            counts["ads_spend_snapshots"] = await process_due_ads_spend_snapshots(session)
+        except Exception as exc:
+            logger.exception("ads-spend-snapshots tick error: %s", exc)
+            counts["ads_spend_snapshots"] = {"error": "unhandled"}
         return _ok(counts)
     except Exception as exc:
         logger.exception("publication-commands cron error: %s", exc)

--- a/backend/app/services/ads_boost_execution.py
+++ b/backend/app/services/ads_boost_execution.py
@@ -141,7 +141,7 @@ async def request_ads_boost_start(
 
 async def _request_toggle(
     db: AsyncSession, *, org_id: uuid.UUID, gate_id: uuid.UUID, requester_member_id: uuid.UUID,
-    operation: str,
+    operation: str, initiated_by: str | None = None,
 ) -> PublicationCommand:
     gate = await _resolve_gate(db, org_id=org_id, gate_id=gate_id)
     destination = gate.sealed_ads_connection_id
@@ -177,7 +177,7 @@ async def _request_toggle(
     command, _ = await create_or_get_publication_command(
         db, org_id=org_id, gate_id=gate.id, destination=destination, approved_version=approved_version,
         requested_by_member_id=requester_member_id, scheduled_at=None, operation=operation,
-        content_kind=_ADS_BOOST_CONTENT_KIND, toggle_seq=toggle_seq,
+        content_kind=_ADS_BOOST_CONTENT_KIND, toggle_seq=toggle_seq, initiated_by=initiated_by,
     )
     await db.commit()
     return command
@@ -185,9 +185,16 @@ async def _request_toggle(
 
 async def request_ads_boost_pause(
     db: AsyncSession, *, org_id: uuid.UUID, gate_id: uuid.UUID, requester_member_id: uuid.UUID,
+    initiated_by: str | None = None,
 ) -> PublicationCommand:
+    """story #3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z) — `initiated_by`는
+    선택값(기본 None)이다: 사람 「홍보 중지」 경로(라우터)는 여전히 안 넘겨(boost_start와
+    달리 pause/resume은 애初부터 scheduler/human 구분 요건이 없었다, PR6 정정 배경
+    문서 참고) — 오직 `_enforce_spend_cap`(ads_spend_snapshots.py)의 자동 중지만
+    "scheduler"를 명시로 넘긴다."""
     return await _request_toggle(
         db, org_id=org_id, gate_id=gate_id, requester_member_id=requester_member_id, operation=OP_PAUSE,
+        initiated_by=initiated_by,
     )
 
 

--- a/backend/app/services/ads_spend_snapshots.py
+++ b/backend/app/services/ads_spend_snapshots.py
@@ -114,7 +114,74 @@ async def _resolve_spend_context(db: AsyncSession, snapshot: InsightSnapshot) ->
     return {
         "module": module, "campaign_id": run.campaign_id,
         "access_token": decrypt_channel_credential(conn.encrypted_access_token),
+        # story #3806(Phase3·3-2 PR 11) — 캡처 직후 상한 판정(_enforce_spend_cap)이
+        # 이미 여기서 조회한 gate·run을 그대로 재사용(추가 쿼리 0).
+        "gate": gate, "run": run,
     }
+
+
+async def _captured_spend_minor_for_gate(db: AsyncSession, *, org_id: uuid.UUID, publication_id: uuid.UUID) -> int:
+    """story #3806(Phase3·3-2 PR 11) — `get_ads_boost_spend_summary`가 이미 하던
+    "그 gate의 캡처된 paid spend 합" 계산을 추출(드리프트 금지 — 상한 판정
+    (`_enforce_spend_cap`)과 조회 API가 같은 계산을 각자 다시 적으면 나중에
+    한쪽만 고쳐질 위험)."""
+    snapshots = (await db.execute(
+        select(InsightSnapshot).where(
+            InsightSnapshot.org_id == org_id, InsightSnapshot.publication_id == publication_id,
+            InsightSnapshot.source == _PAID_SOURCE, InsightSnapshot.status == "captured",
+        )
+    )).scalars().all()
+    return sum((s.normalized or {}).get("spend") or 0 for s in snapshots)
+
+
+async def _enforce_spend_cap(db: AsyncSession, *, gate: Gate, run, now: datetime) -> bool:
+    """story #3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z) — 「상한 내
+    실행」의 실물: 캡처된 paid 지출 합이 봉인 예산에 도달/초과하면 자동으로 중지
+    명령을 낸다(scheduler 귀속, PR6·PR8의 `initiated_by` 사상 재사용). `run.
+    cap_reached_at`이 이미 찍혀 있으면 즉시 반환(1회만 — 매 tick 재요청 금지,
+    `_request_toggle`의 더블클릭 재사용/거부 방어와는 별개의 앞단 게이트).
+    반환값은 이번 호출에서 실제로 상한을 새로 판정했는지(테스트 가시성용)."""
+    if run.cap_reached_at is not None:
+        return False
+    if gate.sealed_ads_budget_minor is None or not gate.scope_key:
+        return False
+
+    captured = await _captured_spend_minor_for_gate(
+        db, org_id=gate.org_id, publication_id=uuid.UUID(gate.scope_key),
+    )
+    if captured < gate.sealed_ads_budget_minor:
+        return False
+
+    # 「도달했다」는 사실은 중지 명령의 성패와 무관하게 확정(먼저 커밋) — 아래
+    # request_ads_boost_pause가 이미-paused 등으로 거부돼도 매 tick 재판정하지
+    # 않는다(사실 관측과 그에 대한 대응 조치를 별개 실패단위로 취급).
+    run.cap_reached_at = now
+    await db.commit()
+
+    if gate.resolver_id is None:
+        return True  # PR6과 동형 방어 — 귀속 불가 상태는 이론상 불가하나 침묵 안 함.
+
+    from app.services.ads_boost_execution import (
+        AdsBoostAlreadyInStateError,
+        AdsBoostGateNotApprovedError,
+        AdsBoostGateNotFoundError,
+        AdsBoostNotStartedError,
+        request_ads_boost_pause,
+    )
+
+    try:
+        await request_ads_boost_pause(
+            db, org_id=gate.org_id, gate_id=gate.id, requester_member_id=gate.resolver_id,
+            initiated_by="scheduler",
+        )
+    except (AdsBoostGateNotFoundError, AdsBoostGateNotApprovedError, AdsBoostAlreadyInStateError, AdsBoostNotStartedError):
+        # 이미 중지됐거나(사람이 먼저 pause) 게이트가 그 사이 재오픈된 경우 —
+        # 「상한 도달」 관측 자체는 위에서 이미 확정됐으니 이 건은 이 워커의
+        # 실패가 아니다.
+        pass
+    except Exception:  # noqa: BLE001 — publication_command.py와 동형 2중 방어.
+        await db.rollback()
+    return True
 
 
 async def process_due_ads_spend_snapshots(db: AsyncSession, *, now: datetime | None = None) -> dict[str, int]:
@@ -140,7 +207,7 @@ async def process_due_ads_spend_snapshots(db: AsyncSession, *, now: datetime | N
         snapshot.status = "in_progress"
     await db.commit()
 
-    counts = {"captured": 0, "failed": 0, "error": 0}
+    counts = {"captured": 0, "failed": 0, "error": 0, "capped": 0}
     for snapshot in rows:
         try:
             ctx = await _resolve_spend_context(db, snapshot)
@@ -161,6 +228,11 @@ async def process_due_ads_spend_snapshots(db: AsyncSession, *, now: datetime | N
             snapshot.error_code = None
             await db.commit()
             counts["captured"] += 1
+            # story #3806(Phase3·3-2 PR 11) — 이 캡처가 상한을 새로 넘겼는지 즉시
+            # 판정(같은 tick 안, 다음 tick까지 안 미룬다 — 「상한 내 실행」은 발견
+            # 즉시 멈추는 것이 취지).
+            if await _enforce_spend_cap(db, gate=ctx["gate"], run=ctx["run"], now=now):
+                counts["capped"] += 1
         except AdsSpendFetchError as exc:
             snapshot.error_code = exc.code
             snapshot.status = "failed"
@@ -226,8 +298,12 @@ async def get_ads_boost_spend_summary(db: AsyncSession, *, org_id: uuid.UUID, ga
         )
     )).scalar_one_or_none()
 
-    captured_spend_minor = sum(
-        (s.normalized or {}).get("spend") or 0 for s in snapshots if s.status == "captured"
+    # story #3806(Phase3·3-2 PR 11) — _enforce_spend_cap과 같은 계산(드리프트 금지,
+    # 이 파일 상단 `_captured_spend_minor_for_gate` docstring 참고). 위에서 이미
+    # 가져온 `snapshots`로 직접 합해도 값은 같지만, 두 소비처가 각자 다시 적으면
+    # 나중에 한쪽만 고쳐질 위험을 없애기 위해 공유 함수를 그대로 부른다.
+    captured_spend_minor = await _captured_spend_minor_for_gate(
+        db, org_id=org_id, publication_id=uuid.UUID(gate.scope_key),
     )
     return {
         "gate_id": gate.id,
@@ -237,6 +313,10 @@ async def get_ads_boost_spend_summary(db: AsyncSession, *, org_id: uuid.UUID, ga
         "captured_spend_minor": captured_spend_minor,
         "remaining_minor": (gate.sealed_ads_budget_minor or 0) - captured_spend_minor,
         "run_status": run.status if run is not None else None,
+        # story #3806(Phase3·3-2 PR 11, §7 실측 열 「상한 초과 0건」의 장치) — run이
+        # 없으면(미실행) 당연히 null, run은 있는데 아직 미도달이어도 null(지어내지
+        # 않는다) — 도달한 시각이 찍혀야만 값이 있다.
+        "cap_reached_at": run.cap_reached_at if run is not None else None,
         "snapshots": [
             {
                 "due_at": s.due_at, "captured_at": s.captured_at, "status": s.status,

--- a/backend/tests/test_3806_ads_boost_execution.py
+++ b/backend/tests/test_3806_ads_boost_execution.py
@@ -50,11 +50,13 @@ def _configure_secrets(monkeypatch):
     importlib.reload(crypto_module)
 
 
-async def _setup_approved_gate(session_factory_result, *, approve=True, objective="POST_ENGAGEMENT"):
+async def _setup_approved_gate(session_factory_result, *, approve=True, objective="POST_ENGAGEMENT", budget_minor=100_000):
     """PR 2 API 경유로 게이트를 만들고(봉인 6열 전부 실제로 채워짐), approve=True면
     바로 승인까지 전이시킨다. 반환: (engine, Session, org_id, owner_id, gate_id).
     `objective`는 워커 fix 테스트가 [sandbox:budget-exceeded]/[sandbox:pause-delayed]
-    마커를 실어 보내는 자리(ads_sandbox_campaign.py 모듈 docstring 참고)."""
+    마커를 실어 보내는 자리(ads_sandbox_campaign.py 모듈 docstring 참고). `budget_minor`는
+    PR 11(상한 판정) 테스트가 sandbox 고정 spend(12,345/스냅샷)와 대조해 상한을 의도적으로
+    낮게 봉인할 자리."""
     from app.main import app
 
     engine, Session = session_factory_result
@@ -70,7 +72,7 @@ async def _setup_approved_gate(session_factory_result, *, approve=True, objectiv
     async with _client_for(app) as client:
         r = await client.post(
             f"/api/v2/organizations/{org_id}/publications/{pub.id}/boosts",
-            json=_boost_body(ad_connection_id=ad_conn.id, objective=objective),
+            json=_boost_body(ad_connection_id=ad_conn.id, objective=objective, budget_minor=budget_minor),
         )
     assert r.status_code == 201, r.text
     gate_id = uuid.UUID(r.json()["gate_id"])

--- a/backend/tests/test_3806_ads_boost_spend.py
+++ b/backend/tests/test_3806_ads_boost_spend.py
@@ -129,6 +129,119 @@ async def test_process_due_ads_spend_snapshots_captures_with_source_paid():
 
 
 @pytest.mark.anyio
+async def test_capture_exceeding_budget_auto_pauses_and_stamps_cap_reached_at():
+    """story #3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z) — 「상한 내
+    실행」의 실물. budget_minor=10_000(<sandbox 고정 12,345/스냅샷)로 봉인해 첫
+    캡처만으로 이미 초과 — 그 tick 안에서 즉시 자동 중지 명령(scheduler 귀속)이
+    나가고 `AdsBoostRun.cap_reached_at`이 찍히는지 확認. 두 스냅샷이 같은 tick에서
+    처리돼도(각자 12,345) `capped`가 정확히 1(멱등 — 두 번째 캡처는 이미 찍힌
+    cap_reached_at을 보고 조용히 스킵)인지까지 pin.
+    뮤테이션 대상: `process_due_ads_spend_snapshots`가 캡처 후 `_enforce_spend_cap`을
+    안 부르면(또는 그 함수가 `run.cap_reached_at`을 안 찍으면) 아래 세 단언이 전부
+    실패한다."""
+    from app.models.ads_boost_run import AdsBoostRun
+    from app.models.publication_command import PublicationCommand
+    from app.services.ads_boost_execution import OP_PAUSE
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from sqlalchemy import select
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(
+        await _session_factory(), budget_minor=10_000,
+    )
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+
+        async with Session() as s:
+            counts = await process_due_ads_spend_snapshots(s)
+        assert counts["captured"] == 2, counts
+        assert counts["capped"] == 1, counts  # 두 번째 캡처는 이미 도달 후라 재판정 스킵.
+
+        async with Session() as s:
+            run = (await s.execute(select(AdsBoostRun).where(AdsBoostRun.gate_id == gate_id))).scalar_one()
+            assert run.cap_reached_at is not None
+
+            pause_cmd = (await s.execute(
+                select(PublicationCommand).where(
+                    PublicationCommand.gate_id == gate_id, PublicationCommand.operation == OP_PAUSE,
+                )
+            )).scalar_one_or_none()
+        assert pause_cmd is not None, "상한 도달 시 자동 중지 명령이 생성돼야 한다"
+        assert pause_cmd.initiated_by == "scheduler"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_capture_within_budget_does_not_trigger_cap():
+    """budget_minor=100_000(기본, 2스냅샷 합 24,690 < 100,000)이면 상한 미도달 —
+    cap_reached_at·자동중지 둘 다 없어야 한다(지어낸 조기종료 금지)."""
+    from app.models.ads_boost_run import AdsBoostRun
+    from app.models.publication_command import PublicationCommand
+    from app.services.ads_boost_execution import OP_PAUSE
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from sqlalchemy import select
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+
+        async with Session() as s:
+            counts = await process_due_ads_spend_snapshots(s)
+        assert counts["captured"] == 2, counts
+        assert counts["capped"] == 0, counts
+
+        async with Session() as s:
+            run = (await s.execute(select(AdsBoostRun).where(AdsBoostRun.gate_id == gate_id))).scalar_one()
+            assert run.cap_reached_at is None
+
+            pause_cmd = (await s.execute(
+                select(PublicationCommand).where(
+                    PublicationCommand.gate_id == gate_id, PublicationCommand.operation == OP_PAUSE,
+                )
+            )).scalar_one_or_none()
+        assert pause_cmd is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_spend_endpoint_serializes_cap_reached_at():
+    """§7 실측 열 「상한 초과 0건」의 장치 — /spend 응답 직렬화 확認(PR8이 겪은
+    "컬럼은 있는데 응답엔 없다" 클래스 재발 방지, 이번엔 자체 pin)."""
+    from app.main import app
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(
+        await _session_factory(), budget_minor=10_000,
+    )
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+        async with Session() as s:
+            await process_due_ads_spend_snapshots(s)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/spend")
+        assert r.status_code == 200, r.text
+        assert r.json()["cap_reached_at"] is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_organic_loop_skips_paid_channel_snapshots():
     """process_due_insight_snapshots(organic 루프)가 paid 채널 행을 안 건드려야
     한다 — 안 그러면 insight_metrics=() 게이트에 걸려 즉시 'unsupported'로

--- a/backend/tests/test_3806_ads_boost_spend_cron_wiring.py
+++ b/backend/tests/test_3806_ads_boost_spend_cron_wiring.py
@@ -1,0 +1,127 @@
+"""story #3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z) —
+`ads_spend_snapshots.py::process_due_ads_spend_snapshots`가 실제로 `/publication-
+commands` cron tick에 배선됐는지(신규 엔드포인트 0, 피기백) 확認. PR4가 이 함수를
+만든 뒤 3-7 그라운딩 도중 자체발견된 배선 갭 — 이 함수는 만들어진 뒤 한 번도
+프로덕션 cron 축에서 호출된 적이 없었다(테스트 직접호출만). test_3806_ads_boost_
+starts_cron_wiring.py·test_3527_comment_collection_cron_wiring.py와 동형 구조."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.mark.anyio
+async def test_cron_tick_captures_due_ads_spend_snapshot_via_worker_db(monkeypatch):
+    """AC — tick 호출 → due 지난 paid 스냅샷이 캡처된다(카운트로 확認, 되돌리면
+    test_3806_ads_boost_spend.py의 단위 테스트들이 이미 RED — 여기선 "cron
+    엔드포인트가 이 함수를 실제로 부르는가" 배선만 겨눈다)."""
+    import app.routers.cron as cron_module
+    from app.dependencies.database import get_worker_db
+    from app.main import app
+    from httpx import AsyncClient, ASGITransport
+
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+    from tests.test_3806_ads_boost_execution import _setup_approved_gate
+    from tests.test_3806_ads_boost_spend import _start_boost, _make_spend_snapshots_due
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "test-cron-secret")
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+
+        async def _worker_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_worker_db] = _worker_db
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/v2/internal/cron/publication-commands",
+                headers={"Authorization": "Bearer test-cron-secret"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()["data"]
+        assert body["ads_spend_snapshots"]["captured"] == 2, body
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_ads_spend_snapshots_exception_does_not_corrupt_other_axes_counts(monkeypatch):
+    """test_3527_comment_collection_cron_wiring.py와 동형 — ads_spend_snapshots
+    축 예외가 publication_commands 카운트를 오염시키지 않는다(독립 try 격리 확認)."""
+    import app.routers.cron as cron_module
+    import app.services.ads_spend_snapshots as ads_spend_snapshots_module
+    from app.dependencies.database import get_worker_db
+    from app.main import app
+    from httpx import AsyncClient, ASGITransport
+
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "test-cron-secret")
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("ads spend snapshots boom(테스트 주입)")
+
+    monkeypatch.setattr(ads_spend_snapshots_module, "process_due_ads_spend_snapshots", _boom)
+
+    engine, Session = await _session_factory()
+    try:
+        async def _worker_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_worker_db] = _worker_db
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/v2/internal/cron/publication-commands",
+                headers={"Authorization": "Bearer test-cron-secret"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()["data"]
+        assert body["ads_spend_snapshots"] == {"error": "unhandled"}
+        assert body["completed"] == 0 and body["error"] == 0, (
+            "ads_spend_snapshots 축 예외가 publication_commands 카운트 필드까지 오염시켰다"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1620,8 +1620,8 @@
     },
     {
       "file": "tests/test_3806_ads_boost_spend.py",
-      "sec": 6.4,
-      "source": "story-3806(Phase3·3-2 PR4, 페드루 PO 追加 確定 2026-09-11 — offset_label 판단 콜② 답으로 organic 목록 필터 테스트 1건 추가) — 재측(로컬, uv run pytest --durations=0 직접 1회 실행, 7건 wall time 약 6.4s — test_3766 등재 선례와 동일 방법론)"
+      "sec": 8.1,
+      "source": "story-3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z — 상한 판정 테스트 3건+PR8 initiated_by 테스트 1건 누적 추가) — 재측(로컬, uv run pytest --durations=0 직접 1회 실행, 12건 wall time 약 8.1s — test_3766 등재 선례와 동일 방법론)"
     },
     {
       "file": "tests/test_3805_pr4_reply_collection.py",
@@ -1637,6 +1637,11 @@
       "file": "tests/test_3806_ads_boost_starts_cron_wiring.py",
       "sec": 1.8,
       "source": "story-3806(Phase3·3-2 PR 6, 페드루 PO 確定 2026-09-11 13:27Z — cron 배선 회귀, test_3527_comment_collection_cron_wiring.py 선례와 동형) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 2건 call+setup 합산 약 1.8s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3806_ads_boost_spend_cron_wiring.py",
+      "sec": 3.1,
+      "source": "story-3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z — process_due_ads_spend_snapshots cron 미배선 갭 처방, test_3806_ads_boost_starts_cron_wiring.py 선례와 동형) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 2건 wall time 약 3.1s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }


### PR DESCRIPTION
## 배경
3-7(고급 보고) 그라운딩 도중 자체발견: `process_due_ads_spend_snapshots`(PR4)가 만들어진 뒤 어떤 cron 축에도 피기백되지 않아 paid 지출이 한 번도 자동 수집된 적이 없었다 — "만들어졌는데 도는 자리 없음" 클래스(PR6의 `process_due_ads_boost_starts`와 달리 이 캡처 워커만 미배선). AC 「상한 내 실행」도 실물 장치가 없어 이번에 같이 처방(페드루 PO 確定 2026-09-11 16:20Z).

## 변경
- `cron.py`: `/publication-commands` tick에 독립 try로 `process_due_ads_spend_snapshots` 피기백(기존 5개 축과 동형 사상, 새 Cloud Scheduler 잡 0).
- `ads_boost_runs.cap_reached_at`(0368 마이그, nullable): 캡처된 paid 지출 합이 `gate.sealed_ads_budget_minor`에 도달한 시각을 1회 기록 — §7 실측 열 「상한 초과 0건」의 장치.
- `_enforce_spend_cap`(ads_spend_snapshots.py): 캡처 직후 같은 tick 안에서 즉시 판정. 도달 시 scheduler 귀속 자동 중지 명령을 낸다(`request_ads_boost_pause`에 `initiated_by` 선택 인자 추가, 사람 「홍보 중지」 경로는 그대로 안 넘김 — PR6·PR8의 initiated_by 사상 재사용). `cap_reached_at`을 먼저 커밋해 그 뒤 중지 명령이 "이미 중지됨" 등으로 거부돼도 다음 tick에 재판정하지 않는 멱등.
- `GET /ads-boosts/{gate_id}/spend`에 `cap_reached_at` 직렬화(PR8이 겪은 "컬럼은 있는데 응답엔 없다" 클래스 재발 방지 — 이번엔 같은 PR 안에서 자체 pin).
- `get_ads_boost_spend_summary`/`_enforce_spend_cap`이 같은 "캡처된 paid spend 합" 계산을 공유하도록 `_captured_spend_minor_for_gate` 추출(드리프트 금지).

## 테스트
- cron 배선 회귀 2건(`test_3806_ads_boost_spend_cron_wiring.py` 신규 — 호출 확認·다른 축 카운트 오염 방지).
- 상한 판정 3건: 예산 초과 시 자동중지+`cap_reached_at`(`test_capture_exceeding_budget_auto_pauses_and_stamps_cap_reached_at`), 예산 이내면 무동작(`test_capture_within_budget_does_not_trigger_cap`), 응답 직렬화(`test_spend_endpoint_serializes_cap_reached_at`).
- 뮤테이션 셀프체크 2건: ① cron 피기백 제거 → 신규 배선 테스트 2건만 RED ② `_enforce_spend_cap` 호출 제거 → 상한 판정 테스트 중 정확히 2건(초과 검증·직렬화)만 RED, 미달 통제 테스트는 그대로 GREEN. 둘 다 원복 확認.
- 회귀: ads_boost 관련 전 스위트(execution/spend/spend_cron_wiring/starts_worker/starts_cron_wiring/worker/gate) 58/58 GREEN.

## 범위 밖
- 유나(design) 스킵 — 화면 없음(BE 전용). FE 표기(성과 보드 「초과」 배지 등)는 결과 반영해 디디 후속.
- `remaining_minor` 바닥 0 처리는 기존 설계 그대로(음수 허용) — exceeded 사실은 이번 `cap_reached_at`로 별도 표현.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn