### PR TITLE
[SID:3808] PR5d — x_sandbox 1회성 실패 마커 [sandbox:429-once]

### DIFF
--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -2091,6 +2091,12 @@ async def _publish_x_thread_draft(
             succeeded = await publish_x_thread_fn(
                 client, access_token=access_token, texts=remaining_texts,
                 media_id=image_public_url, initial_reply_to_tweet_id=prev_external_id,
+                # story #3808 PR5d(페드루 PO 確定) — "이번 호출의 texts[0]이 이미
+                # 한 번 실패해 재개하는 자리인가"를 DB 실물(resume_row=그 sequence의
+                # status='failed' 행)로 판정해 넘긴다(process 메모리 0 — 워커
+                # 재기동에도 결정적). x_sandbox_publish.py::[sandbox:429-once]
+                # 전용 신호, 실 x_publish.py는 무시.
+                is_retry=resume_row is not None,
             )
         except ThreadsPublishError as exc:
             succeeded = list(getattr(exc, "published_segments", []) or [])

--- a/backend/app/services/x_publish.py
+++ b/backend/app/services/x_publish.py
@@ -169,7 +169,7 @@ async def get_tweet_permalink(client: httpx.AsyncClient, *, access_token: str, t
 
 async def publish_x_thread(
     client: httpx.AsyncClient, *, access_token: str, texts: list[str], media_id: str | None = None,
-    initial_reply_to_tweet_id: str | None = None,
+    initial_reply_to_tweet_id: str | None = None, is_retry: bool = False,
 ) -> list[dict]:
     """스레드 N세그먼트 프리미티브 — 각 세그먼트를 직전 세그먼트의 reply로 순차
     발행(reply 체인). `media_id`는 **첫 세그먼트(헤드)에만** 첨부(AC2 「텍스트·
@@ -185,7 +185,13 @@ async def publish_x_thread(
     실패 시 이미 발행된 앞 세그먼트는 그대로 남는다(부분 성공 — Threads 컨테이너
     부분성공과 다른 성격이지만 "이미 나간 tweet을 되돌리지 않는다"는 같은 정직성
     원칙, delete_tweet류 자동 롤백은 이 카드 범위 밖). 호출부가 이미 발행된
-    세그먼트 목록(예외의 `.published_segments`)을 볼 수 있게 예외에 실어 던진다."""
+    세그먼트 목록(예외의 `.published_segments`)을 볼 수 있게 예외에 실어 던진다.
+
+    story #3808 PR5d — `is_retry`는 `x_sandbox_publish.py`의 `[sandbox:429-once]`
+    마커 시뮬레이션 전용 축(시그니처 동형 유지, `initial_reply_to_tweet_id`가
+    PR5b-1 때 sandbox 쪽에 무시된 채 얹힌 것의 반대 방향) — 실 X 호출은 provider가
+    실제로 응답하는 대로일 뿐 이 함수 안에서 흉내 낼 재시도-성공 판정이 없어 값
+    자체는 무시한다."""
     results: list[dict] = []
     prev_tweet_id: str | None = initial_reply_to_tweet_id
     for index, text in enumerate(texts):

--- a/backend/app/services/x_sandbox_publish.py
+++ b/backend/app/services/x_sandbox_publish.py
@@ -17,7 +17,19 @@ ads_sandbox_campaign.py::_BUDGET_EXCEEDED_MARKER와 동형 축 — 우리 조직
 막는 «우리 상한»과는 다른 축, "X 공급자 자신의 계정 종량 상한에 걸렸다"는
 provider-측 거부를 흉내낸다(두 축이 다른 이유: 우리 상한은 create_container
 호출 前에 이미 걸러지므로, 이 마커가 여기서 걸린다는 것 자체가 "우리 통과는
-됐지만 provider가 별도로 거부"하는 시나리오 재현)."""
+됐지만 provider가 별도로 거부"하는 시나리오 재현).
+
+story #3808 PR5d(2026-09-12, 페드루 PO 確定) — 6번째 마커 `[sandbox:429-once]`.
+배포 80 라이브 회차에서 발견된 갭: 기존 `[sandbox:429]`는 텍스트에 마커가
+남아 있는 한 재시도해도 영원히 429라, "같은 버전(같은 세그먼트 텍스트)을
+고치지 않고 재시도만으로 성공"하는 시나리오(PR5b-1 AC4③④가 실제로 약속한
+그 재시도 성공 경로)를 sandbox로 증명할 수 없었다. `[sandbox:429-once]`는
+"같은 (gate·version·sequence)의 두 번째 시도"에서만 통과시킨다 — 판정은
+process 메모리가 아니라 호출부(channel_posts.py::_publish_x_thread_draft)가
+DB 실물(그 sequence 자리에 이미 남은 status='failed' 행=`resume_row`)로
+센 뒤 `publish_x_thread(..., is_retry=True)`로 넘겨주는 값 하나뿐이다 —
+그래서 워커가 재기동해도(process 메모리 0) 다음 tick이 DB를 다시 읽으면
+그대로 같은 판정이 나온다."""
 from __future__ import annotations
 
 import uuid
@@ -27,19 +39,33 @@ import httpx
 from app.services.threads_publish import ThreadsPublishError
 
 _MARKER_429 = "[sandbox:429]"
+_MARKER_429_ONCE = "[sandbox:429-once]"
 _MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
 _MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
 _MARKER_DUPLICATE_POST = "[sandbox:duplicate-post]"
 _MARKER_API_BUDGET_EXCEEDED = "[sandbox:api-budget-exceeded]"
 
 
-def _raise_if_marked(text: str) -> None:
+def _raise_if_marked(text: str, *, is_retry: bool = False) -> None:
     """.message는 provider 원문 축(threads_publish.py::ThreadsPublishError 상단
     딱지 그대로) — 로그·디버그용 영문 기술 문구지 사람에게 보이는 최종 문장이
     아니다. x_oauth.py/x_sandbox_oauth.py(PR1)와 동형으로 영문 유지 — 한글로
     쓰면 story #3779 baseline 「줄기만 허용」 ratchet에 걸린다(기존 facebook_
     sandbox_publish.py류 한글 마커 문구는 이 ratchet 도입 前 grandfather된
-    것이라 재사용 불가, 신규 파일은 이 함정을 피해야 한다)."""
+    것이라 재사용 불가, 신규 파일은 이 함정을 피해야 한다).
+
+    story #3808 PR5d — `is_retry`는 `[sandbox:429-once]` 전용 축(호출부가 DB
+    실물로 판정해 넘긴 값, 이 함수 자신은 아무 상태도 안 든다). `create_container`
+    (단일 발행, retry 개념 자체가 없는 자리)는 이 인자를 안 넘겨 기본값 False —
+    그 경로에서 이 마커는 여전히 매번 실패(단일 발행 재시도 성공 시나리오는
+    이 카드 범위 밖)."""
+    if _MARKER_429_ONCE in text:
+        if is_retry:
+            return
+        raise ThreadsPublishError(
+            "SANDBOX_X_RATE_LIMITED_ONCE", "sandbox: [sandbox:429-once] marker simulation (first attempt)",
+            status_code=429,
+        )
     if _MARKER_429 in text:
         raise ThreadsPublishError("SANDBOX_X_RATE_LIMITED", "sandbox: [sandbox:429] marker simulation", status_code=429)
     if _MARKER_PROVIDER_ERROR in text:
@@ -94,18 +120,25 @@ async def get_publishing_limit(
 
 async def publish_x_thread(
     client: httpx.AsyncClient, *, access_token: str, texts: list[str], media_id: str | None = None,
-    initial_reply_to_tweet_id: str | None = None,
+    initial_reply_to_tweet_id: str | None = None, is_retry: bool = False,
 ) -> list[dict]:
     """`x_publish.py::publish_x_thread`와 동형 계약(N세그먼트 reply 체인) — 결정적
     시뮬레이션. 세그먼트 중 하나라도 마커가 있으면 그 세그먼트에서 멈추고(이전
     세그먼트는 이미 "발행"됐다는 사실을 예외의 `.published_segments`로 실어 던진다
     — x_publish.py 부분성공 계약과 동형). `initial_reply_to_tweet_id`는 시그니처
     동형 유지용(story #3808 PR5b-1) — 샌드박스는 실 reply 체인이 없어 값 자체는
-    무시(결정적 tweet_id 생성에 영향 없음)."""
+    무시(결정적 tweet_id 생성에 영향 없음).
+
+    story #3808 PR5d — `is_retry`는 호출부(channel_posts.py)가 "이 호출의 texts[0]
+    자리가 이미 한 번 실패해 재개하는 세그먼트인가"를 DB(`resume_row`)로 판정해
+    넘긴 값. `texts` 리스트 중 **index 0에만** 적용한다 — 재개 호출은 항상
+    `all_texts[last_published_seq:]`(실패했던 그 자리부터)라 배치 안에서 "두 번째
+    시도"일 수 있는 자리는 구조적으로 index 0 하나뿐이고, 그 뒤(index>=1)는 이번이
+    첫 시도인 새 세그먼트라 `[sandbox:429-once]`가 있으면 그대로 첫 실패를 낸다."""
     results: list[dict] = []
     for index, text in enumerate(texts):
         try:
-            _raise_if_marked(text)
+            _raise_if_marked(text, is_retry=is_retry and index == 0)
         except ThreadsPublishError as exc:
             exc.published_segments = results  # type: ignore[attr-defined]
             raise

--- a/backend/tests/test_3808_x_thread_publish.py
+++ b/backend/tests/test_3808_x_thread_publish.py
@@ -747,3 +747,134 @@ async def test_mutation_publish_time_thread_revalidation_removed_lets_lowered_ca
             await engine.dispose()
     finally:
         channel_posts_module._validate_thread_segments = original_validate
+
+
+# ─── PR5d(페드루 PO 確定 2026-09-12, 배포 80 라이브 회차 갭) — [sandbox:429-once] ──
+# 「같은 버전(같은 세그먼트 텍스트)을 고치지 않고 재시도만으로 성공」 시나리오를
+# sandbox로 증명한다 — 기존 [sandbox:429]는 텍스트에 마커가 남아 있는 한 영원히
+# 실패해 이 경로를 재현할 수 없었다(라이브 회차 "못 잰 것 1").
+
+@pytest.mark.anyio
+async def test_thread_publish_429_once_marker_fails_first_then_succeeds_on_unedited_retry():
+    from sqlalchemy import select
+    from app.models.channel_publication import ChannelPublication
+    from app.models.evidence import Evidence
+    from app.services.channel_posts import ChannelRateLimitedError, publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                s, thread=["[sandbox:429-once] 첫 시도만 실패", "세그먼트 3"],
+            )
+
+            with pytest.raises(ChannelRateLimitedError):
+                await publish_channel_post_draft(
+                    s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+                )
+
+            rows = list((await s.execute(
+                select(ChannelPublication)
+                .where(ChannelPublication.gate_id == gate_id, ChannelPublication.version_id == version.id)
+                .order_by(ChannelPublication.sequence)
+            )).scalars().all())
+            assert [r.sequence for r in rows] == [1, 2]
+            assert rows[0].status == "published"
+            assert rows[1].status == "failed"
+            head_external_id = rows[0].external_id
+            failed_row_id = rows[1].id
+
+            evidence_after_first_call = len((await s.execute(
+                select(Evidence).where(Evidence.org_id == org_id, Evidence.type == "metric")
+            )).scalars().all())
+            assert evidence_after_first_call == 1, "헤드 1건만 실제로 성공 — 실패분은 evidence 없음"
+
+        # 재시도 — channel_payload를 «전혀 안 건드리고» 같은 함수를 다시 부른다
+        # (기존 [sandbox:429] 테스트와 다른 지점 — 여기가 이 마커의 존재 이유다).
+        async with Session() as s:
+            head_row = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+            )
+            assert head_row.sequence == 1
+            assert head_row.status == "published"
+            assert head_row.external_id == head_external_id, "헤드는 재발행되지 않는다(그대로)"
+
+            rows = list((await s.execute(
+                select(ChannelPublication)
+                .where(ChannelPublication.gate_id == gate_id, ChannelPublication.version_id == version.id)
+                .order_by(ChannelPublication.sequence)
+            )).scalars().all())
+            assert [r.sequence for r in rows] == [1, 2, 3], "3번째까지 완주"
+            assert all(r.status == "published" for r in rows)
+            assert rows[1].id == failed_row_id, "실패했던 2번 행을 재사용(새 행 추가 아님)"
+            assert rows[1].error_code is None
+
+            evidence_after_retry = len((await s.execute(
+                select(Evidence).where(Evidence.org_id == org_id, Evidence.type == "metric")
+            )).scalars().all())
+            assert evidence_after_retry == 3, "1(첫 호출 헤드) + 2(재시도 seq2·seq3) — remaining_count 단위만 청구"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_thread_publish_429_once_marker_still_fails_on_fresh_first_attempt_at_other_sequence():
+    """양성대조 — 재개 자리(index 0)가 아닌 세그먼트에 이 마커가 있으면(첫 시도이므로)
+    그대로 실패한다(무조건 통과가 아니라 "그 자리의 두 번째 시도"만 통과)."""
+    from app.services.channel_posts import ChannelRateLimitedError, publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                s, thread=["세그먼트 2", "[sandbox:429-once] 첫 시도"],
+            )
+            with pytest.raises(ChannelRateLimitedError):
+                await publish_channel_post_draft(
+                    s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+                )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_429_once_retry_pass_removed_makes_unedited_retry_fail_forever():
+    """⭐뮤테이션 셀프체크 — 호출부가 넘기는 `is_retry` 신호를 무력화(항상 False로
+    덮어씀)하면, 마커를 안 지운 재시도가 [sandbox:429] 옛 마커처럼 영원히 실패해야
+    한다(=이 처방이 실제로 그 시나리오를 가른다는 증명)."""
+    # publish_x_thread_fn 호출부 자체를 패치하기보다, 더 정확히 처방 지점만 겨냥한다 —
+    # _publish_x_thread_draft가 넘기는 is_retry 인자를 sandbox 쪽에서 무시하도록
+    # x_sandbox_publish.publish_x_thread를 감싼다(실제 처방 라인은 channel_posts.py의
+    # `is_retry=resume_row is not None`이지만, 함수 내부 지역변수라 몽키패치 대상이
+    # 아니다 — 같은 효과를 내는 소비측 무력화로 검증).
+    import app.services.x_sandbox_publish as x_sandbox_publish_module
+    original_publish_x_thread = x_sandbox_publish_module.publish_x_thread
+
+    async def _mutated_always_first_attempt(*args, **kwargs):
+        kwargs["is_retry"] = False
+        return await original_publish_x_thread(*args, **kwargs)
+
+    x_sandbox_publish_module.publish_x_thread = _mutated_always_first_attempt
+    try:
+        from app.services.channel_posts import ChannelRateLimitedError, publish_channel_post_draft
+
+        engine, Session = await _session_factory()
+        try:
+            async with Session() as s:
+                org_id, owner_id, draft_id, gate_id, version = await _seed_ready_thread_draft(
+                    s, thread=["[sandbox:429-once] 첫 시도만 실패", "세그먼트 3"],
+                )
+                with pytest.raises(ChannelRateLimitedError):
+                    await publish_channel_post_draft(
+                        s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+                    )
+
+            async with Session() as s:
+                with pytest.raises(ChannelRateLimitedError):
+                    await publish_channel_post_draft(
+                        s, org_id=org_id, draft_id=draft_id, published_by_member_id=owner_id,
+                    )
+        finally:
+            await engine.dispose()
+    finally:
+        x_sandbox_publish_module.publish_x_thread = original_publish_x_thread


### PR DESCRIPTION
## 요약

배포 80 라이브 회차(3808, 페드루 PO 2026-09-12 08:35Z)에서 발견된 갭 — "같은 버전(같은 세그먼트 텍스트)을 고치지 않고 재시도만으로 성공"하는 경로(PR5b-1 AC4③④가 실제로 약속한 재시도-성공 시나리오)를 sandbox로 증명할 수 없었다. 기존 `[sandbox:429]`는 텍스트에 마커가 남아 있는 한 재시도해도 영원히 429라, 사람이 draft 본문을 편집해 마커를 지워야만 재시도가 성공 — 그건 "다른 버전으로 성공"이지 "같은 버전 재시도 성공"이 아니다.

## 변경

- **`x_sandbox_publish.py`**: 신규 마커 `[sandbox:429-once]` — "같은 (gate·version·sequence)의 두 번째 시도"에서만 통과. `publish_x_thread()`가 새 `is_retry: bool = False` 파라미터를 받아, 배치의 index 0(재개 호출은 항상 실패했던 그 자리부터 시작하므로 "두 번째 시도"일 수 있는 유일한 자리)에만 적용.
- **`channel_posts.py`**: `_publish_x_thread_draft`가 이미 재시도 이어달리기용으로 계산해 둔 `resume_row`(그 sequence 자리의 기존 status='failed' 행)를 그대로 재사용해 `is_retry=resume_row is not None`을 넘긴다 — **process 메모리 0, DB 실물로만 판정**(워커 재기동에도 결정적).
- **`x_publish.py`**(실 X): 같은 파라미터를 받되 무시(호출부가 한 표현식으로 두 모듈을 함께 부르므로 시그니처 동형 필요 — `initial_reply_to_tweet_id`가 PR5b-1 때 sandbox 쪽에 얹힌 것의 반대 방향).

## 선행 확인 (착수 전 페드루 PO 요청)

기존 `[sandbox:429]`/`[sandbox:provider-error]` 등 4개 마커 전부 `_MARKER_XXX in text` 정확 문자열(닫는 대괄호 포함) 매치라 `[sandbox:429-once]`는 그 어떤 기존 마커의 부분문자열도 포함하지 않음 — 이름 충돌 0.

## 검증

- 신규 3 tests: 첫 실패→미편집 재시도로 완주(헤드 재발행 안 됨·실패했던 행 재사용·evidence는 remaining_count 단위로만)·재개 자리가 아닌 곳에 마커가 있으면 그대로 실패하는 양성대조·`is_retry` 신호 무력화 뮤테이션(영구 보관).
- 인라인 뮤테이션 셀프체크(호출부의 `is_retry=resume_row is not None`을 `False`로) 정확히 1건 RED → revert GREEN.
- 관련 회귀 222 tests(channel_post/x_publish/x_thread/x_sandbox/x_oauth) 전부 통과.
- 한글가드 baseline 그대로, shard-weights 등록 lint 통과(신규 테스트 파일 없음 — 기존 파일에 함수만 추가).

착지 뒤 PO가 dev-app에서 실제 resume→성공 라이브 실측 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8