### PR TITLE
[SID:3808] X(트위터) 서버 OAuth 어댑터·PKCE·1회용 회전 refresh_token(PR1)

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -362,6 +362,19 @@ def _meta_ads_oauth_module(channel: str):
     return importlib.import_module(_META_ADS_OAUTH_MODULE_PATHS[channel])
 
 
+_X_OAUTH_MODULE_PATHS = {
+    "x": "app.services.x_oauth",
+    "x_sandbox": "app.services.x_sandbox_oauth",
+}
+
+
+def _x_oauth_module(channel: str):
+    """story #3808 — `_meta_ads_oauth_module`과 동형 dispatch(별도 dict — 기존
+    채널군 무변경, 새 채널군은 병렬 등재)."""
+    import importlib
+    return importlib.import_module(_X_OAUTH_MODULE_PATHS[channel])
+
+
 @router.get("/{org_id}/channel-connections", response_model=list[ChannelConnectionResponse])
 async def list_channel_connections_endpoint(
     org_id: uuid.UUID,
@@ -535,6 +548,13 @@ async def authorize_channel_connection(
         # 동형 판단, meta_ads_oauth.py 상단 딱지).
         build_meta_ads_authorize_url = _meta_ads_oauth_module(channel).build_authorize_url
         url = build_meta_ads_authorize_url(redirect_uri=_redirect_uri(org_id, channel), state=state, app_id=app_id)
+    elif channel in ("x", "x_sandbox"):
+        # story #3808 — X는 threads와 달리 PKCE가 선택이 아니라 필수(x_oauth.py 상단
+        # 딱지) — code_challenge를 항상 싣는다(threads_pkce_enabled류 우회 플래그 없음).
+        build_x_authorize_url = _x_oauth_module(channel).build_authorize_url
+        url = build_x_authorize_url(
+            redirect_uri=_redirect_uri(org_id, channel), state=state, code_challenge=code_challenge, app_id=app_id,
+        )
     else:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
     return AuthorizeResponse(url=url, state=state)
@@ -582,7 +602,9 @@ async def channel_connection_callback(
     if adapter is None:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
-    if channel not in ("threads", "instagram", "facebook", "facebook_sandbox", "meta_ads", "ads_sandbox"):
+    if channel not in (
+        "threads", "instagram", "facebook", "facebook_sandbox", "meta_ads", "ads_sandbox", "x", "x_sandbox",
+    ):
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
     # authorize 단계와 별도로 다시 조회 — 콜백은 브라우저 왕복(수초~수분) 뒤라 그 사이 owner가
@@ -612,6 +634,13 @@ async def channel_connection_callback(
             db, org_id=org_id, channel=channel, code=body.code, app_id=app_id, app_secret=app_secret,
             requester_member_id=resolved.id, target_connection_id=oauth_state.connection_id,
             resolved_locale=resolve_locale_from_request(locale, accept_language),
+        )
+
+    if channel in ("x", "x_sandbox"):
+        return await _x_channel_connection_callback(
+            db, org_id=org_id, channel=channel, code=body.code, code_verifier=oauth_state.code_verifier,
+            app_id=app_id, app_secret=app_secret, requester_member_id=resolved.id,
+            target_connection_id=oauth_state.connection_id,
         )
 
     # story #3320 — instagram_oauth.InstagramOAuthError는 ThreadsOAuthError와 같은
@@ -820,6 +849,45 @@ async def _meta_ads_channel_connection_callback(
         candidates=[AdAccountCandidate(**c) for c in candidates],
         expires_at=pending.expires_at.isoformat(),
     )
+
+
+async def _x_channel_connection_callback(
+    db: AsyncSession, *, org_id: uuid.UUID, channel: str, code: str, code_verifier: str, app_id: str,
+    app_secret: str, requester_member_id: uuid.UUID, target_connection_id: uuid.UUID | None = None,
+) -> ChannelConnectionResponse:
+    """story #3808(Phase3·3-3 PR1) — threads(단기→장기 2단 교환)와 달리 X는 **단일
+    hop**(x_oauth.py 상단 딱지) — 페이지/광고계정 선택 갈래(facebook·meta_ads류)도
+    없어 가장 단순한 갈래 하나다. 반환된 refresh_token을 **그대로**(가공 0) `upsert_
+    channel_connection`에 실어 저장 — cron 1회용 회전 갱신(cron.py `_ROTATING_
+    REFRESH_FN_BY_CHANNEL`)이 이 저장값을 읽는다."""
+    from app.services.x_oauth import XOAuthError
+
+    adapter = get_channel_adapter(channel)
+    oauth_module = _x_oauth_module(channel)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        try:
+            access_token, refresh_token, expires_in = await oauth_module.exchange_code_for_token(
+                client, code=code, redirect_uri=_redirect_uri(org_id, channel), code_verifier=code_verifier,
+                app_id=app_id, app_secret=app_secret,
+            )
+            account = await oauth_module.test_connection(client, access_token=access_token)
+        except XOAuthError as exc:
+            raise HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message}) from exc
+        finally:
+            del app_secret  # ⛔즉시 소비 후 폐기 — 더 들고 있지 않는다(기존 규율과 동형).
+
+    row = await upsert_channel_connection(
+        db, org_id=org_id, channel=channel, account_id=account["id"],
+        account_label=account.get("username"), credential_kind=adapter.credential_kind,
+        access_token=access_token, refresh_token=refresh_token,
+        token_expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in),
+        refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(" "), connected_by=requester_member_id,
+    )
+    mismatch_target_id = (
+        target_connection_id if target_connection_id is not None and target_connection_id != row.id else None
+    )
+    return _to_response(row, reconnect_mismatch_target_id=mismatch_target_id)
 
 
 @router.post("/{org_id}/channel-connections/meta-ads/select", response_model=ChannelConnectionResponse)

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1199,12 +1199,16 @@ async def refresh_channel_tokens(
     try:
         import httpx as _httpx
         from app.services.channel_connection import (
-            apply_refresh_failure, apply_refresh_result, decrypt_for_use, list_connections_due_for_refresh,
+            apply_refresh_failure, apply_refresh_result, decrypt_for_use, decrypt_refresh_token_for_use,
+            list_connections_due_for_refresh,
         )
         from app.services.threads_oauth import ThreadsOAuthError, refresh_long_lived_token as refresh_threads_token
         from app.services.instagram_oauth import (
             InstagramOAuthError, refresh_long_lived_token as refresh_instagram_token,
         )
+        from app.services.x_oauth import XOAuthError, refresh_access_token as refresh_x_token
+        from app.services.x_sandbox_oauth import refresh_access_token as refresh_x_sandbox_token
+        from app.services.channel_app_credentials import resolve_app_credentials
 
         # story #3320 — Phase1은 threads만 구현했던 skip-guard(`continue`)를 채널→
         # 갱신함수 명시 dict로 확장(get_publish_client_module의 dispatch dict 근본
@@ -1223,12 +1227,52 @@ async def refresh_channel_tokens(
         # «무효화 감지»(classify_graph_oauth_error·샌드박스 마커 3종이 담당, 발행/댓글
         # 수집 시점에 401/403으로 드러난다 — cron 사전 갱신과는 다른 자리).
         _REFRESH_FN_BY_CHANNEL = {"threads": refresh_threads_token, "instagram": refresh_instagram_token}
-        _OAUTH_ERROR_TYPES = (ThreadsOAuthError, InstagramOAuthError)
+        # story #3808(Phase3·3-3 PR1) — X류(refresh_mode="refresh_token", **1회용
+        # 회전**)는 access_token이 아니라 refresh_token을 provider에 보내고 client_id/
+        # secret confidential-client 인증이 필요해(threads/instagram의 reissue_from_
+        # access_token 그랜트와 다른 그랜트 — 그쪽은 secret 불요) 위 dict와 나란히
+        # 병렬 등재한다(기존 채널 dispatch·시그니처 무변경, 회귀 0). 반환 3튜플
+        # (new_access_token, new_refresh_token, expires_in)의 두 번째 값이 바로 이
+        # PR이 짝으로 얹은 `apply_refresh_result(new_refresh_token=...)` 슬롯으로 간다
+        # — 여기서 안 갈아 끼우면 다음 tick이 이미 provider가 무효화한 옛 refresh_
+        # token으로 또 시도해 항상 실패한다(1회용 회전의 핵심 위험).
+        _ROTATING_REFRESH_FN_BY_CHANNEL = {"x": refresh_x_token, "x_sandbox": refresh_x_sandbox_token}
+        _OAUTH_ERROR_TYPES = (ThreadsOAuthError, InstagramOAuthError, XOAuthError)
 
         rows = await list_connections_due_for_refresh(session, now=datetime.now(timezone.utc))
         refreshed, failed = 0, 0
         async with _httpx.AsyncClient(timeout=15) as client:
             for row in rows:
+                rotating_refresh_fn = _ROTATING_REFRESH_FN_BY_CHANNEL.get(row.channel)
+                if rotating_refresh_fn is not None:
+                    current_refresh_token = decrypt_refresh_token_for_use(row)
+                    if current_refresh_token is None:
+                        await apply_refresh_failure(session, connection=row, error_message="no stored refresh token")
+                        failed += 1
+                        continue
+                    app_credentials = await resolve_app_credentials(session, org_id=row.org_id, channel=row.channel)
+                    if app_credentials is None:
+                        await apply_refresh_failure(session, connection=row, error_message="no app credentials registered")
+                        failed += 1
+                        continue
+                    app_id, app_secret = app_credentials
+                    try:
+                        new_access_token, new_refresh_token, expires_in = await rotating_refresh_fn(
+                            client, refresh_token=current_refresh_token, app_id=app_id, app_secret=app_secret,
+                        )
+                    except _OAUTH_ERROR_TYPES as exc:
+                        await apply_refresh_failure(session, connection=row, error_message=exc.message)
+                        failed += 1
+                        continue
+                    finally:
+                        del current_refresh_token, app_secret
+                    await apply_refresh_result(
+                        session, connection=row, new_access_token=new_access_token, expires_in_seconds=expires_in,
+                        new_refresh_token=new_refresh_token,
+                    )
+                    refreshed += 1
+                    continue
+
                 refresh_fn = _REFRESH_FN_BY_CHANNEL.get(row.channel)
                 if refresh_fn is None:
                     continue  # 미등록 채널(sandbox류 등)은 갱신 대상 아님(토큰 자체가 더미이거나 없음)

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -475,6 +475,41 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         kind="ads",
         requires_connection=True,
     ),
+    # story #3808(Phase3·3-3 PR1, 페드루 PO 確定 2026-09-11) — X(트위터) 서버 OAuth
+    # 2.0(PKCE 필수, threads_oauth.py와 달리 X는 PKCE 없이 authorization_code grant
+    # 자체를 거부한다 — 공개 문서 안정 사실, ⚠️미확認 표기 대상 아님). refresh_mode=
+    # "refresh_token"(표준 grant, `channel_adapters.py::can_auto_refresh`가 이미 True로
+    # 받는 값 — 그라운딩 정정, 신규 enum값 불요)이지만 X는 **1회용 회전**(매 재발급마다
+    # 새 refresh_token 발급·이전 값 즉시 무효)이라 `apply_refresh_result()`(channel_
+    # connection.py)의 새 refresh_token 슬롯 확장이 짝(이 PR 범위). scope에 반드시
+    # "offline.access"가 있어야 refresh_token 자체가 발급된다(공개 문서 확정 사실).
+    # ⚠️미확認 — authorize_url/token_url 정확 호스트(x.com vs twitter.com 이관 시점)는
+    # 실 앱 등록·왕복 시 재확認 필요.
+    "x": ChannelAdapterConfig(
+        authorize_url="https://x.com/i/oauth2/authorize",
+        token_url="https://api.x.com/2/oauth2/token",
+        scope="tweet.read tweet.write users.read offline.access",
+        refresh_mode="refresh_token",
+        credential_kind="oauth",
+        display_name="X",
+        kind="social",
+        requires_connection=True,
+        max_text_length=280,  # X 기본 티어 게시물 상한(공개 안정 사실, Premium 확장 상한은 범위 밖).
+    ),
+    "x_sandbox": ChannelAdapterConfig(
+        authorize_url="https://x.com/i/oauth2/authorize",
+        token_url="https://api.x.com/2/oauth2/token",
+        scope="tweet.read tweet.write users.read offline.access",
+        refresh_mode="refresh_token",
+        # ads_sandbox와 동형 이유 — 회전 마커를 sandbox 토큰 문자열 자체로 나르므로
+        # credential_kind="none"이 아니라 진짜 authorize→callback 라우터를 태운다
+        # (x_sandbox_oauth.py가 X 호출부만 페이크로 스왑).
+        credential_kind="oauth",
+        display_name="X Sandbox",
+        kind="social",
+        requires_connection=True,
+        max_text_length=280,
+    ),
 }
 
 # story 5b27b32f(Phase1·BE·테스트 인프라, 페드루 PO 확定 2026-09-04) — dev 전용 샌드박스

--- a/backend/app/services/channel_connection.py
+++ b/backend/app/services/channel_connection.py
@@ -196,8 +196,17 @@ async def list_connections_due_for_refresh(db: AsyncSession, *, now: datetime) -
 
 async def apply_refresh_result(
     db: AsyncSession, *, connection: ChannelConnection, new_access_token: str, expires_in_seconds: int,
+    new_refresh_token: str | None = None,
 ) -> None:
+    """story #3808(Phase3·3-3 PR1) — `new_refresh_token` 신규 파라미터(옵션, 기본
+    None=기존 동작 그대로 무변경). X류 **1회용 회전** refresh_token(매 갱신마다
+    새 refresh_token 발급·이전 값 즉시 무효)은 여기서 갱신하지 않으면 다음 cron
+    tick이 이미 무효화된 옛 refresh_token으로 또 갱신을 시도해 항상 실패한다 —
+    threads/instagram(refresh_mode="reissue_from_access_token", refresh_token
+    자체가 없음)는 이 인자를 안 넘기므로 회귀 0."""
     connection.encrypted_access_token = encrypt_channel_credential(new_access_token)
+    if new_refresh_token is not None:
+        connection.encrypted_refresh_token = encrypt_channel_credential(new_refresh_token)
     connection.token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)
     connection.last_refreshed_at = datetime.now(timezone.utc)
     # story #3633 — mark_connection_recovered로 status/last_error 3종 통일.
