### PR TITLE
[SID:3806] boost start/pause/resume 실행 성공 지점 결재 이력(PR14)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4826,6 +4826,10 @@
     "gateActivityActionVoided": "Voided",
     "gateActivityActionOverridden": "Overridden",
     "gateActivityActionAdsSpendRefreshRequested": "Requested ad spend refresh",
+    "gateActivityActionAdsBoostStarted": "Started the ad boost",
+    "gateActivityActionAdsBoostPaused": "Paused the ad boost",
+    "gateActivityActionAdsBoostResumed": "Resumed the ad boost",
+    "gateActivityActionAdsBoostAutoPausedCapReached": "Auto-paused (ad spend cap reached)",
     "gateHeadChangedError": "The commit this gate targets changed after you confirmed. Please review the latest changes before approving.",
     "gateAlreadyResolvedError": "This approval has already been processed. Ask the PO for a re-review if you'd like it reconsidered."
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4826,6 +4826,10 @@
     "gateActivityActionVoided": "무효화",
     "gateActivityActionOverridden": "강제 결정",
     "gateActivityActionAdsSpendRefreshRequested": "광고비 다시 수집 요청",
+    "gateActivityActionAdsBoostStarted": "홍보 시작",
+    "gateActivityActionAdsBoostPaused": "홍보 중지",
+    "gateActivityActionAdsBoostResumed": "홍보 재개",
+    "gateActivityActionAdsBoostAutoPausedCapReached": "자동 중지(광고비 상한 도달)",
     "gateHeadChangedError": "게이트 대상 커밋이 승인 확인 이후 변경되었습니다. 최신 내용을 다시 확인한 뒤 승인해주세요.",
     "gateAlreadyResolvedError": "이미 처리된 결재입니다. 되돌리려면 PO에게 재검토를 요청해주세요."
   },

--- a/apps/web/src/components/cage/gate-evidence-render.test.tsx
+++ b/apps/web/src/components/cage/gate-evidence-render.test.tsx
@@ -909,6 +909,53 @@ describe('GateActivityHistory — 결재 이력 실 응답 shape 마운트(story
     expect(container.textContent).not.toContain('ads_spend_refresh_requested');
   });
 
