### PR TITLE
[SID:3810] S7 슬라이스13 ② — /desktop 다운로드 카드 경고 2줄 위계

### DIFF
--- a/apps/web/src/components/desktop/desktop-download-card.tsx
+++ b/apps/web/src/components/desktop/desktop-download-card.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Loader2 } from 'lucide-react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 
@@ -102,12 +103,17 @@ export function DesktopDownloadCard() {
           <span data-testid="desktop-download-build-sha">{' · '}{t('buildLabel', { sha: buildSha })}</span>
         ) : null}
       </p>
-      <p className="text-xs text-muted-foreground" data-testid="desktop-download-notarization-notice">
-        {t('notarizationNotice')}
-      </p>
-      <p className="text-xs text-muted-foreground" data-testid="desktop-download-gatekeeper-notice">
-        {t('gatekeeperNotice')}
-      </p>
+      {/* [SID:3810] 슬라이스13② — 두 경고를 한 위계로: 「지금 해야 할 일」(우클릭→열기)을
+          AlertTitle로 먼저 보이고, 「왜」(공증 전 내부용)는 AlertDescription으로 덧붙인다.
+          이전엔 둘 다 위 메타 정보(버전·대상 플랫폼)와 같은 text-xs text-muted-foreground라
+          경고라는 게 눈에 안 띄었다(유나 지적). */}
+      <Alert variant="warning">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle data-testid="desktop-download-gatekeeper-notice">{t('gatekeeperNotice')}</AlertTitle>
+        <AlertDescription data-testid="desktop-download-notarization-notice">
+          {t('notarizationNotice')}
+        </AlertDescription>
+      </Alert>
       <Button asChild size="sm" data-testid="desktop-download-button">
         <a href={downloadUrl} download>{t('downloadCta')}</a>
       </Button>


### PR DESCRIPTION
## 무엇

슬라이스13 마감 묶음 ②. `/desktop` 다운로드 카드의 `notarizationNotice`·`gatekeeperNotice` 두 줄이 위 메타 정보(버전·대상 플랫폼)와 똑같은 `text-xs text-muted-foreground`라 경고라는 게 시각적으로 안 눈에 띄었다.

## 변경

기존 Alert 디자인시스템(`variant="warning"`, 이미 `remove-org-member-dialog.tsx` 등 3곳 이상에서 쓰는 검증된 패턴 — 새 스타일 발명 0)으로 교체:
- **AlertTitle**(우선순위 위) = `gatekeeperNotice`(지금 해야 할 일 — 우클릭→열기, 이걸 모르면 앱이 그냥 안 열려서 고장났다고 오해함)
- **AlertDescription**(우선순위 아래) = `notarizationNotice`(왜 — 공증 전 내부용이라는 맥락)

`AlertTriangle` 아이콘과 함께 한 경고 박스로 묶어, 메타 정보와 명확히 구분되는 시각 위계를 준다.

`data-testid`는 그대로 유지(`desktop-download-gatekeeper-notice`·`-notarization-notice`) — 기존 텍스트 대조 테스트가 손댈 필요 없이 그대로 통과.

## 증거

```
$ pnpm exec vitest run src/components/desktop/desktop-download-card.test.tsx
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ pnpm exec tsc --noEmit -p .
(clean, exit 0)
```

인증 필요 페이지(`(authenticated)/desktop`)라 이 세션에서 실 브라우저 렌더는 아직 못 봤다 — 필요하면 캡처 이어서 만들 수 있는(슬라이스13③에서 한 것처럼).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xkNnQ4d69Wg1HZGm3WoYM