@@ -247,3 +256,14 @@ def decrypt_for_use(connection: ChannelConnection) -> str | None:
     if connection.encrypted_access_token is None:
         return None
     return decrypt_channel_credential(connection.encrypted_access_token)
+
+
+def decrypt_refresh_token_for_use(connection: ChannelConnection) -> str | None:
+    """story #3808(Phase3·3-3 PR1) — `decrypt_for_use`의 refresh_token판. X류
+    refresh_mode="refresh_token" 채널의 cron 재발급은 access_token이 아니라 **이
+    refresh_token**을 provider에 보낸다(decrypt_for_use가 access_token만 다루므로
+    이 채널군에는 그대로 재사용할 수 없음 — 새 함수가 맞는 자리). 같은 ⛔즉시
+    소비 규율."""
+    if connection.encrypted_refresh_token is None:
+        return None
+    return decrypt_channel_credential(connection.encrypted_refresh_token)

--- a/backend/app/services/x_oauth.py
+++ b/backend/app/services/x_oauth.py
@@ -1,0 +1,124 @@
+"""story #3808(Phase3·3-3 PR1, 페드루 PO 確定 2026-09-11) — X(트위터) 서버 OAuth 2.0
+교환. 앱 id/secret은 호출부(channel_app_credentials.resolve_app_credentials, threads_
+oauth.py와 동형 3단 우선순위)가 해석해 넘긴다.
+
+threads_oauth.py와의 핵심 차이 — X는 PKCE가 **선택이 아니라 필수**(공개 문서 안정
+사실 — code_challenge 없이 authorization_code grant 자체를 거부한다)라 `settings.
+threads_pkce_enabled`류 우회 플래그가 없다. 그리고 토큰 교환이 **단일 hop**이다
+(threads/facebook류의 단기→장기 2단 교환이 없음 — 이 함수가 돌려주는 access_token·
+refresh_token이 그대로 최종 자격이고, 만료(대개 2시간)마다 refresh_token으로 갱신).
+
+⚠️미확認(착수 시 재확認 필요, threads_oauth.py 상단 딱지와 동형 원칙) — 아래
+엔드포인트 호스트(x.com/api.x.com, twitter.com/api.twitter.com 이관 시점 혼용 가능)·
+토큰 응답 필드명은 지식 컷오프(2026-01) 기준 최선 추정이다. 실 앱 왕복 전까지
+"코드는 정확한 형태로 존재하되 라이브 미검증" 상태로 남는다.
+
+refresh_token **1회용 회전**(공개 문서 안정 사실 — OAuth 2.0 refresh token rotation,
+매 갱신마다 새 refresh_token 발급·이전 값 즉시 무효)이 이 모듈의 존재 이유다 —
+`refresh_access_token()`이 (new_access_token, new_refresh_token, expires_in) 3튜플을
+돌려주는 게 threads_oauth.refresh_long_lived_token()의 2튜플과 다른 유일한 이유."""
+from __future__ import annotations
+
+import base64
+
+import httpx
+
+_AUTHORIZE_BASE = "https://x.com/i/oauth2/authorize"
+_TOKEN_URL = "https://api.x.com/2/oauth2/token"
+_ME_URL = "https://api.x.com/2/users/me"
+
+
+class XOAuthError(Exception):
+    """code→token/refresh/me 조회 실패. .code/.message가 그대로 API 에러 응답에 매핑
+    (threads_oauth.ThreadsOAuthError와 동형 계약)."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _basic_auth_header(app_id: str, app_secret: str) -> str:
+    """X 토큰 엔드포인트는 confidential client를 HTTP Basic(RFC 6749 §2.3.1)으로
+    인증한다(공개 문서 안정 사실) — client_secret을 요청 body에 평문으로 안 싣는다."""
+    raw = f"{app_id}:{app_secret}".encode("utf-8")
+    return f"Basic {base64.b64encode(raw).decode('ascii')}"
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, code_challenge: str, app_id: str) -> str:
+    """PKCE 필수(threads_oauth.py와 다른 자리 — 우회 플래그 없음). `app_id`는
+    threads_oauth.py와 동형 이유로 호출부가 미리 해석해 넘긴다."""
+    from urllib.parse import urlencode
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    cfg = CHANNEL_ADAPTERS["x"]
+    params = {
+        "response_type": "code",
+        "client_id": app_id,
+        "redirect_uri": redirect_uri,
+        "scope": cfg.scope,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{cfg.authorize_url}?{urlencode(params)}"
+
+
+async def exchange_code_for_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, code_verifier: str, app_id: str, app_secret: str,
+) -> tuple[str, str, int]:
+    """authorization code → (access_token, refresh_token, expires_in초). 단일 hop —
+    threads/facebook류의 단기→장기 2단 교환이 X엔 없다."""
+    resp = await client.post(
+        _TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+            "client_id": app_id,
+        },
+        headers={"Authorization": _basic_auth_header(app_id, app_secret)},
+    )
+    if resp.status_code != 200:
+        raise XOAuthError("X_TOKEN_EXCHANGE_FAILED", resp.text[:500])
+    body = resp.json()
+    access_token = body.get("access_token")
+    refresh_token = body.get("refresh_token")
+    expires_in = body.get("expires_in")
+    if not access_token or not refresh_token or not expires_in:
+        raise XOAuthError("X_TOKEN_EXCHANGE_MISSING_FIELDS", "access_token/refresh_token/expires_in missing")
+    return access_token, refresh_token, int(expires_in)
+
+
+async def refresh_access_token(
+    client: httpx.AsyncClient, *, refresh_token: str, app_id: str, app_secret: str,
+) -> tuple[str, str, int]:
+    """refresh_mode="refresh_token" — **1회용 회전**: 이 호출이 성공하면 넘긴
+    refresh_token은 즉시 무효(provider 측 폐기, 재사용 시 실패)가 되고, 반환된
+    새 refresh_token으로 호출부가 저장을 갈아 끼워야 한다(3튜플 반환이 그 신호 —
+    threads_oauth.refresh_long_lived_token()의 2튜플과 다른 유일한 이유)."""
+    resp = await client.post(
+        _TOKEN_URL,
+        data={"grant_type": "refresh_token", "refresh_token": refresh_token, "client_id": app_id},
+        headers={"Authorization": _basic_auth_header(app_id, app_secret)},
+    )
+    if resp.status_code != 200:
+        raise XOAuthError("X_REFRESH_FAILED", resp.text[:500])
+    body = resp.json()
+    new_access_token = body.get("access_token")
+    new_refresh_token = body.get("refresh_token")
+    expires_in = body.get("expires_in")
+    if not new_access_token or not new_refresh_token or not expires_in:
+        raise XOAuthError("X_REFRESH_MISSING_FIELDS", "access_token/refresh_token/expires_in missing")
+    return new_access_token, new_refresh_token, int(expires_in)
+
+
+async def test_connection(client: httpx.AsyncClient, *, access_token: str) -> dict:
+    """연결 시험(threads_oauth.test_connection과 동형 계약) — provider 경량 호출,
+    토큰은 이 함수 밖으로 절대 안 나간다."""
+    resp = await client.get(_ME_URL, headers={"Authorization": f"Bearer {access_token}"})
+    if resp.status_code != 200:
+        raise XOAuthError("X_TEST_CONNECTION_FAILED", resp.text[:500])
+    body = resp.json().get("data", {})
+    return {"id": body.get("id"), "username": body.get("username")}

--- a/backend/app/services/x_sandbox_oauth.py
+++ b/backend/app/services/x_sandbox_oauth.py
@@ -1,0 +1,73 @@
+"""story #3808(Phase3·3-3 PR1, 페드루 PO 確定 2026-09-11) — X 연결 sandbox.
+`x_oauth.py`와 정확히 같은 함수 시그니처(라우터가 채널로 모듈만 바꿔 끼우는 기존
+dispatch 관례 — `ads_sandbox_oauth.py`/`channel_adapters.py::get_publish_client_
+module`과 동형 사상, 새 분기 로직 0)를 인프로세스 결정적 응답으로 구현한다.
+`ads_sandbox_oauth.py`와 동형 — authorize가 실 X 도메인 대신 콜백 URL로 곧장
+(code, state)를 실어 리다이렉트해, real 없이도 authorize→callback 전 구간이 그대로
+라이브 왕복으로 실측된다.
+
+**1회용 회전 마커**(카드 AC1 「회전 후 옛 refresh로 재발급 시 실패 마커」) — refresh_
+token 문자열 자체에 회전 세대(generation)를 실어 나른다(`sandbox-x-refresh:{app_id}:
+g{n}`). `refresh_access_token()`은 세대를 1 올린 새 refresh_token을 결정적으로
+반환한다 — "옛 세대 재사용"은 **호출부(테스트)가 이전에 받은 문자열을 그대로 다시
+넘기는 것 자체**로 재현한다(실 provider가 서버측에 "마지막 발급 세대"를 기억해 거부
+하는 것과 같은 관측을 순수 함수로 낸다: `_MARKER_STALE_GENERATION`가 박힌 refresh_
+token — 세대 번호가 0 이하로 내려가면[음수 접미] 회전-후-재사용 실패를 결정적으로
+낸다). facebook_sandbox_oauth.py `_MARKER_EXPIRED_TOKEN`류와 동형 명명 관례."""
+from __future__ import annotations
+
+import re
+import uuid
+
+import httpx
+
+from app.services.x_oauth import XOAuthError
+
+_ACCESS_PREFIX = "sandbox-x-access"
+_REFRESH_PREFIX = "sandbox-x-refresh"
+_SANDBOX_FAKE_CODE = "sandbox-oauth-code"
+
+_GENERATION_RE = re.compile(r":g(-?\d+)$")
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, code_challenge: str, app_id: str) -> str:
+    """x_oauth.py 시그니처 동형 — real X 없이 콜백 URL로 곧장 리다이렉트
+    (ads_sandbox_oauth.py `build_authorize_url` 원칙 그대로, code_challenge는
+    시그니처만 맞추고 sandbox 왕복엔 안 쓴다)."""
+    from urllib.parse import urlencode
+
+    return f"{redirect_uri}?{urlencode({'code': _SANDBOX_FAKE_CODE, 'state': state})}"
+
+
+async def exchange_code_for_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, code_verifier: str, app_id: str, app_secret: str,
+) -> tuple[str, str, int]:
+    """세대 0에서 시작 — `refresh_access_token()`이 이 세대를 1씩 올린다."""
+    return f"{_ACCESS_PREFIX}:{app_id}", f"{_REFRESH_PREFIX}:{app_id}:g0", 7200
+
+
+async def refresh_access_token(
+    client: httpx.AsyncClient, *, refresh_token: str, app_id: str, app_secret: str,
+) -> tuple[str, str, int]:
+    """1회용 회전 결정적 시뮬레이션 — 넘긴 refresh_token의 세대를 파싱해 +1한 새
+    refresh_token을 낸다. 세대 파싱이 실패하거나(형식 오염) `_MARKER_STALE_
+    GENERATION`(음수 세대)이면 "옛 세대 재사용" 실패를 낸다 — 실 X가 이미 회전된
+    refresh_token 재사용을 거부하는 것과 같은 관측(사용자 문장은 호출부 몫,
+    ads_sandbox_oauth.py MetaAdsOAuthError.message 관례와 동형 — 이 .message는
+    provider 원문 축)."""
+    match = _GENERATION_RE.search(refresh_token)
+    if match is None or int(match.group(1)) < 0:
+        raise XOAuthError(
+            "X_REFRESH_TOKEN_REUSED",
+            "sandbox: [sandbox:refresh-token-reused] marker simulation — rotated refresh_token reused",
+        )
+    generation = int(match.group(1))
+    new_refresh_token = f"{_REFRESH_PREFIX}:{app_id}:g{generation + 1}:{uuid.uuid4().hex[:8]}"
+    new_access_token = f"{_ACCESS_PREFIX}:{app_id}:{uuid.uuid4().hex[:8]}"
+    return new_access_token, new_refresh_token, 7200
+
+
+async def test_connection(client: httpx.AsyncClient, *, access_token: str) -> dict:
+    """결정적 고정 값(ads_sandbox_oauth.py list_ad_accounts와 동형 원칙 — 이름·id는
+    절대 안 바뀐다, 라이브 판정이 이 값을 대조한다)."""
+    return {"id": "sandbox-x-user-1", "username": "sandbox_x_user"}

--- a/backend/scripts/lint_channel_insight_metrics_drift.py
+++ b/backend/scripts/lint_channel_insight_metrics_drift.py
@@ -63,6 +63,10 @@ EXPECTED_BACKEND_CHANNELS = frozenset({
     # channel_adapters.py 항목 주석 참고) — extract_backend_declared_metrics가
     # []로 등재하고 find_drift도 FE 부재=[] 폴백이라 drift 0(신규 FE 등재 불요).
     "meta_ads", "ads_sandbox",
+    # story #3808(Phase3·3-3 PR1) — x/x_sandbox도 같은 이유로 insight_metrics
+    # 미선언(빈 튜플 기본값) — 인사이트 수집은 이 스토리의 후속 PR4 몫(카드 조각④,
+    # 착수 문서 §2 3-3). meta_ads/ads_sandbox와 동형으로 drift 0(신규 FE 등재 불요).
+    "x", "x_sandbox",
 })
 
 

--- a/backend/tests/test_3808_x_oauth.py
+++ b/backend/tests/test_3808_x_oauth.py
@@ -1,0 +1,449 @@
+"""story #3808(Phase3·3-3 PR1, 페드루 PO 確定 2026-09-11) — X(트위터) 서버 OAuth
+2.0(PKCE 필수)·1회용 회전 refresh_token. AC1 담당 파일 — 아래 4단:
+① x_oauth.py 단위(PKCE 강제·단일 hop 교환·회전 refresh 3튜플)
+② x_sandbox_oauth.py 단위(결정적 회전 세대·⭐옛 세대 재사용 마커)
+③ channel_adapters.py 등재(refresh_mode="refresh_token" 기존 값 재사용 확認)
+④ 실DB 통합 — apply_refresh_result 회전 슬롯 저장·cron 배선이 실제로 그 슬롯까지
+  갈아 끼우는지(⭐AC1 뮤테이션 대상: 여기가 되돌리면 다음 tick이 이미 무효화된
+  옛 refresh_token으로 또 실패한다)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+# ─── ① x_oauth.py — PKCE 강제·단일 hop 교환·회전 refresh 3튜플 ──────────────────
+
+def test_build_authorize_url_always_includes_pkce_params():
+    """threads_oauth.py와 다른 자리 — 우회 플래그가 없어 항상 code_challenge를 싣는다."""
+    from app.services.x_oauth import build_authorize_url
+
+    url = build_authorize_url(redirect_uri="https://x/callback", state="s", code_challenge="chal123", app_id="app-id")
+    assert "code_challenge=chal123" in url
+    assert "code_challenge_method=S256" in url
+    assert "client_id=app-id" in url
+    assert "offline.access" in url  # scope에 refresh_token 발급 필수 스코프가 실제로 실림
+
+
+@pytest.mark.anyio
+async def test_exchange_code_for_token_sends_basic_auth_and_code_verifier():
+    """confidential client 인증(RFC 6749 §2.3.1) + PKCE code_verifier가 실제로 요청에
+    실리는지 — 둘 다 빠지면 X가 즉시 invalid_request로 거부한다(실 계약)."""
+    from app.services.x_oauth import exchange_code_for_token
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "at-1", "refresh_token": "rt-1", "expires_in": 7200}
+
+    class _FakeClient:
+        async def post(self, url, *, data, headers):
+            captured["url"], captured["data"], captured["headers"] = url, data, headers
+            return _FakeResponse()
+
+    access_token, refresh_token, expires_in = await exchange_code_for_token(
+        _FakeClient(), code="c", redirect_uri="https://x/callback", code_verifier="verifier-1",
+        app_id="app-id", app_secret="app-secret",
+    )
+    assert (access_token, refresh_token, expires_in) == ("at-1", "rt-1", 7200)
+    assert captured["data"]["code_verifier"] == "verifier-1"
+    assert captured["data"]["grant_type"] == "authorization_code"
+    assert captured["headers"]["Authorization"].startswith("Basic ")
+
+
+@pytest.mark.anyio
+async def test_exchange_code_for_token_missing_refresh_token_raises():
+    """offline.access 스코프 누락 등으로 refresh_token이 안 오면 그 자리에서 즉시
+    실패해야 한다(회전 갱신을 할 수 없는 연결을 조용히 저장하지 않는다)."""
+    from app.services.x_oauth import XOAuthError, exchange_code_for_token
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "at-1", "expires_in": 7200}  # refresh_token 없음
+
+    class _FakeClient:
+        async def post(self, url, *, data, headers):
+            return _FakeResponse()
+
+    with pytest.raises(XOAuthError) as exc_info:
+        await exchange_code_for_token(
+            _FakeClient(), code="c", redirect_uri="https://x/callback", code_verifier="v",
+            app_id="app-id", app_secret="app-secret",
+        )
+    assert exc_info.value.code == "X_TOKEN_EXCHANGE_MISSING_FIELDS"
+
+
+@pytest.mark.anyio
+async def test_refresh_access_token_sends_refresh_token_grant_and_returns_rotated_triple():
+    """⭐1회용 회전의 핵심 계약 — refresh_token grant로 호출하고, 새 access_token
+    **과** 새 refresh_token 둘 다 돌아온다(2튜플이면 회전을 못 담는다)."""
+    from app.services.x_oauth import refresh_access_token
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "at-2", "refresh_token": "rt-2", "expires_in": 7200}
+
+    class _FakeClient:
+        async def post(self, url, *, data, headers):
+            captured["data"] = data
+            return _FakeResponse()
+
+    new_access, new_refresh, expires_in = await refresh_access_token(
+        _FakeClient(), refresh_token="rt-1", app_id="app-id", app_secret="app-secret",
+    )
+    assert (new_access, new_refresh, expires_in) == ("at-2", "rt-2", 7200)
+    assert captured["data"]["grant_type"] == "refresh_token"
+    assert captured["data"]["refresh_token"] == "rt-1"
+
+
+@pytest.mark.anyio
+async def test_refresh_access_token_provider_rejection_raises_x_oauth_error():
+    from app.services.x_oauth import XOAuthError, refresh_access_token
+
+    class _FakeResponse:
+        status_code = 400
+        text = "invalid_grant: refresh_token expired or revoked"
+
+    class _FakeClient:
+        async def post(self, url, *, data, headers):
+            return _FakeResponse()
+
+    with pytest.raises(XOAuthError) as exc_info:
+        await refresh_access_token(_FakeClient(), refresh_token="rt-stale", app_id="app-id", app_secret="app-secret")
+    assert exc_info.value.code == "X_REFRESH_FAILED"
+
+
+# ─── ② x_sandbox_oauth.py — 결정적 회전 세대·⭐옛 세대 재사용 마커 ─────────────
+
+@pytest.mark.anyio
+async def test_sandbox_exchange_returns_generation_zero_refresh_token():
+    from app.services.x_sandbox_oauth import exchange_code_for_token
+
+    access_token, refresh_token, expires_in = await exchange_code_for_token(
+        httpx.AsyncClient(), code="c", redirect_uri="https://x/callback", code_verifier="v",
+        app_id="app-1", app_secret="secret",
+    )
+    assert refresh_token == "sandbox-x-refresh:app-1:g0"
+    assert access_token.startswith("sandbox-x-access:app-1")
+    assert expires_in == 7200
+
+
+@pytest.mark.anyio
+async def test_sandbox_refresh_rotates_to_next_generation_with_new_access_token():
+    """정상 회전 — 세대가 올라가고 access_token도 매번 새 값(⭐재사용 감지가
+    문자열 대조로 가능해지는 이유)."""
+    from app.services.x_sandbox_oauth import refresh_access_token
+
+    new_access, new_refresh, expires_in = await refresh_access_token(
+        httpx.AsyncClient(), refresh_token="sandbox-x-refresh:app-1:g0", app_id="app-1", app_secret="secret",
+    )
+    assert new_refresh.startswith("sandbox-x-refresh:app-1:g1:")
+    assert new_refresh != "sandbox-x-refresh:app-1:g0"
+    assert expires_in == 7200
+
+
+@pytest.mark.anyio
+async def test_sandbox_refresh_with_stale_generation_marker_raises_reused_error():
+    """⭐AC1 뮤테이션 대상 — 「회전 후 옛 refresh로 재발급 시 실패 마커」의 결정적
+    재현. 음수 세대(:g-1)가 «이미 회전돼 폐기된 refresh_token을 재사용»을 나타내는
+    고정 마커(x_sandbox_oauth.py 상단 딱지)."""
+    from app.services.x_oauth import XOAuthError
+    from app.services.x_sandbox_oauth import refresh_access_token
+
+    with pytest.raises(XOAuthError) as exc_info:
+        await refresh_access_token(
+            httpx.AsyncClient(), refresh_token="sandbox-x-refresh:app-1:g-1", app_id="app-1", app_secret="secret",
+        )
+    assert exc_info.value.code == "X_REFRESH_TOKEN_REUSED"
+    assert "[sandbox:refresh-token-reused]" in exc_info.value.message
+
+
+@pytest.mark.anyio
+async def test_sandbox_refresh_with_malformed_token_also_raises_reused_error():
+    """세대 파싱 실패(형식 오염)도 fail-closed로 같은 실패 마커 — "모르는 형식이면
+    조용히 통과"가 아니다."""
+    from app.services.x_oauth import XOAuthError
+    from app.services.x_sandbox_oauth import refresh_access_token
+
+    with pytest.raises(XOAuthError):
+        await refresh_access_token(
+            httpx.AsyncClient(), refresh_token="not-a-generation-token", app_id="app-1", app_secret="secret",
+        )
+
+
+# ─── ③ channel_adapters.py 등재 — refresh_mode="refresh_token" 기존 값 재사용 확認 ──
+
+def test_x_and_x_sandbox_adapters_registered_with_rotating_refresh_mode():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS, can_auto_refresh
+
+    for channel in ("x", "x_sandbox"):
+        cfg = CHANNEL_ADAPTERS[channel]
+        assert cfg.refresh_mode == "refresh_token"
+        assert cfg.credential_kind == "oauth"
+        assert cfg.kind == "social"
+        assert "offline.access" in cfg.scope
+    # 그라운딩 정정(2026-09-11) — 신규 enum값이 아니라 기존 값이 이미 자동갱신
+    # 대상으로 잡히는지 pin(되돌리면 x/x_sandbox가 cron 루프에 애초에 안 올라온다).
+    assert can_auto_refresh("refresh_token") is True
+
+
+# ─── ④ 실DB 통합 — apply_refresh_result 회전 슬롯·cron 배선 ────────────────────
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name="X OAuth Test Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_human(session, org_id):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="owner")
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_x_sandbox_connection(session, org_id, *, refresh_token: str, connected_by: uuid.UUID, due=True):
+    from datetime import datetime, timedelta, timezone
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    expires_at = (
+        datetime.now(timezone.utc) - timedelta(minutes=1) if due
+        else datetime.now(timezone.utc) + timedelta(days=1)
+    )
+    row = ChannelConnection(
+        id=uuid.uuid4(), org_id=org_id, channel="x_sandbox", account_id=f"acct-{uuid.uuid4().hex[:8]}",
+        credential_kind="oauth", encrypted_access_token=encrypt_channel_credential("sandbox-x-access:app-1"),
+        encrypted_refresh_token=encrypt_channel_credential(refresh_token),
+        token_expires_at=expires_at, refresh_mode="refresh_token", scopes=["tweet.read", "offline.access"],
+        status="active", connected_by=connected_by,
+    )
+    session.add(row)
+    await session.commit()
+    return row.id
+
+
+async def _seed_x_sandbox_app_credentials(session, org_id, *, app_id: str, updated_by: uuid.UUID):
+    from app.models.channel_app_credential import ChannelAppCredentials
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    row = ChannelAppCredentials(
+        id=uuid.uuid4(), org_id=org_id, channel="x_sandbox", app_id=app_id,
+        encrypted_app_secret=encrypt_channel_credential("secret"), updated_by=updated_by,
+    )
+    session.add(row)
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_apply_refresh_result_persists_rotated_refresh_token_when_given():
+    """⭐AC1 뮤테이션 대상(계층 1: 저장 함수 자체) — `new_refresh_token`을 안
+    갈아 끼우면 이 테스트가 즉시 RED(옛 값이 그대로 남는다)."""
+    from app.services.channel_connection import apply_refresh_result, decrypt_refresh_token_for_use
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            conn_id = await _seed_x_sandbox_connection(
+                s, org_id, refresh_token="sandbox-x-refresh:app-1:g0", connected_by=owner_id,
+            )
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.channel_connection import ChannelConnection
+
+            row = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == conn_id))).scalar_one()
+            await apply_refresh_result(
+                s, connection=row, new_access_token="sandbox-x-access:app-1:rotated",
+                expires_in_seconds=7200, new_refresh_token="sandbox-x-refresh:app-1:g1:rotated",
+            )
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.channel_connection import ChannelConnection
+
+            row = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == conn_id))).scalar_one()
+            assert decrypt_refresh_token_for_use(row) == "sandbox-x-refresh:app-1:g1:rotated"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_refresh_channel_tokens_rotates_x_sandbox_refresh_token(monkeypatch):
+    """⭐AC1 뮤테이션 대상(계층 2: 실 cron 배선) — `_ROTATING_REFRESH_FN_BY_CHANNEL`
+    dispatch나 `apply_refresh_result(new_refresh_token=...)` 배선을 되돌리면 RED
+    (DB에 남는 refresh_token이 계속 "g0"이거나 status가 expired로 뒤집힌다)."""
+    import app.routers.cron as cron_module
+    from app.dependencies.database import get_worker_db
+    from app.main import app
+    from httpx import AsyncClient, ASGITransport
+    from app.services.channel_connection import decrypt_refresh_token_for_use, decrypt_for_use
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "test-cron-secret")
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            await _seed_x_sandbox_app_credentials(s, org_id, app_id="app-1", updated_by=owner_id)
+            conn_id = await _seed_x_sandbox_connection(
+                s, org_id, refresh_token="sandbox-x-refresh:app-1:g0", connected_by=owner_id,
+            )
+
+        async def _worker_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_worker_db] = _worker_db
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get(
+                    "/api/v2/internal/cron/refresh-channel-tokens",
+                    headers={"Authorization": "Bearer test-cron-secret"},
+                )
+            assert r.status_code == 200, r.text
+            body = r.json()["data"]
+            assert body["refreshed"] == 1
+            assert body["failed"] == 0
+        finally:
+            app.dependency_overrides.pop(get_worker_db, None)
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.channel_connection import ChannelConnection
+
+            row = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == conn_id))).scalar_one()
+            new_refresh = decrypt_refresh_token_for_use(row)
+            assert new_refresh != "sandbox-x-refresh:app-1:g0"
+            assert new_refresh.startswith("sandbox-x-refresh:app-1:g1:")
+            assert decrypt_for_use(row) != "sandbox-x-access:app-1"
+            assert row.status == "active"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_refresh_channel_tokens_marks_stale_rotated_refresh_reuse_as_failure(monkeypatch):
+    """카드 AC1 원문 그대로 — "회전 후 옛 refresh로 재발급 시 실패 마커"의 cron
+    레벨 재현. 이미 폐기된(음수 세대 마커) refresh_token으로 저장돼 있는 연결은
+    cron이 실패로 분류하고 status=expired로 sticky 전환한다(재시도 스톰 방지)."""
+    import app.routers.cron as cron_module
+    from app.dependencies.database import get_worker_db
+    from app.main import app
+    from httpx import AsyncClient, ASGITransport
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "test-cron-secret")
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            await _seed_x_sandbox_app_credentials(s, org_id, app_id="app-1", updated_by=owner_id)
+            conn_id = await _seed_x_sandbox_connection(
+                s, org_id, refresh_token="sandbox-x-refresh:app-1:g-1", connected_by=owner_id,
+            )
+
+        async def _worker_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_worker_db] = _worker_db
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get(
+                    "/api/v2/internal/cron/refresh-channel-tokens",
+                    headers={"Authorization": "Bearer test-cron-secret"},
+                )
+            assert r.status_code == 200, r.text
+            body = r.json()["data"]
+            assert body["refreshed"] == 0
+            assert body["failed"] == 1
+        finally:
+            app.dependency_overrides.pop(get_worker_db, None)
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.channel_connection import ChannelConnection
+
+            row = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == conn_id))).scalar_one()
+            assert row.status == "expired"
+            assert "[sandbox:refresh-token-reused]" in (row.last_error or "")
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1652,6 +1652,11 @@
       "file": "tests/test_3806_ads_boost_spend_refresh.py",
       "sec": 5.3,
       "source": "story-3806(Phase3·3-2 PR 12, 페드루 PO 確定 2026-09-11 17:26Z — 「광고비 다시 수집」 수동 갱신 엔드포인트, comments/refresh 동형) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 7건 wall time 약 5.3s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3808_x_oauth.py",
+      "sec": 3.4,
+      "source": "story-3808(Phase3·3-3 PR1, 페드루 PO 確定 2026-09-11) — X OAuth 어댑터·PKCE·1회용 회전 refresh_token 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 13건 wall time 약 3.4s — test_3806_ads_boost_spend_cron_wiring.py 선례와 동일 방법론, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- story #3808 PR1 — X(트위터) 서버 OAuth 2.0(PKCE 필수) 어댑터 + 1회용 회전 refresh_token 갱신 배선.
- `channel_adapters.py`에 `x`/`x_sandbox` 등재 — `refresh_mode="refresh_token"`은 기존 값 재사용(신규 enum 0, 그라운딩 정정 반영).
- `x_oauth.py`(실 provider, PKCE 필수·단일 hop 교환·`refresh_access_token()` 3튜플 반환) + `x_sandbox_oauth.py`(같은 시그니처의 결정적 인프로세스 미러 — 회전 세대 시뮬레이션, 음수 세대=옛 refresh_token 재사용 마커).
- `channel_connection.py`: `apply_refresh_result(new_refresh_token=...)` 신규 옵션 슬롯(기존 채널은 안 넘기므로 회귀 0) + `decrypt_refresh_token_for_use()` 신규.
- `cron.py`: `_ROTATING_REFRESH_FN_BY_CHANNEL` 병렬 dispatch — refresh_token(access_token 아님)을 provider에 보내고 반환된 새 access+refresh 쌍을 그대로 영속화.
- `channel_connections.py`: authorize/callback에 `x`/`x_sandbox` 배선(`_x_channel_connection_callback`, `_x_oauth_module` 모듈-스왑 dispatch — facebook/meta_ads와 동형).