+  // story #3806(Phase3·3-2 PR 14, 페드루 PO 確定 2026-09-11 19:52Z) — boost start/
+  // pause/resume 명령 실행 성공 지점 신설 액션 3개. 사람 pause(initiated_by="human")
+  // 는 일반 문구, scheduler+cap_reached 조합만 별도 문구("왜 멈췄는지" 화면에서
+  // 바로 읽혀야 한다는 이 PR의 존재 이유).
+  it('ads_boost_started/paused/resumed — raw 키 아니라 정식 문구로 뜬다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        { id: 'log-3', action: 'ads_boost_resumed', actor_id: 'm-1', actor_name: '미르코', context: { initiated_by: 'human' }, created_at: '2026-09-11T20:00:00Z' },
+        { id: 'log-2', action: 'ads_boost_paused', actor_id: 'm-1', actor_name: '미르코', context: { initiated_by: 'human' }, created_at: '2026-09-11T19:59:00Z' },
+        { id: 'log-1', action: 'ads_boost_started', actor_id: 'm-1', actor_name: '미르코', context: { initiated_by: 'human' }, created_at: '2026-09-11T19:58:00Z' },
+      ]),
+    } as Response);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateActivityHistory gateId="gate-1" />)); });
+
+    expect(container.textContent).toContain(koMessages.cage.gateActivityActionAdsBoostStarted);
+    expect(container.textContent).toContain(koMessages.cage.gateActivityActionAdsBoostPaused);
+    expect(container.textContent).toContain(koMessages.cage.gateActivityActionAdsBoostResumed);
+    expect(container.textContent).not.toContain('ads_boost_started');
+    expect(container.textContent).not.toContain('ads_boost_paused');
+    expect(container.textContent).not.toContain('ads_boost_resumed');
+  });
+
+  it('⭐scheduler+cap_reached pause는 「자동 중지(광고비 상한 도달)」 별도 문구(사람 pause와 다른 문구)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        {
+          id: 'log-1', action: 'ads_boost_paused', actor_id: 'm-1', actor_name: '미르코',
+          context: { initiated_by: 'scheduler', reason: 'cap_reached' }, created_at: '2026-09-11T19:41:17Z',
+        },
+      ]),
+    } as Response);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateActivityHistory gateId="gate-1" />)); });
+
+    expect(container.textContent).toContain(koMessages.cage.gateActivityActionAdsBoostAutoPausedCapReached);
+    expect(container.textContent).not.toContain(koMessages.cage.gateActivityActionAdsBoostPaused);
+  });
+
   // story #3806(Phase3·3-2 PR 12) — 「눌렀는데 아무 일도 없었다」 결함 처방 — 형제
   // BoostExecutionControl의 뮤테이션이 이 컴포넌트에 반영되는 유일한 경로(refreshKey).
   it('refreshKey가 바뀌면 재조회한다(형제 컴포넌트 뮤테이션 반영 경로)', async () => {

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -480,7 +480,27 @@ const GATE_ACTIVITY_LABEL_KEY: Record<string, string> = {
   // refresh_ads_boost_spend_now(ads_spend_snapshots.py)가 남기는 액션. 매핑
   // 누락 시 raw 키가 그대로 노출되던 걸 실 캡처로 적발.
   ads_spend_refresh_requested: 'gateActivityActionAdsSpendRefreshRequested',
+  // story #3806(Phase3·3-2 PR 14, 페드루 PO 確定 2026-09-11 19:52Z) —
+  // process_one_ads_boost_command 실행 성공 지점 신설 액션(ads_boost_execution.py
+  // ::_ACTIVITY_ACTION_BY_OP). ads_boost_paused는 scheduler+cap_reached 조합일
+  // 때만 아래 adsBoostActivityLabel()이 별도 문구로 덮어쓴다(이 맵은 그 기본값).
+  ads_boost_started: 'gateActivityActionAdsBoostStarted',
+  ads_boost_paused: 'gateActivityActionAdsBoostPaused',
+  ads_boost_resumed: 'gateActivityActionAdsBoostResumed',
 };
+
+// story #3806(Phase3·3-2 PR 14) — ads_boost_paused 한 action이 두 얼굴이다: 사람이
+// 「중지」를 눌렀거나(일반 문구), 상한 도달로 scheduler가 자동 중지했거나(별도 문구
+// — 사용자가 "왜 멈췄는지" 화면에서 바로 읽어야 한다는 게 이 PR의 존재 이유 그
+// 자체). context는 BE가 이미 실어 보낸다(ads_boost_execution.py::activity_context
+// — {initiated_by, reason?}), 여기서 새로 지어내지 않는다.
+function adsBoostActivityLabel(item: GateActivityLogItem, t: ReturnType<typeof useTranslations>): string | null {
+  if (item.action !== 'ads_boost_paused') return null;
+  if (item.context['initiated_by'] === 'scheduler' && item.context['reason'] === 'cap_reached') {
+    return t('gateActivityActionAdsBoostAutoPausedCapReached');
+  }
+  return null;
+}
 
 /**
  * story #2975 AC4(PO 확定 2026-08-24) — 「누가·언제·무엇을·어느 SHA에」 결재했는지. 2026-08-23
@@ -529,11 +549,12 @@ export function GateActivityHistory({ gateId, refreshKey }: { gateId: string; re
           {items.map((item) => {
             const sha = typeof item.context['head_sha'] === 'string' ? (item.context['head_sha'] as string) : null;
             const labelKey = GATE_ACTIVITY_LABEL_KEY[item.action];
+            const adsBoostLabel = adsBoostActivityLabel(item, t);
             return (
               <li key={item.id} className="text-[11px] text-muted-foreground">
                 <span className="font-medium text-foreground">{item.actor_name ?? t('gateActivityActorFallback')}</span>
                 {' · '}
-                {labelKey ? t(labelKey) : item.action}
+                {adsBoostLabel ?? (labelKey ? t(labelKey) : item.action)}
                 {sha ? <span className="ml-1 font-mono">{t('githubCheckShaLabel', { sha: sha.slice(0, 7) })}</span> : null}
                 {/* story #3493 — 게이트 활동 로그 항목은 "기록"(정본 formatRelativeTime). */}
                 <span className="ml-1">· {formatRelativeTime(item.created_at, locale, displayTimezone)}</span>

--- a/backend/app/services/ads_boost_execution.py
+++ b/backend/app/services/ads_boost_execution.py
@@ -44,6 +44,14 @@ OP_BOOST_START = "boost_start"
 OP_PAUSE = "pause"
 OP_RESUME = "resume"
 
+# story #3806(Phase3·3-2 PR 13) — process_one_ads_boost_command 실행 성공 지점의
+# ActivityLog action 키. FE gate-evidence.tsx::GATE_ACTIVITY_LABEL_KEY와 1:1 대응.
+_ACTIVITY_ACTION_BY_OP = {
+    OP_BOOST_START: "ads_boost_started",
+    OP_PAUSE: "ads_boost_paused",
+    OP_RESUME: "ads_boost_resumed",
+}
+
 # publication_command.py::BATCH_SIZE·channel_post_comments.py::BATCH_SIZE와 동형 값
 # (신규 상수 발명 0 — 그 둘을 import하면 이 모듈의 gate_type 무관 워커 배치와
 # 우연히 같은 상수를 공유하게 돼 오히려 결합이 생긴다, 여기선 리터럴로 동형만).
@@ -428,6 +436,29 @@ async def process_one_ads_boost_command(db: AsyncSession, command: PublicationCo
                 )
                 run.status = "running"
                 run.paused_at = None
+
+        # story #3806(Phase3·3-2 PR 13, 페드루 PO 確定 2026-09-11 19:52Z) — 「중지
+        # 스위치·상한 도달 자동 중지」가 3806 AC인데 그 실행이 결재 이력에 한 줄도
+        # 안 남으면(PR11까지 이 축 ActivityLog 호출 0건이었음, 라이브 재측 中
+        # 자체발견) 사용자가 자기 광고가 왜 멈췄는지 화면에서 알 길이 없다. **요청
+        # 시점(명령 생성)엔 안 남긴다** — 그건 이미 command 테이블 자체가 사실이고,
+        # 여기(실행 성공 지점)에서만 기록한다. actor는 명령의 requested_by_member_id
+        # (scheduler 귀속 pause도 항상 사람 resolver_id로 채워져 있다 —
+        # ads_boost_execution.py::request_ads_boost_pause 그대로) — human/scheduler
+        # 구분은 actor가 아니라 context.initiated_by가 담당한다.
+        from app.services.activity_log import ActivityLogService
+
+        activity_context: dict = {"initiated_by": command.initiated_by or "human"}
+        if command.operation == OP_PAUSE and command.initiated_by == "scheduler":
+            # 이 조합(scheduler 귀속 pause)의 유일한 발생원은 _enforce_spend_cap
+            # (ads_spend_snapshots.py)의 상한 도달 자동 중지뿐이다(다른 scheduler
+            # 발신 pause 경로 0, grep 확認) — reason을 지어내지 않고 그 사실 그대로.
+            activity_context["reason"] = "cap_reached"
+        await ActivityLogService(db).record(
+            org_id=command.org_id, action=_ACTIVITY_ACTION_BY_OP[command.operation],
+            actor_id=command.requested_by_member_id, actor_type="human",
+            entity_type="gate", entity_id=gate.id, context=activity_context,
+        )
 
         await record_publication_attempt(
             db, command=command, approval_check="ok", adapter_called=True,

--- a/backend/tests/test_3806_ads_boost_activity_log.py
+++ b/backend/tests/test_3806_ads_boost_activity_log.py
@@ -1,0 +1,209 @@
+"""story #3806(Phase3·3-2 PR 13, 페드루 PO 確定 2026-09-11 19:52Z) — 「중지 스위치·
+상한 도달 자동 중지」 실행이 결재 이력에 한 줄도 안 남던 기존 결함(PR11 이전부터,
+라이브 재측 中 자체발견) 처방. boost start/pause/resume **명령 실행 성공 지점**
+(`process_one_ads_boost_command`)에만 ActivityLog 1행 — 요청(명령 생성) 시점엔
+안 남긴다(그건 이미 command 테이블 자체가 사실). 세팅 헬퍼는
+test_3806_ads_boost_execution.py/test_3806_ads_boost_spend.py 재사용(중복
+재발명 금지). 새 마이그 0건(기존 ActivityLog 테이블 그대로 재사용 — PR12와 동형)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_3806_ads_boost_execution import _setup_approved_gate
+from tests.test_3806_ads_boost_spend import _make_spend_snapshots_due, _start_boost
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _org_member_id(session, org_id, user_id):
+    from app.models.project import OrgMember
+
+    return (await session.execute(
+        select(OrgMember.id).where(OrgMember.org_id == org_id, OrgMember.user_id == user_id)
+    )).scalar_one()
+
+
+async def _activity_log(session, *, gate_id, action):
+    from app.models.activity_log import ActivityLog
+
+    return (await session.execute(
+        select(ActivityLog).where(
+            ActivityLog.entity_type == "gate", ActivityLog.entity_id == gate_id, ActivityLog.action == action,
+        )
+    )).scalar_one_or_none()
+
+
+@pytest.mark.anyio
+async def test_boost_start_execution_records_activity_log():
+    """`_start_boost`가 이미 `process_due_publication_commands`까지 실행한다 —
+    그 성공 지점에서 `ads_boost_started` 1행이 남아야 한다. `_start_boost`는
+    HTTP 라우터(resolve_member 경유)가 아니라 `request_ads_boost_start`를
+    `owner_id`(User.id)로 직접 호출하는 테스트 헬퍼라(test_3806_ads_boost_spend.py
+    참고) actor_id도 그 값 그대로 — 아래 두 테스트(HTTP 라우터 경유)의 OrgMember.id
+    조회와 다른 이유가 여기 있다(둘 다 「그 호출이 실은 넘긴 값」과 대조하는 것으로
+    각자 정합)."""
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        async with Session() as s:
+            log = await _activity_log(s, gate_id=gate_id, action="ads_boost_started")
+        assert log is not None
+        assert log.actor_id == owner_id
+        assert log.actor_type == "human"
+        assert log.context == {"initiated_by": "human"}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pause_execution_records_activity_log_and_not_before_execution():
+    """PO 지침 — 요청(명령 생성) 시점엔 안 남기고, 실행 성공 지점에만 남긴다.
+    POST /pause 직후(아직 tick 미실행)엔 0행, `process_due_publication_commands`
+    실행 뒤에야 1행."""
+    from app.main import app
+    from app.services.publication_command import process_due_publication_commands
+    from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/pause")
+        assert r.status_code == 201, r.text
+
+        async with Session() as s:
+            assert await _activity_log(s, gate_id=gate_id, action="ads_boost_paused") is None, (
+                "요청(명령 생성) 시점엔 아직 남으면 안 된다"
+            )
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        async with Session() as s:
+            org_member_id = await _org_member_id(s, org_id, owner_id)
+            log = await _activity_log(s, gate_id=gate_id, action="ads_boost_paused")
+        assert log is not None
+        assert log.actor_id == org_member_id
+        assert log.actor_type == "human"
+        assert log.context == {"initiated_by": "human"}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resume_execution_records_activity_log():
+    from app.main import app
+    from app.services.publication_command import process_due_publication_commands
+    from tests.test_3475_publishing_metrics import _client_for, _setup_org_scoped_app
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(await _session_factory())
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        async with _client_for(app) as client:
+            r_pause = await client.post(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/pause")
+            assert r_pause.status_code == 201, r_pause.text
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        async with _client_for(app) as client:
+            r_resume = await client.post(f"/api/v2/organizations/{org_id}/ads-boosts/{gate_id}/resume")
+            assert r_resume.status_code == 201, r_resume.text
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        async with Session() as s:
+            org_member_id = await _org_member_id(s, org_id, owner_id)
+            log = await _activity_log(s, gate_id=gate_id, action="ads_boost_resumed")
+        assert log is not None
+        assert log.actor_id == org_member_id
+        assert log.actor_type == "human"
+        assert log.context == {"initiated_by": "human"}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_scheduler_cap_pause_execution_records_activity_log_with_cap_reached_reason():
+    """상한 도달 자동 중지(PR11, `_enforce_spend_cap`)가 만든 pause 명령이 실행되면
+    `context.reason="cap_reached"`가 실려야 한다 — 사람이 누른 pause(위 두 테스트)와
+    구분되는 유일한 차이. actor는 여전히 사람(gate.resolver_id)이다."""
+    from app.models.gate import Gate
+    from app.services.ads_spend_snapshots import process_due_ads_spend_snapshots
+    from app.services.publication_command import process_due_publication_commands
+    from tests.test_e4fc29fa_site_post_orchestration import _session_factory
+
+    engine, Session, org_id, project_id, owner_id, gate_id = await _setup_approved_gate(
+        await _session_factory(), budget_minor=10_000,
+    )
+    try:
+        await _start_boost(Session, org_id, gate_id, owner_id)
+
+        async with Session() as s:
+            await _make_spend_snapshots_due(s, org_id, gate_id)
+        async with Session() as s:
+            counts = await process_due_ads_spend_snapshots(s)
+        assert counts["capped"] == 1, counts
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts  # 방금 만들어진 scheduler pause 명령.
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            resolver_org_member_id = gate.resolver_id
+            log = await _activity_log(s, gate_id=gate_id, action="ads_boost_paused")
+        assert log is not None
+        assert log.actor_id == resolver_org_member_id
+        assert log.actor_type == "human"
+        assert log.context == {"initiated_by": "scheduler", "reason": "cap_reached"}
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1662,6 +1662,11 @@
       "file": "tests/test_3806_ads_boost_reseal_command_identity.py",
       "sec": 3.0,
       "source": "story-3806(Phase3·3-2 PR 13, 페드루 PO 確定 2026-09-11 19:58Z — 감액 재봉인 뒤 명령 사슬 정체성 결함(approved_version 스코프→gate_id 스코프) 근본수정) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 2건 wall time 약 3.0s — test_3766 등재 선례와 동일 방법론)"
+    },
+    {
+      "file": "tests/test_3806_ads_boost_activity_log.py",
+      "sec": 3.9,
+      "source": "story-3806(Phase3·3-2 PR 14, 페드루 PO 確定 2026-09-11 19:52Z — boost start/pause/resume 명령 실행 성공 지점 ActivityLog 신설) — 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 4건 wall time 약 3.9s — test_3766 등재 선례와 동일 방법론)"
     }
   ]
 }


### PR DESCRIPTION
## 요약
- 「중지 스위치·상한 도달 자동 중지」가 3806 AC인데 그 실행이 결재 이력에 한 줄도 안 남던 기존 결함(PR11 이전부터, 라이브 재측 中 자체발견) 처방.
- ⚠️ **base=`feat/3806-ads-boost-command-identity`(#4199)** — PO 지시(2026-09-11 20:11Z)대로 그 브랜치 위에 쌓음. #4199 squash 뒤 rebase onto develop+force-push 예정.

## BE
- `process_one_ads_boost_command`(ads_boost_execution.py) 실행 **성공 지점에만** ActivityLog 1행 — 요청(명령 생성) 시점엔 안 남김(그건 이미 command 테이블 자체가 사실).
- action 3키: `ads_boost_started`/`ads_boost_paused`/`ads_boost_resumed`. actor는 명령의 `requested_by_member_id`(scheduler 귀속 pause도 항상 사람 resolver_id) — human/scheduler 구분은 `context.initiated_by`가 담당. scheduler 귀속 cap 도달 pause는 `context.reason="cap_reached"` 추가.
- 테스트 4건(실행경로 3+scheduler cap 문구 1), 뮤테이션 셀프체크(기록 지점 제거) → 정확히 이 4건만 RED 확認 후 원복.

## FE
- `GATE_ACTIVITY_LABEL_KEY`에 3키 추가(ko/en). `ads_boost_paused`는 두 얼굴 — 사람 pause(일반 문구)와 scheduler+cap_reached 자동 중지(「자동 중지(광고비 상한 도달)」 별도 문구)를 `adsBoostActivityLabel()`로 구분.
- 테스트 2건(3액션 raw키 미노출·scheduler+cap 별도문구), 뮤테이션 셀프체크(scheduler+cap 조건 무력화) → 해당 테스트만 RED 확認 후 원복.

## 검증
- BE 회귀: ads_boost 전체 스위트(#4199 포함) 64/64. organic_snapshots_only 가드 4/4, BE 한글 사용자 문장 가드 신규 0건.
- FE 회귀: vitest 7620/7620, `tsc --noEmit` 0, eslint 0, i18n 키가드·한글하드코딩가드 신규 0건, `next build` 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn