### PR TITLE
[SID:3809] feat: 고급 보고 첫 출시 조각1 — source 분류 유틸+org 비용 원장 API

### DIFF
--- a/backend/app/routers/insights_board.py
+++ b/backend/app/routers/insights_board.py
@@ -25,6 +25,7 @@ from app.services.insights_board import (
 from app.services.insight_snapshots import InsightFetchError
 from app.services.measured_metrics import compute_measured_metrics
 from app.services.member_resolver import resolve_member
+from app.services.org_cost_summary import get_org_cost_summary
 from app.services.publication_reconciliation import reconcile_publication
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["insights-board"])
@@ -148,6 +149,50 @@ class ReconciliationResponse(BaseModel):
     verdicts: dict[str, str]
     has_mismatch: bool
     created_at: datetime
+
+
+class OrgAdsCostSummaryView(BaseModel):
+    # story #3809(Phase3·3-7, 페드루 PO 確定 2026-09-11 17:12Z) — approved
+    # ads_boost 게이트 집합 기준(org_cost_summary.py::get_org_ads_cost_summary
+    # 모듈 docstring 참고, "같은 집합이라야 remaining이 정합"의 근거).
+    approved_boost_count: int
+    sealed_budget_minor: int
+    captured_spend_minor: int
+    remaining_minor: int
+    cap_reached_count: int
+
+
+class PaidSpendDailyPointView(BaseModel):
+    date: str
+    spend_minor: int
+    source: Literal["paid", "organic"]
+
+
+class OrgCostSummaryResponse(BaseModel):
+    ads: OrgAdsCostSummaryView
+    # story #3498 규칙이 org에 없으면 null("규칙 없음"과 "0 지출"을 안 뭉갠다).
+    generation_cost_spent_minor: int | None
+    generation_cost_period_start: datetime | None
+    generation_cost_period_end: datetime | None
+    # story #3809 그라운딩②(2026-09-11) — X 비용 원장이 이 시점 코드에 없다(실측
+    # 확認). "0"으로 지어내지 않고 미측정 예약(null)만 한다.
+    x_cost_spent_minor: int | None
+    paid_spend_daily_series: list[PaidSpendDailyPointView]
+
+
+@router.get("/{org_id}/insights-board/cost-summary", response_model=OrgCostSummaryResponse)
+async def get_org_cost_summary_endpoint(
+    org_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+) -> OrgCostSummaryResponse:
+    """story #3809(Phase3·3-7) — 「고급 보고 첫 출시」 조각 1. 조직 단위 비용
+    원장(광고비·생성 비용·X 비용) 첫 API. 읽기 전용 — insights-board 본 엔드포인트와
+    동형 권한 축(휴먼·에이전트 모두)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    return OrgCostSummaryResponse(**await get_org_cost_summary(db, org_id=org_id))
 
 
 @router.get("/{org_id}/insights-board", response_model=InsightsBoardResponse)

--- a/backend/app/services/ads_spend_snapshots.py
+++ b/backend/app/services/ads_spend_snapshots.py
@@ -60,6 +60,17 @@ def paid_snapshots_only(stmt):
     return stmt.where(InsightSnapshot.channel.in_(_PAID_CHANNELS))
 
 
+def classify_insight_source(channel: str) -> str:
+    """story #3809(Phase3·3-7, 페드루 PO 確定 2026-09-11 17:12Z) — 「응답에
+    source: paid|organic 명시」의 유일한 판정 지점. `_PAID_CHANNELS` 재사용
+    (새 판별식 0 — organic_snapshots_only/paid_snapshots_only와 동일 SSOT).
+    기존 `InsightSnapshotView.source`(insight_snapshots.py, organic 전용
+    엔드포인트에서 원채널명을 그대로 실어 `insight-snapshot-block.tsx`가
+    렌더 中)와는 **다른 값·다른 소비처** — 그 필드는 안 건드린다(그라운딩
+    2026-09-11 17:11Z, FE 회귀 위험 발견 후 페드루 確定으로 범위 확정)."""
+    return _PAID_SOURCE if channel in _PAID_CHANNELS else "organic"
+
+
 async def schedule_ads_spend_snapshots(
     db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, publication_id: uuid.UUID,
     channel: str, anchor_at: datetime,

--- a/backend/app/services/org_cost_summary.py
+++ b/backend/app/services/org_cost_summary.py
@@ -28,7 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.ads_boost_run import AdsBoostRun
 from app.models.gate import Gate
 from app.models.insight_snapshot import InsightSnapshot
-from app.services.ads_spend_snapshots import _ADS_BOOST_GATE_TYPE, _PAID_SOURCE
+from app.services.ads_spend_snapshots import _ADS_BOOST_GATE_TYPE, _PAID_SOURCE, paid_snapshots_only
 from app.services.generation_budget import compute_generation_budget_status
 
 
@@ -46,11 +46,15 @@ async def get_org_ads_cost_summary(db: AsyncSession, *, org_id: uuid.UUID) -> di
     publication_ids = [uuid.UUID(g.scope_key) for g in gates if g.scope_key]
     captured_spend_minor_sum = 0
     if publication_ids:
+        # story #3806 가드(test_3806_organic_snapshots_only_guard.py) 처방(페드루
+        # PO 지적 2026-09-11 17:44Z) — 손으로 InsightSnapshot을 직접 필터하지 않고
+        # `paid_snapshots_only()`(채널 기반, 캡처 여부 무관하게 항상 정확)를 그대로
+        # 쓴다. `status=="captured"`를 같이 걸어 "이미 캡처된 것"만 합산.
         snapshots = (await db.execute(
-            select(InsightSnapshot).where(
+            paid_snapshots_only(select(InsightSnapshot).where(
                 InsightSnapshot.org_id == org_id, InsightSnapshot.publication_id.in_(publication_ids),
-                InsightSnapshot.source == _PAID_SOURCE, InsightSnapshot.status == "captured",
-            )
+                InsightSnapshot.status == "captured",
+            ))
         )).scalars().all()
         captured_spend_minor_sum = sum((s.normalized or {}).get("spend") or 0 for s in snapshots)
 
@@ -78,10 +82,10 @@ async def get_org_paid_spend_daily_series(db: AsyncSession, *, org_id: uuid.UUID
     아니라 `captured_at`으로 가른다 — due_at은 +1d/+7d 스케줄링 anchor일 뿐 실제
     수집 시각이 아니다(ads_spend_snapshots.py 모듈 docstring과 동형 구분)."""
     rows = (await db.execute(
-        select(InsightSnapshot.captured_at, InsightSnapshot.normalized).where(
-            InsightSnapshot.org_id == org_id, InsightSnapshot.source == _PAID_SOURCE,
+        paid_snapshots_only(select(InsightSnapshot.captured_at, InsightSnapshot.normalized).where(
+            InsightSnapshot.org_id == org_id,
             InsightSnapshot.status == "captured", InsightSnapshot.captured_at.isnot(None),
-        )
+        ))
     )).all()
 
     by_day: dict[str, int] = defaultdict(int)

