### PR TITLE
[SID:3809] org cost-summary 통화 안전(PR2b)

### DIFF
--- a/backend/app/routers/insights_board.py
+++ b/backend/app/routers/insights_board.py
@@ -156,9 +156,14 @@ class OrgAdsCostSummaryView(BaseModel):
     # ads_boost 게이트 집합 기준(org_cost_summary.py::get_org_ads_cost_summary
     # 모듈 docstring 참고, "같은 집합이라야 remaining이 정합"의 근거).
     approved_boost_count: int
-    sealed_budget_minor: int
-    captured_spend_minor: int
-    remaining_minor: int
+    # story #3809(Phase3·3-7 PR 2b, 페드루 PO 確定 2026-09-11 18:46Z) — 통화 안전.
+    # `sealed_ads_currency`는 0건(더할 게 없음)이거나 통화가 섞이면(2개 이상)
+    # null. 세 합계 필드는 **섞였을 때만** null(0건은 정직한 0 — "더할 게 없다"는
+    # 사실이지 "지어낸 숫자"가 아니다, get_org_ads_cost_summary docstring 참고).
+    sealed_ads_currency: str | None
+    sealed_budget_minor: int | None
+    captured_spend_minor: int | None
+    remaining_minor: int | None
     cap_reached_count: int
 
 
@@ -174,6 +179,9 @@ class OrgCostSummaryResponse(BaseModel):
     generation_cost_spent_minor: int | None
     generation_cost_period_start: datetime | None
     generation_cost_period_end: datetime | None
+    # story #3809(Phase3·3-7 PR 2b, 페드루 PO 確定 2026-09-11 18:46Z) — PR#3848
+    # PO 지침②("FE가 'KRW' 추정 절대금지") 준수. 규칙 없으면(위와 동형) null.
+    generation_currency: str | None
     # story #3809 그라운딩②(2026-09-11) — X 비용 원장이 이 시점 코드에 없다(실측
     # 확認). "0"으로 지어내지 않고 미측정 예약(null)만 한다.
     x_cost_spent_minor: int | None

