### PR TITLE
[SID:3811] GCS 매니페스트 fetch에 캐시버스터 — 업스트림 캐시 이중 방어

### DIFF
--- a/apps/web/src/lib/desktop-updates.test.ts
+++ b/apps/web/src/lib/desktop-updates.test.ts
@@ -16,10 +16,22 @@ describe('fetchDesktopUpdateManifest', () => {
     });
     const body = await fetchDesktopUpdateManifest(mockFetch as unknown as typeof fetch);
     expect(body).toBe(FIXTURE_MANIFEST);
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://storage.googleapis.com/sprintable-desktop-releases-dev/macos/latest/macos.json',
-      { cache: 'no-store' },
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(calledOptions).toEqual({ cache: 'no-store' });
+    // [SID:3811] 캐시버스터 — GCS 앞단 캐시가 URL을 키로 삼아도 매 호출 새 쿼리스트링이면
+    // 안 먹힌다. 정확한 타임스탬프 값은 안 보되(고정하면 헛도는 테스트), 형태는 실측한다.
+    expect(calledUrl).toMatch(
+      /^https:\/\/storage\.googleapis\.com\/sprintable-desktop-releases-dev\/macos\/latest\/macos\.json\?_t=\d+-[a-z0-9]+$/,
     );
+  });
+
+  it('busts the cache with a different query string on each call — two calls must not hit the same URL', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: async () => FIXTURE_MANIFEST });
+    await fetchDesktopUpdateManifest(mockFetch as unknown as typeof fetch);
+    await fetchDesktopUpdateManifest(mockFetch as unknown as typeof fetch);
+    const urls = mockFetch.mock.calls.map((c) => c[0] as string);
+    expect(urls[0]).not.toBe(urls[1]);
   });
 
   it('throws DesktopManifestUnavailableError when GCS returns non-2xx — mutation guard: bucket object missing/gone must not surface as a broken 200', async () => {

--- a/apps/web/src/lib/desktop-updates.ts
+++ b/apps/web/src/lib/desktop-updates.ts
@@ -9,11 +9,23 @@ const GCS_MANIFEST_URL =
 
 export class DesktopManifestUnavailableError extends Error {}
 
+// [SID:3811] mobile CI가 이 객체를 no-cache 메타데이터로 올리는 쪽이 1차 방어(원인 쪽 수정,
+// sprintable-mobile#… 워크플로) — 이 fetch의 no-store는 이 프로세스 자신의 캐시만 끈다.
+// GCS 앞단(CDN·엣지)이 그 메타데이터를 못 읽거나 아직 반영 전이어도(실측: 릴리스 직후
+// 프런트 노드마다 세대가 갈렸다) 매번 다른 쿼리스트링을 붙이면 URL 키 캐시 자체가 안 먹혀
+// 이중으로 막힌다 — 어느 한쪽이 빠져도 서게.
+function cacheBustedManifestUrl(): string {
+  // Date.now()만 쓰면 같은 밀리초 안의 두 호출이 같은 URL이 될 수 있다(타이밍에 기대는 값은
+  // 테스트도 실사용도 불안정하게 만든다) — 난수를 더해 항상 다른 쿼리스트링을 보장한다.
+  const nonce = Math.random().toString(36).slice(2);
+  return `${GCS_MANIFEST_URL}?_t=${Date.now()}-${nonce}`;
+}
+
 /** GCS의 실 매니페스트를 그대로 가져온다(파싱·재조립 0 — 원문 그대로 중계). */
 export async function fetchDesktopUpdateManifest(
   fetchImpl: typeof fetch = fetch,
 ): Promise<string> {
-  const res = await fetchImpl(GCS_MANIFEST_URL, { cache: 'no-store' });
+  const res = await fetchImpl(cacheBustedManifestUrl(), { cache: 'no-store' });
   if (!res.ok) {
     throw new DesktopManifestUnavailableError(
       `GCS manifest fetch failed: ${res.status} ${res.statusText}`,


### PR DESCRIPTION
## 무엇

#3811(데스크톱 업데이트 매니페스트 간헐 캐시 오답) 할 일 3. mobile 레포 쪽 PR(no-cache 업로드 메타데이터, 원인 수정)과 짝을 이루는 이중 방어 — 어느 한쪽이 빠져도 서게.

## 배경

실측(2026-09-11): `latest/macos.json`을 no-cache 메타데이터로 올려도 GCS 앞단 캐시 반영에 시차가 있어, 릴리스 직후 프런트 캐시 노드마다 다른 세대를 들고 있을 수 있다(같은 시점 GCS 직접 요청 8회가 구/신 버전 교대). 이 route가 쓰는 기존 `fetch(..., {cache:'no-store'})`는 **이 프로세스 자신의** 캐시만 끄는 옵션이라 GCS 앞단 캐시엔 영향이 없다.

## 변경

- `desktop-updates.ts`: 매 호출마다 쿼리스트링(`?_t=<timestamp>-<random>`)을 다르게 붙여 URL 키 캐시 자체를 우회. `Date.now()`만 쓰면 같은 밀리초 안의 두 호출이 같은 URL이 될 수 있어 난수를 더했다.
- 테스트: 캐시버스터 쿼리스트링 형태 실측 + 연속 두 호출이 서로 다른 URL을 쓰는지 확認 추가. 기존 "원문 그대로 중계(재조립 0)" 테스트도 그대로 유지·통과.

## 증거

```
$ pnpm exec vitest run src/lib/desktop-updates.test.ts src/app/desktop/updates/macos.json/route.test.ts
 Test Files  2 passed (2)
      Tests  5 passed (5)

$ pnpm exec tsc --noEmit -p .
(clean, exit 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xkNnQ4d69Wg1HZGm3WoYM