### PR TITLE
[SID:3808] PR5b-1 — X 스레드(N세그먼트) 발행 오케스트레이터

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -162,6 +162,11 @@ class ChannelConnectionResponse(BaseModel):
     video_aspect_target: float = 0.0
     video_aspect_tolerance: float = 0.0
     video_codecs: list[str] = []
+    # story #3808(Phase3·3-3 PR5b-2, 페드루 PO 確定 2026-09-12) — 스레드(연속 게시)
+    # 이어쓰기 세그먼트 상한(image_max_count와 동형 관례 — 미선언 채널은 0="이 채널은
+    # 스레드 이어쓰기 미지원", FE가 이 값으로 편집기의 「스레드 이어쓰기」 목록 UI
+    # 노출 여부를 판단한다, 채널 이름 하드코딩 목록 금지).
+    thread_max_segments: int = 0
     # story #3492 — 붙여넣기(pasted_secret) 재방문 표시(§2 규격 3, app_id_suffix와
     # 동형). oauth 채널은 항상 null(secret_hint 자체를 안 씀).
     secret_hint: str | None = None
@@ -232,6 +237,7 @@ def _to_response(row, *, reconnect_mismatch_target_id: uuid.UUID | None = None) 
         video_aspect_target=adapter.video_aspect_target if adapter is not None else 0.0,
         video_aspect_tolerance=adapter.video_aspect_tolerance if adapter is not None else 0.0,
         video_codecs=list(adapter.video_codecs) if adapter is not None else [],
+        thread_max_segments=adapter.thread_max_segments if adapter is not None else 0,
         secret_hint=row.secret_hint,
         reconnect_mismatch_target_id=reconnect_mismatch_target_id,
     )

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -238,6 +238,18 @@ class ChannelPostVideoMeta(BaseModel):
     original_bytes: int
 
 
+class ThreadSegmentStatusView(BaseModel):
+    """story #3808(Phase3·3-3 PR5b-2, 페드루 PO 確定 2026-09-12) — X 스레드
+    (N세그먼트) 개별 행 상태. sequence=1이 헤드(기존 단일값 4필드의 출처와 동일
+    행) — k+1..N(아직 시도 안 한 세그먼트)은 배열에 아예 없다(지어내지 않는다)."""
+
+    sequence: int
+    status: str
+    external_id: str | None = None
+    permalink: str | None = None
+    error_code: str | None = None
+
+
 class ChannelPostDraftListItem(BaseModel):
     draft_id: uuid.UUID
     work_item_id: uuid.UUID
@@ -344,6 +356,12 @@ class ChannelPostDraftListItem(BaseModel):
     # 뒤집는다). true=둘 다 non-null이고 서로 다름(원문이 파생 이후 개정됨) · false=둘 다
     # non-null이고 같음 · None=하나라도 null("모른다" — 레거시 파생분).
     source_changed: bool | None = None
+    # story #3808(Phase3·3-3 PR5b-2, 페드루 PO 確定 2026-09-12) — X 스레드(N세그먼트)
+    # 부분 실패 상태. 세그먼트 2개 미만(스레드 아님)이면 null(빈 배열 아님 — "스레드"
+    # 라는 사실 자체가 없다는 신호). 있으면 sequence 오름차순, 시도 안 한 세그먼트
+    # (k+1..N)는 배열에 아예 없다. 기존 publication_status/permalink/external_id/
+    # error_code 4필드는 하위호환으로 무변(헤드=sequence 1 값 그대로).
+    thread_segments: list[ThreadSegmentStatusView] | None = None
     # story #3497 조각4(페드루 PO 決定 — 미르코 #3499 그라운딩 갭)·**story #3525 재정의
     # (2026-09-06, 페드루 PO 確定, 유나 §22-12)** — 3497 조회 API(`/publications/
     # {publication_id}/insights`)·3516 댓글 API(`/publications/{publication_id}/
@@ -1172,7 +1190,7 @@ def _to_draft_list_item(
     False(안전 쪽으로 fail, "모른다=버튼 안 보임")."""
     (
         draft, latest, origin, gate, published_pub, latest_pub, published_body_sha256,
-        latest_command, latest_image,
+        latest_command, latest_image, latest_thread_pubs,
     ) = row
     source_title: str | None = None
     source_current_site_post_version_id: uuid.UUID | None = None
@@ -1200,6 +1218,19 @@ def _to_draft_list_item(
     # 순수 가시성 축, 발행된 draft도 보관 가능 — #3291 정합).
     can_archive = requester_member_id is not None and (
         is_org_admin or str(origin.author_member_id) == str(requester_member_id)
+    )
+    # story #3808(PR5b-2, 페드루 PO 確定 2026-09-12) — 세그먼트가 2개 미만이면
+    # "스레드"라는 사실 자체가 없다 — 빈 배열이 아니라 null(신호 축소, 단일-발행
+    # 채널의 기존 화면은 이 필드를 아예 안 봐도 되게).
+    thread_segments = (
+        [
+            ThreadSegmentStatusView(
+                sequence=p.sequence, status=p.status, external_id=p.external_id,
+                permalink=p.permalink, error_code=p.error_code,
+            )
+            for p in latest_thread_pubs
+        ]
+        if len(latest_thread_pubs) >= 2 else None
     )
     command_status = latest_command.status if latest_command else None
     # story #3525 — publication_status/error_code는 의도적으로 latest_pub(현재
@@ -1260,6 +1291,7 @@ def _to_draft_list_item(
         source_site_post_version_id=draft.source_site_post_version_id,
         source_current_site_post_version_id=source_current_site_post_version_id,
         source_changed=source_changed,
+        thread_segments=thread_segments,
     )
 
 

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -125,6 +125,13 @@ class ChannelAdapterConfig:
     video_aspect_target: float = 0.0
     video_aspect_tolerance: float = 0.0
     video_codecs: tuple[str, ...] = ()
+    # story #3808(Phase3·3-3 PR5b-1, 페드루 PO 確定 2026-09-12) — 스레드(연속 게시)
+    # 이어쓰기 세그먼트 상한(헤드=`text` 제외, `channel_payload["thread"]` 배열
+    # 길이 자체의 상한). image_max_count=0과 동형 관례 — 0(기본)=이 채널은 스레드
+    # 이어쓰기 미지원(channel_payload.thread가 있어도 무시가 아니라 422로 거부,
+    # ChannelThreadUnsupportedError). X/X Sandbox만 10(⚠️미확認 — 실 X API 자체
+    # 상한 문서 재확認 대상, 지금은 제품 판단값).
+    thread_max_segments: int = 0
 
 
 CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
@@ -534,6 +541,7 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # user-context 토큰만 쓰므로(그라운딩상) 저촉 없을 것으로 추정 — 실 앱 왕복
         # 재확認 대상.
         insight_metrics=("impressions", "engagements"),
+        thread_max_segments=10,
     ),
     "x_sandbox": ChannelAdapterConfig(
         authorize_url="https://x.com/i/oauth2/authorize",
@@ -552,6 +560,7 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         insight_metrics=("impressions", "engagements"),
         requires_connection=True,
         max_text_length=280,
+        thread_max_segments=10,
     ),
 }
 

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -846,7 +846,7 @@ async def list_channel_post_drafts(
     tuple[
         ChannelPostDraft, ChannelPostVersion, ChannelPostVersion,
         Gate | None, ChannelPublication | None, ChannelPublication | None, str | None,
-        PublicationCommand | None, ChannelPostImage | None,
+        PublicationCommand | None, ChannelPostImage | None, list[ChannelPublication],
     ]
 ]:
     """site_posts.list_site_post_drafts와 동형(latest+origin 버전 조인, "최신"은 최신
@@ -883,11 +883,23 @@ async def list_channel_post_drafts(
       "이 게이트의 아무 행이나≠이 게이트의 최신 행").
 
     반환: (draft, latest_version, origin_version, gate, published_publication,
-    latest_version_publication, published_body_sha256, latest_command, latest_image) —
+    latest_version_publication, published_body_sha256, latest_command, latest_image,
+    latest_version_thread_publications) —
     gate·publication·command·image 계열은 없으면 None(지어내지 않는다, "모른다≠다르다").
     `latest_image`(9번째 원소, story 620beefc)는 **최신 버전**에 붙은 `ChannelPostImage`
     (없으면 None) — 썸네일·§17-14 배지(원본/파생본 width·bytes) 출처, latest_command와
     같은 "최신 버전/게이트 기준" 원칙.
+
+    `latest_version_thread_publications`(10번째 원소, story #3808 PR5b-2, 페드루 PO
+    確定 2026-09-12) — **최신 버전**의 publication 행 **전부**(sequence 오름차순,
+    배치③이 이미 gate_id로 전 행을 긁어 오므로 신규 쿼리 0 — `latest_version_pub_by_gate`
+    가 "그중 하나"만 남기는 것과 달리 이건 그룹 전체를 보존한다). X 스레드(N≥2)의
+    부분 실패(1..k-1 published·k failed·k+1..N은 행 자체가 없음)를 화면이 그리려면
+    단일값(`latest_version_pub_by_gate`)로는 "몇 번째에서 멈췄나"를 못 담는다 — 기존
+    단일값 4필드(publication_status·error_code·published_at·permalink·external_id)는
+    무변(하위호환, 헤드=sequence 1 값을 그대로 씀). 세그먼트가 1개 이하(스레드 아님)면
+    라우터가 이 배열을 null로 접는다(신호 축소 — "스레드"라는 사실 자체가 없으면
+    빈 배열보다 null이 더 정직하다).
 
     story #3734 — `include_deleted=False`(기본)면 보관된(`deleted_at` not null) 초안을
     결과에서 뺀다. `status`(draft|withdrawn)와 독립 축 — withdrawn이면서 보관 안 됐거나,
@@ -1011,16 +1023,26 @@ async def list_channel_post_drafts(
     }
 
     latest_version_pub_by_gate: dict[uuid.UUID, ChannelPublication] = {}
+    latest_version_thread_pubs_by_gate: dict[uuid.UUID, list[ChannelPublication]] = {}
     published_pub_by_gate: dict[uuid.UUID, ChannelPublication] = {}
     published_version_ids: set[uuid.UUID] = set()
     if gate_ids:
-        # 배치 ③: 최신 버전의 publication 행(publication_status·error_code 축).
+        # 배치 ③: 최신 버전의 publication 행 — sequence 오름차순으로 받아 그룹 전체를
+        # 보존한다(story #3808 PR5b-2 — 예전엔 "아무 행이나 마지막에 덮어쓴 것"이
+        # 단일값 축이었는데, 그 순서가 sequence 오름차순이 아니면 스레드에서 헤드가
+        # 아닌 임의 세그먼트 값이 대표로 새는 잠재 결함이었다 — 이번에 명시 정렬로
+        # 고정). 첫 원소(가장 작은 sequence — 비스레드는 항상 0, 스레드는 헤드=1)가
+        # 기존 단일값 4필드의 출처(하위호환, 헤드 값 그대로) — setdefault로 그 첫
+        # 원소만 latest_version_pub_by_gate에 남긴다.
         pub_rows = (await db.execute(
-            select(ChannelPublication).where(ChannelPublication.gate_id.in_(gate_ids))
+            select(ChannelPublication)
+            .where(ChannelPublication.gate_id.in_(gate_ids))
+            .order_by(ChannelPublication.sequence.asc())
         )).scalars().all()
         for p in pub_rows:
             if latest_version_id_by_gate.get(p.gate_id) == p.version_id:
-                latest_version_pub_by_gate[p.gate_id] = p
+                latest_version_pub_by_gate.setdefault(p.gate_id, p)
+                latest_version_thread_pubs_by_gate.setdefault(p.gate_id, []).append(p)
 
         # 배치 ④: 가장 최근 published 상태(published_at·permalink·external_id 축) —
         # published_at desc로 이미 정렬돼 오므로 setdefault로 최신만 남는다.
@@ -1078,9 +1100,10 @@ async def list_channel_post_drafts(
         )
         latest_command = latest_command_by_gate.get(gate.id) if gate else None
         latest_image = image_by_version.get(latest_v.id)
+        latest_thread_pubs = latest_version_thread_pubs_by_gate.get(gate.id, []) if gate else []
         result.append((
             draft, latest_v, origin_v, gate, published_pub, latest_pub, published_body_sha256,
-            latest_command, latest_image,
+            latest_command, latest_image, latest_thread_pubs,
         ))
     return result
 

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -34,6 +34,7 @@ from app.models.channel_post_image import ChannelPostImage
 from app.models.channel_post_version import ChannelPostVersion
 from app.models.channel_publication import UQ_GATE_VERSION_SEQUENCE_CONSTRAINT_NAME, ChannelPublication
 from app.models.gate import Gate, set_gate_status
+from app.models.org_content_rule import OrgContentRule
 from app.models.publication_command import PublicationCommand
 from app.models.site_post_draft import SitePostDraft
 from app.models.site_post_version import SitePostVersion
@@ -93,6 +94,48 @@ class ChannelTextTooLongError(ValueError):
         self.max_length = max_length
         self.current_length = current_length
         super().__init__(f"본문이 한도를 넘었습니다(한도 {max_length}자, 현재 {current_length}자)")
+
+
+class ChannelThreadUnsupportedError(ValueError):
+    """story #3808(PR5b-1, 페드루 PO 確定 2026-09-12) — `channel_payload.thread`가
+    있는데 그 채널의 `thread_max_segments`가 0(미선언=미지원, image_max_count=0과
+    동형 관례). 422 — 입력 형태 오류 축(ChannelTextTooLongError와 동열)."""
+
+    def __init__(self, *, channel: str) -> None:
+        self.channel = channel
+        # story #3779 한글 사용자 문장 재발 가드(ratchet — baseline만 축소 가능) —
+        # 신규 코드는 영문으로(PR3/PR4/PR5a의 동일 상황 정정 전례 그대로).
+        super().__init__(f"The {channel} channel does not support thread continuations.")
+
+
+class ChannelThreadSegmentLimitExceededError(ValueError):
+    """story #3808(PR5b-1) — 이어쓰기 세그먼트 수가 어댑터 선언 `thread_max_segments`를
+    넘음(헤드=`text` 제외, `channel_payload.thread` 배열 길이만 잰다)."""
+
+    def __init__(self, *, max_segments: int, current_count: int) -> None:
+        self.max_segments = max_segments
+        self.current_count = current_count
+        # story #3779 한글 사용자 문장 재발 가드 — 신규 코드는 영문으로.
+        super().__init__(
+            f"Thread continuation supports at most {max_segments} segments (got {current_count})."
+        )
+
+
+class ChannelThreadSegmentTooLongError(ValueError):
+    """story #3808(PR5b-1) — 이어쓰기 세그먼트 하나가 어댑터 선언 max_text_length를
+    넘음. `segment_number`는 헤드=1부터 세는 전체 스레드 순번(사람이 에디터에서 보는
+    "몇 번째"와 일치시키기 위해 — thread 배열 자체는 0-indexed·헤드 제외이지만
+    이 필드는 +2부터 시작, ChannelTextTooLongError와 나란한 필드 완결성 검사)."""
+
+    def __init__(self, *, segment_number: int, max_length: int, current_length: int) -> None:
+        self.segment_number = segment_number
+        self.max_length = max_length
+        self.current_length = current_length
+        # story #3779 한글 사용자 문장 재발 가드 — 신규 코드는 영문으로.
+        super().__init__(
+            f"Thread segment {segment_number} exceeds the limit "
+            f"(limit {max_length} chars, current {current_length} chars)."
+        )
 
 
 class ChannelImageRequiredError(ValueError):
@@ -467,6 +510,28 @@ def _validate_text_length(*, channel: str, text: str) -> None:
         raise ChannelTextTooLongError(max_length=adapter.max_text_length, current_length=current_length)
 
 
+def _validate_thread_segments(*, channel: str, thread: list[str]) -> None:
+    """story #3808(PR5b-1, 페드루 PO 確定 2026-09-12) — `channel_payload.thread`
+    검증. 저장 시점(create_channel_post_draft_version)·발행 시점(publish_channel_
+    post_draft) 둘 다에서 호출한다(②, ChannelTextTooLongError의 헤드 검증과 같은
+    두 호출부 패턴 — 승인 뒤 어댑터 선언이 안 바뀌지만 방어적으로 재검사)."""
+    if not thread:
+        return
+    adapter = get_channel_adapter(channel)
+    max_segments = adapter.thread_max_segments if adapter is not None else 0
+    if max_segments <= 0:
+        raise ChannelThreadUnsupportedError(channel=channel)
+    if len(thread) > max_segments:
+        raise ChannelThreadSegmentLimitExceededError(max_segments=max_segments, current_count=len(thread))
+    for index, segment in enumerate(thread):
+        current_length = text_char_count(segment)
+        if current_length > adapter.max_text_length:
+            raise ChannelThreadSegmentTooLongError(
+                segment_number=index + 2,  # 헤드=1, thread[0]=2번째 세그먼트
+                max_length=adapter.max_text_length, current_length=current_length,
+            )
+
+
 async def create_channel_post_draft_version(
     db: AsyncSession,
     *,
@@ -515,6 +580,8 @@ async def create_channel_post_draft_version(
     슬롯이 아직 요구하지 않는다, 필요해지면 그때 승격)."""
     connection = await _get_active_connection(db, org_id=org_id, connection_id=connection_id)
     _validate_text_length(channel=connection.channel, text=text)
+    if channel_payload:
+        _validate_thread_segments(channel=connection.channel, thread=channel_payload.get("thread") or [])
 
     resolved_source_site_post_version_id: uuid.UUID | None = None
     if source_content_item_id is not None:
@@ -1371,17 +1438,33 @@ async def publish_channel_post_draft(
     # story #3808(Phase3·3-3 PR3, 페드루 PO 確定 2026-09-11) — X 종량 API 지출 월
     # 상한. 위 3498 체크(생성비, 무변경)와 병렬 — 다른 지갑(kind="api_usage_cost")
     # 이라 서로 안 갉아먹는다. x/x_sandbox만 대상(다른 채널은 API 종량 개념 자체가
-    # 없음). estimated_cost_minor = 단가 × 세그먼트 수 — PR2는 실 호출부를 항상
-    # N=1로 통과시키므로 지금은 항상 단가 그 자체(스레드 N≥2는 PR5 몫). 이 블록에서
-    # 구한 `x_unit_cost_minor`는 아래 함수 끝(발행 성공 뒤 evidence 기록)에서도
-    # 재사용한다(같은 요청 안 재조회 0).
+    # 없음). estimated_cost_minor = 단가 × 세그먼트 수 — 스레드(N≥2)는 PR5b-1부터
+    # `_publish_x_thread_draft()`가 자체 재계산(이번 호출에서 실제로 시도할 세그먼트
+    # 수, 재시도 시 남은 수만) 하므로 여기 단일-호출부는 N=1(스레드 아닌 단일 발행)
+    # 경우에만 단가 그 자체를 쓴다. 이 블록에서 구한 `x_unit_cost_minor`는 아래
+    # 단일-발행 경로 끝(발행 성공 뒤 evidence 기록)·스레드 경로 둘 다에서 재사용한다
+    # (같은 요청 안 재조회 0).
     x_unit_cost_minor: int | None = None
+    content_rules_row = None
+    thread_segments = list((latest.channel_payload or {}).get("thread") or []) if draft.channel in ("x", "x_sandbox") else []
     if draft.channel in ("x", "x_sandbox"):
         from app.services.x_publish_budget import check_api_usage_budget_or_raise, get_api_usage_unit_cost_minor
 
         content_rules_row = await get_org_content_rules(db, org_id=org_id)
         x_unit_cost_minor = get_api_usage_unit_cost_minor(content_rules_row.rules if content_rules_row else None)
-        await check_api_usage_budget_or_raise(db, org_id=org_id, estimated_cost_minor=x_unit_cost_minor)
+        # story #3808(PR5b-1, 페드루 PO 確定 2026-09-12) — 스레드(thread_segments 有)는
+        # 예산 재검사를 여기서 하지 않는다 — `_publish_x_thread_draft()`가 「이번 호출에서
+        # 실제로 시도할 세그먼트 수」(재시도 시 전체 N이 아니라 남은 수만)로 자체 재검사한다.
+        # 여기서 먼저 단가 1건으로 검사해 버리면 스레드에 대해 과소평가(단가 1건만 있으면
+        # 통과)된 뒤 실제로는 N건을 시도하는 안전하지 않은 순서가 된다.
+        if not thread_segments:
+            await check_api_usage_budget_or_raise(db, org_id=org_id, estimated_cost_minor=x_unit_cost_minor)
+
+    if thread_segments:
+        return await _publish_x_thread_draft(
+            db, org_id=org_id, draft=draft, gate=gate, latest=latest, thread_segments=thread_segments,
+            x_unit_cost_minor=x_unit_cost_minor, content_rules_row=content_rules_row,
+        )
 
     # 멱등 — 이미 완료된 발행이면 새 POST 없이 그대로 반환(뮤테이션 대상: 이 UNIQUE
     # 조회를 제거하면 같은 버전 재요청이 Threads에 두 번 POST된다).
@@ -1825,6 +1908,184 @@ async def publish_channel_post_draft(
         )
 
     return row
+
+
+async def _publish_x_thread_draft(
+    db: AsyncSession, *, org_id: uuid.UUID, draft: ChannelPostDraft, gate: Gate, latest: ChannelPostVersion,
+    thread_segments: list[str], x_unit_cost_minor: int | None, content_rules_row: OrgContentRule | None,
+) -> ChannelPublication:
+    """story #3808(Phase3·3-3 PR5b-1, 페드루 PO 確定 2026-09-12) — X 스레드(N세그먼트)
+    발행 오케스트레이터. `publish_channel_post_draft()`의 기존 단일-발행물 흐름(이미지/
+    캐러셀/릴스 비동기 컨테이너)과 완전히 분리된 전용 경로다 — X 텍스트 스레드는
+    이미지(있어도 헤드 1장뿐, 기존 image_max_count=1 제약 그대로)+동기 1회 API 왕복
+    (`publish_x_thread`)이라 그 비동기 폴링 기계 전체가 필요 없다.
+
+    ChannelPublication 1행=세그먼트 1개(sequence 1..N, 헤드=1) — 기존 (gate_id,
+    version_id) 단일 조회 전제가 이 세그먼트별 다중 행과 안 맞아 여기서 별도 조회를
+    한다(UQ 제약은 여전히 (gate_id, version_id, sequence)라 세그먼트당 유니크는
+    그대로 보장).
+
+    부분 실패(k번째)는 롤백하지 않는다(PO 決定④ — 이미 나간 tweet은 그대로 둔다,
+    delete_tweet류 자동 회수는 범위 밖) — 1..k-1행 published·k행 failed·k+1..N행은
+    아예 안 만든다. 재시도(같은 함수 재호출, 라우터·워커 둘 다 공용)는 이미 published
+    된 마지막 sequence 다음부터 이어 발행 — k행이 failed로 남아 있으면 그 자리를
+    갱신(새 행 추가 아님, 재시도 히스토리를 행 개수로 부풀리지 않는다)."""
+    from app.services.channel_adapters import get_publish_client_module
+    from app.services.channel_connection import apply_connection_failure, apply_refresh_failure
+    from app.services.insight_snapshots import schedule_insight_snapshots
+    from app.services.threads_publish import ThreadsPublishError
+    from app.services.x_publish_budget import check_api_usage_budget_or_raise, record_api_usage_cost_evidence
+
+    # 발행 직전 재검증(②) — 저장 시점 검증과 같은 함수, 승인 뒤 어댑터 선언이 바뀌었을
+    # 가능성에 대한 방어(ChannelTextTooLongError 헤드 재검증과 동형 위치).
+    _validate_thread_segments(channel=draft.channel, thread=thread_segments)
+
+    utm_rules = (content_rules_row.rules or {}).get("utm_rules") if content_rules_row else None
+    tagged_link = (
+        build_tagged_link(channel=draft.channel, link_url=latest.link_url, draft_id=draft.id, utm_rules=utm_rules)
+        if latest.link_url else None
+    )
+    head_text = f"{latest.text}\n\n{tagged_link}" if tagged_link else latest.text
+    _validate_text_length(channel=draft.channel, text=head_text)
+    all_texts = [head_text, *thread_segments]
+    total_n = len(all_texts)
+
+    connection = await _get_active_connection(db, org_id=org_id, connection_id=draft.connection_id)
+    access_token = decrypt_for_use(connection)
+    if access_token is None:
+        raise ChannelConnectionNotActiveError(connection_id=connection.id)
+
+    existing_rows = list((await db.execute(
+        select(ChannelPublication)
+        .where(ChannelPublication.gate_id == gate.id, ChannelPublication.version_id == latest.id)
+        .order_by(ChannelPublication.sequence)
+    )).scalars().all())
+    head_row = next((r for r in existing_rows if r.sequence == 1), None)
+
+    # 멱등 — N개 전부 이미 published면 새 API 호출 없이 헤드 행 그대로 반환.
+    if len(existing_rows) == total_n and all(r.status == "published" for r in existing_rows):
+        return head_row  # type: ignore[return-value]
+
+    published_seqs = sorted(r.sequence for r in existing_rows if r.status == "published")
+    last_published_seq = published_seqs[-1] if published_seqs else 0
+    # 재시도 대상(같은 sequence 자리를 갱신) — 직전 시도에서 failed로 남은 행.
+    resume_row = next((r for r in existing_rows if r.sequence == last_published_seq + 1 and r.status == "failed"), None)
+
+    remaining_texts = all_texts[last_published_seq:]
+    remaining_count = len(remaining_texts)
+
+    # story #3808(PR5b-1) — 예산 재검사는 "이번 호출에서 실제로 시도할 세그먼트 수"만큼
+    # (재시도 시 전체 N이 아니라 남은 수만 — 안 그러면 이미 지출된 세그먼트분까지 다시
+    # 청구하는 꼴이 되어 정당한 재시도를 잔량 부족으로 잘못 거부할 수 있다).
+    if x_unit_cost_minor is not None:
+        await check_api_usage_budget_or_raise(
+            db, org_id=org_id, estimated_cost_minor=x_unit_cost_minor * remaining_count,
+        )
+
+    # 이미지는 헤드에만(기존 단일-발행 경로와 동형 판단) — last_published_seq>0(재시도로
+    # 헤드가 이미 나간 뒤)이면 이미지 재첨부 불필요(헤드는 이미 완결).
+    image_public_url: str | None = None
+    if last_published_seq == 0 and latest.image_sha256 is not None:
+        from app.services.channel_post_images import list_channel_post_images_for_version, public_url_for_object_path
+
+        image_rows = await list_channel_post_images_for_version(db, version_id=latest.id)
+        urls = [
+            url for row in image_rows if (url := public_url_for_object_path(row.final_object_path)) is not None
+        ]
+        image_public_url = urls[0] if urls else None
+
+    prev_external_id: str | None = None
+    if last_published_seq > 0:
+        prev_row = next(r for r in existing_rows if r.sequence == last_published_seq)
+        prev_external_id = prev_row.external_id
+
+    _publish_client = get_publish_client_module(draft.channel)
+    publish_x_thread_fn = _publish_client.publish_x_thread
+
+    import httpx
+
+    succeeded: list[dict] = []
+    failure_exc: ThreadsPublishError | None = None
+    async with httpx.AsyncClient(timeout=20) as client:
+        try:
+            succeeded = await publish_x_thread_fn(
+                client, access_token=access_token, texts=remaining_texts,
+                media_id=image_public_url, initial_reply_to_tweet_id=prev_external_id,
+            )
+        except ThreadsPublishError as exc:
+            succeeded = list(getattr(exc, "published_segments", []) or [])
+            failure_exc = exc
+
+    now = datetime.now(timezone.utc)
+    for index, item in enumerate(succeeded):
+        seq = last_published_seq + 1 + index
+        row = resume_row if (resume_row is not None and seq == resume_row.sequence) else ChannelPublication(
+            id=uuid.uuid4(), org_id=org_id, gate_id=gate.id, version_id=latest.id,
+            connection_id=connection.id, channel=draft.channel, sequence=seq,
+        )
+        row.status = "published"
+        row.external_id = item["external_id"]
+        row.permalink = item.get("permalink")
+        row.published_at = now
+        row.error_code = None
+        row.last_error = None
+        db.add(row)
+        await db.flush()
+        if x_unit_cost_minor is not None:
+            await record_api_usage_cost_evidence(
+                db, org_id=org_id, work_item_id=draft.work_item_id, publication_id=row.id,
+                sequence=seq, cost_minor=x_unit_cost_minor,
+            )
+        if seq == 1:
+            head_row = row
+
+    if failure_exc is not None:
+        fail_seq = last_published_seq + 1 + len(succeeded)
+        error_code, mapped_exc = _classify_threads_error(failure_exc, connection_id=connection.id)
+        row = resume_row if (resume_row is not None and fail_seq == resume_row.sequence) else ChannelPublication(
+            id=uuid.uuid4(), org_id=org_id, gate_id=gate.id, version_id=latest.id,
+            connection_id=connection.id, channel=draft.channel, sequence=fail_seq,
+        )
+        row.status = "failed"
+        row.error_code = error_code
+        row.last_error = failure_exc.message
+        db.add(row)
+        await db.commit()
+        if error_code == "CHANNEL_TOKEN_EXPIRED":
+            await apply_refresh_failure(db, connection=connection, error_message=failure_exc.message)
+        elif error_code == "CHANNEL_CONNECTION_REVOKED":
+            await apply_connection_failure(db, connection=connection, status="revoked", error_message=failure_exc.message)
+        raise mapped_exc
+
+    await db.commit()
+    await db.refresh(head_row)  # type: ignore[arg-type]
+
+    # 인사이트 = seq=1(헤드) 행에만 스케줄(⑤, PR4 스펙이 애초에 "헤드 트윗만" — 이번
+    # 호출에서 헤드가 막 새로 발행됐을 때만 1회, 재시도로 seq≥2만 발행되는 호출에서는
+    # 중복 스케줄 0).
+    if last_published_seq == 0:
+        await schedule_insight_snapshots(
+            db, org_id=org_id, work_item_id=draft.work_item_id, publication_id=head_row.id,
+            publication_kind="channel_publication", channel=connection.channel,
+            external_id=head_row.external_id, anchor_at=head_row.published_at,
+        )
+
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(db).record(
+        org_id=org_id, action="channel_post_published", actor_type="platform", actor_id=None,
+        entity_type="channel_publication", entity_id=head_row.id,
+        context={
+            "gate_id": str(gate.id), "version_id": str(latest.id),
+            "thread_total_segments": total_n, "thread_published_segments": last_published_seq + len(succeeded),
+        },
+    )
+    # schedule_insight_snapshots()·ActivityLogService.record() 둘 다 flush만 하고
+    # commit은 호출자 몫(각자 독스트링 명시) — 이 함수의 나머지 커밋 지점(evidence
+    # 내부 커밋)이 이미 다 끝난 뒤라 여기서 명시적으로 마무리한다(암묵적으로 "다음
+    # 호출이 우연히 커밋해 주길" 기대하지 않는다).
+    await db.commit()
+    return head_row
 
 
 # ─── story #3419(Phase1·마케팅운영) — 발행 취소(예약 명령 취소·발행분 회수) ─────────────────

--- a/backend/app/services/x_publish.py
+++ b/backend/app/services/x_publish.py
@@ -29,10 +29,11 @@ posts.py` 무변경 — 이 파일이 그 구조에 맞춰 스스로를 접는�
 
 ## `publish_x_thread` — 스레드 N세그먼트 프리미티브(카드 PR2 조각, 페드루 PO 決定
 2026-09-11 20:09Z)
-`create_container`(단일 세그먼트, image_url 유무 무관)가 이 함수를 texts=[text]
-하나로 호출해 **오늘부터 N=1이 실 서비스**. N≥2(진짜 스레드)는 이 함수의 계약
-테스트로만 고정돼 있고 실 호출부는 없다(그 텍스트들의 출처=PR5, draft segments
-스키마 설계 몫 — 카드 본문에 명시). 반환 `[{sequence, external_id, permalink}, ...]`
+`create_container`(단일 세그먼트, image_url 유무 무관)는 이 함수를 texts=[text]
+하나로 호출한다(N=1, 기존 단일-발행 경로). N≥2(진짜 스레드)는 story #3808
+PR5b-1(`channel_posts.py::_publish_x_thread_draft`)부터 실 호출부가 생겼다 —
+`channel_post_versions.channel_payload.thread`(story #3813 공유 슬롯)가 텍스트
+출처. 반환 `[{sequence, external_id, permalink}, ...]`
 (1-indexed, 헤드=1) — 두 번째부터 `in_reply_to_tweet_id`로 직전 세그먼트를 참조해
 실제 reply 체인을 만든다(X 스레드의 진짜 메커니즘 — 전용 "스레드" API는 없다).
 
@@ -168,18 +169,25 @@ async def get_tweet_permalink(client: httpx.AsyncClient, *, access_token: str, t
 
 async def publish_x_thread(
     client: httpx.AsyncClient, *, access_token: str, texts: list[str], media_id: str | None = None,
+    initial_reply_to_tweet_id: str | None = None,
 ) -> list[dict]:
     """스레드 N세그먼트 프리미티브 — 각 세그먼트를 직전 세그먼트의 reply로 순차
     발행(reply 체인). `media_id`는 **첫 세그먼트(헤드)에만** 첨부(AC2 「텍스트·
     이미지 1건」·「스레드 3건」이 별개 항목인 것과 정합 — 스레드 각 세그먼트마다
     이미지를 붙이는 경로는 이 카드 범위 밖).
 
+    story #3808(PR5b-1, 페드루 PO 確定 2026-09-12) — `initial_reply_to_tweet_id`는
+    부분 실패 재시도용(AC4③④). k번째에서 실패하면 1..k-1은 이미 발행됐고, 재시도는
+    이 함수를 「남은 세그먼트만」으로 다시 부른다 — 그 첫 세그먼트가 "새 스레드의
+    헤드"가 아니라 "이미 발행된 k-1번째의 reply"여야 하므로, 시작 값을 None(항상
+    새 스레드) 대신 이 인자로 넘겨받는다(생략 시 기존 동작 그대로 — 회귀 0).
+
     실패 시 이미 발행된 앞 세그먼트는 그대로 남는다(부분 성공 — Threads 컨테이너
     부분성공과 다른 성격이지만 "이미 나간 tweet을 되돌리지 않는다"는 같은 정직성
     원칙, delete_tweet류 자동 롤백은 이 카드 범위 밖). 호출부가 이미 발행된
     세그먼트 목록(예외의 `.published_segments`)을 볼 수 있게 예외에 실어 던진다."""
     results: list[dict] = []
-    prev_tweet_id: str | None = None
+    prev_tweet_id: str | None = initial_reply_to_tweet_id
     for index, text in enumerate(texts):
         sequence = index + 1
         try:

--- a/backend/app/services/x_sandbox_publish.py
+++ b/backend/app/services/x_sandbox_publish.py
@@ -94,11 +94,14 @@ async def get_publishing_limit(
 
 async def publish_x_thread(
     client: httpx.AsyncClient, *, access_token: str, texts: list[str], media_id: str | None = None,
+    initial_reply_to_tweet_id: str | None = None,
 ) -> list[dict]:
     """`x_publish.py::publish_x_thread`와 동형 계약(N세그먼트 reply 체인) — 결정적
     시뮬레이션. 세그먼트 중 하나라도 마커가 있으면 그 세그먼트에서 멈추고(이전
     세그먼트는 이미 "발행"됐다는 사실을 예외의 `.published_segments`로 실어 던진다
-    — x_publish.py 부분성공 계약과 동형)."""
+    — x_publish.py 부분성공 계약과 동형). `initial_reply_to_tweet_id`는 시그니처
+    동형 유지용(story #3808 PR5b-1) — 샌드박스는 실 reply 체인이 없어 값 자체는
+    무시(결정적 tweet_id 생성에 영향 없음)."""
     results: list[dict] = []
     for index, text in enumerate(texts):
         try:

--- a/backend/tests/test_3808_x_thread_publish.py
+++ b/backend/tests/test_3808_x_thread_publish.py
@@ -472,3 +472,178 @@ async def test_thread_publish_retry_budget_check_uses_remaining_count_not_full_n
         await engine.dispose()
 
 
+
+
+# ─── PR5b-2 그라운딩 — thread_max_segments 연결 응답 노출 ──────────────────────
+
+@pytest.mark.anyio
+async def test_channel_connection_response_exposes_thread_max_segments_for_x():
+    """story #3808(PR5b-2, 페드루 PO 確定 2026-09-12) — image_max_count와 동형
+    관례로 어댑터 선언이 코드 변경 0으로 연결 응답에 자동 노출돼야 한다(FE가
+    「스레드 이어쓰기」 목록 UI 노출 여부를 이 값으로 판단, 채널 이름 하드코딩
+    금지)."""
+    from tests.test_3471_org_content_rules_lint import _client_for, _setup_org_scoped_app
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            from app.services.channel_connection import upsert_channel_connection
+            await upsert_channel_connection(
+                s, org_id=org_id, channel="x_sandbox", account_id="x-sandbox-thread-cap-1",
+                account_label="cap_user", credential_kind="oauth",
+                access_token="sandbox-x-access:app-1", refresh_token="sandbox-x-refresh:app-1:g0",
+                token_expires_at=datetime.now(timezone.utc), refresh_mode="refresh_token",
+                scopes=["tweet.read", "tweet.write", "offline.access"], connected_by=owner_id,
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+            assert r.status_code == 200, r.text
+            row = r.json()[0]
+            assert row["thread_max_segments"] == 10
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_channel_connection_response_thread_max_segments_zero_for_unsupported_channel():
+    """양성대조 — 스레드 이어쓰기 미선언 채널(threads)은 0(미지원, image_max_count=0과
+    동형 관례 — null이 아니다)."""
+    from tests.test_3471_org_content_rules_lint import _client_for, _setup_org_scoped_app
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            from app.services.channel_connection import upsert_channel_connection
+            await upsert_channel_connection(
+                s, org_id=org_id, channel="threads", account_id="threads-1",
+                account_label="threads_user", credential_kind="oauth",
+                access_token="plain-access-token", refresh_token=None, token_expires_at=None,
+                refresh_mode="reissue_from_access_token", scopes=[], connected_by=owner_id,
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+            assert r.status_code == 200, r.text
+            row = r.json()[0]
+            assert row["thread_max_segments"] == 0
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── PR5b-2 — thread_segments 배열 노출(부분 실패 상태) ────────────────────────
+
+@pytest.mark.anyio
+async def test_draft_detail_exposes_thread_segments_array_for_n3_all_published():
+    """story #3808(PR5b-2, 페드루 PO 確定 2026-09-12) — N=3 전부 발행 성공하면
+    thread_segments 배열이 sequence 1..3 전부(published)를 담고, 기존 단일값
+    4필드(publication_status 등)는 헤드(seq=1) 값 그대로(하위호환)."""
+    from tests.test_3471_org_content_rules_lint import _client_for, _setup_org_scoped_app
+    from app.main import app
+    from app.services.channel_posts import publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                s, thread=["세그먼트 2", "세그먼트 3"],
+            )
+            head_row = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+            )
+            assert head_row.status == "published"
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert r.status_code == 200, r.text
+            body = r.json()
+            segments = body["thread_segments"]
+            assert segments is not None
+            assert [seg["sequence"] for seg in segments] == [1, 2, 3]
+            assert all(seg["status"] == "published" for seg in segments)
+            assert body["publication_status"] == "published", "기존 단일값은 헤드 그대로(하위호환)"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_draft_detail_exposes_thread_segments_array_for_partial_failure():
+    """k=2에서 실패하면 thread_segments가 [seq1=published, seq2=failed]만 담고
+    3번째(시도 자체를 안 함)는 배열에 없다(지어내지 않는다)."""
+    from tests.test_3471_org_content_rules_lint import _client_for, _setup_org_scoped_app
+    from app.main import app
+    from app.services.channel_posts import ChannelRateLimitedError, publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                s, thread=["[sandbox:429] 실패 유발", "세그먼트 3"],
+            )
+            with pytest.raises(ChannelRateLimitedError):
+                await publish_channel_post_draft(
+                    s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+                )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert r.status_code == 200, r.text
+            body = r.json()
+            segments = body["thread_segments"]
+            assert [seg["sequence"] for seg in segments] == [1, 2]
+            assert segments[0]["status"] == "published"
+            assert segments[1]["status"] == "failed"
+            assert segments[1]["error_code"] == "CHANNEL_RATE_LIMITED"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_draft_detail_thread_segments_null_for_non_thread_draft():
+    """양성대조 — 스레드가 아닌(channel_payload.thread 없는) 단일 발행은
+    thread_segments가 null(빈 배열 아님)."""
+    from tests.test_3471_org_content_rules_lint import _client_for, _setup_org_scoped_app
+    from app.main import app
+    from app.services.channel_posts import publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(s, thread=[])
+            row = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+            )
+            assert row.status == "published"
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert r.status_code == 200, r.text
+            assert r.json()["thread_segments"] is None
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3808_x_thread_publish.py
+++ b/backend/tests/test_3808_x_thread_publish.py
@@ -1,0 +1,474 @@
+"""story #3808(Phase3·3-3 PR5b-1, 페드루 PO 確定 2026-09-12) — X 스레드(N세그먼트)
+발행 오케스트레이터. PR2가 만든 `publish_x_thread` 프리미티브(N지원)는 그대로 두고,
+`publish_channel_post_draft`의 실 호출부가 처음으로 N≥2를 통과시킨다.
+
+계약값 5종(카드 확定):
+① N=3 정상 — 행 3·permalink 3·evidence 3·인사이트 스케줄은 헤드(seq=1) 1건만.
+② k=2 실패 — 행 2(1=published·2=failed)·재시도 시 3번째까지 이어 완주(같은 seq=2
+  행을 갱신, 새 행 추가 아님).
+③ thread_max_segments(10) 초과(11개) → 422(저장 시점).
+④ 예산 부족(N×unit_cost) → 422(발행 시점, 재시도 시 "남은 수"만으로 재계산).
+⑤ 뮤테이션 셀프체크 각 1(②·③·④ 축마다)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="X Thread Test Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_human(session, org_id):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="owner")
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="X 스레드 발행 테스트"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+async def _seed_ready_thread_draft(
+    session, *, thread: list[str], head_text: str = "헤드 세그먼트",
+):
+    """org·human·story·역할·x_sandbox 연결까지 세팅한 뒤 승인 완료 상태의 스레드
+    초안을 하나 만들어 (org_id, owner_id, draft_id, gate_id, version) 반환한다 —
+    5종 테스트가 전부 이 상태(발행 직전)에서 시작한다."""
+    from app.models.gate import Gate
+    from app.services.channel_connection import upsert_channel_connection
+    from app.services.channel_posts import (
+        create_channel_post_draft_version, submit_channel_post_draft,
+    )
+    from sqlalchemy import select
+
+    org_id, project_id = await _seed_org(session)
+    owner_id = await _seed_human(session, org_id)
+    story_id = await _seed_story(session, org_id, project_id)
+    await _seed_default_role(session, org_id)
+    connection = await upsert_channel_connection(
+        session, org_id=org_id, channel="x_sandbox", account_id="x-sandbox-thread-1",
+        account_label="sandbox_x_thread_user", credential_kind="oauth",
+        access_token="sandbox-x-access:app-1", refresh_token="sandbox-x-refresh:app-1:g0",
+        token_expires_at=datetime.now(timezone.utc), refresh_mode="refresh_token",
+        scopes=["tweet.read", "tweet.write", "offline.access"], connected_by=owner_id,
+    )
+    version, _channel, _violations = await create_channel_post_draft_version(
+        session, org_id=org_id, work_item_id=story_id, connection_id=connection.id,
+        text=head_text, link_url=None, author_member_id=owner_id, author_kind="human",
+        channel_payload={"thread": thread} if thread else None,
+    )
+    draft_id = version.draft_id
+
+    gate, _ = await submit_channel_post_draft(
+        session, org_id=org_id, draft_id=draft_id, version_id=version.id, requester_member_id=owner_id,
+    )
+    gate_row = (await session.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+    gate_row.status = "approved"
+    gate_row.resolver_id = uuid.uuid4()
+    gate_row.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+    return org_id, owner_id, draft_id, gate.id, version
+
+
+# ─── ① N=3 정상 ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_thread_publish_n3_creates_three_rows_three_evidence_one_insight_schedule():
+    from sqlalchemy import select
+    from app.models.channel_publication import ChannelPublication
+    from app.models.evidence import Evidence
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.channel_posts import publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                s, thread=["세그먼트 2", "세그먼트 3"],
+            )
+
+            head_row = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+            )
+            assert head_row.sequence == 1
+            assert head_row.status == "published"
+
+            rows = list((await s.execute(
+                select(ChannelPublication)
+                .where(ChannelPublication.gate_id == gate_id, ChannelPublication.version_id == version.id)
+                .order_by(ChannelPublication.sequence)
+            )).scalars().all())
+            assert [r.sequence for r in rows] == [1, 2, 3]
+            assert all(r.status == "published" for r in rows)
+            assert all(r.permalink is not None for r in rows)
+            assert len({r.external_id for r in rows}) == 3, "세그먼트마다 서로 다른 tweet id"
+
+            evidence_rows = list((await s.execute(
+                select(Evidence).where(Evidence.org_id == org_id, Evidence.type == "metric")
+            )).scalars().all())
+            assert len(evidence_rows) == 3, "세그먼트마다 evidence 1건씩(publication_id+sequence 멱등 축)"
+
+            snapshots = list((await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.org_id == org_id)
+            )).scalars().all())
+            head_publication_id = rows[0].id
+            assert all(snap.publication_id == head_publication_id for snap in snapshots), (
+                "인사이트 스케줄은 헤드(seq=1) 행에만 — 다른 세그먼트는 스케줄 0건"
+            )
+            assert len(snapshots) == 2, "헤드 1건에 대해 1d·7d 두 행(schedule_insight_snapshots 계약)"
+    finally:
+        await engine.dispose()
+
+
+# ─── ② k=2 실패 → 재시도 완주 ─────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_thread_publish_partial_failure_at_k2_then_retry_completes():
+    from sqlalchemy import select
+    from app.models.channel_publication import ChannelPublication
+    from app.services.channel_posts import publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            # 2번째 세그먼트에 sandbox 429 마커 — 정확히 그 자리에서 멈춰야 한다(양성대조).
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                s, thread=["[sandbox:429] 실패 유발", "세그먼트 3"],
+            )
+
+            from app.services.channel_posts import ChannelRateLimitedError
+            with pytest.raises(ChannelRateLimitedError):
+                await publish_channel_post_draft(
+                    s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+                )
+
+            rows = list((await s.execute(
+                select(ChannelPublication)
+                .where(ChannelPublication.gate_id == gate_id, ChannelPublication.version_id == version.id)
+                .order_by(ChannelPublication.sequence)
+            )).scalars().all())
+            assert [r.sequence for r in rows] == [1, 2], "3번째는 아예 행이 없어야 한다(시도 자체를 안 함)"
+            assert rows[0].status == "published"
+            assert rows[1].status == "failed"
+            assert rows[1].error_code == "CHANNEL_RATE_LIMITED"
+            failed_row_id = rows[1].id
+
+        # 재시도 — 같은 함수 재호출. 실 서비스에선 초안 텍스트를 고쳐 마커를 없애고
+        # 재상신하지만, 이 테스트는 "이미 승인된 같은 gate/version"으로 그대로 재호출해
+        # 오케스트레이터의 이어달리기 로직만 격리 검증한다(channel_payload를 직접
+        # 마커 없는 값으로 바꿔치기).
+        async with Session() as s:
+            from app.models.channel_post_version import ChannelPostVersion
+            v = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == version.id)
+            )).scalar_one()
+            v.channel_payload = {"thread": ["재시도 성공", "세그먼트 3"]}
+            await s.commit()
+
+            head_row = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+            )
+            assert head_row.sequence == 1
+            assert head_row.status == "published"
+
+            rows = list((await s.execute(
+                select(ChannelPublication)
+                .where(ChannelPublication.gate_id == gate_id, ChannelPublication.version_id == version.id)
+                .order_by(ChannelPublication.sequence)
+            )).scalars().all())
+            assert [r.sequence for r in rows] == [1, 2, 3], "3번째까지 완주"
+            assert all(r.status == "published" for r in rows)
+            assert rows[1].id == failed_row_id, "실패했던 2번 행을 재사용(새 행 추가 아님)"
+            assert rows[1].error_code is None, "재시도 성공 후 실패 마커가 지워져야 한다"
+    finally:
+        await engine.dispose()
+
+
+# ─── ③ thread_max_segments(10) 초과 → 422(저장 시점) ──────────────────────
+
+@pytest.mark.anyio
+async def test_thread_segment_count_over_cap_rejected_at_save_time():
+    from app.services.channel_connection import upsert_channel_connection
+    from app.services.channel_posts import ChannelThreadSegmentLimitExceededError, create_channel_post_draft_version
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection = await upsert_channel_connection(
+                s, org_id=org_id, channel="x_sandbox", account_id="x-sandbox-cap-1",
+                account_label="cap_user", credential_kind="oauth",
+                access_token="sandbox-x-access:app-1", refresh_token="sandbox-x-refresh:app-1:g0",
+                token_expires_at=datetime.now(timezone.utc), refresh_mode="refresh_token",
+                scopes=["tweet.read", "tweet.write", "offline.access"], connected_by=owner_id,
+            )
+            eleven_segments = [f"세그먼트 {i}" for i in range(11)]
+            with pytest.raises(ChannelThreadSegmentLimitExceededError) as exc_info:
+                await create_channel_post_draft_version(
+                    s, org_id=org_id, work_item_id=story_id, connection_id=connection.id,
+                    text="헤드", link_url=None, author_member_id=owner_id, author_kind="human",
+                    channel_payload={"thread": eleven_segments},
+                )
+            assert exc_info.value.max_segments == 10
+            assert exc_info.value.current_count == 11
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_thread_segment_count_at_exactly_cap_is_fine():
+    """양성대조 — 정확히 10개(상한)는 통과해야 한다(위 11개 초과 테스트와 대비되는 경계)."""
+    from app.services.channel_connection import upsert_channel_connection
+    from app.services.channel_posts import create_channel_post_draft_version
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection = await upsert_channel_connection(
+                s, org_id=org_id, channel="x_sandbox", account_id="x-sandbox-cap-2",
+                account_label="cap_user_2", credential_kind="oauth",
+                access_token="sandbox-x-access:app-1", refresh_token="sandbox-x-refresh:app-1:g0",
+                token_expires_at=datetime.now(timezone.utc), refresh_mode="refresh_token",
+                scopes=["tweet.read", "tweet.write", "offline.access"], connected_by=owner_id,
+            )
+            ten_segments = [f"세그먼트 {i}" for i in range(10)]
+            version, _channel, _violations = await create_channel_post_draft_version(
+                s, org_id=org_id, work_item_id=story_id, connection_id=connection.id,
+                text="헤드", link_url=None, author_member_id=owner_id, author_kind="human",
+                channel_payload={"thread": ten_segments},
+            )
+            assert version.channel_payload == {"thread": ten_segments}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_thread_cap_check_removed_lets_11_segments_through():
+    """⭐뮤테이션 셀프체크 — `_validate_thread_segments()`의 상한 검사를 무력화하면
+    11개짜리 저장이 그대로 통과해야(=이 가드가 실제로 그 시나리오를 잡는다는 증명)."""
+    import app.services.channel_posts as channel_posts_module
+
+    original = channel_posts_module._validate_thread_segments
+
+    def _mutated_no_cap_check(*, channel, thread):
+        pass  # MUTATION-SELFCHECK-3808: 상한/미지원/길이 검사 전부 무력화
+
+    channel_posts_module._validate_thread_segments = _mutated_no_cap_check
+    try:
+        engine, Session = await _session_factory()
+        try:
+            async with Session() as s:
+                org_id, project_id = await _seed_org(s)
+                owner_id = await _seed_human(s, org_id)
+                story_id = await _seed_story(s, org_id, project_id)
+                from app.services.channel_connection import upsert_channel_connection
+
+                connection = await upsert_channel_connection(
+                    s, org_id=org_id, channel="x_sandbox", account_id="x-sandbox-cap-3",
+                    account_label="cap_user_3", credential_kind="oauth",
+                    access_token="sandbox-x-access:app-1", refresh_token="sandbox-x-refresh:app-1:g0",
+                    token_expires_at=datetime.now(timezone.utc), refresh_mode="refresh_token",
+                    scopes=["tweet.read", "tweet.write", "offline.access"], connected_by=owner_id,
+                )
+                eleven_segments = [f"세그먼트 {i}" for i in range(11)]
+                version, _channel, _violations = await channel_posts_module.create_channel_post_draft_version(
+                    s, org_id=org_id, work_item_id=story_id, connection_id=connection.id,
+                    text="헤드", link_url=None, author_member_id=owner_id, author_kind="human",
+                    channel_payload={"thread": eleven_segments},
+                )
+                assert len(version.channel_payload["thread"]) == 11, "가드 무력화 시 11개가 그대로 통과(RED 재현)"
+        finally:
+            await engine.dispose()
+    finally:
+        channel_posts_module._validate_thread_segments = original
+
+
+# ─── ④ 예산 부족(N×unit_cost) → 422(발행 시점) ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_thread_publish_insufficient_budget_for_n_segments_rejected():
+    """한도가 딱 2세그먼트분만 남아 있는데 3세그먼트를 발행하려 하면 422(예산 초과) —
+    실제로 provider 호출(publish_x_thread) 자체가 0건이어야 한다(발행 前 재검사)."""
+    from app.services.content_rules import put_org_content_rules
+    from app.services.generation_budget import GenerationBudgetExceededError
+    from app.services.x_publish_budget import get_api_usage_unit_cost_minor
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                s, thread=["세그먼트 2", "세그먼트 3"],
+            )
+            unit_cost = get_api_usage_unit_cost_minor(None)
+            await put_org_content_rules(
+                s, org_id=org_id,
+                rules={"api_usage_budget": {"limit_minor": unit_cost * 2, "currency": "KRW", "period": "month"}},
+                expected_version=0, updated_by_member_id=owner_id,
+            )
+
+            from app.services.channel_posts import publish_channel_post_draft
+            with pytest.raises(GenerationBudgetExceededError) as exc_info:
+                await publish_channel_post_draft(
+                    s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+                )
+            assert exc_info.value.limit_minor == unit_cost * 2
+            assert exc_info.value.estimated_cost_minor == unit_cost * 3
+
+            from sqlalchemy import select
+            from app.models.channel_publication import ChannelPublication
+            rows = list((await s.execute(
+                select(ChannelPublication).where(
+                    ChannelPublication.gate_id == gate_id, ChannelPublication.version_id == version.id,
+                )
+            )).scalars().all())
+            assert rows == [], "예산 재검사가 provider 호출보다 먼저라 행이 하나도 안 생겨야 한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_thread_publish_retry_budget_check_uses_remaining_count_not_full_n():
+    """⭐재시도 시 예산 재검사가 "남은 세그먼트 수"만 본다 — 이미 1개(헤드) 발행 뒤
+    남은 한도가 1세그먼트분뿐이어도(전체 재검사면 3세그먼트분 요구해 거부되겠지만)
+    남은 2개(2·3번)분만 있으면 통과해야 한다."""
+    from app.services.content_rules import put_org_content_rules
+    from app.services.x_publish_budget import get_api_usage_unit_cost_minor
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                s, thread=["[sandbox:429] 실패 유발", "세그먼트 3"],
+            )
+            unit_cost = get_api_usage_unit_cost_minor(None)
+            # 한도=3세그먼트분(헤드+실패한 2번째까지 소진 예정 — 실은 실패라 2번째는
+            # evidence가 안 남는다). 헤드 1건 소진 뒤 재시도 시점엔 「남은 2개」만
+            # 검사해야 하므로 한도를 "헤드 1건 + 2개"에 딱 맞춰 둔다(3세그먼트분).
+            await put_org_content_rules(
+                s, org_id=org_id,
+                rules={"api_usage_budget": {"limit_minor": unit_cost * 3, "currency": "KRW", "period": "month"}},
+                expected_version=0, updated_by_member_id=owner_id,
+            )
+
+            from app.services.channel_posts import ChannelRateLimitedError
+            from app.services.channel_posts import publish_channel_post_draft
+            with pytest.raises(ChannelRateLimitedError):
+                await publish_channel_post_draft(
+                    s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+                )
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.channel_post_version import ChannelPostVersion
+            v = (await s.execute(
+                select(ChannelPostVersion).where(ChannelPostVersion.id == version.id)
+            )).scalar_one()
+            v.channel_payload = {"thread": ["재시도 성공", "세그먼트 3"]}
+            await s.commit()
+
+            from app.services.channel_posts import publish_channel_post_draft
+            head_row = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+            )
+            assert head_row.status == "published"
+            # 헤드(1건, 성공 evidence 기록됨)+재시도 2개(성공) = 실제로 소비된 evidence는
+            # 3건(헤드 1+재시도 2, 실패했던 2번째 시도는 evidence 미기록) — 한도 3세그먼트분
+            # 안에 정확히 들어맞는다는 것이 이 테스트의 핵심(재시도 재검사가 "3개 전체"를
+            # 다시 요구했다면 총 필요량이 1(헤드,이미소비)+3(전체 재검사)=4가 되어 거부됐을
+            # 것).
+    finally:
+        await engine.dispose()
+
+

--- a/infra/destructive-schema-shard-weights/test_3808_x_thread_publish.py.json
+++ b/infra/destructive-schema-shard-weights/test_3808_x_thread_publish.py.json
@@ -1,0 +1,1 @@
+{"file": "tests/test_3808_x_thread_publish.py", "sec": 3.9, "source": "story-3808(Phase3·3-3 PR5b-1, 페드루 PO 確定 2026-09-12) — X 스레드(N세그먼트) 발행 오케스트레이터(publish_channel_post_draft의 실 호출부가 N≥2 통과) 신규 파일 실측(로컬, uv run pytest --durations=0 직접 1회 실행, 7건 wall time 약 3.9s — test_3808_x_insights.py 선례와 동일 방법론, 실 CI 샤드 로그로 재확認 필요)"}


### PR DESCRIPTION
## 배경

`publish_x_thread` 프리미티브(PR2, N지원)는 이미 있었지만 실 호출부(`create_container`/`publish_container` 5-함수 파사드)가 항상 `texts=[text]`(N=1)로만 통과시켰다 — 이 PR이 그 실 호출부를 처음으로 N≥2에 연결한다.

## 계약(페드루 PO 確定 2026-09-12)

- **슬롯**: 본문=헤드(세그먼트 1)·`channel_payload={"thread":[seg2,…]}`(이어쓰기만, story #3813 공유 슬롯 재사용, 신규 컬럼/테이블 0). x/x_sandbox 어댑터가 `thread_max_segments=10` 선언(image_max_count=0과 동형 관례 — 미선언 채널은 422로 거부).
- **검증**: 저장 시점(`create_channel_post_draft_version`)·발행 시점(`_publish_x_thread_draft`) 둘 다에서 상한·세그먼트별 280자 검사(`ChannelThreadUnsupportedError`·`ChannelThreadSegmentLimitExceededError`·`ChannelThreadSegmentTooLongError`, 422).
- **오케스트레이터**: `publish_x_thread(texts=[head,*thread])` 1회 호출 → `ChannelPublication` N행(sequence 1..N, 각자 external_id/permalink). 인사이트 스케줄은 seq=1(헤드) 행에만(PR4 스펙이 애초에 "헤드 트윗만"). 비용 재검사는 "이번 호출에서 실제로 시도할 세그먼트 수"(재시도 시 남은 수만 — 전체 N을 다시 청구하면 정당한 재시도가 잔량 부족으로 오거부될 수 있다).
- **부분 실패**: 롤백 없음(이미 나간 tweet 그대로) — 1..k-1 published·k failed·k+1..N은 행 자체가 없음. 재시도는 마지막 published 다음부터 이어 발행, k행이 failed면 그 자리를 갱신(새 행 추가 아님 — resume_row 매칭).
- **x_sandbox 마커**는 PR2가 이미 세그먼트 단위 지원(`publish_x_thread`의 `published_segments` 계약) — 신규 코드 0, 재사용만.

## 검증

- 신규 7 tests(N=3 정상·k=2 부분실패+재시도 완주·상한 10/11 경계·예산 부족 422).
- 뮤테이션 셀프체크 2건 인라인 수행(resume_row 재사용 제거 → `UniqueViolationError` 재현, 재시도 예산검사를 remaining_count 대신 total_n으로 바꿈 → 정상 재시도가 `GenerationBudgetExceededError`로 오거부됨 재현) 후 원복, +3번째(상한 검사 몽키패치)는 파일에 영구 보존.
- 기존 X publish 200+ tests 전부 회귀 0.
- 한글 사용자 문장 가드 baseline 그대로(신규 에러 메시지 3종은 영문 — 이 스토리 세션의 기존 정정 전례와 동형).
- shard-weights 등재(story #3812 디렉터리 형식, `test_3808_x_thread_publish.py.json` 1개 신규).

base=develop(de0d26999, #4213 포함) — 마이그 0(sequence 컬럼은 PR2 착지분).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8