### PR TITLE
[SID:3807] 데스크톱 업데이트 매니페스트 공개 중계(/desktop/updates/macos.json)

### DIFF
--- a/apps/web/src/app/desktop/updates/macos.json/route.test.ts
+++ b/apps/web/src/app/desktop/updates/macos.json/route.test.ts
@@ -1,0 +1,38 @@
+// [SID:3807] 슬라이스12 AC2 — 리다이렉트 0·Content-Type application/json 정확히(no-store)·
+// 원문 그대로 중계(재조립 0)·업스트림 실패 시 502(깨진 200 아님) 회귀가드.
+import { describe, expect, it, vi } from 'vitest';
+
+const { fetchDesktopUpdateManifestMock } = vi.hoisted(() => ({
+  fetchDesktopUpdateManifestMock: vi.fn(),
+}));
+vi.mock('@/lib/desktop-updates', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/desktop-updates')>();
+  return { ...actual, fetchDesktopUpdateManifest: fetchDesktopUpdateManifestMock };
+});
+
+import { GET } from './route';
+import { DesktopManifestUnavailableError } from '@/lib/desktop-updates';
+
+// [SID:3807] 카디르 QA #4187 발견 ③ — 압축형 픽스처는 parse→stringify 재조립 뮤테이션이
+// 공허통과한다(우연히 바이트 동일). mobile CI의 실 macos.json 모양(jq 2칸 들여쓰기)을 그대로
+// 써서 재조립이 일어나면 반드시 바이트가 달라지게 한다.
+const FIXTURE_MANIFEST = '{\n  "version": "9.9.9",\n  "platforms": {\n    "darwin-aarch64": {\n      "signature": "abc",\n      "url": "https://example/x"\n    }\n  }\n}\n';
+
+describe('GET /desktop/updates/macos.json', () => {
+  it('relays the GCS manifest verbatim with 200 + application/json + no-store, no redirect', async () => {
+    fetchDesktopUpdateManifestMock.mockResolvedValue(FIXTURE_MANIFEST);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    expect(res.headers.get('Location')).toBeNull();
+    const body = await res.text();
+    expect(body).toBe(FIXTURE_MANIFEST);
+  });
+
+  it('fails loud (502, not a broken 200) when the GCS manifest is unavailable', async () => {
+    fetchDesktopUpdateManifestMock.mockRejectedValue(new DesktopManifestUnavailableError('boom'));
+    const res = await GET();
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/src/app/desktop/updates/macos.json/route.ts
+++ b/apps/web/src/app/desktop/updates/macos.json/route.ts
@@ -1,0 +1,21 @@
+// §10.2류 공개 경로 — 데스크톱 컴패니언이 인증 쿠키 없이 업데이트를 확인하는 자리
+// (proxy.ts PUBLIC_PREFIX '/desktop/updates/'). 본문은 desktop-updates.ts 단일 출처
+// (mobile 레포 CI가 만든 GCS 매니페스트를 그대로 중계, 이 파일은 손으로 안 지음).
+import { NextResponse } from 'next/server';
+import { DesktopManifestUnavailableError, fetchDesktopUpdateManifest } from '@/lib/desktop-updates';
+
+export async function GET() {
+  try {
+    const body = await fetchDesktopUpdateManifest();
+    return new NextResponse(body, {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+  } catch (err) {
+    if (err instanceof DesktopManifestUnavailableError) {
+      console.error('desktop_updates.manifest_unavailable', err);
+      return NextResponse.json({ error: 'manifest_unavailable' }, { status: 502 });
+    }
+    throw err;
+  }
+}

--- a/apps/web/src/lib/desktop-updates.test.ts
+++ b/apps/web/src/lib/desktop-updates.test.ts
@@ -1,0 +1,31 @@
+// [SID:3807] 슬라이스12 AC2 — GCS 공개읽기 버킷(mobile 레포 CI가 채움) 중계 순수 로직.
+import { describe, expect, it, vi } from 'vitest';
+import { DesktopManifestUnavailableError, fetchDesktopUpdateManifest } from './desktop-updates';
+
+// [SID:3807] 카디르 QA #4187 발견 ③ — 압축형 2키 JSON은 parse→stringify 재조립을 해도
+// 바이트가 우연히 같아 "원문 그대로" 뮤테이션가드가 공허통과한다. mobile CI의 실 macos.json은
+// jq가 2칸 들여쓰기로 찍는다(pretty-print) — 그 실제 모양을 픽스처로 써서 재조립이 일어나면
+// (들여쓰기 손실) 반드시 바이트가 달라지게 한다.
+const FIXTURE_MANIFEST = '{\n  "version": "0.1.0",\n  "pub_date": "2026-09-11T00:00:00Z",\n  "platforms": {\n    "darwin-aarch64": {\n      "signature": "abc",\n      "url": "https://example/x"\n    }\n  }\n}\n';
+
+describe('fetchDesktopUpdateManifest', () => {
+  it('returns the GCS manifest body verbatim on success — no reparsing/reassembly', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => FIXTURE_MANIFEST,
+    });
+    const body = await fetchDesktopUpdateManifest(mockFetch as unknown as typeof fetch);
+    expect(body).toBe(FIXTURE_MANIFEST);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://storage.googleapis.com/sprintable-desktop-releases-dev/macos/latest/macos.json',
+      { cache: 'no-store' },
+    );
+  });
+
+  it('throws DesktopManifestUnavailableError when GCS returns non-2xx — mutation guard: bucket object missing/gone must not surface as a broken 200', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+    await expect(
+      fetchDesktopUpdateManifest(mockFetch as unknown as typeof fetch),
+    ).rejects.toThrow(DesktopManifestUnavailableError);
+  });
+});

--- a/apps/web/src/lib/desktop-updates.ts
+++ b/apps/web/src/lib/desktop-updates.ts
@@ -1,0 +1,23 @@
+// [SID:3807] 슬라이스12 AC2(PO 確定 2026-09-11) — 데스크톱 컴패니언(sprintable-mobile)의
+// check_for_updates가 WEB_ORIGIN에서 파생하는 경로({WEB_ORIGIN}/desktop/updates/macos.json)를
+// 여기서 받는다. 매니페스트 원본은 이 레포가 손으로 안 짓는다 — mobile 레포 CI(PR #95)가
+// 실 빌드·실 서명해서 공개읽기 GCS 버킷(gs://sprintable-desktop-releases-dev)의
+// macos/latest/macos.json에 올려둔 걸 그대로 중계만 한다.
+
+const GCS_MANIFEST_URL =
+  'https://storage.googleapis.com/sprintable-desktop-releases-dev/macos/latest/macos.json';
+
+export class DesktopManifestUnavailableError extends Error {}
+
+/** GCS의 실 매니페스트를 그대로 가져온다(파싱·재조립 0 — 원문 그대로 중계). */
+export async function fetchDesktopUpdateManifest(
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  const res = await fetchImpl(GCS_MANIFEST_URL, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new DesktopManifestUnavailableError(
+      `GCS manifest fetch failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  return res.text();
+}

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -66,6 +66,10 @@ export const RESERVED_FIRST_SEGMENTS = new Set([
   // 라우트. `scripts/verify-reserved-first-segments-sync.ts`가 어긋남을 CI에서 잡는다.
   '.well-known', 'activity', 'api', 'apple-app-site-association', 'apple-icon.png', 'auth',
   'campaigns', 'channel', 'chats', 'content', 'dashboard',
+  // [SID:3807] 슬라이스12 AC2 — 새 최상위 app/desktop/updates/macos.json(공개 업데이트
+  // 매니페스트 중계) 신설. 미등재 시 '/desktop/...'가 워크스페이스 slug로 오인될 수 있다
+  // (카디르 QA #4187 발견).
+  'desktop',
   'favicon.ico', 'forgot-password', 'gates', 'icon.svg', 'inbox', 'internal-dogfood',
   'invite', 'login', 'loop-queue', 'manifest.webmanifest', 'meetings', 'mfa', 'more',
   // [P1] iOS TestFlight 구글 로그인 후 404 인시던트 — AASA(.well-known/apple-app-site-association)

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -109,6 +109,11 @@ describe('proxy', () => {
     expect(response.status).toBe(200);
   });
 
+  it('treats /desktop/updates/macos.json as public — [SID:3807] 데스크톱 컴패니언이 로그인 세션 없이 업데이트를 확인하는 자리, 누락 시 /login 307로 튕겨 check_for_updates가 항상 실패한다', async () => {
+    const response = await middleware(makeRequest('/desktop/updates/macos.json'));
+    expect(response.status).toBe(200);
+  });
+
   it('treats /native/oauth-return as public (no cookie) — [P1] 실측(next start+curl)으로 발견: 누락 시 307-to-login으로 폴백 페이지가 렌더되지 않았다', async () => {
     // native 핸드오프 콜백은 이 응답에 웹 세션 쿠키를 세팅하지 않으므로(격리 rail) 쿠키 없는
     // 요청이 정상 케이스 — /auth/native와 동일 결함 클래스.

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -110,6 +110,11 @@ const PUBLIC_PREFIX = [
   // 놓치면(위 두 개와 별개 가드 — route-resolve.ts RESERVED_FIRST_SEGMENTS와는 다른 축)
   // 방문자가 보호 라우트로 오인돼 /login 307로 튕긴다.
   '/refund-policy',
+  // [SID:3807] 슬라이스12 AC2(PO 確定 2026-09-11) — 데스크톱 컴패니언(sprintable-mobile)의
+  // check_for_updates가 인증 세션 없이 호출하는 업데이트 매니페스트 자리. 실 파일은 mobile
+  // 레포 CI(PR #95)가 만들어 GCS 공개읽기 버킷에 올린 걸 이 경로가 그대로 중계만 한다
+  // (route.ts §desktop/updates/macos.json, 본문 desktop-updates.ts).
+  '/desktop/updates/',
 ];
 
 export const SP_AT_COOKIE = 'sp_at';


### PR DESCRIPTION
## 정정

#4187(같은 내용)이 base=main으로 잘못 열려 PO가 base 확認 없이 squash해 main 직행했다(PO 실수 — prod 배포는 취소, prod 무변경). 웹 레포 PR은 항상 base=develop 규율이라 재정정: `origin/develop`에서 새 브랜치를 따고 main에 이미 들어간 커밋(`b8d4c74035`)을 cherry-pick — **내용은 완전히 동일(diff 0 변경)**, base만 develop으로 바로잡는다.

cherry-pick 중 `apps/web/src/lib/route-resolve.ts`에서 1건 충돌(develop에 먼저 착지한 다른 스토리가 같은 `RESERVED_FIRST_SEGMENTS` 배열에 `campaigns`/`content`를 추가해 둔 상태) — `desktop` 추가분과 병합해 해결, `verify:reserved-first-segments-sync` 재실행으로 실 통과 확認(라이브 디렉터리 36개 — main 기준 34개보다 많은 건 develop이 더 앞서 있어서 정상).

## 무엇 (원 PR #4187과 동일)

슬라이스12(다운로드·설치·업데이트 매니페스트 호스팅) AC2. sprintable-mobile 데스크톱 컴패니언의 `check_for_updates`가 인증 세션 없이 조회하는 `{WEB_ORIGIN}/desktop/updates/macos.json`을 공개 경로로 연다.

- `apps/web/src/lib/desktop-updates.ts` — 매니페스트 원본은 이 레포가 손으로 안 짓는다. mobile 레포 CI(PR #95)가 실 빌드·실 서명해서 공개읽기 GCS 버킷의 `macos/latest/macos.json`에 올린 걸 그대로 중계만 한다(파싱·재조립 0).
- `apps/web/src/app/desktop/updates/macos.json/route.ts` — `.well-known/apple-app-site-association` 선례와 동일 패턴.
- `apps/web/src/proxy.ts` — `PUBLIC_PREFIX`에 `/desktop/updates/` 추가.
- `apps/web/src/lib/route-resolve.ts` — `RESERVED_FIRST_SEGMENTS`에 `desktop` 등재(카디르 QA #4187 발견 — 누락 시 워크스페이스 slug로 오인 위험).

## 증거

```
$ pnpm exec vitest run src/lib/desktop-updates.test.ts src/app/desktop/updates/macos.json/route.test.ts src/proxy.test.ts src/lib/route-resolve.test.ts scripts/verify-reserved-first-segments-sync.test.ts
 Test Files  5 passed (5)
      Tests  109 passed (109)

$ pnpm run verify:reserved-first-segments-sync
OK: RESERVED_FIRST_SEGMENTS 어긋남 0건 (라이브 디렉터리 36개 + 메타데이터 라우트 4개 전부 예약됨, 레거시 리소스명 13개는 파생 축)
```

원 PR #4187에서 유나 PASS(화면 없음)·카디르 qa:pass(codex 01a0913f) 이미 받은 내용과 diff 0 — 재앵커는 PO가 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xkNnQ4d69Wg1HZGm3WoYM