--- a/backend/app/services/org_cost_summary.py
+++ b/backend/app/services/org_cost_summary.py
@@ -34,17 +34,30 @@ from app.services.generation_budget import compute_generation_budget_status
 
 async def get_org_ads_cost_summary(db: AsyncSession, *, org_id: uuid.UUID) -> dict:
     """승인된(status=="approved") ads_boost 게이트 집합 기준 예산·지출·상한. 그
-    집합이 비어 있으면(승인된 boost가 org에 0건) 전부 0/None — 지어내지 않는다."""
+    집합이 비어 있으면(승인된 boost가 org에 0건) 전부 0/None — 지어내지 않는다.
+
+    story #3809(Phase3·3-7 PR 2b, 페드루 PO 確定 2026-09-11 18:46Z) — 통화 안전.
+    `sealed_ads_currency`는 게이트별 nullable 값이라 org 안에 서로 다른 통화의
+    승인 boost가 섞일 수 있다(막는 장치 0). 그 경우 `sealed_budget_minor`/
+    `captured_spend_minor`/`remaining_minor`를 그냥 더하면 "달러+원을 그냥 더한
+    숫자"가 나온다 — 통화가 하나로 안 모이면(0건 제외 — 0은 "더할 게 없다"는
+    정직한 사실이지 "섞였다"가 아니다) 세 합계 필드를 전부 None으로 낸다(지어낸
+    숫자보다 "모른다"가 정직하다)."""
     gates = (await db.execute(
         select(Gate).where(
             Gate.org_id == org_id, Gate.gate_type == _ADS_BOOST_GATE_TYPE, Gate.status == "approved",
         )
     )).scalars().all()
 
-    sealed_budget_minor_sum = sum(g.sealed_ads_budget_minor or 0 for g in gates)
+    distinct_currencies = {g.sealed_ads_currency for g in gates if g.sealed_ads_currency}
+    # 0건(더할 게 없음)·1건(그 통화로 확정) 둘 다 "섞이지 않음" — 2개 이상만 섞임.
+    currency = next(iter(distinct_currencies), None) if len(distinct_currencies) <= 1 else None
+    mixed_currencies = len(distinct_currencies) > 1
+
+    sealed_budget_minor_sum: int | None = sum(g.sealed_ads_budget_minor or 0 for g in gates)
 
     publication_ids = [uuid.UUID(g.scope_key) for g in gates if g.scope_key]
-    captured_spend_minor_sum = 0
+    captured_spend_minor_sum: int | None = 0
     if publication_ids:
         # story #3806 가드(test_3806_organic_snapshots_only_guard.py) 처방(페드루
         # PO 지적 2026-09-11 17:44Z) — 손으로 InsightSnapshot을 직접 필터하지 않고
@@ -58,6 +71,13 @@ async def get_org_ads_cost_summary(db: AsyncSession, *, org_id: uuid.UUID) -> di
         )).scalars().all()
         captured_spend_minor_sum = sum((s.normalized or {}).get("spend") or 0 for s in snapshots)
 
+    remaining_minor: int | None = sealed_budget_minor_sum - captured_spend_minor_sum
+
+    if mixed_currencies:
+        sealed_budget_minor_sum = None
+        captured_spend_minor_sum = None
+        remaining_minor = None
+
     gate_ids = [g.id for g in gates]
     cap_reached_count = 0
     if gate_ids:
@@ -68,9 +88,10 @@ async def get_org_ads_cost_summary(db: AsyncSession, *, org_id: uuid.UUID) -> di
 
     return {
         "approved_boost_count": len(gates),
+        "sealed_ads_currency": currency,
         "sealed_budget_minor": sealed_budget_minor_sum,
         "captured_spend_minor": captured_spend_minor_sum,
-        "remaining_minor": sealed_budget_minor_sum - captured_spend_minor_sum,
+        "remaining_minor": remaining_minor,
         "cap_reached_count": cap_reached_count,
     }
 
@@ -115,6 +136,12 @@ async def get_org_cost_summary(db: AsyncSession, *, org_id: uuid.UUID, now: date
         "generation_cost_spent_minor": generation["spent_minor"] if generation is not None else None,
         "generation_cost_period_start": generation["period_start"] if generation is not None else None,
         "generation_cost_period_end": generation["period_end"] if generation is not None else None,
+        # story #3809(Phase3·3-7 PR 2b, 페드루 PO 確定 2026-09-11 18:46Z) — PR#3848
+        # PO 지침②("FE가 'KRW' 추정 절대금지")를 이 응답도 지킨다. compute_
+        # generation_budget_status가 이미 통화를 계산해 두고도 이 함수가 그 필드를
+        # 조용히 버려(그라운딩 中 자체발견) 카드가 통화기호를 못 낼 뻔했다 — 그대로
+        # 통과만.
+        "generation_currency": generation["currency"] if generation is not None else None,
         # story #3809 그라운딩②(2026-09-11) — X 비용 원장 자체가 이 시점 코드에
         # 없다(실측 확認). "0"으로 지어내지 않고 미측정을 null로 예약만 한다.
         "x_cost_spent_minor": None,

--- a/backend/tests/test_3809_org_cost_summary.py
+++ b/backend/tests/test_3809_org_cost_summary.py
@@ -24,7 +24,9 @@ from tests.test_3498_generation_budget_evidence_and_config import (
     _put_generation_budget,
     _seed_generation_cost_evidence,
 )
+from tests.test_3497_insight_snapshots import _seed_channel_connection
 from tests.test_3806_ads_boost_execution import _setup_approved_gate
+from tests.test_3806_ads_boost_gate import _approve_gate, _boost_body, _seed_publication
 from tests.test_3806_ads_boost_spend import _make_spend_snapshots_due, _start_boost
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
@@ -88,7 +90,8 @@ async def test_org_ads_cost_summary_zero_when_no_approved_boosts():
         async with Session() as s:
             summary = await get_org_ads_cost_summary(s, org_id=org_id)
         assert summary == {
-            "approved_boost_count": 0, "sealed_budget_minor": 0, "captured_spend_minor": 0,
+            "approved_boost_count": 0, "sealed_ads_currency": None,
+            "sealed_budget_minor": 0, "captured_spend_minor": 0,
             "remaining_minor": 0, "cap_reached_count": 0,
         }
     finally:
@@ -158,6 +161,84 @@ async def test_org_ads_cost_summary_excludes_pending_gate():
         await engine.dispose()
 
 
+async def _add_second_approved_gate(Session, *, org_id, owner_id, budget_minor, currency):
+    """`_setup_approved_gate`는 매번 새 org를 만들어 「같은 org 안에 승인된
+    boost 게이트 2개」를 세팅할 수 없다 — 이미 있는 org에 발행물+ads_sandbox
+    채널연결을 새로 하나 더 심고 PR 2 API로 두 번째 게이트를 만들어 승인까지
+    전이시킨다(PR 2b 통화 혼재 대조군 전용)."""
+    from app.main import app
+
+    async with Session() as s:
+        conn = await _seed_channel_connection(s, org_id, channel="threads")
+        ad_conn = await _seed_channel_connection(s, org_id, channel="ads_sandbox")
+        pub, _ = await _seed_publication(s, org_id=org_id, connection_id=conn.id)
+
+    _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+    async with _client_for(app) as client:
+        r = await client.post(
+            f"/api/v2/organizations/{org_id}/publications/{pub.id}/boosts",
+            json=_boost_body(ad_connection_id=ad_conn.id, budget_minor=budget_minor, currency=currency),
+        )
+    assert r.status_code == 201, r.text
+    gate_id = uuid.UUID(r.json()["gate_id"])
+    app.dependency_overrides.clear()
+
+    async with Session() as s:
+        await _approve_gate(s, gate_id, owner_id)
+
+    return gate_id
+
+
+@pytest.mark.anyio
+async def test_org_ads_cost_summary_sums_when_same_currency():
+    """PO 確定(2026-09-11 18:46Z) 양성대조 1/2 — KRW+KRW 게이트 2개는 통화가
+    하나로 모이니 그대로 합산돼야 한다(None으로 숨기면 그것도 거짓)."""
+    from app.services.org_cost_summary import get_org_ads_cost_summary
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(
+        await _session_factory(), budget_minor=100_000,
+    )
+    try:
+        await _add_second_approved_gate(Session, org_id=org_id, owner_id=owner_id, budget_minor=50_000, currency="KRW")
+
+        async with Session() as s:
+            summary = await get_org_ads_cost_summary(s, org_id=org_id)
+        assert summary["approved_boost_count"] == 2
+        assert summary["sealed_ads_currency"] == "KRW"
+        assert summary["sealed_budget_minor"] == 150_000
+        assert summary["captured_spend_minor"] == 0
+        assert summary["remaining_minor"] == 150_000
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_ads_cost_summary_nulls_sums_when_currencies_mixed():
+    """PO 確定(2026-09-11 18:46Z) 양성대조 2/2 — KRW+USD가 섞이면 통화도
+    합계 3필드도 전부 None(「달러+원을 그냥 더한 숫자」를 지어내지 않는다).
+    뮤테이션: 섞임 판정(`mixed_currencies`)을 걷으면 이 테스트만 RED여야 한다."""
+    from app.services.org_cost_summary import get_org_ads_cost_summary
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(
+        await _session_factory(), budget_minor=100_000,
+    )
+    try:
+        await _add_second_approved_gate(Session, org_id=org_id, owner_id=owner_id, budget_minor=50_000, currency="USD")
+
+        async with Session() as s:
+            summary = await get_org_ads_cost_summary(s, org_id=org_id)
+        assert summary["approved_boost_count"] == 2
+        assert summary["sealed_ads_currency"] is None
+        assert summary["sealed_budget_minor"] is None
+        assert summary["captured_spend_minor"] is None
+        assert summary["remaining_minor"] is None
+        # 섞였어도 상한도달 카운트는 통화와 무관한 별개 축 — 지어낸 방식으로
+        # 함께 숨기지 않는다.
+        assert summary["cap_reached_count"] == 0
+    finally:
+        await engine.dispose()
+
+
 @pytest.mark.anyio
 async def test_generation_cost_null_when_no_rule():
     from app.services.org_cost_summary import get_org_cost_summary
@@ -196,6 +277,27 @@ async def test_generation_cost_reflects_evidence_sum():
         async with Session() as s:
             summary = await get_org_cost_summary(s, org_id=org_id)
         assert summary["generation_cost_spent_minor"] == 5_000
+        # PR#3848 PO 지침② — FE가 통화를 "KRW"로 추정하지 않도록 실값을 그대로
+        # 통과시켜야 한다(_put_generation_budget 기본 통화 KRW).
+        assert summary["generation_currency"] == "KRW"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_generation_currency_null_when_no_rule():
+    """규칙 자체가 없으면(`compute_generation_budget_status`가 None) 통화도
+    지어내지 않고 None — 지출/기간 필드와 동형."""
+    from app.services.org_cost_summary import get_org_cost_summary
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+
+        async with Session() as s:
+            summary = await get_org_cost_summary(s, org_id=org_id)
+        assert summary["generation_currency"] is None
     finally:
         await engine.dispose()
 
@@ -270,11 +372,12 @@ async def test_cost_summary_endpoint_returns_shape():
         body = r.json()
         assert set(body.keys()) == {
             "ads", "generation_cost_spent_minor", "generation_cost_period_start",
-            "generation_cost_period_end", "x_cost_spent_minor", "paid_spend_daily_series",
+            "generation_cost_period_end", "generation_currency", "x_cost_spent_minor",
+            "paid_spend_daily_series",
         }
         assert set(body["ads"].keys()) == {
-            "approved_boost_count", "sealed_budget_minor", "captured_spend_minor",
-            "remaining_minor", "cap_reached_count",
+            "approved_boost_count", "sealed_ads_currency", "sealed_budget_minor",
+            "captured_spend_minor", "remaining_minor", "cap_reached_count",
         }
         assert body["ads"]["approved_boost_count"] == 1
     finally:

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1645,8 +1645,8 @@
     },
     {
       "file": "tests/test_3809_org_cost_summary.py",
-      "sec": 6.7,
-      "source": "story-3809(Phase3·3-7, 페드루 PO 確定 2026-09-11 17:12Z — 고급 보고 첫 출시 조각1: classify_insight_source 드리프트가드+org cost-summary API) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 11건 wall time 약 6.7s — test_3766 등재 선례와 동일 방법론)"
+      "sec": 7.5,
+      "source": "story-3809(Phase3·3-7 PR 2b, 페드루 PO 確定 2026-09-11 18:46Z — 통화 안전 테스트 3건 추가로 갱신) — 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 14건 wall time 약 7.5s — test_3766 등재 선례와 동일 방법론)"
     },
     {
       "file": "tests/test_3806_ads_boost_spend_refresh.py",


### PR DESCRIPTION
## 요약
- story #3809 PR1(#4193)의 `get_org_ads_cost_summary`는 승인 boost 게이트 집합의 `sealed_budget_minor`/`captured_spend_minor`/`remaining_minor`를 통화 구분 없이 그냥 더했다 — `sealed_ads_currency`는 게이트별 nullable이라 같은 org 안에 KRW+USD가 섞여도 막는 장치가 없었다(포크가 발견, PO 確定 2026-09-11 18:46Z).
- 처방: 승인 게이트 집합의 distinct 통화가 0건(더할 게 없음)·1건(그 통화로 확定)이면 그대로 합산, 2건 이상 섞이면 `sealed_ads_currency`와 세 합계 필드를 전부 `null`로 낸다("달러+원을 그냥 더한 숫자"보다 "모른다"가 정직).
- `generation_currency`도 새로 응답에 추가 — `compute_generation_budget_status`가 이미 계산해 둔 통화를 org_cost_summary가 조용히 버리고 있던 것을 그라운딩 中 자체발견(PR#3848 PO 지침② "FE가 'KRW' 추정 절대금지" 위반 소지).

## 변경
- `backend/app/services/org_cost_summary.py`: `get_org_ads_cost_summary` 통화 혼재 감지·null 전파, `get_org_cost_summary`에 `generation_currency` 통과
- `backend/app/routers/insights_board.py`: `OrgAdsCostSummaryView.sealed_ads_currency`(신규)·세 합계 필드 `int|None`, `OrgCostSummaryResponse.generation_currency`(신규)
- `backend/tests/test_3809_org_cost_summary.py`: KRW+KRW 양성대조·KRW+USD 양성대조·generation_currency null/positive 케이스 추가(14건 GREEN)
- `infra/destructive-schema-shard-weights.json`: 실측 재등재(7.5s)

## 검증
- FE 소비처 0건 확인(`grep -rln "cost-summary\|OrgCostSummary" apps/web/src` 빈 결과) — 계약 변경 안전
- `uv run pytest tests/test_3809_org_cost_summary.py` 단독 14 passed
- 회귀: `test_3806_ads_boost_execution.py`·`test_3806_ads_boost_gate.py`·`test_3806_ads_boost_spend.py`·`test_3498_generation_budget_evidence_and_config.py` 합쳐 66 passed
- `test_3806_organic_snapshots_only_guard.py` 4 passed, BE 한글 사용자 문장 신규 가드 0건 증가
- 뮤테이션 셀프체크: `mixed_currencies` 분기 비활성화 → `test_org_ads_cost_summary_nulls_sums_when_currencies_mixed`만 RED, 나머지 13건 GREEN 확인 후 원복

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn