### PR TITLE
[SID:3806] 감액 재봉인 뒤 명령 사슬 정체성 결함 근본수정(PR13)

### DIFF
--- a/backend/app/services/ads_boost_execution.py
+++ b/backend/app/services/ads_boost_execution.py
@@ -105,15 +105,18 @@ async def _resolve_gate(db: AsyncSession, *, org_id: uuid.UUID, gate_id: uuid.UU
     return gate
 
 
-async def _latest_toggle(
-    db: AsyncSession, *, org_id: uuid.UUID, destination: uuid.UUID, approved_version: uuid.UUID,
-) -> PublicationCommand | None:
+async def _latest_toggle(db: AsyncSession, *, gate_id: uuid.UUID) -> PublicationCommand | None:
+    """story #3806(Phase3·3-2 PR 13, 페드루 PO 確定 2026-09-11 19:58Z 정정) —
+    「명령 사슬 정체성」은 `gate_id`(PublicationCommand 자체 컬럼)다, `(destination,
+    approved_version)`이 아니다. `approved_version`(=gate.sealed_ads_boost_version_id)
+    은 재봉인마다 새로 발급되는 값이라 "재봉인해도 실행 중 run은 하나"라는 불변식을
+    못 담는다 — 감액 재봉인 뒤 이 스코프로 조회하면 최초 실행 당시(낡은 version)의
+    토글 이력을 못 찾아 「한 번도 토글된 적 없다」로 오판했다(라이브 재측 中 PO
+    발견: 실행 중인데 「중지」가 409, 상한 도달 자동 중지도 조용히 실패)."""
     return (await db.execute(
         select(PublicationCommand)
         .where(
-            PublicationCommand.org_id == org_id,
-            PublicationCommand.destination == destination,
-            PublicationCommand.approved_version == approved_version,
+            PublicationCommand.gate_id == gate_id,
             PublicationCommand.operation.in_((OP_PAUSE, OP_RESUME)),
         )
         .order_by(PublicationCommand.toggle_seq.desc())
@@ -147,18 +150,19 @@ async def _request_toggle(
     destination = gate.sealed_ads_connection_id
     approved_version = gate.sealed_ads_boost_version_id
 
+    # story #3806(Phase3·3-2 PR 13 정정) — gate_id로 스코프(위 _latest_toggle
+    # docstring과 동형 이유) — 감액 재봉인으로 approved_version이 바뀌어도 "이
+    # 게이트가 시작된 적 있나"는 그대로 참이어야 한다.
     started = (await db.execute(
         select(PublicationCommand.id).where(
-            PublicationCommand.org_id == org_id,
-            PublicationCommand.destination == destination,
-            PublicationCommand.approved_version == approved_version,
+            PublicationCommand.gate_id == gate.id,
             PublicationCommand.operation == OP_BOOST_START,
         )
     )).scalar_one_or_none()
     if started is None:
         raise AdsBoostNotStartedError(gate.id)
 
-    latest = await _latest_toggle(db, org_id=org_id, destination=destination, approved_version=approved_version)
+    latest = await _latest_toggle(db, gate_id=gate.id)
 
     if latest is None:
         if operation == OP_RESUME:

--- a/backend/app/services/ads_spend_snapshots.py
+++ b/backend/app/services/ads_spend_snapshots.py
@@ -19,6 +19,7 @@ Meta 외 다른 ad 채널이 추가돼도 대시보드가 채널명 나열 없�
 from __future__ import annotations
 
 import importlib
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -29,6 +30,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.ads_boost_run import AdsBoostRun
 from app.models.gate import Gate
 from app.models.insight_snapshot import InsightSnapshot
+
+logger = logging.getLogger(__name__)
 
 _ADS_BOOST_GATE_TYPE = "ads_boost"
 _PAID_CHANNELS = ("meta_ads", "ads_sandbox")
@@ -189,11 +192,17 @@ async def _enforce_spend_cap(db: AsyncSession, *, gate: Gate, run, now: datetime
             db, org_id=gate.org_id, gate_id=gate.id, requester_member_id=gate.resolver_id,
             initiated_by="scheduler",
         )
-    except (AdsBoostGateNotFoundError, AdsBoostGateNotApprovedError, AdsBoostAlreadyInStateError, AdsBoostNotStartedError):
+    except (AdsBoostGateNotFoundError, AdsBoostGateNotApprovedError, AdsBoostAlreadyInStateError, AdsBoostNotStartedError) as exc:
         # 이미 중지됐거나(사람이 먼저 pause) 게이트가 그 사이 재오픈된 경우 —
         # 「상한 도달」 관측 자체는 위에서 이미 확정됐으니 이 건은 이 워커의
-        # 실패가 아니다.
-        pass
+        # 실패가 아니다(재-raise 안 함). 다만 story #3806(Phase3·3-2 PR 13, 페드루
+        # PO 確定 2026-09-11 19:58Z) — 「조용히 지나가는 자리 0」: 이 삼킴이
+        # AdsBoostNotStartedError(명령 사슬 정체성 결함, 이 PR이 근본수정)처럼
+        # 실은 버그의 증거일 수도 있다 — 최소 로그는 남겨 다음 사고 때 흔적이
+        # 있게 한다(재-raise는 여전히 안 함, 이 함수의 반환 계약 무변경).
+        logger.warning(
+            "ads_spend_cap_pause_request_skipped gate_id=%s exception=%s", gate.id, type(exc).__name__,
+        )
     except Exception:  # noqa: BLE001 — publication_command.py와 동형 2중 방어.
         await db.rollback()
     return True

--- a/backend/tests/test_3806_ads_boost_reseal_command_identity.py
+++ b/backend/tests/test_3806_ads_boost_reseal_command_identity.py
@@ -1,0 +1,166 @@
+"""story #3806(Phase3·3-2 PR 13, 페드루 PO 確定 2026-09-11 19:58Z) — 「명령 사슬
+정체성」 결함. 라이브 재측 中 PO 발견: 감액 재봉인(approved 상태에서 낮은 예산으로
+재요청 — `ads_boost.py::request_ads_boost`가 매 재봉인마다 `gate.sealed_ads_
+boost_version_id`를 새 UUID로 갱신)이 일어난 뒤엔, 이미 실행 중(run.status=
+"running")인 boost의 사람 「중지」 버튼이 409(`ADS_BOOST_NOT_STARTED`)로 죽고,
+상한 도달 자동 중지(`_enforce_spend_cap`)도 같은 예외를 조용히 삼켜(pass) pause
+명령을 아예 못 만든다 — 광고가 상한을 넘겨도 안 멈춘다.
+
+근본원인: `_request_toggle`의 `started` 조회·`_latest_toggle`이 `(destination,
+approved_version)`으로 스코프돼 있는데, `approved_version`은 재봉인마다 바뀌는
+반면 실제 boost_start 명령 행은 최초 실행 당시의 (이제는 낡은) approved_version에
+그대로 박혀 있다 — "재봉인해도 실행 중 run은 하나"라는 불변식을 approved_version이
+못 담는다. 처방: 이 두 조회를 `gate_id`(PublicationCommand 자체 컬럼, 재봉인과
+무관하게 안정)로 스코프한다.
+
+이 파일은 먼저 **현재(수정 전) 코드에서 RED임을 고정**한 뒤(PO 明示 요청 — 재현
+먼저), 수정 뒤 GREEN으로 전환한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_3806_ads_boost_gate import _approve_gate, _boost_body, _client_for, _setup, _setup_org_scoped_app
+from tests.test_3806_ads_boost_spend import _make_spend_snapshots_due, _start_boost
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _start_reapprove_and_reseal(*, initial_budget_minor, resealed_budget_minor):
+    """게이트 생성→승인→시작(실행 完, v1 approved_version)→감액 재봉인(pending
+    재오픈+v2 발급)→재승인(approved 복귀, v2 그대로). 반환: (engine, Session,
+    org_id, owner_id, gate_id)."""
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, pub, _work_item_id, ad_conn_id = await _setup(
+        await _session_factory(),
+    )
+
+    from app.main import app
+
+    _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+    async with _client_for(app) as client:
+        r1 = await client.post(
+            f"/api/v2/organizations/{org_id}/publications/{pub.id}/boosts",
+            json=_boost_body(ad_connection_id=ad_conn_id, budget_minor=initial_budget_minor),
+        )
+    assert r1.status_code == 201, r1.text
+    gate_id = uuid.UUID(r1.json()["gate_id"])
+    app.dependency_overrides.clear()
+
+    async with Session() as s:
+        await _approve_gate(s, gate_id, owner_id)
+
+    await _start_boost(Session, org_id, gate_id, owner_id)
+
+    # 감액 재봉인 — request_ads_boost가 approved→pending 재오픈+새 sealed_ads_
+    # boost_version_id 발급(이 결함의 원인 그 자체).
+    _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+    async with _client_for(app) as client:
+        r2 = await client.post(
+            f"/api/v2/organizations/{org_id}/publications/{pub.id}/boosts",
+            json=_boost_body(ad_connection_id=ad_conn_id, budget_minor=resealed_budget_minor),
+        )
+    assert r2.status_code == 201, r2.text
+    assert uuid.UUID(r2.json()["gate_id"]) == gate_id
+    app.dependency_overrides.clear()
+
+    async with Session() as s:
+        await _approve_gate(s, gate_id, owner_id)  # 재승인 — PO 라이브 회차와 동형.
+
+    return engine, Session, org_id, owner_id, gate_id
+
+
+@pytest.mark.anyio
+async def test_human_pause_after_reseal_returns_201_not_409():
+    """PO 라이브 재현(19:54Z) — 실행 중 boost를 감액 재봉인한 뒤 「중지」를 누르면
+    409 ADS_BOOST_NOT_STARTED가 뜬다(실은 실행 중인데). 수정 뒤엔 201이어야 한다."""
+    from app.main import app
+
+    engine, Session, org_id, owner_id, gate_id = await _start_reapprove_and_reseal(
+        initial_budget_minor=100_000, resealed_budget_minor=90_000,
+    )
+    try:
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/pause")
+        assert r.status_code == 201, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_scheduler_cap_pause_after_reseal_actually_pauses_the_run():
+    """PO 라이브 재현 — 감액 재봉인 뒤 상한 도달 자동 중지가 AdsBoostNotStartedError를
+    조용히 삼켜(pass) pause 명령을 못 만들고, 광고가 상한을 넘겨도 계속 돈다. 수정
+    뒤엔 명령이 생성되고, 다음 tick 실행 뒤 run.status가 paused여야 한다."""
+    from app.models.ads_boost_run import AdsBoostRun
+    from app.models.publication_command import PublicationCommand
+    from app.services.ads_boost_execution import OP_PAUSE
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from app.services.publication_command import process_due_publication_commands
+    from sqlalchemy import select
+
+    engine, Session, org_id, owner_id, gate_id = await _start_reapprove_and_reseal(
+        initial_budget_minor=100_000, resealed_budget_minor=10_000,
+    )
+    try:
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+        async with Session() as s:
+            counts = await process_due_ads_spend_snapshots(s)
+        assert counts["capped"] == 1, counts
+
+        async with Session() as s:
+            run = (await s.execute(select(AdsBoostRun).where(AdsBoostRun.gate_id == gate_id))).scalar_one()
+            assert run.cap_reached_at is not None
+            pause_cmd = (await s.execute(
+                select(PublicationCommand).where(
+                    PublicationCommand.gate_id == gate_id, PublicationCommand.operation == OP_PAUSE,
+                )
+            )).scalar_one_or_none()
+        assert pause_cmd is not None, "감액 재봉인 뒤에도 상한 도달 pause 명령이 생성돼야 한다"
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        async with Session() as s:
+            run = (await s.execute(select(AdsBoostRun).where(AdsBoostRun.gate_id == gate_id))).scalar_one()
+        assert run.status == "paused", "pause 명령이 실행되면 run이 실제로 멈춰야 한다"
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1657,6 +1657,11 @@
       "file": "tests/test_3808_x_oauth.py",
       "sec": 3.4,
       "source": "story-3808(Phase3·3-3 PR1, 페드루 PO 確定 2026-09-11) — X OAuth 어댑터·PKCE·1회용 회전 refresh_token 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 13건 wall time 약 3.4s — test_3806_ads_boost_spend_cron_wiring.py 선례와 동일 방법론, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3806_ads_boost_reseal_command_identity.py",
+      "sec": 3.0,
+      "source": "story-3806(Phase3·3-2 PR 13, 페드루 PO 確定 2026-09-11 19:58Z — 감액 재봉인 뒤 명령 사슬 정체성 결함(approved_version 스코프→gate_id 스코프) 근본수정) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 2건 wall time 약 3.0s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
- 라이브 재측 中 PO 발견(2026-09-11 19:52Z): 실행 중(`run.status=running`)인 boost를 감액 재봉인(approved→pending 재오픈+새 `sealed_ads_boost_version_id` 발급)한 뒤 사람 「중지」가 **409 ADS_BOOST_NOT_STARTED**로 죽고, 상한 도달 자동 중지(`_enforce_spend_cap`)도 같은 예외를 **조용히 삼켜** pause 명령을 아예 못 만든다 — 광고가 상한을 넘겨도 계속 돈다.
- 근본원인: `_request_toggle`의 "이미 시작됐나" 조회와 `_latest_toggle`이 `(destination, approved_version)`으로 스코프돼 있었다. `approved_version`은 재봉인마다 새로 발급되는데, 최초 실행 당시의 boost_start 명령 행은 그 낡은 값에 그대로 박혀 있어 새 버전 기준 조회로는 못 찾는다.
- 처방: 두 조회 모두 `PublicationCommand` 자체 컬럼인 `gate_id`로 스코프 — 재봉인과 무관하게 안정("재봉인해도 실행 중 run은 하나"라는 불변식을 `gate_id`가 그대로 담는다).
- `_enforce_spend_cap`의 4종 예외 삼킴엔 최소 `logger.warning(gate_id·예외명)` 추가 — 조용히 지나가는 자리 0(재-raise는 안 함, 반환 계약 무변경).

## 검증
- **재현 먼저**: 수정 전 코드에서 `test_human_pause_after_reseal_returns_201_not_409`·`test_scheduler_cap_pause_after_reseal_actually_pauses_the_run` 둘 다 RED로 정확히 재현(PO 라이브 관측과 동일 에러 코드/증상) 확認 후 처방.
- 처방 뒤 GREEN 전환. 뮤테이션 셀프체크(gate_id 스코프를 원래 `(destination, approved_version)`으로 되돌림) → 정확히 이 2건만 RED, 원복 후 재GREEN.
- 회귀: ads_boost 전체 스위트 60/60. `organic_snapshots_only` 가드 4/4, BE 한글 사용자 문장 가드 신규 0건.

## 참고
- 이 PR 착수 前 스코프였던 「boost start/pause/resume 실행 성공 지점 ActivityLog 신설」은 PO 지시(19:52Z→19:58Z 재조정)로 **PR14로 순서를 미룸** — 이미 구현+테스트 완료된 상태로 로컬 커밋만 해 두었고, 이 PR13 착지 뒤 rebase하여 별도 오픈 예정.
- 착지·배포76 뒤 PO가 새 boost(재봉인 포함)로 라이브 재측 — 3806 DONE 판정은 그 결과 뒤.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn