### PR TITLE
[SID:3528] sandbox 댓글 벽시계 고정 타임스탬프 근본처방

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,6 +815,22 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_business_info_email_footer_drift.py
 
+  # story #3528(재발 가드, 페드루 PO 근본처방 2026-09-12) — sandbox_publish.py류가
+  # 댓글 timestamp를 벽시계 고정 절대일시로 박아 뒀다가, 그 날짜를 벽시계가 지나는
+  # 순간부터 _is_publication_active의 「마지막 댓글 7일」 창이 영구 False가 돼 자가
+  # 회수 재생성 전체가 죽은 실사고(develop 2026-09-12 00:00Z 전수 RED). PG 불요
+  # 정적 AST 스캔이라 독립 job으로 배선.
+  no-hardcoded-iso-timestamp-lint:
+    name: backend/app ISO 절대 일시 하드코딩 lint (guard, story #3528)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan backend/app for hardcoded ISO absolute timestamps
+        working-directory: backend
+        run: python3 scripts/lint_no_hardcoded_iso_timestamp.py
+
   # story #3219(카디르 3라운드, 2026-08-30) — 이 검증은 run-migrations.test.sh 시나리오
   # [9]로 먼저 만들어졌지만 그 .test.sh는 CI 어디에도 안 걸려 있어(convention 자체가
   # manual-only) 매 PR에 실제로 도는 자리가 없었다("만들어졌는데 도는 자리 없음" 결함).

--- a/backend/app/services/channel_post_comments.py
+++ b/backend/app/services/channel_post_comments.py
@@ -197,32 +197,40 @@ async def _fetch_replies_raw(
     if channel in ("sandbox", "instagram_sandbox"):
         if external_id is None:
             raise CommentFetchError(error_code="COMMENT_EXTERNAL_ID_MISSING", message="external_id가 없습니다")
+        from app.models.channel_publication import ChannelPublication
+
+        # story #3528(2026-09-12 근본처방) — sandbox 댓글의 결정적 timestamp는
+        # 이 발행물의 실 published_at을 필요로 한다(sandbox_publish.py::
+        # _deterministic_comment 참고, 벽시계 고정값이 「마지막 댓글로부터 7일」
+        # 활성 창을 영구 False로 고정시키던 실사고 재발 방지) — 이전엔 instagram_
+        # sandbox의 만료 마커 분기에서만 조건부로 pub을 조회했으나, 이제 두 sandbox
+        # 채널 다 published_at이 항상 필요해 무조건 조회로 승격한다(옛 "새 DB 왕복
+        # 0" 최적화 전제가 이 근본처방으로 무효가 됨).
+        pub = await db.get(ChannelPublication, publication_id)
+        if pub is None or pub.published_at is None:
+            raise CommentFetchError(
+                error_code="COMMENT_PUBLICATION_NOT_FOUND",
+                message=f"channel_publication을 찾을 수 없습니다: {publication_id}",
+            )
         # story #3640 — instagram_sandbox의 [sandbox:expire-after-publish] 마커가
         # media_id에 새긴 영구 접미사를 fetch_replies가 볼 때마다 401을 던지던
         # 「영구 지뢰」를 닫는다: 이 발행물이 이미 한 번 그 401을 관측했으면
         # (sandbox_expired_once) 접미사를 벗긴 media_id로 불러 200을 받는다.
-        # sandbox_publish.py(channel="sandbox")엔 이 마커가 없어(그라운딩 확認)
-        # pub 조회 자체를 skip — 새 DB 왕복 0.
-        pub = None
         effective_external_id = external_id
         if channel == "instagram_sandbox":
             from app.services.instagram_sandbox_publish import (
                 _EXPIRE_AFTER_PUBLISH_SUFFIX as _IG_EXPIRE_SUFFIX,
             )
 
-            if external_id.endswith(_IG_EXPIRE_SUFFIX):
-                from app.models.channel_publication import ChannelPublication
-
-                pub = await db.get(ChannelPublication, publication_id)
-                if pub is not None and pub.sandbox_expired_once:
-                    effective_external_id = external_id[: -len(_IG_EXPIRE_SUFFIX)]
+            if external_id.endswith(_IG_EXPIRE_SUFFIX) and pub.sandbox_expired_once:
+                effective_external_id = external_id[: -len(_IG_EXPIRE_SUFFIX)]
         _publish_client = get_publish_client_module(channel)
         from app.services.threads_publish import ThreadsPublishError
         import httpx
         try:
             async with httpx.AsyncClient() as client:
                 return await _publish_client.fetch_replies(
-                    client, access_token="sandbox", media_id=effective_external_id,
+                    client, access_token="sandbox", media_id=effective_external_id, published_at=pub.published_at,
                 )
         except ThreadsPublishError as exc:
             # story #3640 — 위에서 접미사를 못 벗겼다(=이번이 첫 401)면 여기서
@@ -297,11 +305,17 @@ async def _fetch_replies_raw(
         if pub.external_id.endswith(_FB_EXPIRE_SUFFIX) and pub.sandbox_expired_once:
             effective_external_id = pub.external_id[: -len(_FB_EXPIRE_SUFFIX)]
 
+    # story #3528(2026-09-12 근본처방) — facebook_sandbox만 published_at을 받는다
+    # (sandbox_publish.py/instagram_sandbox_publish.py와 동형 이유, 위 §참고). 실
+    # threads/instagram/facebook의 fetch_replies는 이 인자 자체가 없다(실 provider
+    # 응답이 진짜 시각을 주므로 불필요) — 시그니처가 갈리는 유일한 자리라 kwargs를
+    # 조건부로 조립한다(새 판정 로직 0, 위 effective_external_id 분기와 동형 축).
+    extra_kwargs = {"published_at": pub.published_at} if channel == "facebook_sandbox" else {}
     import httpx
     try:
         async with httpx.AsyncClient() as client:
             return await _publish_client.fetch_replies(
-                client, access_token=access_token, media_id=effective_external_id,
+                client, access_token=access_token, media_id=effective_external_id, **extra_kwargs,
             )
     except Exception as exc:  # noqa: BLE001 — ThreadsPublishError는 상태코드로 분류(threads/instagram/facebook 공용)
         if isinstance(exc, ThreadsPublishError):

--- a/backend/app/services/facebook_sandbox_publish.py
+++ b/backend/app/services/facebook_sandbox_publish.py
@@ -9,6 +9,7 @@ reply, instagram_sandbox_publish.py와 동형 결정적 표본 — 실 provider 
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timedelta
 
 import httpx
 
@@ -145,13 +146,16 @@ async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id
 # (instagram_sandbox_publish.py와 동형 계약) ──────────────────────────────────
 
 
-def _deterministic_comment(*, media_id: str, index: int) -> dict:
+def _deterministic_comment(*, media_id: str, index: int, published_at: datetime) -> dict:
+    """story #3528(2026-09-12 근본처방, sandbox_publish.py::_deterministic_comment와
+    동형) — `timestamp`는 벽시계 고정값이 아니라 이 발행물의 published_at 기준
+    (+index분)."""
     seed = int(uuid.uuid5(uuid.NAMESPACE_URL, f"{media_id}:{index}").hex[:8], 16)
     item = {
         "id": f"sandbox-fb-comment-{media_id}-{index}",
         "text": f"샌드박스 FB 댓글 {index}(seed={seed % 1000})",
         "username": f"sandbox_fb_user_{index}",
-        "timestamp": "2026-09-06T00:00:00+00:00",
+        "timestamp": (published_at + timedelta(minutes=index)).isoformat(),
     }
     # story #3805(Phase3·3-1·PR 4, 페드루 PO 確定 2026-09-11 12:12Z) — sandbox_
     # publish.py::_deterministic_comment와 동형(댓글 2=댓글 1의 답글).
@@ -163,20 +167,22 @@ def _deterministic_comment(*, media_id: str, index: int) -> dict:
 
 
 async def fetch_replies(
-    client: httpx.AsyncClient, *, access_token: str, media_id: str,
+    client: httpx.AsyncClient, *, access_token: str, media_id: str, published_at: datetime,
 ) -> tuple[list[dict], bool, int | None]:
     """instagram_sandbox_publish.py::fetch_replies와 동형 — media_id 하나엔 항상
     같은 2건(순서 고정), complete=True 고정(페이지네이션 개념 없음). 세 번째 값
     (채널이 말하는 전체 개수, story #3618)도 동형 — 항상 `len(items)`.
 
     story #3597 — media_id가 `_EXPIRE_AFTER_PUBLISH_SUFFIX`를 달고 있으면 401을
-    던진다(instagram_sandbox_publish.py::fetch_replies와 동형)."""
+    던진다(instagram_sandbox_publish.py::fetch_replies와 동형).
+
+    story #3528(2026-09-12 근본처방) — `published_at` 필수(기본값 없음, 동형 원칙)."""
     if media_id.endswith(_EXPIRE_AFTER_PUBLISH_SUFFIX):
         raise ThreadsPublishError(
             "SANDBOX_FACEBOOK_TOKEN_EXPIRED",
             "sandbox: [sandbox:expire-after-publish] 마커 시뮬레이션(발행 후 토큰 만료)", status_code=401,
         )
-    items = [_deterministic_comment(media_id=media_id, index=i) for i in (1, 2)]
+    items = [_deterministic_comment(media_id=media_id, index=i, published_at=published_at) for i in (1, 2)]
     return items, True, len(items)
 
 

--- a/backend/app/services/instagram_sandbox_publish.py
+++ b/backend/app/services/instagram_sandbox_publish.py
@@ -12,6 +12,7 @@ TEXT-optional 채널을 흉내내는 값이라, 「이미지 필수」인 Instag
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timedelta
 
 import httpx
 
@@ -173,13 +174,16 @@ async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id
 # ─── story #3320 조각③ — 댓글 수집+답변(sandbox_publish.py와 동형 계약) ────────
 
 
-def _deterministic_comment(*, media_id: str, index: int) -> dict:
+def _deterministic_comment(*, media_id: str, index: int, published_at: datetime) -> dict:
+    """story #3528(2026-09-12 근본처방, sandbox_publish.py::_deterministic_comment와
+    동형) — `timestamp`는 벽시계 고정값이 아니라 이 발행물의 published_at 기준
+    (+index분)."""
     seed = int(uuid.uuid5(uuid.NAMESPACE_URL, f"{media_id}:{index}").hex[:8], 16)
     item = {
         "id": f"sandbox-ig-comment-{media_id}-{index}",
         "text": f"샌드박스 IG 댓글 {index}(seed={seed % 1000})",
         "username": f"sandbox_ig_user_{index}",
-        "timestamp": "2026-09-05T00:00:00+00:00",
+        "timestamp": (published_at + timedelta(minutes=index)).isoformat(),
     }
     # story #3805(Phase3·3-1·PR 4, 페드루 PO 確定 2026-09-11 12:12Z) — sandbox_
     # publish.py::_deterministic_comment와 동형(댓글 2=댓글 1의 답글).
@@ -191,7 +195,7 @@ def _deterministic_comment(*, media_id: str, index: int) -> dict:
 
 
 async def fetch_replies(
-    client: httpx.AsyncClient, *, access_token: str, media_id: str,
+    client: httpx.AsyncClient, *, access_token: str, media_id: str, published_at: datetime,
 ) -> tuple[list[dict], bool, int | None]:
     """sandbox_publish.py::fetch_replies와 동형 — media_id 하나엔 항상 같은 2건
     (순서 고정), complete=True 고정(페이지네이션 개념 없음). 세 번째 값(채널이
@@ -202,13 +206,16 @@ async def fetch_replies(
     story #3597 — media_id가 `_EXPIRE_AFTER_PUBLISH_SUFFIX`를 달고 있으면(발행
     시점에 [sandbox:expire-after-publish] 마커를 봤을 때만) 401을 던진다 —
     "발행은 성공했는데 나중에 토큰이 만료됐다"를 라이브에서 재현하는 유일한
-    신호(서버 메모리 0, media_id 문자열 자체가 표식)."""
+    신호(서버 메모리 0, media_id 문자열 자체가 표식).
+
+    story #3528(2026-09-12 근본처방) — `published_at` 필수(기본값 없음, sandbox_
+    publish.py::fetch_replies와 동형 원칙)."""
     if media_id.endswith(_EXPIRE_AFTER_PUBLISH_SUFFIX):
         raise ThreadsPublishError(
             "SANDBOX_INSTAGRAM_TOKEN_EXPIRED",
             "sandbox: [sandbox:expire-after-publish] 마커 시뮬레이션(발행 후 토큰 만료)", status_code=401,
         )
-    items = [_deterministic_comment(media_id=media_id, index=i) for i in (1, 2)]
+    items = [_deterministic_comment(media_id=media_id, index=i, published_at=published_at) for i in (1, 2)]
     return items, True, len(items)
 
 

--- a/backend/app/services/sandbox_publish.py
+++ b/backend/app/services/sandbox_publish.py
@@ -103,6 +103,7 @@ from __future__ import annotations
 import re
 import time
 import uuid
+from datetime import datetime, timedelta
 
 import httpx
 
@@ -266,13 +267,22 @@ async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id
 # 이번 fetch엔 없다"를 diff로 판정해 soft-delete한다(테스트는 두 번째 호출을
 # monkeypatch로 comment 하나 뺀 리스트로 바꿔 이 경로를 재현한다) — 일반적인 리컨실
 # 로직이라 sandbox뿐 아니라 실 Threads 응답에도 그대로 먹힌다.
-def _deterministic_comment(*, media_id: str, index: int) -> dict:
+def _deterministic_comment(*, media_id: str, index: int, published_at: datetime) -> dict:
+    """story #3528(카디르 QA 실사고 2026-09-12, 페드루 PO 근본처방) —
+    `timestamp`는 **벽시계 고정 절대일시가 아니라 그 발행물 자신의 published_at**
+    기준(+index분 결정적 오프셋)이어야 한다. 예전엔 "2026-09-05T00:00:00+00:00"
+    고정값이었는데, `channel_post_comments.py::_is_publication_active`의 「마지막
+    댓글로부터 7일 이내」 창이 벽시계가 그 날짜를 지나는 순간부터 **영구** False가
+    돼(발행물이 몇 분 전에 새로 생겨도 상관없이) 자가회수 재생성 전체가 죽었다
+    (develop 2026-09-12 00:00Z 이후 CI 전수 RED의 원인). published_at 기준이면
+    "발행 후 7일 지나 비활성"이라는 원래 설계 그대로 발행물 나이와 같이 움직인다
+    (같은 입력→같은 값 결정성은 유지)."""
     seed = int(uuid.uuid5(uuid.NAMESPACE_URL, f"{media_id}:{index}").hex[:8], 16)
     item = {
         "id": f"sandbox-comment-{media_id}-{index}",
         "text": f"샌드박스 댓글 {index}(seed={seed % 1000})",
         "username": f"sandbox_user_{index}",
-        "timestamp": "2026-09-05T00:00:00+00:00",
+        "timestamp": (published_at + timedelta(minutes=index)).isoformat(),
     }
     # story #3805(Phase3·3-1·PR 4, 페드루 PO 確定 2026-09-11 12:12Z) — 댓글 2를
     # 댓글 1의 답글로(인바운드·「남이 우리 댓글에 단 답글」) 고정해, PO Test Org에서
@@ -291,7 +301,7 @@ _COMMENT2_DELETE_MARKER_RE = re.compile(r"-c2del(\d+)$")
 
 
 async def fetch_replies(
-    client: httpx.AsyncClient, *, access_token: str, media_id: str,
+    client: httpx.AsyncClient, *, access_token: str, media_id: str, published_at: datetime,
 ) -> tuple[list[dict], bool, int | None]:
     """AC(조각①) "기본 2건" — media_id 하나엔 항상 같은 2건(순서도 고정, 테스트가
     인덱스로 단언 가능). 페드루 PO REQUIRED(2026-09-05, PR#3865 리뷰) — threads가
@@ -307,12 +317,16 @@ async def fetch_replies(
     story #3516 AC8 — media_id가 `-c2del{epoch}` 접미사를 달고 있고(퍼블리시 시점에
     [sandbox:comment-2-deleted] 마커를 봤을 때만) 지금이 그 epoch를 지났으면 댓글
     2는 이제 없다(1건만 반환) — «처음 refresh=2건, 5분 rate-limit 뒤 재수집=1건»을
-    라이브에서 재현하는 유일한 신호(서버 메모리 0, media_id 문자열 자체가 시계)."""
+    라이브에서 재현하는 유일한 신호(서버 메모리 0, media_id 문자열 자체가 시계).
+
+    story #3528(2026-09-12 근본처방) — `published_at`은 필수(기본값 없음) —
+    벽시계 고정값으로 조용히 되돌아갈 여지를 원천 차단한다(호출자가 반드시 이
+    발행물의 실 published_at을 들고 오게 강제, _deterministic_comment 참고)."""
     match = _COMMENT2_DELETE_MARKER_RE.search(media_id)
     if match is not None and time.time() >= int(match.group(1)):
-        items = [_deterministic_comment(media_id=media_id, index=1)]
+        items = [_deterministic_comment(media_id=media_id, index=1, published_at=published_at)]
         return items, True, len(items)
-    items = [_deterministic_comment(media_id=media_id, index=i) for i in (1, 2)]
+    items = [_deterministic_comment(media_id=media_id, index=i, published_at=published_at) for i in (1, 2)]
     return items, True, len(items)
 
 

--- a/backend/scripts/lint_no_hardcoded_iso_timestamp.py
+++ b/backend/scripts/lint_no_hardcoded_iso_timestamp.py
@@ -1,0 +1,114 @@
+"""story #3528(BE·재발 가드, 페드루 PO 근본처방 2026-09-12) — `backend/app/**`
+(tests 제외) 문자열 리터럴에 ISO 절대 일시(`"20\\d\\d-\\d\\d-\\d\\dT`)가 박히는 재발
+클래스를 막는다.
+
+## 실사고(2026-09-12 00:00Z 넘어가며 develop 전수 destructive-schema shard RED)
+`sandbox_publish.py`/`instagram_sandbox_publish.py`/`facebook_sandbox_publish.py`
+세 파일이 sandbox 댓글의 `external_created_at`을 벽시계 고정 절대 타임스탬프
+("2026-09-05T00:00:00+00:00" 등)로 박아 뒀다 — 그 발행물이 **언제 발행됐든** 벽시계가
+그 날짜+7일을 지나는 순간부터 `channel_post_comments.py::_is_publication_active`의
+「마지막 댓글로부터 7일 이내」 창이 영구 False가 돼 자가회수 재생성 전체가 죽었다.
+근본처방은 그 타임스탬프를 벽시계가 아니라 **그 발행물 자신의 published_at 기준
+결정적 오프셋**으로 바꾸는 것 — 이 가드는 그 klass(고정 절대 일시)가 다시 코드에
+박히는 것을 잡는다.
+
+## 기전 — AST(story #3779 한글 가드와 동형 사상, 정규식 줄 스캔이 아니라 `ast.Constant`
+문자열 노드만 본다). docstring(모듈/클래스/함수 body의 첫 statement가 문자열 리터럴인
+경우)은 제외 — 이 파일 자신의 위 문단처럼 "과거에 있었던 버그값"을 설명하는 문서
+텍스트까지 걸리면 이 가드 자신이 이 스크립트를 걸 정도로 우스워진다.
+
+## 허용 목록(ALLOWLIST) — 명시(fail-closed 원칙: 여기 없는 매치는 전부 FAIL)
+지금은 0건. 진짜로 "이 시각 이후부터 사양이 바뀐다" 같은 의도적 절대 기준일이
+필요해지면 `(file, line, literal)` 튜플로 여기 추가하고 그 옆에 사유를 남길 것 —
+말없이 넘어가는 예외는 없다."""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+APP_DIR = Path(__file__).resolve().parent.parent / "app"
+
+_ISO_TIMESTAMP_RE = re.compile(r"\b20\d\d-\d\d-\d\dT")
+
+# (상대경로, 리터럴 문자열) — 명시적으로 봐준 자리. 지금은 0건(위 docstring 참고).
+ALLOWLIST: frozenset[tuple[str, str]] = frozenset()
+
+# self-assert — 스캔 대상이 비정상적으로 적으면(경로가 헛돌면) 조용한 통과 대신 죽는다.
+MIN_EXPECTED_FILES = 300
+
+
+def _docstring_constant_ids(tree: ast.AST) -> set[int]:
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = node.body
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                ids.add(id(body[0].value))
+    return ids
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    text: str
+
+
+def scan_source(source: str, file_label: str) -> list[Violation]:
+    tree = ast.parse(source)
+    docstring_ids = _docstring_constant_ids(tree)
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if id(node) in docstring_ids:
+            continue
+        if not _ISO_TIMESTAMP_RE.search(node.value):
+            continue
+        if (file_label, node.value) in ALLOWLIST:
+            continue
+        violations.append(Violation(file=file_label, line=node.lineno, text=node.value))
+    return violations
+
+
+def scan_repo() -> list[Violation]:
+    py_files = sorted(APP_DIR.rglob("*.py"))
+    if len(py_files) < MIN_EXPECTED_FILES:
+        raise RuntimeError(
+            f"스캔 대상 파일이 비정상적으로 적습니다({len(py_files)}건 < {MIN_EXPECTED_FILES}) — "
+            "경로가 잘못됐을 가능성(조용한 통과 대신 죽는다, story #3164/#3741류 관례)."
+        )
+    violations: list[Violation] = []
+    for path in py_files:
+        file_label = str(path.relative_to(REPO_ROOT))
+        violations.extend(scan_source(path.read_text(encoding="utf-8"), file_label))
+    return violations
+
+
+def main() -> int:
+    violations = scan_repo()
+    if violations:
+        print(f"FAIL: backend/app/** ISO 절대 일시 하드코딩 {len(violations)}건(story #3528 재발 클래스)")
+        for v in violations:
+            print(f"  {v.file}:{v.line} {v.text!r}")
+        print(
+            "벽시계 고정 절대 타임스탬프는 시간이 지나면 조용히 썩는다(2026-09-12 실사고) — "
+            "그 값을 요구하는 자신의 데이터(예: 발행물의 published_at)에서 상대 오프셋으로 "
+            "유도할 것. 정말 의도적인 절대 기준일이면 이 스크립트의 ALLOWLIST에 사유와 함께 등재."
+        )
+        return 1
+    print("OK: backend/app/** ISO 절대 일시 하드코딩 0건")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -69,6 +69,10 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
                                                    # 산출 도구(model_db_drift_audit.py와 동일
                                                    # 범주, CI 미등재). 운영 DB 무접속, app/ 정적
                                                    # AST 스캔만.
+    "lint_no_hardcoded_iso_timestamp.py",         # story #3528(재발 가드) — CI lint 게이트
+                                                   # (backend/app/** AST 정적 스캔, 운영 DB
+                                                   # 무접속 — lint_business_info_email_footer_
+                                                   # drift.py와 동형 관례).
 })
 
 

--- a/backend/tests/test_3320_instagram_piece3.py
+++ b/backend/tests/test_3320_instagram_piece3.py
@@ -281,14 +281,23 @@ async def test_instagram_reply_failure_raises():
 async def test_instagram_sandbox_fetch_replies_deterministic_two_comments():
     from app.services.instagram_sandbox_publish import fetch_replies
 
-    items, complete, _reported = await fetch_replies(None, access_token="x", media_id="media-1")
+    # story #3528(2026-09-12) — published_at은 이제 필수 입력이라(재발 방지 근본처방)
+    # 같은 고정값으로 두 번 불러야 "결정적"의 원래 취지(같은 입력→같은 값)가 그대로
+    # 성립한다(datetime.now()를 매번 새로 재면 그 자체가 비결정 소스가 돼 이 assert가
+    # 무의미해진다).
+    published_at = datetime.now(timezone.utc)
+    items, complete, _reported = await fetch_replies(
+        None, access_token="x", media_id="media-1", published_at=published_at,
+    )
     assert complete is True
     assert [i["id"] for i in items] == [
         "sandbox-ig-comment-media-1-1", "sandbox-ig-comment-media-1-2",
     ]
 
-    items2, _, _reported2 = await fetch_replies(None, access_token="x", media_id="media-1")
-    assert items == items2, "결정적이어야 함(같은 media_id는 매번 같은 값)"
+    items2, _, _reported2 = await fetch_replies(
+        None, access_token="x", media_id="media-1", published_at=published_at,
+    )
+    assert items == items2, "결정적이어야 함(같은 media_id·published_at은 매번 같은 값)"
 
 
 @pytest.mark.anyio
@@ -349,9 +358,18 @@ async def test_collect_comments_for_publication_dispatches_instagram_sandbox():
     try:
         async with Session() as s:
             org_id, _ = await _seed_org(s)
+            # story #3528(2026-09-12 근본처방) — sandbox 댓글의 timestamp가 이제
+            # 이 발행물의 실 published_at을 필요로 해(벽시계 고정값 재발 방지),
+            # 예전처럼 임의 uuid(실물 없는 publication_id)로는 더는 안 통과한다 —
+            # 실 ChannelPublication 행이 필요해졌다(옛 "DB 왕복 0" 전제 무효화,
+            # channel_post_comments.py 정정 docstring 참고).
+            conn = await _seed_channel_connection(s, org_id, channel="instagram_sandbox")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=conn.id, channel="instagram_sandbox", external_id="ig-sandbox-media-1",
+            )
 
             await collect_comments_for_publication(
-                s, org_id=org_id, publication_id=uuid.uuid4(), channel="instagram_sandbox",
+                s, org_id=org_id, publication_id=pub.id, channel="instagram_sandbox",
                 external_id="ig-sandbox-media-1",
             )
             await s.commit()

--- a/backend/tests/test_3516_channel_post_comments.py
+++ b/backend/tests/test_3516_channel_post_comments.py
@@ -136,7 +136,7 @@ async def test_collect_upserts_two_comments_then_reconciles_one_as_deleted(monke
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _first_fetch(client, *, access_token, media_id):
+            async def _first_fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1", "안녕"), _fake_comment("c2", "반가워요")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _first_fetch)
@@ -151,7 +151,7 @@ async def test_collect_upserts_two_comments_then_reconciles_one_as_deleted(monke
             assert all(r.deleted_at is None for r in rows)
 
             # 두 번째 수집 — c2가 사라짐(외부에서 삭제됨을 시뮬레이션).
-            async def _second_fetch(client, *, access_token, media_id):
+            async def _second_fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1", "안녕")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _second_fetch)
@@ -188,10 +188,10 @@ async def test_collect_reappearing_comment_undeletes():
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _only_c1(client, *, access_token, media_id):
+            async def _only_c1(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
-            async def _both(client, *, access_token, media_id):
+            async def _both(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1"), _fake_comment("c2")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _both)
@@ -255,14 +255,14 @@ async def test_collect_incomplete_page_skips_deletion_reconciliation(monkeypatch
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _both_complete(client, *, access_token, media_id):
+            async def _both_complete(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1"), _fake_comment("c2")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _both_complete)
             await collect_comments_for_publication(s, org_id=org_id, publication_id=pub.id, channel="sandbox", external_id="media-1")
             await s.commit()
 
-            async def _only_c1_incomplete(client, *, access_token, media_id):
+            async def _only_c1_incomplete(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], False, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _only_c1_incomplete)
@@ -296,14 +296,14 @@ async def test_collect_complete_page_still_reconciles_deletion(monkeypatch):
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _both_complete(client, *, access_token, media_id):
+            async def _both_complete(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1"), _fake_comment("c2")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _both_complete)
             await collect_comments_for_publication(s, org_id=org_id, publication_id=pub.id, channel="sandbox", external_id="media-1")
             await s.commit()
 
-            async def _only_c1_complete(client, *, access_token, media_id):
+            async def _only_c1_complete(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _only_c1_complete)
@@ -346,7 +346,7 @@ async def test_process_due_marks_incomplete_page_error_code_without_failing():
             )
             await s.commit()
 
-            async def _incomplete(client, *, access_token, media_id):
+            async def _incomplete(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], False, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _incomplete)
@@ -387,7 +387,7 @@ async def test_process_due_marks_captured_and_ignores_not_yet_due(monkeypatch):
             )
             await s.commit()
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
@@ -419,7 +419,7 @@ async def test_refresh_now_rate_limited_within_five_minutes(monkeypatch):
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
@@ -445,7 +445,7 @@ async def test_refresh_now_allowed_again_after_five_minutes(monkeypatch):
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
@@ -487,7 +487,7 @@ async def test_list_comments_null_before_collection_then_zero_after_empty_collec
             assert before["last_collected_at"] is None, "한 번도 수집 안 됐으면 null(미수집)이어야 한다"
             assert before["comments"] == []
 
-            async def _empty_fetch(client, *, access_token, media_id):
+            async def _empty_fetch(client, *, access_token, media_id, **kwargs):
                 return [], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _empty_fetch)
@@ -520,7 +520,7 @@ async def test_list_comments_active_and_deleted_count_match_board_definition(mon
 
             # 비대칭 수(active 2·deleted 1) — active_count↔deleted_count 정의가
             # 뒤바뀌어도(뮤테이션) 우연히 같은 값이 나와 안 잡히는 일이 없게 한다.
-            async def _three(client, *, access_token, media_id):
+            async def _three(client, *, access_token, media_id, **kwargs):
                 return [
                     _fake_comment("c1", "살아있음1"), _fake_comment("c2", "살아있음2"), _fake_comment("c3", "곧 지워짐"),
                 ], True, None
@@ -529,7 +529,7 @@ async def test_list_comments_active_and_deleted_count_match_board_definition(mon
             await collect_comments_for_publication(s, org_id=org_id, publication_id=pub.id, channel="sandbox", external_id="media-1")
             await s.commit()
 
-            async def _two(client, *, access_token, media_id):
+            async def _two(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1", "살아있음1"), _fake_comment("c2", "살아있음2")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _two)
@@ -583,14 +583,14 @@ async def test_count_comments_by_publication_ids_excludes_deleted(monkeypatch):
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _two(client, *, access_token, media_id):
+            async def _two(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1"), _fake_comment("c2")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _two)
             await collect_comments_for_publication(s, org_id=org_id, publication_id=pub.id, channel="sandbox", external_id="media-1")
             await s.commit()
 
-            async def _one(client, *, access_token, media_id):
+            async def _one(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _one)
@@ -633,7 +633,7 @@ async def test_api_list_comments_allows_agent_caller(monkeypatch):
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
@@ -697,7 +697,7 @@ async def test_api_refresh_allows_human_and_returns_counts(monkeypatch):
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
             human_id = await _seed_human(s, org_id)
 
-        async def _fetch(client, *, access_token, media_id):
+        async def _fetch(client, *, access_token, media_id, **kwargs):
             return [_fake_comment("c1"), _fake_comment("c2")], True, None
 
         monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
@@ -776,7 +776,7 @@ async def test_api_refresh_provider_error_returns_503_not_502(monkeypatch):
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
             human_id = await _seed_human(s, org_id)
 
-        async def _fetch_fails(client, *, access_token, media_id):
+        async def _fetch_fails(client, *, access_token, media_id, **kwargs):
             raise ThreadsPublishError("PROVIDER_DOWN", "provider down", status_code=500)
 
         monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch_fails)
@@ -822,7 +822,7 @@ async def test_insights_board_row_carries_comments_count_for_channel_publication
                 s, org_id=org_id, gate_id=gate.id, channel="sandbox", published_at=datetime.now(timezone.utc),
             )
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)

--- a/backend/tests/test_3516_comment_reply.py
+++ b/backend/tests/test_3516_comment_reply.py
@@ -614,7 +614,7 @@ async def test_insights_board_carries_three_comment_signal_fields(monkeypatch):
             s.add(version)
             await s.commit()
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)

--- a/backend/tests/test_3516_comment_scope_and_runbook.py
+++ b/backend/tests/test_3516_comment_scope_and_runbook.py
@@ -242,13 +242,17 @@ async def test_sandbox_fetch_replies_shows_two_before_epoch_and_one_after(monkey
     )
     assert media_id.endswith(f"-c2del{1000 + sandbox_publish._COMMENT2_DELETE_AFTER_SECONDS}")
 
-    before_items, before_complete, before_reported = await sandbox_publish.fetch_replies(_FakeClient(), access_token="x", media_id=media_id)
+    before_items, before_complete, before_reported = await sandbox_publish.fetch_replies(
+        _FakeClient(), access_token="x", media_id=media_id, published_at=datetime.now(timezone.utc),
+    )
     assert len(before_items) == 2
     assert before_complete is True
     assert before_reported == 2, "샌드박스는 페이지네이션이 없어 돌려준 개수가 곧 채널이 말하는 전체 개수"
 
     fake_now[0] = 1000.0 + sandbox_publish._COMMENT2_DELETE_AFTER_SECONDS + 1
-    after_items, after_complete, after_reported = await sandbox_publish.fetch_replies(_FakeClient(), access_token="x", media_id=media_id)
+    after_items, after_complete, after_reported = await sandbox_publish.fetch_replies(
+        _FakeClient(), access_token="x", media_id=media_id, published_at=datetime.now(timezone.utc),
+    )
     assert len(after_items) == 1
     assert after_complete is True
     assert after_reported == 1
@@ -263,9 +267,13 @@ async def test_sandbox_fetch_replies_without_marker_unaffected_by_time(monkeypat
     fake_now = [1000.0]
     monkeypatch.setattr(sandbox_publish.time, "time", lambda: fake_now[0])
 
-    items_now, _, _reported2 = await sandbox_publish.fetch_replies(None, access_token="x", media_id="sandbox-media-plain")
+    items_now, _, _reported2 = await sandbox_publish.fetch_replies(
+        None, access_token="x", media_id="sandbox-media-plain", published_at=datetime.now(timezone.utc),
+    )
     fake_now[0] = 999999999.0
-    items_later, _, _reported2 = await sandbox_publish.fetch_replies(None, access_token="x", media_id="sandbox-media-plain")
+    items_later, _, _reported2 = await sandbox_publish.fetch_replies(
+        None, access_token="x", media_id="sandbox-media-plain", published_at=datetime.now(timezone.utc),
+    )
     assert len(items_now) == 2
     assert len(items_later) == 2
 

--- a/backend/tests/test_3528_comment_continuous_polling.py
+++ b/backend/tests/test_3528_comment_continuous_polling.py
@@ -84,6 +84,67 @@ async def _seed_due_schedule_row(session, *, org_id, publication_id, channel="sa
     return row.id
 
 
+# ─── story #3528 재발 가드(2026-09-12, 페드루 PO 근본처방) — sandbox 댓글 timestamp가
+# 벽시계 고정 절대값이 아니라 published_at 기준임을 실 fetch 경로(단위 함수가 아니라
+# process_due_comment_collections 전 구간)로 증명. 이 축이 실사고의 정확한 원인이었다
+# (_is_publication_active 자체는 늘 옳았다 — 그 입력(last_comment_at)을 sandbox가
+# 잘못 공급한 것이 문제) ─────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_sandbox_comment_timestamp_tracks_published_at_not_wall_clock():
+    """⭐양성대조 — 발행일+8일을 now로 주입하면 «지금이 언제든» 정확히 비활성으로
+    떨어져야 한다(발행물이 오늘 막 생겼어도, 벽시계가 어느 날짜를 지났든 상관없이).
+    이 테스트가 실사고 재현 그 자체 — 정정 前에는 sandbox 댓글의 external_created_at이
+    "2026-09-05T00:00:00+00:00" 고정이라 이 발행물이 **언제 발행됐든** 벽시계가 그
+    날짜+7일을 지나는 순간 이 assert가 (거짓으로) False가 아니라 계속 False로
+    «고정»됐다 — 아래는 그 반대: published_at 기준 8일 뒤엔 비활성이 맞고, 3일
+    뒤엔 여전히 활성이어야 한다(발행물 나이와 같이 움직인다는 것 자체를 증명)."""
+    from app.services.channel_post_comments import _is_publication_active, process_due_comment_collections
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org(s)
+            conn = await _seed_channel_connection(s, org_id, channel="sandbox")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
+            await _seed_due_schedule_row(s, org_id=org_id, publication_id=pub.id, external_id="media-1")
+
+        # 실 fetch 경로로 댓글을 실제로 수집 — sandbox_publish.py가 이제 published_at
+        # 기준 timestamp를 준다(정정 대상 그 자체).
+        async with Session() as s:
+            counts = await process_due_comment_collections(s, now=datetime.now(timezone.utc))
+            assert counts["captured"] == 1, counts
+
+        async with Session() as s:
+            pub_row = await s.get(type(pub), pub.id)
+            published_at = pub_row.published_at
+            # 발행 3일 뒤 — 여전히 활성(7일 창 안).
+            assert await _is_publication_active(
+                s, publication_id=pub.id, now=published_at + timedelta(days=3),
+            ) is True
+            # 발행 8일 뒤 — 마지막 댓글(=published_at+1·2분)로부터도 8일 가까이 지나
+            # 7일 창을 벗어난다 — 정확히 비활성이어야 한다(버그 재현 시나리오의 반대편).
+            assert await _is_publication_active(
+                s, publication_id=pub.id, now=published_at + timedelta(days=8),
+            ) is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sandbox_comment_timestamp_deterministic_same_inputs_same_value():
+    """결정성 회귀 — 같은 media_id·index·published_at이면 항상 같은 timestamp(호출
+    2회 비교). 벽시계(datetime.now()) 등 비결정 소스로 되돌아가는 재발을 막는다."""
+    import app.services.sandbox_publish as sandbox_publish
+
+    published_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    first = sandbox_publish._deterministic_comment(media_id="m-1", index=1, published_at=published_at)
+    second = sandbox_publish._deterministic_comment(media_id="m-1", index=1, published_at=published_at)
+    assert first["timestamp"] == second["timestamp"]
+    assert first["timestamp"] == (published_at + timedelta(minutes=1)).isoformat()
+
+
 # ─── 활성 판정 자체(_is_publication_active) ──────────────────────────────────
 
 
@@ -273,7 +334,7 @@ async def test_transient_failure_sets_next_attempt_at_backoff_and_tick_respects_
     from app.services.channel_post_comments import CommentFetchError, process_due_comment_collections
     from app.models.channel_post_comment import CommentCollectionSchedule
 
-    async def _rate_limited(client, *, access_token, media_id):
+    async def _rate_limited(client, *, access_token, media_id, **kwargs):
         raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message="429 시뮬레이션")
 
     monkeypatch.setattr(sandbox_publish, "fetch_replies", _rate_limited)
@@ -318,7 +379,7 @@ async def test_transient_failure_exceeds_5_attempts_marks_failed(monkeypatch):
     from app.services.channel_post_comments import CommentFetchError, process_due_comment_collections
     from app.models.channel_post_comment import CommentCollectionSchedule
 
-    async def _rate_limited(client, *, access_token, media_id):
+    async def _rate_limited(client, *, access_token, media_id, **kwargs):
         raise CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message="429 시뮬레이션")
 
     monkeypatch.setattr(sandbox_publish, "fetch_replies", _rate_limited)
@@ -353,7 +414,7 @@ async def test_backoff_mutation_check_removing_next_attempt_at_lets_immediate_re
     import app.services.sandbox_publish as sandbox_publish
     from app.models.channel_post_comment import CommentCollectionSchedule
 
-    async def _rate_limited(client, *, access_token, media_id):
+    async def _rate_limited(client, *, access_token, media_id, **kwargs):
         raise comments_module.CommentFetchError(error_code="CHANNEL_RATE_LIMITED", message="429 시뮬레이션")
 
     monkeypatch.setattr(sandbox_publish, "fetch_replies", _rate_limited)

--- a/backend/tests/test_3528_no_hardcoded_iso_timestamp_lint.py
+++ b/backend/tests/test_3528_no_hardcoded_iso_timestamp_lint.py
@@ -1,0 +1,69 @@
+"""story #3528(재발 가드, 페드루 PO 근본처방 2026-09-12) —
+lint_no_hardcoded_iso_timestamp.py의 정탐/오탐 회귀 가드. 합성 fixture로 짓는다
+(실물이 고쳐져도 이 테스트는 안 사라진다 — test_3697/test_3216류와 동형 관례)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from lint_no_hardcoded_iso_timestamp import main as lint_main, scan_source  # noqa: E402
+
+
+def test_clean_source_reports_zero_violations():
+    source = '''
+"""모듈 docstring — "2026-09-05T00:00:00+00:00" 같은 값이 여기 있어도(문서 텍스트)
+안 걸려야 한다."""
+from datetime import timedelta
+
+
+def foo(published_at):
+    """함수 docstring도 동형 제외 — "2026-09-06T00:00:00+00:00" 언급."""
+    return published_at + timedelta(minutes=1)
+'''
+    assert scan_source(source, "app/services/fixture.py") == []
+
+
+def test_hardcoded_iso_timestamp_in_real_code_is_detected():
+    """⭐뮤테이션 표적 — docstring이 아니라 실제 코드 값(딕셔너리 리터럴)에 박힌
+    절대 일시는 정확히 잡혀야 한다(실사고 재현 그 자체)."""
+    source = '''
+def _deterministic_comment(*, media_id, index):
+    return {
+        "id": f"sandbox-comment-{media_id}-{index}",
+        "timestamp": "2026-09-05T00:00:00+00:00",
+    }
+'''
+    violations = scan_source(source, "app/services/fixture.py")
+    assert len(violations) == 1
+    assert violations[0].text == "2026-09-05T00:00:00+00:00"
+    assert violations[0].line == 5
+
+
+def test_non_docstring_first_line_string_constant_still_scanned():
+    """docstring 제외는 "함수/클래스/모듈 body의 첫 statement"로 한정 — 두 번째
+    statement 이후의 문자열 상수(진짜 코드 값)는 여전히 스캔 대상이어야 한다."""
+    source = '''
+def foo():
+    x = 1
+    y = "2026-01-01T00:00:00+00:00"
+    return y
+'''
+    violations = scan_source(source, "app/services/fixture.py")
+    assert len(violations) == 1
+
+
+def test_non_iso_shaped_string_is_ignored():
+    """날짜꼴이 아닌 일반 문자열(예: 년-월-일 없이 T만 있거나, 자릿수가 다른 경우)은
+    오탐 없이 통과해야 한다."""
+    source = '''
+def foo():
+    return "hello T world" + "2026-1-1T00:00:00"
+'''
+    assert scan_source(source, "app/services/fixture.py") == []
+
+
+# ─── AC — 실물 backend/app/**이 지금 실제로 깨끗한지 ────────────────────────────
+
+def test_current_repo_passes_the_guard():
+    assert lint_main() == 0

--- a/backend/tests/test_3528_self_recovery_sweep.py
+++ b/backend/tests/test_3528_self_recovery_sweep.py
@@ -74,12 +74,20 @@ def _enable_sandbox_adapter(monkeypatch):
 
 async def _seed_terminal_schedule_row(session, *, org_id, publication_id, channel="sandbox", external_id="media-1", status="captured", due_at=None):
     """due 3창이 이미 전부 소진된 상태 재현 — captured/failed 등 terminal 상태로만
-    남고 pending/in_progress는 0(배포 前 시나리오)."""
+    남고 pending/in_progress는 0(배포 前 시나리오).
+
+    카디르 QA 재현(2026-09-12) — `due_at` 기본값이 매 호출마다 `datetime.now()`를
+    새로 재던 자리라, 같은 테스트 안에서 이 헬퍼를 짧은 시간에 여러 번 부르면(3회
+    루프류) 시스템 시계 해상도에 따라 같은 마이크로초가 나와 `uq_comment_
+    collection_schedule_publication_due_at` UNIQUE 위반이 났다 — `uuid.uuid4()`
+    시드 마이크로초 지터로 같은 publication_id 안에서도 사실상 항상 서로 다른
+    `due_at`을 보장한다(값 자체의 의미는 무관 — "이미 지난 due"라는 사실만 필요)."""
     from app.models.channel_post_comment import CommentCollectionSchedule
 
     row = CommentCollectionSchedule(
         id=uuid.uuid4(), org_id=org_id, publication_id=publication_id, channel=channel,
-        external_id=external_id, due_at=due_at or (datetime.now(timezone.utc) - timedelta(days=7)),
+        external_id=external_id,
+        due_at=due_at or (datetime.now(timezone.utc) - timedelta(days=7, microseconds=uuid.uuid4().int % 1_000_000)),
         status=status, captured_at=datetime.now(timezone.utc) - timedelta(days=7),
     )
     session.add(row)

--- a/backend/tests/test_3571_facebook_comments_insights.py
+++ b/backend/tests/test_3571_facebook_comments_insights.py
@@ -255,12 +255,20 @@ async def test_facebook_reply_failure_raises():
 async def test_facebook_sandbox_fetch_replies_deterministic_two_comments():
     from app.services.facebook_sandbox_publish import fetch_replies
 
-    items, complete, _reported = await fetch_replies(None, access_token="x", media_id="post-1")
+    # story #3528(2026-09-12) — published_at 필수화(재발 방지 근본처방) 후에도
+    # "결정적"의 원래 취지(같은 입력→같은 값)를 지키려면 두 호출에 같은 고정값을
+    # 줘야 한다(instagram_sandbox 동형 테스트 참고).
+    published_at = datetime.now(timezone.utc)
+    items, complete, _reported = await fetch_replies(
+        None, access_token="x", media_id="post-1", published_at=published_at,
+    )
     assert complete is True
     assert [i["id"] for i in items] == ["sandbox-fb-comment-post-1-1", "sandbox-fb-comment-post-1-2"]
 
-    items2, _, _reported2 = await fetch_replies(None, access_token="x", media_id="post-1")
-    assert items == items2, "결정적이어야 함(같은 media_id는 매번 같은 값)"
+    items2, _, _reported2 = await fetch_replies(
+        None, access_token="x", media_id="post-1", published_at=published_at,
+    )
+    assert items == items2, "결정적이어야 함(같은 media_id·published_at은 매번 같은 값)"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_3805_pr4_reply_collection.py
+++ b/backend/tests/test_3805_pr4_reply_collection.py
@@ -106,7 +106,7 @@ async def test_collect_resolves_parent_when_parent_arrives_in_same_batch(monkeyp
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1"), _fake_comment("c2", parent_external_id="c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
@@ -139,14 +139,14 @@ async def test_collect_resolves_parent_when_parent_already_collected_earlier(mon
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _first_fetch(client, *, access_token, media_id):
+            async def _first_fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _first_fetch)
             await collect_comments_for_publication(s, org_id=org_id, publication_id=pub.id, channel="sandbox", external_id="media-1")
             await s.commit()
 
-            async def _second_fetch(client, *, access_token, media_id):
+            async def _second_fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1"), _fake_comment("c2", parent_external_id="c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _second_fetch)
@@ -180,7 +180,7 @@ async def test_collect_leaves_parent_null_when_parent_not_collected(monkeypatch)
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c2", parent_external_id="ghost-never-collected")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
@@ -276,7 +276,9 @@ async def test_kind_filter_narrows_to_comment_or_reply():
 async def test_sandbox_threads_mirror_marks_comment_two_as_reply_to_comment_one():
     import app.services.sandbox_publish as sandbox_publish
 
-    items, complete, _total = await sandbox_publish.fetch_replies(None, access_token="sandbox", media_id="media-x")
+    items, complete, _total = await sandbox_publish.fetch_replies(
+        None, access_token="sandbox", media_id="media-x", published_at=datetime.now(timezone.utc),
+    )
     assert complete is True
     assert items[0].get("parent_external_id") is None
     assert items[1]["parent_external_id"] == items[0]["id"]
@@ -286,7 +288,9 @@ async def test_sandbox_threads_mirror_marks_comment_two_as_reply_to_comment_one(
 async def test_sandbox_instagram_mirror_marks_comment_two_as_reply_to_comment_one():
     import app.services.instagram_sandbox_publish as instagram_sandbox_publish
 
-    items, complete, _total = await instagram_sandbox_publish.fetch_replies(None, access_token="sandbox", media_id="media-x")
+    items, complete, _total = await instagram_sandbox_publish.fetch_replies(
+        None, access_token="sandbox", media_id="media-x", published_at=datetime.now(timezone.utc),
+    )
     assert complete is True
     assert items[0].get("parent_external_id") is None
     assert items[1]["parent_external_id"] == items[0]["id"]
@@ -296,7 +300,9 @@ async def test_sandbox_instagram_mirror_marks_comment_two_as_reply_to_comment_on
 async def test_sandbox_facebook_mirror_marks_comment_two_as_reply_to_comment_one():
     import app.services.facebook_sandbox_publish as facebook_sandbox_publish
 
-    items, complete, _total = await facebook_sandbox_publish.fetch_replies(None, access_token="sandbox", media_id="media-x")
+    items, complete, _total = await facebook_sandbox_publish.fetch_replies(
+        None, access_token="sandbox", media_id="media-x", published_at=datetime.now(timezone.utc),
+    )
     assert complete is True
     assert items[0].get("parent_external_id") is None
     assert items[1]["parent_external_id"] == items[0]["id"]
@@ -330,7 +336,7 @@ async def test_reply_detection_flagged_unavailable_when_parent_field_key_missing
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment_without_parent_field_marker("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)
@@ -360,7 +366,7 @@ async def test_reply_detection_self_heals_when_parent_field_observed_again(monke
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _fetch_missing(client, *, access_token, media_id):
+            async def _fetch_missing(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment_without_parent_field_marker("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch_missing)
@@ -369,7 +375,7 @@ async def test_reply_detection_self_heals_when_parent_field_observed_again(monke
             await s.refresh(conn)
             assert conn.reply_detection_unavailable_at is not None
 
-            async def _fetch_observed(client, *, access_token, media_id):
+            async def _fetch_observed(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch_observed)
@@ -395,7 +401,7 @@ async def test_collection_status_exposes_reply_detection_unavailable(monkeypatch
             conn = await _seed_channel_connection(s, org_id, channel="sandbox")
             pub = await _seed_channel_publication(s, org_id=org_id, connection_id=conn.id, channel="sandbox", external_id="media-1")
 
-            async def _fetch(client, *, access_token, media_id):
+            async def _fetch(client, *, access_token, media_id, **kwargs):
                 return [_fake_comment_without_parent_field_marker("c1")], True, None
 
             monkeypatch.setattr(sandbox_publish, "fetch_replies", _fetch)


### PR DESCRIPTION
[SID:3528] develop 전수 RED(2026-09-12 00:00Z 이후) 근본처방 — 최우선.

## 원인
`sandbox_publish.py`/`instagram_sandbox_publish.py`/`facebook_sandbox_publish.py`의 `_deterministic_comment`가 댓글 `external_created_at`을 벽시계 고정 절대 타임스탬프("2026-09-05T00:00:00+00:00"·"2026-09-06T00:00:00+00:00")로 박아 뒀다. 그 날짜+7일을 벽시계가 지나는 순간부터 `channel_post_comments.py::_is_publication_active`의 「마지막 댓글 7일」 활성 창이 영구 False가 돼 자가회수 재생성이 전부 죽음 — `test_3528_self_recovery_sweep.py`/`test_3528_comment_continuous_polling.py`가 destructive-schema shard에서 전수 RED, 열려 있던 PR #4206·#4208·#4209 전부 머지 불가.

## 처방(불변식 — 코드 안 시각과 테스트가 넘긴 now는 한 시계)
timestamp를 벽시계가 아니라 **그 발행물 자신의 published_at 기준(+index분) 결정적 오프셋**으로 — 발행 나이와 활성 판정이 같이 움직인다(원 설계 "발행 7일 지나 비활성" 그대로 성립).

## 변경 파일(15개)
- `sandbox_publish.py`·`instagram_sandbox_publish.py`·`facebook_sandbox_publish.py` — `_deterministic_comment`/`fetch_replies` published_at 기준 정정(3곳 고정 리터럴 → 0건, 아래 lint로 확認)
- `channel_post_comments.py` — 양쪽 호출부 published_at 배선(sandbox/instagram_sandbox 무조건 pub 조회로 승격, facebook_sandbox 조건부 kwargs)
- `scripts/lint_no_hardcoded_iso_timestamp.py`(신규) — `backend/app/**` ISO 절대 일시 하드코딩 AST fail-closed 가드(허용 목록 명시, 현재 0건) + `.github/workflows/ci.yml` 독립 job(`no-hardcoded-iso-timestamp-lint`) 신설
- `tests/test_3528_no_hardcoded_iso_timestamp_lint.py`(신규, 5 tests) — 위 lint 정탐/오탐 회귀
- `tests/test_3528_comment_continuous_polling.py` — 양성대조 2 tests 추가(발행+3일=활성·발행+8일=비활성, 결정성 회귀)
- `tests/test_3528_self_recovery_sweep.py` — 카디르 QA 발견 픽스처 취약(`_seed_terminal_schedule_row` 3회 루프 `due_at` 동일 충돌) uuid 시드 지터로 정정
- `test_3320_instagram_piece3.py`·`test_3516_channel_post_comments.py`·`test_3516_comment_reply.py`·`test_3516_comment_scope_and_runbook.py`·`test_3571_facebook_comments_insights.py`·`test_3805_pr4_reply_collection.py` — `fetch_replies` 소비 전수 grep(19개 파일 분류) 결과 실제 조정 필요한 6개 파일: 직접 호출 8곳(published_at 명시 주입)·가짜 함수 시그니처 30곳(**kwargs 흡수)·임의 uuid로 publication 없이 통과하던 테스트 1곳(실 seed로 정정)

## 검증
- 뮤테이션 셀프체크: 벽시계 고정값 재도입 → 정확히 신규 positive-control 2 tests RED, 복원 → GREEN
- 3528 지목 2 파일 30 tests + 확장 회귀(fetch_replies 소비 실제 영향 파일) 94 tests + 신규 lint 5 tests = **127 tests 전부 GREEN**
- `lint_no_hardcoded_iso_timestamp.py` 실물 스캔: `backend/app/**` 0건
- Korean-user-string 가드(story #3779) baseline 무변경, shard-weights 등재 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8