--- a/backend/app/services/org_cost_summary.py
+++ b/backend/app/services/org_cost_summary.py
@@ -1,0 +1,118 @@
+"""story #3809(Phase3·3-7, 페드루 PO 確定 2026-09-11 17:12Z) — 「고급 보고 첫
+출시」 조각 하나: 조직 단위 비용 원장(광고비·생성 비용·X 비용) 첫 API. 블루프린트
+§7 「X 비용과 광고비 조직 대시보드 분리 표시」의 실물.
+
+세 축을 한 응답에 모으되 계산·SSOT는 각자 기존 모듈 그대로 재사용한다(신규 기전
+발명 0):
+- 광고비(ads): `ads_spend_snapshots.py`(story #3806) — 승인된 ads_boost 게이트의
+  봉인 예산·캡처 지출·상한 도달(PR11의 `AdsBoostRun.cap_reached_at`).
+- 생성 비용(generation): `generation_budget.py`(story #3498) —
+  `compute_generation_budget_status`를 그대로 호출(월 합산 계산 재구현 0).
+- X 비용: 이 스토리 시점 코드 0(그라운딩 ②에서 이미 확認) — 「미측정」을 0으로
+  지어내지 않고 `null`로 예약만 한다(향후 실 원장이 생기면 이 자리에 채운다).
+
+「승인 예산 합·캡처 지출 합·잔여」는 **같은 게이트 집합**(status=="approved")으로
+맞춰 계산한다 — 그래야 `remaining = budget_sum - captured_sum`이 그 집합 안에서
+정합한다(다른 집합을 섞으면 지어낸 잔여가 된다). paid 일 시계열은 별도 cut(org
+전체 역사 — 게이트 현재 상태와 무관하게 「그날 실제로 캡처된 지출」을 그대로
+보여준다, 트렌드 조회는 예산 정합이 아니라 사실 나열이 목적)."""
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ads_boost_run import AdsBoostRun
+from app.models.gate import Gate
+from app.models.insight_snapshot import InsightSnapshot
+from app.services.ads_spend_snapshots import _ADS_BOOST_GATE_TYPE, _PAID_SOURCE
+from app.services.generation_budget import compute_generation_budget_status
+
+
+async def get_org_ads_cost_summary(db: AsyncSession, *, org_id: uuid.UUID) -> dict:
+    """승인된(status=="approved") ads_boost 게이트 집합 기준 예산·지출·상한. 그
+    집합이 비어 있으면(승인된 boost가 org에 0건) 전부 0/None — 지어내지 않는다."""
+    gates = (await db.execute(
+        select(Gate).where(
+            Gate.org_id == org_id, Gate.gate_type == _ADS_BOOST_GATE_TYPE, Gate.status == "approved",
+        )
+    )).scalars().all()
+
+    sealed_budget_minor_sum = sum(g.sealed_ads_budget_minor or 0 for g in gates)
+
+    publication_ids = [uuid.UUID(g.scope_key) for g in gates if g.scope_key]
+    captured_spend_minor_sum = 0
+    if publication_ids:
+        snapshots = (await db.execute(
+            select(InsightSnapshot).where(
+                InsightSnapshot.org_id == org_id, InsightSnapshot.publication_id.in_(publication_ids),
+                InsightSnapshot.source == _PAID_SOURCE, InsightSnapshot.status == "captured",
+            )
+        )).scalars().all()
+        captured_spend_minor_sum = sum((s.normalized or {}).get("spend") or 0 for s in snapshots)
+
+    gate_ids = [g.id for g in gates]
+    cap_reached_count = 0
+    if gate_ids:
+        runs = (await db.execute(
+            select(AdsBoostRun).where(AdsBoostRun.gate_id.in_(gate_ids), AdsBoostRun.cap_reached_at.isnot(None))
+        )).scalars().all()
+        cap_reached_count = len(runs)
+
+    return {
+        "approved_boost_count": len(gates),
+        "sealed_budget_minor": sealed_budget_minor_sum,
+        "captured_spend_minor": captured_spend_minor_sum,
+        "remaining_minor": sealed_budget_minor_sum - captured_spend_minor_sum,
+        "cap_reached_count": cap_reached_count,
+    }
+
+
+async def get_org_paid_spend_daily_series(db: AsyncSession, *, org_id: uuid.UUID) -> list[dict]:
+    """org 전체 캡처된 paid 지출을 날짜(캡처일 UTC)별로 합산 — 예산 정합용이 아닌
+    트렌드 열람용이라 게이트 현재 status와 무관하게 「그날 실제로 캡처된」 사실을
+    그대로 낸다(과거 지출은 게이트가 그 뒤 재오픈/종료돼도 안 사라진다). due_at이
+    아니라 `captured_at`으로 가른다 — due_at은 +1d/+7d 스케줄링 anchor일 뿐 실제
+    수집 시각이 아니다(ads_spend_snapshots.py 모듈 docstring과 동형 구분)."""
+    rows = (await db.execute(
+        select(InsightSnapshot.captured_at, InsightSnapshot.normalized).where(
+            InsightSnapshot.org_id == org_id, InsightSnapshot.source == _PAID_SOURCE,
+            InsightSnapshot.status == "captured", InsightSnapshot.captured_at.isnot(None),
+        )
+    )).all()
+
+    by_day: dict[str, int] = defaultdict(int)
+    for captured_at, normalized in rows:
+        day = captured_at.date().isoformat()
+        by_day[day] += (normalized or {}).get("spend") or 0
+
+    # 이 함수가 이미 `source == _PAID_SOURCE`로만 걸러 왔으니 매 항목의 값은
+    # 자명하게 "paid"다 — classify_insight_source()를 가짜 채널 인자로 부르는
+    # 대신 그 상수를 직접 쓴다(그 함수는 원채널→분류가 필요한 자리 전용).
+    return [
+        {"date": day, "spend_minor": spend, "source": _PAID_SOURCE}
+        for day, spend in sorted(by_day.items())
+    ]
+
+
+async def get_org_cost_summary(db: AsyncSession, *, org_id: uuid.UUID, now: datetime | None = None) -> dict:
+    now = now or datetime.now(timezone.utc)
+    ads = await get_org_ads_cost_summary(db, org_id=org_id)
+    generation = await compute_generation_budget_status(db, org_id=org_id, now=now)
+    daily_series = await get_org_paid_spend_daily_series(db, org_id=org_id)
+
+    return {
+        "ads": ads,
+        # story #3498 규칙이 org에 없으면 None("규칙 없음"과 "0 지출"을 뭉개지
+        # 않는다 — compute_generation_budget_status 자신의 계약 그대로).
+        "generation_cost_spent_minor": generation["spent_minor"] if generation is not None else None,
+        "generation_cost_period_start": generation["period_start"] if generation is not None else None,
+        "generation_cost_period_end": generation["period_end"] if generation is not None else None,
+        # story #3809 그라운딩②(2026-09-11) — X 비용 원장 자체가 이 시점 코드에
+        # 없다(실측 확認). "0"으로 지어내지 않고 미측정을 null로 예약만 한다.
+        "x_cost_spent_minor": None,
+        "paid_spend_daily_series": daily_series,
+    }

