### PR TITLE
[SID:3815] PR1 — YouTube(Google) 서버 OAuth 어댑터·비회전 refresh_token·youtube_sandbox 미러

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -381,6 +381,19 @@ def _x_oauth_module(channel: str):
     return importlib.import_module(_X_OAUTH_MODULE_PATHS[channel])
 
 
+_YOUTUBE_OAUTH_MODULE_PATHS = {
+    "youtube": "app.services.youtube_oauth",
+    "youtube_sandbox": "app.services.youtube_sandbox_oauth",
+}
+
+
+def _youtube_oauth_module(channel: str):
+    """story #3815 — `_x_oauth_module`과 동형 dispatch(별도 dict — 기존 채널군
+    무변경, 새 채널군은 병렬 등재)."""
+    import importlib
+    return importlib.import_module(_YOUTUBE_OAUTH_MODULE_PATHS[channel])
+
+
 @router.get("/{org_id}/channel-connections", response_model=list[ChannelConnectionResponse])
 async def list_channel_connections_endpoint(
     org_id: uuid.UUID,
@@ -561,6 +574,13 @@ async def authorize_channel_connection(
         url = build_x_authorize_url(
             redirect_uri=_redirect_uri(org_id, channel), state=state, code_challenge=code_challenge, app_id=app_id,
         )
+    elif channel in ("youtube", "youtube_sandbox"):
+        # story #3815 — Google은 PKCE를 지원(필수도 거부도 아님, youtube_oauth.py
+        # 상단 딱지) — X와 동형으로 항상 싣는다.
+        build_youtube_authorize_url = _youtube_oauth_module(channel).build_authorize_url
+        url = build_youtube_authorize_url(
+            redirect_uri=_redirect_uri(org_id, channel), state=state, code_challenge=code_challenge, app_id=app_id,
+        )
     else:
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
     return AuthorizeResponse(url=url, state=state)
@@ -610,6 +630,7 @@ async def channel_connection_callback(
 
     if channel not in (
         "threads", "instagram", "facebook", "facebook_sandbox", "meta_ads", "ads_sandbox", "x", "x_sandbox",
+        "youtube", "youtube_sandbox",
     ):
         raise HTTPException(status_code=404, detail=f"unsupported channel: {channel}")
 
@@ -644,6 +665,13 @@ async def channel_connection_callback(
 
     if channel in ("x", "x_sandbox"):
         return await _x_channel_connection_callback(
+            db, org_id=org_id, channel=channel, code=body.code, code_verifier=oauth_state.code_verifier,
+            app_id=app_id, app_secret=app_secret, requester_member_id=resolved.id,
+            target_connection_id=oauth_state.connection_id,
+        )
+
+    if channel in ("youtube", "youtube_sandbox"):
+        return await _youtube_channel_connection_callback(
             db, org_id=org_id, channel=channel, code=body.code, code_verifier=oauth_state.code_verifier,
             app_id=app_id, app_secret=app_secret, requester_member_id=resolved.id,
             target_connection_id=oauth_state.connection_id,
@@ -886,6 +914,46 @@ async def _x_channel_connection_callback(
     row = await upsert_channel_connection(
         db, org_id=org_id, channel=channel, account_id=account["id"],
         account_label=account.get("username"), credential_kind=adapter.credential_kind,
+        access_token=access_token, refresh_token=refresh_token,
+        token_expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in),
+        refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(" "), connected_by=requester_member_id,
+    )
+    mismatch_target_id = (
+        target_connection_id if target_connection_id is not None and target_connection_id != row.id else None
+    )
+    return _to_response(row, reconnect_mismatch_target_id=mismatch_target_id)
+
+
+async def _youtube_channel_connection_callback(
+    db: AsyncSession, *, org_id: uuid.UUID, channel: str, code: str, code_verifier: str, app_id: str,
+    app_secret: str, requester_member_id: uuid.UUID, target_connection_id: uuid.UUID | None = None,
+) -> ChannelConnectionResponse:
+    """story #3815(Phase3·3-5 PR1) — `_x_channel_connection_callback`과 동형(단일
+    hop, 페이지/광고계정류 선택 갈래 없음 — 가장 단순한 갈래 하나). 반환된
+    refresh_token을 **그대로**(가공 0) `upsert_channel_connection`에 저장 — cron
+    회전 갱신(cron.py `_ROTATING_REFRESH_FN_BY_CHANNEL`, youtube_oauth.py 상단
+    딱지 — Google은 회전하지 않지만 같은 dispatch 계약을 재사용한다)이 이 저장값을
+    읽는다."""
+    from app.services.youtube_oauth import YouTubeOAuthError
+
+    adapter = get_channel_adapter(channel)
+    oauth_module = _youtube_oauth_module(channel)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        try:
+            access_token, refresh_token, expires_in = await oauth_module.exchange_code_for_token(
+                client, code=code, redirect_uri=_redirect_uri(org_id, channel), code_verifier=code_verifier,
+                app_id=app_id, app_secret=app_secret,
+            )
+            account = await oauth_module.test_connection(client, access_token=access_token)
+        except YouTubeOAuthError as exc:
+            raise HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message}) from exc
+        finally:
+            del app_secret  # ⛔즉시 소비 후 폐기 — 더 들고 있지 않는다(기존 규율과 동형).
+
+    row = await upsert_channel_connection(
+        db, org_id=org_id, channel=channel, account_id=account["id"],
+        account_label=account.get("title"), credential_kind=adapter.credential_kind,
         access_token=access_token, refresh_token=refresh_token,
         token_expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in),
         refresh_mode=adapter.refresh_mode, scopes=adapter.scope.split(" "), connected_by=requester_member_id,

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1208,6 +1208,8 @@ async def refresh_channel_tokens(
         )
         from app.services.x_oauth import XOAuthError, refresh_access_token as refresh_x_token
         from app.services.x_sandbox_oauth import refresh_access_token as refresh_x_sandbox_token
+        from app.services.youtube_oauth import YouTubeOAuthError, refresh_access_token as refresh_youtube_token
+        from app.services.youtube_sandbox_oauth import refresh_access_token as refresh_youtube_sandbox_token
         from app.services.channel_app_credentials import resolve_app_credentials
 
         # story #3320 — Phase1은 threads만 구현했던 skip-guard(`continue`)를 채널→
@@ -1236,8 +1238,13 @@ async def refresh_channel_tokens(
         # PR이 짝으로 얹은 `apply_refresh_result(new_refresh_token=...)` 슬롯으로 간다
         # — 여기서 안 갈아 끼우면 다음 tick이 이미 provider가 무효화한 옛 refresh_
         # token으로 또 시도해 항상 실패한다(1회용 회전의 핵심 위험).
-        _ROTATING_REFRESH_FN_BY_CHANNEL = {"x": refresh_x_token, "x_sandbox": refresh_x_sandbox_token}
-        _OAUTH_ERROR_TYPES = (ThreadsOAuthError, InstagramOAuthError, XOAuthError)
+        _ROTATING_REFRESH_FN_BY_CHANNEL = {
+            "x": refresh_x_token, "x_sandbox": refresh_x_sandbox_token,
+            # story #3815(Phase3·3-5 PR1) — youtube_oauth.py 상단 딱지: Google은
+            # 회전하지 않지만 이 dispatch 계약(3튜플 반환)을 그대로 재사용한다.
+            "youtube": refresh_youtube_token, "youtube_sandbox": refresh_youtube_sandbox_token,
+        }
+        _OAUTH_ERROR_TYPES = (ThreadsOAuthError, InstagramOAuthError, XOAuthError, YouTubeOAuthError)
 
         rows = await list_connections_due_for_refresh(session, now=datetime.now(timezone.utc))
         refreshed, failed = 0, 0

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -562,6 +562,39 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         max_text_length=280,
         thread_max_segments=10,
     ),
+    # story #3815(Phase3·3-5 PR1, 페드루 PO 確定 2026-09-12) — YouTube 첫 출시.
+    # PR1은 OAuth 연결만 연다(발행·업로드는 PR2, 인사이트는 후속 — insight_metrics
+    # 미선언 기본값 그대로, story #3696 가드가 요구하는 "선언=dispatch 존재" 계약을
+    # 어길 자리 자체가 없다). refresh_mode="refresh_token" 재사용은 youtube_oauth.py
+    # 상단 딱지 참고(Google은 회전하지 않지만 기존 3튜플 dispatch 계약을 그대로
+    # 만족시킨다 — 새 refresh_mode 값 발명 0). image_*/video_*/max_text_length 등
+    # 콘텐츠 필드는 PR2가 resumable 업로드를 열 때 채운다(ads_sandbox PR1과 동형
+    # 판단 — 아직 없는 능력을 미리 선언하지 않는다).
+    "youtube": ChannelAdapterConfig(
+        authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        # ⚠️미확認 — 정확한 스코프 문자열은 실 GCP 프로젝트 등록 시 재확認 대상
+        # (지식 컷오프 기준 안정적으로 공개된 두 스코프 이름 그대로).
+        scope="https://www.googleapis.com/auth/youtube.upload https://www.googleapis.com/auth/youtube.readonly",
+        refresh_mode="refresh_token",
+        credential_kind="oauth",
+        display_name="YouTube",
+        kind="social",
+        requires_connection=True,
+    ),
+    "youtube_sandbox": ChannelAdapterConfig(
+        authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        scope="https://www.googleapis.com/auth/youtube.upload https://www.googleapis.com/auth/youtube.readonly",
+        refresh_mode="refresh_token",
+        # x_sandbox와 동형 이유 — 결정적 가짜 토큰을 문자열로 나르므로
+        # credential_kind="none"이 아니라 진짜 authorize→callback 라우터를 태운다
+        # (youtube_sandbox_oauth.py가 Google 호출부만 페이크로 스왑).
+        credential_kind="oauth",
+        display_name="YouTube Sandbox",
+        kind="social",
+        requires_connection=True,
+    ),
 }
 
 # story 5b27b32f(Phase1·BE·테스트 인프라, 페드루 PO 확定 2026-09-04) — dev 전용 샌드박스

--- a/backend/app/services/youtube_oauth.py
+++ b/backend/app/services/youtube_oauth.py
@@ -1,0 +1,139 @@
+"""story #3815(Phase3·3-5 PR1, 페드루 PO 確定 2026-09-12) — YouTube(Google) 서버
+OAuth 2.0 교환. `x_oauth.py`(threads_oauth.py 계열)와 동형 3단 우선순위로 앱 id/
+secret은 호출부(channel_app_credentials.resolve_app_credentials)가 해석해 넘긴다.
+
+x_oauth.py와의 핵심 차이 — X는 refresh_token이 **1회용 회전**(매 갱신마다 새 값
+발급·이전 값 즉시 무효)인 반면, Google 표준 OAuth 2.0 refresh_token grant는
+**회전하지 않는다**(공개 문서 안정 사실 — 갱신 응답엔 access_token/expires_in만
+오고 refresh_token은 최초 발급값이 그대로 계속 유효, provider가 명시적으로 폐기
+하지 않는 한). 그런데도 `refresh_access_token()`이 X와 같은 3튜플을 반환하는
+이유는 순수 시그니처 호환 — `cron.py::_ROTATING_REFRESH_FN_BY_CHANNEL` 디스패치
+계약(refresh_token 인자로 받고 (new_access, new_refresh, expires_in) 3튜플 반환)에
+그대로 맞추기 위함이다(새 refresh_mode 값 발명 대신 기존 계약 재사용 — 세 번째
+반환값은 항상 "넘겨받은 값을 그대로 되돌려주는 것"이지 진짜 새 자격이 아니다).
+
+Google 표준 사실(공개 문서 안정) — authorize 요청에 `access_type=offline`+
+`prompt=consent`가 둘 다 없으면, 이미 한 번 동의한 사용자의 재인증 시 refresh_token
+자체가 응답에서 아예 빠진다(최초 동의 시에만 기본 발급) — 이 두 파라미터는 항상
+같이 싣는다. 토큰 엔드포인트는 X(HTTP Basic)와 달리 client_id/client_secret을
+POST body에 평문으로 받는다(공개 문서 안정 사실).
+
+⚠️미확認(착수 시 재확認 필요, x_oauth.py 상단 딱지와 동형 원칙) — YouTube Data
+API v3의 정확한 스코프 문자열·quota 비용표는 지식 컷오프(2026-01) 기준 최선
+추정이다. 실 앱 왕복 전까지 "코드는 정확한 형태로 존재하되 라이브 미검증" 상태로
+남는다."""
+from __future__ import annotations
+
+import httpx
+
+_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+_TOKEN_URL = "https://oauth2.googleapis.com/token"
+_CHANNELS_URL = "https://www.googleapis.com/youtube/v3/channels"
+
+
+class YouTubeOAuthError(Exception):
+    """code→token/refresh/channel 조회 실패. .code/.message가 그대로 API 에러 응답에
+    매핑(x_oauth.XOAuthError와 동형 계약)."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, code_challenge: str, app_id: str) -> str:
+    """PKCE 사용(Google은 공개·기밀 클라이언트 둘 다 지원 — X처럼 필수도 Threads
+    처럼 거부도 아니라 우회 플래그 불요). `app_id`는 x_oauth.py와 동형 이유로
+    호출부가 미리 해석해 넘긴다."""
+    from urllib.parse import urlencode
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    cfg = CHANNEL_ADAPTERS["youtube"]
+    params = {
+        "response_type": "code",
+        "client_id": app_id,
+        "redirect_uri": redirect_uri,
+        "scope": cfg.scope,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        # 위 모듈 딱지 — 이 둘이 없으면 재인증 시 refresh_token이 응답에서 빠진다.
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    return f"{_AUTHORIZE_URL}?{urlencode(params)}"
+
+
+async def exchange_code_for_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, code_verifier: str, app_id: str, app_secret: str,
+) -> tuple[str, str, int]:
+    """authorization code → (access_token, refresh_token, expires_in초). 단일 hop —
+    threads/facebook류의 단기→장기 2단 교환이 Google엔 없다."""
+    resp = await client.post(
+        _TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+            "client_id": app_id,
+            "client_secret": app_secret,
+        },
+    )
+    if resp.status_code != 200:
+        raise YouTubeOAuthError("YOUTUBE_TOKEN_EXCHANGE_FAILED", resp.text[:500])
+    body = resp.json()
+    access_token = body.get("access_token")
+    refresh_token = body.get("refresh_token")
+    expires_in = body.get("expires_in")
+    if not access_token or not refresh_token or not expires_in:
+        raise YouTubeOAuthError(
+            "YOUTUBE_TOKEN_EXCHANGE_MISSING_FIELDS", "access_token/refresh_token/expires_in missing",
+        )
+    return access_token, refresh_token, int(expires_in)
+
+
+async def refresh_access_token(
+    client: httpx.AsyncClient, *, refresh_token: str, app_id: str, app_secret: str,
+) -> tuple[str, str, int]:
+    """refresh_mode="refresh_token" 재사용(모듈 상단 딱지) — Google은 회전하지
+    않으므로 세 번째 반환값(new_refresh_token)은 항상 넘겨받은 `refresh_token`을
+    그대로 되돌린다(호출부가 그 값을 다시 저장해도 무해 — 실제로는 아무것도 안
+    바뀐 것과 같다)."""
+    resp = await client.post(
+        _TOKEN_URL,
+        data={
+            "grant_type": "refresh_token", "refresh_token": refresh_token,
+            "client_id": app_id, "client_secret": app_secret,
+        },
+    )
+    if resp.status_code != 200:
+        raise YouTubeOAuthError("YOUTUBE_REFRESH_FAILED", resp.text[:500])
+    body = resp.json()
+    new_access_token = body.get("access_token")
+    expires_in = body.get("expires_in")
+    if not new_access_token or not expires_in:
+        raise YouTubeOAuthError("YOUTUBE_REFRESH_MISSING_FIELDS", "access_token/expires_in missing")
+    return new_access_token, refresh_token, int(expires_in)
+
+
+async def test_connection(client: httpx.AsyncClient, *, access_token: str) -> dict:
+    """연결 시험(x_oauth.test_connection과 동형 계약) — 인증된 Google 계정이 소유한
+    YouTube 채널을 조회한다(`mine=true`). 계정에 채널이 하나도 없으면(콘텐츠
+    크리에이터 등록 前) 명시 에러로 죽는다 — 「연결은 됐는데 채널이 안 보인다」는
+    조용한 실패를 만들지 않는다. ⚠️미확認·갭 — 한 Google 계정이 여러 브랜드
+    채널을 가진 경우 `items[0]`(첫 번째)만 쓴다(facebook 페이지류의 다중 선택
+    갈래가 이 카드 범위 밖 — PR1은 X처럼 "가장 단순한 갈래 하나"만 연다)."""
+    resp = await client.get(
+        _CHANNELS_URL, params={"part": "snippet", "mine": "true"},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    if resp.status_code != 200:
+        raise YouTubeOAuthError("YOUTUBE_TEST_CONNECTION_FAILED", resp.text[:500])
+    items = resp.json().get("items") or []
+    if not items:
+        raise YouTubeOAuthError(
+            "YOUTUBE_NO_CHANNEL_FOUND", "authenticated Google account has no YouTube channel",
+        )
+    channel = items[0]
+    return {"id": channel.get("id"), "title": (channel.get("snippet") or {}).get("title")}

--- a/backend/app/services/youtube_sandbox_oauth.py
+++ b/backend/app/services/youtube_sandbox_oauth.py
@@ -1,0 +1,52 @@
+"""story #3815(Phase3·3-5 PR1, 페드루 PO 確定 2026-09-12) — YouTube 연결 sandbox.
+`youtube_oauth.py`와 정확히 같은 함수 시그니처(라우터가 채널로 모듈만 바꿔 끼우는
+기존 dispatch 관례 — `x_sandbox_oauth.py`/`channel_adapters.py::get_publish_client_
+module`과 동형 사상, 새 분기 로직 0)를 인프로세스 결정적 응답으로 구현한다.
+authorize가 실 Google 도메인 대신 콜백 URL로 곧장 (code, state)를 실어 리다이렉트해,
+real 없이도 authorize→callback 전 구간이 그대로 라이브 왕복으로 실측된다(x_sandbox_
+oauth.py와 동형 원칙).
+
+x_sandbox_oauth.py와 다른 자리 — YouTube 표준 refresh는 **회전하지 않는다**
+(youtube_oauth.py 상단 딱지) 라 회전-세대 마커 시뮬레이션이 없다. `refresh_access_
+token()`은 그냥 새 access_token만 결정적으로 내고 refresh_token은 넘겨받은 값을
+그대로 되돌린다 — 실 provider 관측과 정확히 같은 모양."""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+
+_ACCESS_PREFIX = "sandbox-youtube-access"
+_REFRESH_PREFIX = "sandbox-youtube-refresh"
+_SANDBOX_FAKE_CODE = "sandbox-oauth-code"
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, code_challenge: str, app_id: str) -> str:
+    """youtube_oauth.py 시그니처 동형 — real Google 없이 콜백 URL로 곧장 리다이렉트
+    (x_sandbox_oauth.py 원칙 그대로, code_challenge는 시그니처만 맞추고 sandbox
+    왕복엔 안 쓴다)."""
+    from urllib.parse import urlencode
+
+    return f"{redirect_uri}?{urlencode({'code': _SANDBOX_FAKE_CODE, 'state': state})}"
+
+
+async def exchange_code_for_token(
+    client: httpx.AsyncClient, *, code: str, redirect_uri: str, code_verifier: str, app_id: str, app_secret: str,
+) -> tuple[str, str, int]:
+    return f"{_ACCESS_PREFIX}:{app_id}", f"{_REFRESH_PREFIX}:{app_id}", 3600
+
+
+async def refresh_access_token(
+    client: httpx.AsyncClient, *, refresh_token: str, app_id: str, app_secret: str,
+) -> tuple[str, str, int]:
+    """회전 없음 결정적 시뮬레이션 — 새 access_token만 내고 `refresh_token`은
+    넘겨받은 값 그대로 되돌린다(youtube_oauth.refresh_access_token과 같은 계약,
+    x_sandbox_oauth.py의 세대-회전 마커 대상 아님)."""
+    new_access_token = f"{_ACCESS_PREFIX}:{app_id}:{uuid.uuid4().hex[:8]}"
+    return new_access_token, refresh_token, 3600
+
+
+async def test_connection(client: httpx.AsyncClient, *, access_token: str) -> dict:
+    """결정적 고정 값(x_sandbox_oauth.test_connection과 동형 원칙 — 이름·id는
+    절대 안 바뀐다, 라이브 판정이 이 값을 대조한다)."""
+    return {"id": "sandbox-youtube-channel-1", "title": "Sandbox YouTube Channel"}

--- a/backend/scripts/lint_channel_insight_metrics_drift.py
+++ b/backend/scripts/lint_channel_insight_metrics_drift.py
@@ -27,7 +27,7 @@ loud로 여겼으나 실은 **fails-silent 구멍**이었다: `find_drift`가 `b
 채널의 선언 형태를 못 읽는 형태로 바뀜) 그 채널이 backend dict에 아예 없어 **비교 자체를
 건너뛰고 조용히 green**이 났다 — 그 채널이 실제로 드리프트해도 파서가 못 보는 한 영원히
 못 잡는다. `_assert_extraction_complete`가 이 구멍을 막는다: 파서가 뽑은 채널 집합이
-`EXPECTED_BACKEND_CHANNELS`(9개, 아래) 전부를 커버하는지 매 호출마다 확認하고, 하나라도
+`EXPECTED_BACKEND_CHANNELS`(17개, 아래) 전부를 커버하는지 매 호출마다 확認하고, 하나라도
 빠지면 "채널 N개 중 M개만 봄=파싱 실패"로 즉시 예외(fail-loud) — fails-silent를
 fails-closed로 바꾼다.
 """
@@ -51,8 +51,9 @@ _CHANNEL_BLOCK_START_RE = re.compile(
 )
 
 
-# channel_adapters.py에 실제로 등록된 채널 9개(2026-09-08 실측 — grep으로 재확認 가능:
-# `grep -c 'ChannelAdapterConfig(' backend/app/services/channel_adapters.py`). 이 집합
+# channel_adapters.py에 실제로 등록된 채널 17개(2026-09-12 실측, story #3815 PR1
+# 갱신 — grep으로 재확認 가능: `grep -c 'ChannelAdapterConfig(' backend/app/services/
+# channel_adapters.py`). 이 집합
 # 자체가 바뀌면(새 채널 추가·기존 채널 삭제) 여기도 같이 고쳐야 한다 — 그 자체가
 # "채널 목록이 바뀌었다"는 사실을 코드로 드러내는 지점이다(조용히 안 넘어간다).
 EXPECTED_BACKEND_CHANNELS = frozenset({
@@ -72,6 +73,11 @@ EXPECTED_BACKEND_CHANNELS = frozenset({
     # (opens/delivered/clicks) 캡처 배선은 후속 PR3 몫. x/x_sandbox와 동형으로 drift
     # 0(신규 FE 등재 불요, PR3에서 stibee_sandbox만 채움).
     "stibee", "stibee_sandbox",
+    # story #3815(Phase3·3-5 PR1, 페드루 PO 確定 2026-09-12) — youtube/youtube_
+    # sandbox도 같은 이유로 이 PR 시점엔 insight_metrics 미선언(빈 튜플 기본값)
+    # — 통계 수집(views/likeCount+commentCount→engagements) 배선은 후속 PR
+    # 몫. x/stibee와 동형으로 drift 0(신규 FE 등재 불요).
+    "youtube", "youtube_sandbox",
 })
 
 
@@ -138,9 +144,9 @@ def find_drift(
     순회한다(BE가 정본이라 BE에 새 채널이 생기면 FE가 그걸 안 따라온 것도 이 순회가
     자동으로 잡는다). 비교 前 _assert_extraction_complete가 파서 자체의 완전성부터
     확認한다(fails-silent 백스톱, 카디르 QA) — expected_channels는 실물 호출(main())
-    에선 EXPECTED_BACKEND_CHANNELS(9개) 기본값을 쓰고, 합성 fixture 테스트는 그 fixture가
-    실제로 선언한 채널 집합을 넘겨 좁힌다(9개 전부를 요구하면 모든 합성 테스트가 매번
-    9채널을 다 적어야 해 테스트 자체가 무거워진다)."""
+    에선 EXPECTED_BACKEND_CHANNELS(17개) 기본값을 쓰고, 합성 fixture 테스트는 그 fixture가
+    실제로 선언한 채널 집합을 넘겨 좁힌다(17개 전부를 요구하면 모든 합성 테스트가 매번
+    17채널을 다 적어야 해 테스트 자체가 무거워진다)."""
     backend = extract_backend_declared_metrics(backend_text)
     _assert_extraction_complete(backend, expected_channels)
     frontend = extract_frontend_declared_metrics(frontend_text)

--- a/backend/tests/test_3815_youtube_oauth.py
+++ b/backend/tests/test_3815_youtube_oauth.py
@@ -1,0 +1,472 @@
+"""story #3815(Phase3·3-5 PR1, 페드루 PO 確定 2026-09-12) — YouTube(Google) 서버
+OAuth 2.0(PKCE 지원·표준 비회전 refresh_token). x_oauth.py/test_3808_x_oauth.py와
+동형 구조 4단:
+① youtube_oauth.py 단위(PKCE·단일 hop 교환·⭐비회전 refresh — 3튜플이지만 세 번째
+  값은 항상 입력값 그대로)
+② youtube_sandbox_oauth.py 단위(결정적 응답, 회전 세대 마커 없음 — X와 다른 자리)
+③ channel_adapters.py 등재(refresh_mode="refresh_token" 재사용 — 새 enum 값 발명 0)
+④ 실DB 통합 — cron 배선이 비회전 refresh 함수도 기존 `_ROTATING_REFRESH_FN_BY_
+  CHANNEL` 디스패치 그대로 태우는지(⭐뮤테이션 대상: youtube_sandbox_oauth.py가
+  실수로 새 refresh_token을 만들어 내면 이 테스트가 RED — "회전 안 함"이 실제
+  계약이지 우연이 아님을 pin)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+import pytest
+
+from tests.test_3373_channel_connections_auth import (
+    _seed_org as _seed_org_scoped, _seed_human as _seed_human_scoped, _session_factory as _scoped_session_factory,
+    _client_for, _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+    monkeypatch.setattr(config_module.settings, "channel_oauth_state_secret", "test-channel-oauth-state-secret")
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+# ─── ① youtube_oauth.py — PKCE·단일 hop 교환·비회전 refresh ───────────────────
+
+def test_build_authorize_url_includes_pkce_and_offline_consent_params():
+    """Google 표준 딱지 — access_type=offline·prompt=consent가 둘 다 없으면 재인증
+    시 refresh_token 자체가 응답에서 빠진다(youtube_oauth.py 상단 딱지)."""
+    from app.services.youtube_oauth import build_authorize_url
+
+    url = build_authorize_url(
+        redirect_uri="https://yt/callback", state="s", code_challenge="chal123", app_id="app-id",
+    )
+    assert "code_challenge=chal123" in url
+    assert "code_challenge_method=S256" in url
+    assert "client_id=app-id" in url
+    assert "access_type=offline" in url
+    assert "prompt=consent" in url
+    assert "youtube.upload" in url
+
+
+@pytest.mark.anyio
+async def test_exchange_code_for_token_sends_client_secret_in_body_not_basic_auth():
+    """X(HTTP Basic)와 다른 자리 — Google 토큰 엔드포인트는 client_id/client_secret을
+    POST body 평문으로 받는다(공개 문서 안정 사실)."""
+    from app.services.youtube_oauth import exchange_code_for_token
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "at-1", "refresh_token": "rt-1", "expires_in": 3600}
+
+    class _FakeClient:
+        async def post(self, url, *, data):
+            captured["url"], captured["data"] = url, data
+            return _FakeResponse()
+
+    access_token, refresh_token, expires_in = await exchange_code_for_token(
+        _FakeClient(), code="c", redirect_uri="https://yt/callback", code_verifier="verifier-1",
+        app_id="app-id", app_secret="app-secret",
+    )
+    assert (access_token, refresh_token, expires_in) == ("at-1", "rt-1", 3600)
+    assert captured["data"]["client_secret"] == "app-secret"
+    assert captured["data"]["code_verifier"] == "verifier-1"
+    assert captured["data"]["grant_type"] == "authorization_code"
+
+
+@pytest.mark.anyio
+async def test_exchange_code_for_token_missing_refresh_token_raises():
+    from app.services.youtube_oauth import YouTubeOAuthError, exchange_code_for_token
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "at-1", "expires_in": 3600}  # refresh_token 없음
+
+    class _FakeClient:
+        async def post(self, url, *, data):
+            return _FakeResponse()
+
+    with pytest.raises(YouTubeOAuthError) as exc_info:
+        await exchange_code_for_token(
+            _FakeClient(), code="c", redirect_uri="https://yt/callback", code_verifier="v",
+            app_id="app-id", app_secret="app-secret",
+        )
+    assert exc_info.value.code == "YOUTUBE_TOKEN_EXCHANGE_MISSING_FIELDS"
+
+
+@pytest.mark.anyio
+async def test_refresh_access_token_echoes_input_refresh_token_unchanged():
+    """⭐핵심 계약 — Google은 회전하지 않는다: 세 번째 반환값(new_refresh_token)은
+    provider 응답에 refresh_token 필드가 아예 없어도 **입력으로 받은 값 그대로**여야
+    한다(X의 3튜플과 형태만 같고 의미는 반대)."""
+    from app.services.youtube_oauth import refresh_access_token
+
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "at-2", "expires_in": 3600}  # refresh_token 필드 자체가 없음(정상)
+
+    class _FakeClient:
+        async def post(self, url, *, data):
+            captured["data"] = data
+            return _FakeResponse()
+
+    new_access, new_refresh, expires_in = await refresh_access_token(
+        _FakeClient(), refresh_token="rt-1", app_id="app-id", app_secret="app-secret",
+    )
+    assert (new_access, new_refresh, expires_in) == ("at-2", "rt-1", 3600)
+    assert captured["data"]["grant_type"] == "refresh_token"
+    assert captured["data"]["refresh_token"] == "rt-1"
+
+
+@pytest.mark.anyio
+async def test_refresh_access_token_provider_rejection_raises_youtube_oauth_error():
+    from app.services.youtube_oauth import YouTubeOAuthError, refresh_access_token
+
+    class _FakeResponse:
+        status_code = 400
+        text = "invalid_grant: Token has been expired or revoked"
+
+    class _FakeClient:
+        async def post(self, url, *, data):
+            return _FakeResponse()
+
+    with pytest.raises(YouTubeOAuthError) as exc_info:
+        await refresh_access_token(_FakeClient(), refresh_token="rt-stale", app_id="app-id", app_secret="app-secret")
+    assert exc_info.value.code == "YOUTUBE_REFRESH_FAILED"
+
+
+@pytest.mark.anyio
+async def test_test_connection_raises_when_account_has_no_channel():
+    """⭐fail-closed — 채널이 하나도 없는 Google 계정으로 연결이 조용히 "성공"하면
+    안 된다(연결은 됐는데 채널이 안 보이는 조용한 실패 방지)."""
+    from app.services.youtube_oauth import YouTubeOAuthError, test_connection
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"items": []}
+
+    class _FakeClient:
+        async def get(self, url, *, params, headers):
+            return _FakeResponse()
+
+    with pytest.raises(YouTubeOAuthError) as exc_info:
+        await test_connection(_FakeClient(), access_token="at-1")
+    assert exc_info.value.code == "YOUTUBE_NO_CHANNEL_FOUND"
+
+
+# ─── ② youtube_sandbox_oauth.py — 결정적 응답, 회전 세대 마커 없음 ─────────────
+
+@pytest.mark.anyio
+async def test_sandbox_exchange_returns_fixed_tokens():
+    from app.services.youtube_sandbox_oauth import exchange_code_for_token
+
+    access_token, refresh_token, expires_in = await exchange_code_for_token(
+        httpx.AsyncClient(), code="c", redirect_uri="https://yt/callback", code_verifier="v",
+        app_id="app-1", app_secret="secret",
+    )
+    assert refresh_token == "sandbox-youtube-refresh:app-1"
+    assert access_token == "sandbox-youtube-access:app-1"
+    assert expires_in == 3600
+
+
+@pytest.mark.anyio
+async def test_sandbox_refresh_returns_new_access_token_but_same_refresh_token():
+    """⭐youtube_oauth.py와 같은 계약 — sandbox도 회전하지 않는다(x_sandbox_oauth.py의
+    세대 상승과 다른 자리)."""
+    from app.services.youtube_sandbox_oauth import refresh_access_token
+
+    new_access, new_refresh, expires_in = await refresh_access_token(
+        httpx.AsyncClient(), refresh_token="sandbox-youtube-refresh:app-1", app_id="app-1", app_secret="secret",
+    )
+    assert new_refresh == "sandbox-youtube-refresh:app-1", "회전하면 안 된다 — 입력값 그대로"
+    assert new_access.startswith("sandbox-youtube-access:app-1:")
+    assert new_access != "sandbox-youtube-access:app-1"
+    assert expires_in == 3600
+
+
+@pytest.mark.anyio
+async def test_mutation_sandbox_refresh_rotating_would_break_non_rotation_contract():
+    """⭐뮤테이션 셀프체크 — sandbox refresh가 실수로 refresh_token을 회전시키면
+    (X와 뒤섞인 구현 사고), 위 "같은 값" 테스트가 그 즉시 RED로 잡는다는 증명."""
+    import app.services.youtube_sandbox_oauth as yt_sandbox_module
+
+    original = yt_sandbox_module.refresh_access_token
+
+    async def _mutated_rotating_refresh(client, *, refresh_token, app_id, app_secret):
+        new_access, _same_refresh, expires_in = await original(
+            client, refresh_token=refresh_token, app_id=app_id, app_secret=app_secret,
+        )
+        return new_access, f"{refresh_token}:rotated-by-mistake", expires_in
+
+    yt_sandbox_module.refresh_access_token = _mutated_rotating_refresh
+    try:
+        _, new_refresh, _ = await yt_sandbox_module.refresh_access_token(
+            httpx.AsyncClient(), refresh_token="sandbox-youtube-refresh:app-1", app_id="app-1", app_secret="secret",
+        )
+        assert new_refresh != "sandbox-youtube-refresh:app-1", "가드 무력화 시 회전이 그대로 통과(RED 재현)"
+    finally:
+        yt_sandbox_module.refresh_access_token = original
+
+
+# ─── ③ channel_adapters.py 등재 — refresh_mode="refresh_token" 재사용 확認 ──────
+
+def test_youtube_and_youtube_sandbox_adapters_registered_with_reused_refresh_mode():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS, can_auto_refresh
+
+    for channel in ("youtube", "youtube_sandbox"):
+        cfg = CHANNEL_ADAPTERS[channel]
+        assert cfg.refresh_mode == "refresh_token"
+        assert cfg.credential_kind == "oauth"
+        assert cfg.kind == "social"
+        assert "youtube.upload" in cfg.scope
+        assert "youtube.readonly" in cfg.scope
+        # PR1은 OAuth만 — 발행/인사이트 능력은 아직 선언하지 않는다(§3696 가드가
+        # 요구하는 "선언=dispatch 존재" 계약을 어길 자리 자체를 안 만든다).
+        assert cfg.insight_metrics == ()
+    assert can_auto_refresh("refresh_token") is True
+
+
+# ─── 라우터 왕복 — story #3613과 동형 종단 재현(브라우저가 authorize URL을 실제로
+# 따라가면 곧장 이 채널 자신의 콜백 라우트에 닿는지) ────────────────────────────
+
+async def _register_youtube_sandbox_app_credentials(session, *, org_id, updated_by, app_id="sandbox-app-id"):
+    from app.services.channel_app_credentials import upsert_channel_app_credentials
+
+    return await upsert_channel_app_credentials(
+        session, org_id=org_id, channel="youtube_sandbox", app_id=app_id, app_secret="sandbox-secret",
+        updated_by=updated_by,
+    )
+
+
+def test_youtube_sandbox_build_authorize_url_redirects_straight_back_to_its_own_callback():
+    """story #3613과 동형 사고 방지 — redirect_uri(=이 채널 콜백 URL 그 자체)로
+    가짜 code+real state를 실어 곧장 돌아간다."""
+    from app.services.youtube_sandbox_oauth import build_authorize_url
+    from urllib.parse import urlparse, parse_qs
+
+    redirect_uri = "https://dev-app.sprintable.ai/api/oauth-channel/callback/youtube_sandbox"
+    url = build_authorize_url(redirect_uri=redirect_uri, state="signed-state-abc", code_challenge="c", app_id="app-id")
+
+    parsed = urlparse(url)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == redirect_uri
+    qs = parse_qs(parsed.query)
+    assert qs["state"] == ["signed-state-abc"]
+    assert qs["code"][0]
+
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_authorize_url_is_navigable_back_into_the_real_callback_endpoint():
+    """실 authorize→callback 라우터 코드를 그대로 태운다(목 없이) — 이번 PR이
+    channel_connections.py에 새로 얹은 elif 분기·`_youtube_channel_connection_
+    callback` 자체가 대상(서비스 단위 테스트로는 못 잡는 배선 실수 축)."""
+    from app.main import app
+    from urllib.parse import urlparse, parse_qs
+
+    engine, Session = await _scoped_session_factory()
+    try:
+        async with Session() as s:
+            org_id, _ = await _seed_org_scoped(s)
+            owner_id = await _seed_human_scoped(s, org_id, role="owner")
+            await _register_youtube_sandbox_app_credentials(s, org_id=org_id, updated_by=owner_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r_auth = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/youtube_sandbox/authorize")
+            assert r_auth.status_code == 200, r_auth.text
+            authorize_url = r_auth.json()["url"]
+
+            parsed = urlparse(authorize_url)
+            qs = parse_qs(parsed.query)
+            code, state = qs["code"][0], qs["state"][0]
+
+            r_cb = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-connections/youtube_sandbox/callback",
+                json={"code": code, "state": state},
+            )
+            assert r_cb.status_code == 200, r_cb.text
+            body = r_cb.json()
+            assert body["channel"] == "youtube_sandbox"
+            assert body["account_label"] == "Sandbox YouTube Channel"
+    finally:
+        await engine.dispose()
+
+
+def test_youtube_publish_dispatch_not_registered_yet_fails_closed():
+    """⭐PR 경계 pin — stibee_sandbox_publish 선례(channel_adapters.py, 3813 PR2)와
+    동형: 실 발행 클라이언트가 아직 없는 채널은 `_PUBLISH_CLIENT_MODULE_PATHS`에
+    아예 등재하지 않는다(더미 모듈·dangling import path 0) — 기존
+    ChannelPublishDispatchNotImplementedError가 그대로 fail-closed한다."""
+    from app.services.channel_adapters import ChannelPublishDispatchNotImplementedError, get_publish_client_module
+
+    for channel in ("youtube", "youtube_sandbox"):
+        with pytest.raises(ChannelPublishDispatchNotImplementedError):
+            get_publish_client_module(channel)
+
+
+# ─── ④ 실DB 통합 — cron 배선이 비회전 refresh도 그대로 태우는지 ────────────────
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name="YouTube OAuth Test Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_human(session, org_id):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="owner")
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_youtube_sandbox_connection(session, org_id, *, refresh_token: str, connected_by: uuid.UUID, due=True):
+    from datetime import datetime, timedelta, timezone
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    expires_at = (
+        datetime.now(timezone.utc) - timedelta(minutes=1) if due
+        else datetime.now(timezone.utc) + timedelta(days=1)
+    )
+    row = ChannelConnection(
+        id=uuid.uuid4(), org_id=org_id, channel="youtube_sandbox", account_id=f"acct-{uuid.uuid4().hex[:8]}",
+        credential_kind="oauth", encrypted_access_token=encrypt_channel_credential("sandbox-youtube-access:app-1"),
+        encrypted_refresh_token=encrypt_channel_credential(refresh_token),
+        token_expires_at=expires_at, refresh_mode="refresh_token",
+        scopes=["https://www.googleapis.com/auth/youtube.readonly"],
+        status="active", connected_by=connected_by,
+    )
+    session.add(row)
+    await session.commit()
+    return row.id
+
+
+async def _seed_youtube_sandbox_app_credentials(session, org_id, *, app_id: str, updated_by: uuid.UUID):
+    from app.models.channel_app_credential import ChannelAppCredentials
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    row = ChannelAppCredentials(
+        id=uuid.uuid4(), org_id=org_id, channel="youtube_sandbox", app_id=app_id,
+        encrypted_app_secret=encrypt_channel_credential("secret"), updated_by=updated_by,
+    )
+    session.add(row)
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_cron_refresh_channel_tokens_refreshes_youtube_sandbox_without_rotating_refresh_token(monkeypatch):
+    """⭐뮤테이션 대상(cron 배선 계층) — `_ROTATING_REFRESH_FN_BY_CHANNEL`에서
+    youtube_sandbox 항목을 빼면 이 연결이 갱신 루프에 아예 안 올라와 access_token이
+    그대로 남는다(RED). refresh_token은 access_token과 달리 회전하지 않아야
+    한다는 게 X 테스트와 대비되는 이 테스트의 값."""
+    import app.routers.cron as cron_module
+    from app.dependencies.database import get_worker_db
+    from app.main import app
+    from httpx import AsyncClient, ASGITransport
+    from app.services.channel_connection import decrypt_refresh_token_for_use, decrypt_for_use
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "test-cron-secret")
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            await _seed_youtube_sandbox_app_credentials(s, org_id, app_id="app-1", updated_by=owner_id)
+            conn_id = await _seed_youtube_sandbox_connection(
+                s, org_id, refresh_token="sandbox-youtube-refresh:app-1", connected_by=owner_id,
+            )
+
+        async def _worker_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_worker_db] = _worker_db
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get(
+                    "/api/v2/internal/cron/refresh-channel-tokens",
+                    headers={"Authorization": "Bearer test-cron-secret"},
+                )
+            assert r.status_code == 200, r.text
+            body = r.json()["data"]
+            assert body["refreshed"] == 1
+            assert body["failed"] == 0
+        finally:
+            app.dependency_overrides.pop(get_worker_db, None)
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.channel_connection import ChannelConnection
+
+            row = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == conn_id))).scalar_one()
+            assert decrypt_refresh_token_for_use(row) == "sandbox-youtube-refresh:app-1", "회전하면 안 된다"
+            assert decrypt_for_use(row) != "sandbox-youtube-access:app-1", "access_token은 갱신돼야 한다"
+            assert row.status == "active"
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights/test_3815_youtube_oauth.py.json
+++ b/infra/destructive-schema-shard-weights/test_3815_youtube_oauth.py.json
@@ -1,0 +1,1 @@
+{"file": "tests/test_3815_youtube_oauth.py", "sec": 3.0, "source": "실측(로컬 pytest 단독 실행, 2026-09-12, 디디)"}


### PR DESCRIPTION
## 요약

카드 §3-5(YouTube 첫 출시) PR1 — 발행/resumable 업로드·인사이트는 이 PR 범위 밖(후속 PR). 연결(OAuth) 왕복만 연다.

## 변경

- **`youtube_oauth.py`**(신규) — PKCE 지원(X처럼 필수도 Threads처럼 거부도 아님)·단일 hop 토큰 교환·**비회전 refresh_token**(Google 표준 OAuth2 — X와 정반대 축: 갱신 응답엔 access_token만 오고 refresh_token은 재사용). 3튜플 반환은 `cron.py::_ROTATING_REFRESH_FN_BY_CHANNEL` 기존 dispatch 계약에 구조적으로 맞추기 위함(새 refresh_mode 값 발명 0) — 세 번째 값은 항상 입력을 그대로 되돌린다. authorize URL엔 `access_type=offline`+`prompt=consent`를 항상 싣는다(Google 표준 — 없으면 재인증 시 refresh_token 자체가 안 옴).
- **`youtube_sandbox_oauth.py`**(신규) — 결정적 시뮬레이션(x_sandbox_oauth.py와 달리 회전 세대 마커 없음 — 실 provider가 회전 안 하니 sandbox도 안 함).
- **`channel_adapters.py`** — youtube/youtube_sandbox 등재(refresh_mode="refresh_token" 재사용, insight_metrics 미선언 — story #3696 가드가 요구하는 "선언=dispatch 존재" 계약을 어길 자리를 안 만든다).
- **`channel_connections.py`** — `_YOUTUBE_OAUTH_MODULE_PATHS`+`_youtube_oauth_module`(x 계열과 동형 병렬 dict, 기존 채널군 무변경)·authorize/callback elif 분기·`_youtube_channel_connection_callback`(단일 hop, 선택 갈래 없음 — X와 동형 "가장 단순한 갈래").
- **`cron.py`** — `_ROTATING_REFRESH_FN_BY_CHANNEL`에 youtube/youtube_sandbox 등재(비회전 refresh 함수도 기존 dispatch 그대로 재사용 — 새 갈래 0).

## PR 경계 정정(재그라운딩, 코드 0)

카드 문구의 "`_PUBLISH_CLIENT_MODULE_PATHS` 등록"은 이번 PR에 넣지 않았다 — git log 재확認 결과 X 자신도 `"x": "app.services.x_publish"` 등재는 PR2(#4201)에서였고 PR1엔 없었다. stibee_sandbox_publish 등재도 stibee PR2(3813)에서였고, stibee 실채널("stibee")은 지금도 미등재 — "실 클라이언트 없는 채널은 dict에 아예 안 넣는다"가 이 코드베이스의 기존 fail-closed 관례(`ChannelPublishDispatchNotImplementedError`가 이미 그 자리를 담당). 더미 모듈·dangling import path를 새로 만드는 대신 기존 관례를 그대로 따랐다 — `get_publish_client_module("youtube"/"youtube_sandbox")`는 지금 그 기존 예외로 깨끗하게 fail-closed(신규 테스트로 pin).

## 검증

- 신규 14 tests(youtube_oauth 6·youtube_sandbox 3·adapter 등재 1·publish dispatch 경계 1·router 왕복 2·cron 배선 1):
  ```
  $ uv run pytest -m destructive_schema tests/test_3815_youtube_oauth.py -q
  14 passed
  ```
- 3696 가드(insight_metrics 선언↔dispatch 짝 강제) 통과:
  ```
  $ uv run pytest -m destructive_schema tests/test_3696_insight_channel_dispatch_registered_guard.py -q
  2 passed
  ```
- 관련 회귀(channel_connection/oauth/cron_refresh/3373/3547/3320/x_oauth) 통과:
  ```
  $ uv run pytest -m destructive_schema tests/ -k "channel_connection or oauth or cron_refresh or 3373 or 3547 or 3320 or 3808_x_oauth" -q
  148 passed
  ```
- 뮤테이션 셀프체크 — 사전 회전(3튜플로 되돌리는) permanent 테스트 1건(`test_mutation_sandbox_refresh_rotating_would_break_non_rotation_contract`) + cron dispatch dict에서 youtube_sandbox 제거하는 인라인 셀프체크. 각각 정확히 1건 RED → revert GREEN.
- 한글가드 baseline 그대로(신규 0)·shard-weights 등록(측정 3.0s, 로컬 실측).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8