## AC1 커버
- 신규 `test_3808_x_oauth.py`(13건) — PKCE 강제·단일 hop 교환·회전 3튜플·sandbox 결정적 회전·⭐옛 refresh 재사용 마커·adapter 등재·apply_refresh_result 저장 슬롯·cron 배선 실DB 2건(정상 회전/재사용 실패 마커).
- 뮤테이션 셀프체크 2건 모두 확인: ① `apply_refresh_result`의 `new_refresh_token` 저장 로직 제거 → 저장 계층 테스트 2건 RED. ② cron의 `_ROTATING_REFRESH_FN_BY_CHANNEL` dispatch 무효화 → cron 레벨 테스트 2건 RED. 원복 후 전부 GREEN 재확認.
- 회귀(**정정 1, 페드루 PO 지적** — 수는 집합과 같이 적어야 함): 아래 **15개 파일**(발견 명령·`grep -rl "from app.services.channel_connection import\|from app.services.channel_adapters import" tests/*.py`가 잡은 16건 중 docstring 안 문자열 참조로 인한 존재하지 않는 파일 1건 제외) 직접 실행 결과 **210건 GREEN**(threads/instagram/facebook/meta_ads/ads_sandbox 무변경 확認) — 카디르 QA가 직접 관련 11파일로 재현한 130/130이 이 PR의 「게시」 판정 숫자이며, 아래 210은 그보다 넓은 import-grep 집합(간접 인접 파일 포함)에서의 결과다. 두 수가 다른 건 집합이 다르기 때문(어느 쪽도 오류 아님) — 게시는 카디르 130/130 기준.
  ```
  tests/test_3419_cancel_unpublish.py
  tests/test_3373_channel_connections_app_credentials.py
  tests/test_3320_instagram_connector.py
  tests/test_3492_credential_replace.py
  tests/test_3567_facebook_page_final.py
  tests/test_3523_generic_channel_sandbox.py
  tests/test_3547_facebook_page_connection.py
  tests/test_3598_facebook_refresh_judgment.py
  tests/test_3612_connection_notactive_precheck_norecord.py
  tests/test_3603_connection_last_error.py
  tests/test_3571_facebook_comments_insights.py
  tests/test_3808_x_oauth.py
  tests/test_3806_meta_ads_account_connection.py
  tests/test_5b27b32f_sandbox_channel.py
  tests/test_f30da19a_available_channels.py
  ```
  실행: `uv run pytest <위 15개 경로> -q` (PARITY_TEST_DATABASE_URL 로컬 Postgres).
- 관련 lint 가드 85건 GREEN(파일 집합: `test_2255_model_registration_completeness_lint.py`·`test_2786_destructive_test_sql_lint.py`·`test_3370_commit_validate_lint_scan_completeness.py`·`test_3370_raw_auth_id_into_member_field_lint.py`·`test_3779_korean_user_strings_lint.py`·`test_2335_query_sentinel_lint.py`·`test_2342_project_access_403_lint.py`).

## Test plan
- [x] 신규 13건 GREEN + 뮤테이션 셀프체크 2쌍 RED→GREEN 확認
- [x] 위 15파일 직접실행 210건 회귀 0(카디르 130/130이 게시 기준 숫자)
- [x] lint 가드 7파일 85건 GREEN
- [x] py_compile 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8