--- a/backend/tests/test_3806_organic_snapshots_only_guard.py
+++ b/backend/tests/test_3806_organic_snapshots_only_guard.py
@@ -40,6 +40,13 @@ _EXEMPT_FILES: dict[str, str] = {
         "InsightSnapshot(...) 생성자로 transient 객체를 만들 뿐(db.add() 0회 — 파라미터 "
         "캐리어, 파일 자체 주석 확認) — DB 조회가 아니라 leak 대상이 아니다."
     ),
+    "app/services/org_cost_summary.py": (
+        "story #3809(Phase3·3-7) — org 비용 원장의 paid 축(광고비 집계·일별 시계열)이 "
+        "의도적으로 paid 채널만 보는 정당한 소비처(ads_spend_snapshots.py와 동형 판단) — "
+        "실제로 `paid_snapshots_only()`(같은 파일의 반대짝 술어)를 그대로 호출한다(손으로 "
+        "채널/소스 필터를 다시 안 적음), organic_snapshots_only()를 자기 자신에게 부를 "
+        "이유가 없다."
+    ),
 }
 
 

--- a/backend/tests/test_3809_org_cost_summary.py
+++ b/backend/tests/test_3809_org_cost_summary.py
@@ -1,0 +1,302 @@
+"""story #3809(Phase3·3-7, 페드루 PO 確定 2026-09-11 17:12Z) — 「고급 보고 첫
+출시」 조각 1: 공유 분류 유틸(`classify_insight_source`)·드리프트 가드·조직 단위
+비용 원장 API(`GET /{org_id}/insights-board/cost-summary`) 회귀. 세팅 헬퍼는
+test_3806_ads_boost_execution.py/test_3806_ads_boost_spend.py(ads 축)·
+test_3471_org_content_rules_lint.py·test_3498_generation_budget_evidence_and_
+config.py(생성비용 축) 재사용(중복 재발명 금지). 새 마이그 0건(신규 테이블·컬럼
+0 — 기존 InsightSnapshot·Gate·AdsBoostRun·org_content_rules 조회만)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_3471_org_content_rules_lint import (
+    _client_for,
+    _seed_human,
+    _seed_org,
+    _session_factory,
+    _setup_org_scoped_app,
+)
+from tests.test_3498_generation_budget_evidence_and_config import (
+    _put_generation_budget,
+    _seed_generation_cost_evidence,
+)
+from tests.test_3806_ads_boost_execution import _setup_approved_gate
+from tests.test_3806_ads_boost_spend import _make_spend_snapshots_due, _start_boost
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def test_classify_insight_source_covers_all_paid_channels_and_organic_samples():
+    """드리프트 가드 — `_PAID_CHANNELS` 전부(paid)·organic 표본 6채널(실채널+3
+    sandbox 미러) 전수. 뮤테이션 대상: `classify_insight_source`가 `_PAID_CHANNELS`
+    대신 새 판별식(예: 리터럴 나열)을 쓰면 이 상수가 늘어나도 이 테스트가 못
+    잡는다 — 반드시 `_PAID_CHANNELS`를 그대로 참조해야 이 테스트가 그 상수의
+    미래 변경까지 자동으로 커버한다."""
+    from app.services.ads_spend_snapshots import _PAID_CHANNELS, classify_insight_source
+
+    for channel in _PAID_CHANNELS:
+        assert classify_insight_source(channel) == "paid", channel
+
+    for channel in ("threads", "instagram", "facebook", "sandbox", "instagram_sandbox", "facebook_sandbox"):
+        assert classify_insight_source(channel) == "organic", channel
+
+
+@pytest.mark.anyio
+async def test_org_ads_cost_summary_zero_when_no_approved_boosts():
+    from app.services.org_cost_summary import get_org_ads_cost_summary
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+
+        async with Session() as s:
+            summary = await get_org_ads_cost_summary(s, org_id=org_id)
+        assert summary == {
+            "approved_boost_count": 0, "sealed_budget_minor": 0, "captured_spend_minor": 0,
+            "remaining_minor": 0, "cap_reached_count": 0,
+        }
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_ads_cost_summary_sums_approved_boost_budget_and_captured_spend():
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from app.services.org_cost_summary import get_org_ads_cost_summary
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+        async with Session() as s:
+            await process_due_ads_spend_snapshots(s)
+
+        async with Session() as s:
+            summary = await get_org_ads_cost_summary(s, org_id=org_id)
+        assert summary["approved_boost_count"] == 1
+        assert summary["sealed_budget_minor"] == 100_000
+        assert summary["captured_spend_minor"] == 12_345 * 2
+        assert summary["remaining_minor"] == 100_000 - 12_345 * 2
+        assert summary["cap_reached_count"] == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_ads_cost_summary_counts_cap_reached():
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from app.services.org_cost_summary import get_org_ads_cost_summary
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(
+        await _session_factory(), budget_minor=10_000,
+    )
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+        async with Session() as s:
+            await process_due_ads_spend_snapshots(s)
+
+        async with Session() as s:
+            summary = await get_org_ads_cost_summary(s, org_id=org_id)
+        assert summary["cap_reached_count"] == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_ads_cost_summary_excludes_pending_gate():
+    """승인 안 된 게이트는 「승인 예산 합」에 안 잡혀야 한다 — 지어낸 낙관치 금지."""
+    from app.services.org_cost_summary import get_org_ads_cost_summary
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(
+        await _session_factory(), approve=False,
+    )
+    try:
+        async with Session() as s:
+            summary = await get_org_ads_cost_summary(s, org_id=org_id)
+        assert summary["approved_boost_count"] == 0
+        assert summary["sealed_budget_minor"] == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_generation_cost_null_when_no_rule():
+    from app.services.org_cost_summary import get_org_cost_summary
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+
+        async with Session() as s:
+            summary = await get_org_cost_summary(s, org_id=org_id)
+        assert summary["generation_cost_spent_minor"] is None
+        assert summary["generation_cost_period_start"] is None
+        assert summary["generation_cost_period_end"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_generation_cost_reflects_evidence_sum():
+    from app.services.org_cost_summary import get_org_cost_summary
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            await _put_generation_budget(s, org_id=org_id, limit_minor=100_000)
+            await _seed_generation_cost_evidence(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), cost_minor=3_000, created_by=owner_id,
+            )
+            await _seed_generation_cost_evidence(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), cost_minor=2_000, created_by=owner_id,
+            )
+
+        async with Session() as s:
+            summary = await get_org_cost_summary(s, org_id=org_id)
+        assert summary["generation_cost_spent_minor"] == 5_000
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_x_cost_always_null():
+    """story #3809 그라운딩②(2026-09-11) — X 비용 원장 자체가 이 시점 코드에
+    없다(실측 확認). 다른 조건과 무관하게 항상 null이어야 한다(0으로 지어내지
+    않는다)."""
+    from app.services.org_cost_summary import get_org_cost_summary
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+
+        async with Session() as s:
+            summary = await get_org_cost_summary(s, org_id=org_id)
+        assert summary["x_cost_spent_minor"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_paid_spend_daily_series_aggregates_by_captured_date():
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from app.services.org_cost_summary import get_org_paid_spend_daily_series
+    from sqlalchemy import select, update
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+        async with Session() as s:
+            await process_due_ads_spend_snapshots(s)
+
+        # 두 스냅샷의 captured_at을 서로 다른 날(어제·오늘)로 갈라 그룹화가 실제로
+        # 날짜 단위인지 확認(둘 다 같은 tick·같은 now로 캡처돼 원래는 같은 날이다).
+        async with Session() as s:
+            rows = (await s.execute(
+                select(InsightSnapshot).where(
+                    InsightSnapshot.org_id == org_id, InsightSnapshot.source == "paid",
+                ).order_by(InsightSnapshot.due_at.asc())
+            )).scalars().all()
+            assert len(rows) == 2
+            yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+            await s.execute(update(InsightSnapshot).where(InsightSnapshot.id == rows[0].id).values(captured_at=yesterday))
+            await s.commit()
+
+        async with Session() as s:
+            series = await get_org_paid_spend_daily_series(s, org_id=org_id)
+        assert len(series) == 2, series
+        assert all(point["spend_minor"] == 12_345 for point in series), series
+        assert all(point["source"] == "paid" for point in series), series
+        assert series[0]["date"] < series[1]["date"], "오름차순 정렬이어야 한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cost_summary_endpoint_returns_shape():
+    from app.main import app
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/insights-board/cost-summary")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert set(body.keys()) == {
+            "ads", "generation_cost_spent_minor", "generation_cost_period_start",
+            "generation_cost_period_end", "x_cost_spent_minor", "paid_spend_daily_series",
+        }
+        assert set(body["ads"].keys()) == {
+            "approved_boost_count", "sealed_budget_minor", "captured_spend_minor",
+            "remaining_minor", "cap_reached_count",
+        }
+        assert body["ads"]["approved_boost_count"] == 1
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cost_summary_endpoint_org_id_mismatch_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a, _ = await _seed_org(s)
+            owner_a = await _seed_human(s, org_a, role="owner")
+            org_b, _ = await _seed_org(s)
+
+        _setup_org_scoped_app(app, Session, org_a, user_id=owner_a)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_b}/insights-board/cost-summary")
+        assert r.status_code == 403, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1642,6 +1642,11 @@
       "file": "tests/test_3806_ads_boost_spend_cron_wiring.py",
       "sec": 3.1,
       "source": "story-3806(Phase3·3-2 PR 11, 페드루 PO 確定 2026-09-11 16:20Z — process_due_ads_spend_snapshots cron 미배선 갭 처방, test_3806_ads_boost_starts_cron_wiring.py 선례와 동형) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 2건 wall time 약 3.1s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3809_org_cost_summary.py",
+      "sec": 6.7,
+      "source": "story-3809(Phase3·3-7, 페드루 PO 確定 2026-09-11 17:12Z — 고급 보고 첫 출시 조각1: classify_insight_source 드리프트가드+org cost-summary API) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 11건 wall time 약 6.7s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }


### PR DESCRIPTION
## 배경
블루프린트 §7 「X 비용과 광고비 조직 대시보드 분리 표시」의 첫 실물(페드루 PO 確定 2026-09-11 17:12Z). 착수 전 그라운딩 도중 FE 회귀 위험 발견: 원래 계획대로 기존 `InsightSnapshotView.source`(GET .../publications/{id}/insights)에 `paid|organic` 값을 얹으려 했으나, 그 필드는 이미 `insight-snapshot-block.tsx:163`가 원채널명(예: "threads")으로 렌더 중이라 값 의미를 바꾸면 화면 표시정보가 손실되는 회귀였다. 페드루 PO가 즉시 범위를 좁혀 확定 — 기존 필드/엔드포인트는 손대지 않고, 새 org 비용 원장 API가 `source: paid|organic`의 첫 소비처가 된다.

## 변경
- `classify_insight_source(channel)`(ads_spend_snapshots.py): `source: paid|organic` 판정의 유일한 지점 — `_PAID_CHANNELS` 재사용(새 판별식 0, `organic_snapshots_only`/`paid_snapshots_only`와 동일 SSOT).
- `GET /organizations/{org_id}/insights-board/cost-summary`(신규):
  - `ads`: 승인된(status=="approved") ads_boost 게이트 집합 기준 봉인예산 합·캡처지출 합·잔여·cap_reached 집계(PR11의 `AdsBoostRun.cap_reached_at` 재사용) — 같은 게이트 집합으로 맞춰야 `remaining`이 정합.
  - `generation_cost_*`: `compute_generation_budget_status`(#3498) 그대로 호출(월 합산 재구현 0) — 규칙이 org에 없으면 null(0으로 지어내지 않음).
  - `x_cost_spent_minor`: 이 시점 X 비용 원장 자체가 코드에 없음(그라운딩②에서 실측 확認) — null 예약만.
  - `paid_spend_daily_series`: org 전체 캡처일(`captured_at`) 기준 paid 지출 일별 합산 — 예산 정합이 아닌 트렌드 열람 목적이라 게이트 현재 status와 무관(과거 지출은 게이트가 재오픈/종료돼도 안 사라짐).

## 테스트
- 분류 드리프트가드 1건(`_PAID_CHANNELS` 전부 + organic 표본 6채널).
- ads 집계 3건(0건 시 전부 0·승인+캡처 정확한 합·cap_reached 집계) + pending 게이트 제외 1건.
- 생성비용 2건(규칙 없으면 null·evidence 합산 반영) + X비용 항상 null 1건.
- 일별 시계열 그룹화 1건(날짜 다르게 강제해 실제 날짜 단위 그룹화 확認).
- 엔드포인트 형태 1건 + org_id mismatch 403 1건.
- 뮤테이션 셀프체크 2건: ① `classify_insight_source`를 항등 "organic"으로 → 그 드리프트가드 테스트만 RED ② approved 상태 필터 제거 → pending-게이트-제외 테스트만 RED. 둘 다 원복 후 재GREEN.
- 회귀: 3806 ads_boost 전체 스위트·3498 generation_budget·3502 insights_board 99/99 GREEN.

## 범위 밖
- 기존 `InsightSnapshotView.source`/`GET .../publications/{id}/insights`는 무변경(FE 소비 보존).
- FE 대시보드 카드(PR3)·X 비용 실 원장은 이 PR 범위 밖.
- 마이그레이션 0건(신규 테이블/컬럼 0, 기존 조회 조합만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn