### PR TITLE
[SID:3815] PR2 — YouTube resumable 업로드 발행+플랫폼 quota+메타 검증+비공개 잠금

### DIFF
--- a/backend/alembic/versions/0372_channel_publications_privacy_locked.py
+++ b/backend/alembic/versions/0372_channel_publications_privacy_locked.py
@@ -1,0 +1,40 @@
+"""story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — `channel_publications.
+privacy_locked`. YouTube API 감사 미완 프로젝트(settings.youtube_api_audit_
+incomplete)면 발행 시 privacyStatus를 요청값 무관 private로 강제한다(PO 決定②)
+— 이 사실은 발행 "그 순간"의 판정이라 나중에 감사가 끝나 플래그가 꺼져도
+과거 발행물이 그때 잠겼었다는 사실 자체는 안 바뀌어야 한다(연결 전역 플래그가
+아니라 발행물 행에 못박는 이유). `status`는 그대로 "published" 유지(페드루 明示
+④ — 이 열은 status 밖의 별개 사실, FE가 "게시됨(비공개)" 라벨을 조합할 때 참고).
+
+다른 채널(threads/instagram/facebook 등)은 이 열을 절대 안 건드려 server_default
+false 그대로(0369 sequence 열과 동형 안전성 논증 — additive, 회귀 0).
+
+Revision ID: 0372
+Revises: 0371
+Create Date: 2026-09-12
+
+페드루 PO 지적(2026-09-12 11:12Z) — 이 파일을 처음 0371로 썼을 때 develop엔
+이미 실 0371(`0371_channel_connections_provider_config.py`, story #3813 PR5-b
+#4222 착지분)이 있었다(내 브랜치가 그 착지 前에 갈라져 로컬엔 안 보였다) —
+alembic heads 2=CI 체인 RED가 됐을 자리. 0372·down_revision=0371로 재번호
+(4223 착지 뒤 develop HEAD로 rebase할 때 그대로 유지)."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0372"
+down_revision = "0371"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_publications",
+        sa.Column("privacy_locked", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("channel_publications", "privacy_locked")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -404,6 +404,23 @@ class Settings(BaseSettings):
     # S-COMM-07: 에이전트 inbox webhook HMAC 검증 시크릿
     agent_inbox_webhook_secret: str = ""
 
+    # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — YouTube 종량 quota는
+    # 조직별이 아니라 **플랫폼 전체**(우리 GCP 프로젝트가 Google에 공유하는 단일
+    # 일일 예산) 축이라 org_content_rules(조직별 규칙) 재사용 대상이 아니다. 정식
+    # 정착지는 platform_settings(어드민 관리, 하드코딩·env 금지 원칙)이지만 그
+    # 테이블은 sprintable-admin(별도 레포)의 write UI가 있어야 실제로 조정 가능—
+    # 이 PR은 백엔드 단독이라 페드루 PO 明示("env/규칙 조정 가능")대로 env로 연다.
+    # ⚠️미확認 — 실제 YouTube Data API v3 quota 비용표(지식 컷오프 2026-01 기준
+    # 최선 추정: 일일 10,000 unit·videos.insert=1,600·videos.list=1)는 재확認 대상.
+    youtube_quota_daily_limit_units: int = 10_000
+    youtube_quota_cost_insert_units: int = 1_600
+    youtube_quota_cost_list_units: int = 1
+    # API 규정 감사 미완=업로드 강제 비공개(페드루 PO 決定②) — 우리 앱의 등급
+    # 자체(고객 자격 아님)라 이 값도 플랫폼 축. True(기본, fail-closed)=감사 미완
+    # 가정 — 실 감사 통과 뒤 이 env를 False로 바꾼다(재배포 필요, platform_settings
+    # 이관 전까지의 임시 조치임을 명시).
+    youtube_api_audit_incomplete: bool = True
+
     # Rate limiting (E-OA1:S5)
     rate_limit_backend: str = "memory"  # "memory" | "redis"
     # ⚠️ story #2078 핫픽스(2026-07-21, Memorystore 배선 직전 PO가 발견): 이 필드가 원래 여기

--- a/backend/app/models/channel_publication.py
+++ b/backend/app/models/channel_publication.py
@@ -68,6 +68,11 @@ class ChannelPublication(Base):
     # 벗긴 media_id로 재조회해 200을 받는다(sandbox 어댑터 자체는 결정적·상태 없음 그대로,
     # 상태는 이 발행물 행에만 산다).
     sandbox_expired_once: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
+    # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — youtube/youtube_
+    # sandbox 감사 미완 강제 비공개(PO 決定②). status는 "published" 그대로,
+    # 이 열이 그 밖의 별개 사실(FE "게시됨(비공개)" 라벨 조합용). 다른 채널은
+    # 절대 안 건드려 server_default false 그대로.
+    privacy_locked: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -50,6 +50,7 @@ from app.services.channel_posts import (
     ChannelTextTooLongError,
     ChannelTokenExpiredError,
     ChannelUnpublishUnsupportedError,
+    ChannelVideoRequiredError,
     ContentRuleViolationError,
     ExternalPublishGateNotApprovedError,
     PublicationCommandNotCancellableError,
@@ -1690,6 +1691,13 @@ async def _submit_channel_post_draft_endpoint(
                 "code": "CONTENT_RULE_VIOLATION", "rules_version": exc.rules_version,
                 "violations": exc.violations,
             },
+        ) from exc
+    except ChannelVideoRequiredError as exc:
+        # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — ChannelImage
+        # RequiredError와 동형 위치·모양(영상판).
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "CHANNEL_VIDEO_REQUIRED", "message": str(exc)},
         ) from exc
     except ChannelImageRequiredError as exc:
         # story #3536(PO 確定 2026-09-06) — 필드 완결성 422(CHANNEL_TEXT_TOO_LONG류와

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -118,6 +118,7 @@ from app.services.channel_post_videos import (
 from app.services.agent_onboarding_config import resolve_locale_from_request
 from app.services.generation_budget import GenerationBudgetExceededError
 from app.services.x_publish_budget import API_USAGE_BUDGET_RULE_KEY
+from app.services.youtube_quota import YouTubeQuotaExceededError
 from app.services.i18n_catalog import t
 from app.services.member_resolver import resolve_member, resolve_member_db_verified
 
@@ -1859,6 +1860,11 @@ async def publish_channel_post_draft_endpoint(
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
+    # story #3815(Phase3·3-5 PR2) — YOUTUBE_QUOTA_EXCEEDED 사용자 문장을
+    # i18n_catalog로 조립하기 위한 최소 추가(다른 채널 분기는 안 씀 — meta_ads
+    # select 엔드포인트의 Header DI 관례 그대로, 라우트 경계에서만 해석).
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
 ) -> PublishChannelPostResponse:
     """story #f8f7cb0f·#3414 — 휴먼 전용(AC1). 발행/예약 요청 둘 다 이 엔드포인트 하나
     (블루프린트 §3 "즉시 발행=scheduled_at 없음인 같은 명령", PO 確定). 게이트가 승인한
@@ -1880,6 +1886,7 @@ async def publish_channel_post_draft_endpoint(
     없음), 일시적(transient/quota)이면 백오프 재시도, connection이면 blocked로
     넘어간다 — 사람이 모르게 방치되지 않도록 실패 응답 body에 `command_status`·
     `next_attempt_at`을 함께 낸다(화면 문구는 후속)."""
+    resolved_locale = resolve_locale_from_request(locale, accept_language)
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
@@ -1997,6 +2004,27 @@ async def publish_channel_post_draft_endpoint(
                 "code": budget_exceeded_code,
                 "limit_minor": exc.limit_minor, "spent_minor": exc.spent_minor,
                 "estimated_cost_minor": exc.estimated_cost_minor, "remaining_minor": exc.remaining_minor,
+            }),
+        ) from exc
+    except YouTubeQuotaExceededError as exc:
+        # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — 위 GenerationBudget
+        # ExceededError와 동형 처리(사전 재검사가 provider 호출 直前에 막는다 —
+        # adapter_called=False, row는 이미 failed로 남겨진 상태 — 오케스트레이션
+        # 안에서 처리, 여기선 command 원장만 마저 채운다). 사용자 문장은
+        # i18n_catalog 경유(페드루 낱말 확定 — "quota" 낱말 배제).
+        await _record_this_attempt(approval_check="ok", adapter_called=False, result_code="YOUTUBE_QUOTA_EXCEEDED")
+        await apply_command_failure(
+            db, command, error_code="YOUTUBE_QUOTA_EXCEEDED", last_error=str(exc), now=now,
+        )
+        await db.commit()
+        raise HTTPException(
+            status_code=422,
+            detail=_with_command_state({
+                "code": "YOUTUBE_QUOTA_EXCEEDED",
+                "message": t("channel_posts.youtube_usage_exceeded", resolved_locale),
+                "limit_units": exc.limit_units, "spent_units": exc.spent_units,
+                "estimated_units": exc.estimated_units, "remaining_units": exc.remaining_units,
+                "reset_at": exc.reset_at.isoformat(),
             }),
         ) from exc
     except ChannelTextTooLongError as exc:

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -145,6 +145,14 @@ class ChannelAdapterConfig:
     # 같은 영상을 새로 업로드하는 사고(quota 이중 차감 포함)로 이어진다 — 채널별
     # 값으로 뺀다(youtube/youtube_sandbox는 86400=24h로 재정의).
     container_poll_timeout_seconds: int = 300
+    # story #3815(Phase3·3-5 PR2 CHANGES③, 페드루 PO 지적 2026-09-12 11:55Z) —
+    # 상한 초과 분기가 채널 무관하게 `external_container_id=None`으로 지워왔다
+    # (Meta는 옳다 — 죽은 컨테이너는 재활성화 안 되니 다음 시도가 완전히 새
+    # 컨테이너를 만들어야 한다). YouTube는 24h를 넘겨도(극히 드문 경우) 자산
+    # 자체는 이미 존재 — id를 지우면 사람이 AC5 재시도 버튼을 눌러도 새로
+    # 업로드(quota 1,600 재소모)하는 같은 사고가 24h 축에서 한 번 더 난다.
+    # False(기본)=기존 Meta류 그대로(회귀 0), youtube/youtube_sandbox만 True.
+    keep_container_on_poll_timeout: bool = False
 
 
 CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
@@ -621,6 +629,7 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         video_min_seconds=1.0,
         video_codecs=("avc1", "hvc1", "hev1"),
         container_poll_timeout_seconds=86_400,  # 24h — 페드루 PO 지적 2026-09-12 11:34Z.
+        keep_container_on_poll_timeout=True,  # CHANGES③ — 페드루 PO 지적 2026-09-12 11:55Z.
     ),
     "youtube_sandbox": ChannelAdapterConfig(
         authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
@@ -643,6 +652,7 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         video_min_seconds=1.0,
         video_codecs=("avc1", "hvc1", "hev1"),
         container_poll_timeout_seconds=86_400,  # 24h — 페드루 PO 지적 2026-09-12 11:34Z.
+        keep_container_on_poll_timeout=True,  # CHANGES③ — 페드루 PO 지적 2026-09-12 11:55Z.
     ),
 }
 

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -125,6 +125,10 @@ class ChannelAdapterConfig:
     video_aspect_target: float = 0.0
     video_aspect_tolerance: float = 0.0
     video_codecs: tuple[str, ...] = ()
+    # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — image_required와
+    # 동형 축(영상판) — YouTube는 영상 0개면 업로드 자체가 무의미하다(Reels류
+    # "영상 지원"과 다른 축: "필수"). 기본 False=기존 채널 회귀 0.
+    video_required: bool = False
     # story #3808(Phase3·3-3 PR5b-1, 페드루 PO 確定 2026-09-12) — 스레드(연속 게시)
     # 이어쓰기 세그먼트 상한(헤드=`text` 제외, `channel_payload["thread"]` 배열
     # 길이 자체의 상한). image_max_count=0과 동형 관례 — 0(기본)=이 채널은 스레드
@@ -568,13 +572,21 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         thread_max_segments=10,
     ),
     # story #3815(Phase3·3-5 PR1, 페드루 PO 確定 2026-09-12) — YouTube 첫 출시.
-    # PR1은 OAuth 연결만 연다(발행·업로드는 PR2, 인사이트는 후속 — insight_metrics
-    # 미선언 기본값 그대로, story #3696 가드가 요구하는 "선언=dispatch 존재" 계약을
-    # 어길 자리 자체가 없다). refresh_mode="refresh_token" 재사용은 youtube_oauth.py
-    # 상단 딱지 참고(Google은 회전하지 않지만 기존 3튜플 dispatch 계약을 그대로
-    # 만족시킨다 — 새 refresh_mode 값 발명 0). image_*/video_*/max_text_length 등
-    # 콘텐츠 필드는 PR2가 resumable 업로드를 열 때 채운다(ads_sandbox PR1과 동형
-    # 판단 — 아직 없는 능력을 미리 선언하지 않는다).
+    # refresh_mode="refresh_token" 재사용은 youtube_oauth.py 상단 딱지 참고
+    # (Google은 회전하지 않지만 기존 3튜플 dispatch 계약을 그대로 만족시킨다 —
+    # 새 refresh_mode 값 발명 0).
+    #
+    # story #3815 PR2(페드루 PO 確定 2026-09-12) — 콘텐츠 필드. `text`(기존 범용
+    # 필드)=영상 설명(description)으로 매핑(X의 head-text 관례와 동형 — FE가
+    # 이미 가진 본문 입력칸을 그대로 재사용, 새 입력칸 발명 0). title/tags/
+    # categoryId/privacyStatus 4개는 `channel_payload`(X thread·stibee subject와
+    # 같은 슬롯)로 얹는다 — description까지 channel_payload에 넣으면 기존 text
+    # 입력 경로가 무용해져 정합이 두 곳으로 갈라진다(재그라운딩 정정 — 카드 원문은
+    # "channel_payload(title·description·...)"였으나 X 선례와 어긋나 description만
+    # text로 옮김, PR 본문에 근거 명시). video_required=True(image_required와 동형
+    # 축 — 영상 0개면 업로드 자체가 무의미). max_text_length·video_max_*는
+    # ⚠️미확認(YouTube 공개 문서 재확認 대상, 지금은 보수적 제품 판단값 — 브라우저
+    # 단일 PUT 업로드 UX 한계를 감안해 대용량 영화급은 배제).
     "youtube": ChannelAdapterConfig(
         authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
         token_url="https://oauth2.googleapis.com/token",
@@ -586,6 +598,10 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         display_name="YouTube",
         kind="social",
         requires_connection=True,
+        max_text_length=5000,
+        video_required=True,
+        video_max_bytes=2 * 1024 * 1024 * 1024,  # 2GiB — ⚠️미확認, 위 딱지 참고.
+        video_codecs=("avc1", "hvc1", "hev1"),
     ),
     "youtube_sandbox": ChannelAdapterConfig(
         authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
@@ -599,6 +615,10 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         display_name="YouTube Sandbox",
         kind="social",
         requires_connection=True,
+        max_text_length=5000,
+        video_required=True,
+        video_max_bytes=2 * 1024 * 1024 * 1024,
+        video_codecs=("avc1", "hvc1", "hev1"),
     ),
 }
 
@@ -778,6 +798,10 @@ _PUBLISH_CLIENT_MODULE_PATHS: dict[str, str] = {
     # 클라이언트 착지(PR2가 "이 PR 범위 밖"이라 미뤘던 자리 — wordpress/webhook의
     # 조각⑤(연결)→③b/④(발행 배선) 선례와 같은 순서, 연결·게이트가 먼저였다).
     "stibee": "app.services.stibee_publish",
+    # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — PR1이 미룬 등재
+    # (git log 재확認 — X도 x_publish 등재는 PR2였다, PR1 본문 참고).
+    "youtube": "app.services.youtube_publish",
+    "youtube_sandbox": "app.services.youtube_sandbox_publish",
 }
 
 

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -136,6 +136,15 @@ class ChannelAdapterConfig:
     # ChannelThreadUnsupportedError). X/X Sandbox만 10(⚠️미확認 — 실 X API 자체
     # 상한 문서 재확認 대상, 지금은 제품 판단값).
     thread_max_segments: int = 0
+    # story #3815(Phase3·3-5 PR2 CHANGES②, 페드루 PO 지적 2026-09-12 11:34Z) —
+    # 컨테이너 IN_PROGRESS 폴링 상한(`channel_posts.py` 재진입 폴링, story
+    # 620beefc B3 origin). 기본 300초(5분)=기존 Meta류 그대로(회귀 0) — Meta
+    # 문서 권장 "평균 30초 대기" 기준 5분이면 충분히 죽은 컨테이너 판정. YouTube는
+    # 트랜스코딩이 5분을 예사로 넘겨(자산은 이미 업로드 완료·처리 중일 뿐) 이
+    # 상한을 그대로 쓰면 "거짓 실패"로 `external_container_id`를 지워 재시도가
+    # 같은 영상을 새로 업로드하는 사고(quota 이중 차감 포함)로 이어진다 — 채널별
+    # 값으로 뺀다(youtube/youtube_sandbox는 86400=24h로 재정의).
+    container_poll_timeout_seconds: int = 300
 
 
 CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
@@ -601,7 +610,17 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         max_text_length=5000,
         video_required=True,
         video_max_bytes=2 * 1024 * 1024 * 1024,  # 2GiB — ⚠️미확認, 위 딱지 참고.
+        # 발견 즉시 수정(PR2 CHANGES 대응 중 자체 발견) — video_max_seconds
+        # 기본값(0.0)을 그대로 두면 channel_post_videos.py의 검증이 "재생시간
+        # > 0.0" 조건에 항상 걸려 **모든** youtube 영상 업로드가 무조건
+        # 거부됐을 것(회귀 테스트가 이 값을 실제로 요구하는 자리를 안 태워
+        # 지금까지 못 잡힘). YouTube는 12시간까지 허용(⚠️미확認 — 공개 문서
+        # 재확認 대상, 실무상 여유 있게 잡음)·아스펙트 비율은 target=0(검사
+        # 생략, YouTube는 가로/세로/정사각 전부 허용).
+        video_max_seconds=12 * 3600,
+        video_min_seconds=1.0,
         video_codecs=("avc1", "hvc1", "hev1"),
+        container_poll_timeout_seconds=86_400,  # 24h — 페드루 PO 지적 2026-09-12 11:34Z.
     ),
     "youtube_sandbox": ChannelAdapterConfig(
         authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
@@ -618,7 +637,12 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         max_text_length=5000,
         video_required=True,
         video_max_bytes=2 * 1024 * 1024 * 1024,
+        # 발견 즉시 수정 — 위 "youtube" 항목과 동형 이유(video_max_seconds
+        # 기본값 0.0 방치 시 모든 영상 업로드 거부).
+        video_max_seconds=12 * 3600,
+        video_min_seconds=1.0,
         video_codecs=("avc1", "hvc1", "hev1"),
+        container_poll_timeout_seconds=86_400,  # 24h — 페드루 PO 지적 2026-09-12 11:34Z.
     ),
 }
 

--- a/backend/app/services/channel_post_videos.py
+++ b/backend/app/services/channel_post_videos.py
@@ -420,6 +420,15 @@ async def confirm_channel_post_video_upload(
         db, org_id=org_id, work_item_id=draft.work_item_id, connection_id=draft.connection_id,
         text=latest.text, link_url=latest.link_url,
         author_member_id=member_id, author_kind=member_kind, image_sha256=composite_sha256,
+        # 발견 즉시 수정(story #3815 PR2, CHANGES② 대응 中 자체 발견) — 이 호출이
+        # text/link_url은 carry-forward하면서 channel_payload는 안 넘겨(기본 None)
+        # 새 버전마다 지워왔다. YouTube는 channel_payload(title 등)가 video_
+        # required=True와 맞물려 이 경로(영상 confirm=새 버전)를 반드시 거치므로
+        # 이 갭이 처음으로 기능을 깼다 — 다른 채널(X 스레드 channel_payload.thread·
+        # stibee subject)도 이론상 같은 결함(영상/이미지 첨부 뒤 조용히 소실)을
+        # 안고 있었을 자리(페드루 보고 — 이 PR 범위는 이 호출부 1곳만, 나머지는
+        # channel_post_images.py 3곳에 동형 패턴 존재·별도 판단 요청).
+        channel_payload=latest.channel_payload,
     )
 
     if existing_cover is not None:

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -2064,7 +2064,17 @@ async def publish_channel_post_draft(
                             f"IN_PROGRESS {elapsed.total_seconds():.0f}s > "
                             f"{_poll_timeout_seconds}s per-adapter poll timeout"
                         )
-                        row.external_container_id = None
+                        # story #3815(Phase3·3-5 PR2 CHANGES③, 페드루 PO 지적 2026-09-12
+                        # 11:55Z) — Meta는 여기서 id를 지우는 게 옳다(ERROR/EXPIRED
+                        # 컨테이너처럼 죽어 재활성화 안 됨 — 아래 위 분기 §③ 참고).
+                        # YouTube는 24h를 넘겨도(극히 드문 경우) 자산 자체는 이미
+                        # 존재 — id를 지우면 사람이 AC5 재시도를 눌러도 새로 업로드
+                        # (quota 1,600 재소모)하는 같은 사고가 24h 축에서 한 번 더
+                        # 난다. `keep_container_on_poll_timeout`이 True인 채널만
+                        # id 보존(재시도=`videos.list` 재조회, insert 0) — 그 외
+                        # 채널은 기존 그대로 None(회귀 0).
+                        if _poll_timeout_adapter is None or not _poll_timeout_adapter.keep_container_on_poll_timeout:
+                            row.external_container_id = None
                         await db.commit()
                         raise ChannelImageContainerFailedError(
                             gate_id=gate.id, container_status="TIMEOUT", error_message=row.last_error,

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -142,6 +142,72 @@ class ChannelThreadSegmentTooLongError(ValueError):
         )
 
 
+class ChannelVideoRequiredError(ValueError):
+    """story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — `ChannelImageRequiredError`
+    와 동형 축(영상판). 어댑터가 video_required=True(YouTube)인데 상신하려는
+    버전에 영상이 없음 — 상신 시점에 막아 승인 게이트를 낭비하지 않는다. 새
+    사용자 문장은 영어로(story #3779 한글가드 ratchet — 신규 위반 0 원칙,
+    ChannelImageRequiredError의 한글 문구는 이 가드 도입 前 grandfather돼
+    재사용 불가)."""
+
+    def __init__(self) -> None:
+        super().__init__("This channel requires a video attachment.")
+
+
+class ChannelYouTubeMetadataError(ValueError):
+    """story #3815(Phase3·3-5 PR2) — `channel_payload`(title/tags/categoryId/
+    privacyStatus) 검증 실패. `ChannelThreadSegmentTooLongError`류와 동형 —
+    필드명+사유를 실어 어느 값이 왜 거부됐는지 사람이 바로 알 수 있게 한다."""
+
+    def __init__(self, *, field: str, reason: str) -> None:
+        self.field = field
+        self.reason = reason
+        super().__init__(f"Invalid YouTube metadata field '{field}': {reason}")
+
+
+_YOUTUBE_TITLE_MAX_LENGTH = 100  # ⚠️미확認 — YouTube 공개 문서 재확認 대상.
+_YOUTUBE_DESCRIPTION_MAX_LENGTH = 5000  # ⚠️미확認.
+_YOUTUBE_TAGS_MAX_TOTAL_LENGTH = 500  # ⚠️미확認 — 전체 태그 문자열 합산 상한(콤마 포함, 공개 문서 관례).
+_YOUTUBE_VALID_PRIVACY_STATUSES = frozenset({"private", "unlisted", "public"})
+
+
+def _validate_youtube_metadata(*, channel: str, channel_payload: dict) -> None:
+    """story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — `channel_payload`
+    (title 필수·tags·categoryId·privacyStatus) 검증. `_validate_thread_segments`
+    와 동형 두 호출부 패턴(저장 시점·발행 시점) — X처럼 이 함수도 채널이
+    youtube/youtube_sandbox가 아니면(다른 채널의 channel_payload는 이 함수의
+    관할 밖) 즉시 통과한다.
+
+    description은 `channel_payload`가 아니라 `text`(기존 범용 필드, X의 head-text
+    관례와 동형)로 매핑돼 있어 여기서 검증하지 않는다 — `_validate_text_length`가
+    이미 그 축을 담당(카드 재그라운딩 정정, PR 본문 참고)."""
+    if channel not in ("youtube", "youtube_sandbox"):
+        return
+    title = channel_payload.get("title")
+    if not title or not isinstance(title, str):
+        raise ChannelYouTubeMetadataError(field="title", reason="title is required and must be a non-empty string")
+    if text_char_count(title) > _YOUTUBE_TITLE_MAX_LENGTH:
+        raise ChannelYouTubeMetadataError(
+            field="title", reason=f"exceeds {_YOUTUBE_TITLE_MAX_LENGTH} characters",
+        )
+    tags = channel_payload.get("tags") or []
+    if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
+        raise ChannelYouTubeMetadataError(field="tags", reason="must be a list of strings")
+    if sum(text_char_count(t) for t in tags) > _YOUTUBE_TAGS_MAX_TOTAL_LENGTH:
+        raise ChannelYouTubeMetadataError(
+            field="tags", reason=f"combined length exceeds {_YOUTUBE_TAGS_MAX_TOTAL_LENGTH} characters",
+        )
+    category_id = channel_payload.get("categoryId")
+    if category_id is not None and not (isinstance(category_id, str) and category_id.isdigit()):
+        raise ChannelYouTubeMetadataError(field="categoryId", reason="must be a numeric string when provided")
+    privacy_status = channel_payload.get("privacyStatus")
+    if privacy_status is not None and privacy_status not in _YOUTUBE_VALID_PRIVACY_STATUSES:
+        raise ChannelYouTubeMetadataError(
+            field="privacyStatus",
+            reason=f"must be one of {sorted(_YOUTUBE_VALID_PRIVACY_STATUSES)} when provided",
+        )
+
+
 class ChannelImageRequiredError(ValueError):
     """story #3536(PO 確定 2026-09-06) — 어댑터가 image_required=True(예: Instagram)인데
     상신하려는 버전에 이미지가 없음. 상신(submit) 시점에 막아 승인 게이트를 낭비하지
@@ -586,6 +652,10 @@ async def create_channel_post_draft_version(
     _validate_text_length(channel=connection.channel, text=text)
     if channel_payload:
         _validate_thread_segments(channel=connection.channel, thread=channel_payload.get("thread") or [])
+        # story #3815(Phase3·3-5 PR2) — youtube/youtube_sandbox가 아니면 즉시
+        # 통과(함수 자신의 채널 가드), 다른 채널의 channel_payload에 어쩌다
+        # title 등의 키가 있어도 이 함수 관할 밖.
+        _validate_youtube_metadata(channel=connection.channel, channel_payload=channel_payload)
 
     resolved_source_site_post_version_id: uuid.UUID | None = None
     if source_content_item_id is not None:
@@ -1230,6 +1300,16 @@ async def submit_channel_post_draft(
     adapter = get_channel_adapter(draft.channel)
     if adapter is not None and adapter.image_required and not target.image_sha256:
         raise ChannelImageRequiredError()
+    # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — image_required와
+    # 동형(영상판). ChannelPostVersion엔 image_sha256과 달리 video_sha256 컬럼
+    # 자체가 없어(그라운딩 확認) `get_channel_post_video_for_version` 조회로
+    # 판단한다(channel_posts.py 오케스트레이션의 has_video 판정과 같은 축).
+    if adapter is not None and adapter.video_required:
+        from app.services.channel_post_videos import get_channel_post_video_for_version
+
+        video_row = await get_channel_post_video_for_version(db, version_id=target.id)
+        if video_row is None:
+            raise ChannelVideoRequiredError()
 
     # story #3471(페드루 PO 確定 2026-09-05) — submit(상신) 시점에 재검사·위반 1건
     # 이상이면 422(금지 AC=서버 거부). create/update의 lint_result 스냅샷을 다시
@@ -1574,21 +1654,33 @@ async def publish_channel_post_draft(
     image_public_urls: list[str] = []
     video_row = None
     video_public_url: str | None = None
+    from app.services.channel_post_images import public_url_for_object_path
+
     if latest.image_sha256 is not None:
-        from app.services.channel_post_images import list_channel_post_images_for_version, public_url_for_object_path
-        from app.services.channel_post_videos import get_channel_post_video_for_version
+        from app.services.channel_post_images import list_channel_post_images_for_version
 
         image_rows = await list_channel_post_images_for_version(db, version_id=latest.id)
         image_public_urls = [
             url for row in image_rows if (url := public_url_for_object_path(row.final_object_path)) is not None
         ]
-        # story #3554(Phase2, 페드루 PO 確定 2026-09-06④) — 릴스(영상). 영상 마스터
-        # 존재 여부로 REELS 경로를 가른다 — 커버는 `channel_post_images` position=0
-        # 재사용이라 위 `image_public_urls`에 커버 1장이 섞여 들어올 수 있지만, 그
-        # 경우도 "영상 있음"이 우선이라 REELS로만 나간다(아래 dispatch 참고).
-        video_row = await get_channel_post_video_for_version(db, version_id=latest.id)
-        if video_row is not None:
-            video_public_url = public_url_for_object_path(video_row.original_object_path)
+    # story #3554(Phase2, 페드루 PO 確定 2026-09-06④) — 릴스(영상). 영상 마스터
+    # 존재 여부로 REELS 경로를 가른다 — 커버는 `channel_post_images` position=0
+    # 재사용이라 위 `image_public_urls`에 커버 1장이 섞여 들어올 수 있지만, 그
+    # 경우도 "영상 있음"이 우선이라 REELS로만 나간다(아래 dispatch 참고).
+    #
+    # story #3815(Phase3·3-5 PR2, 발견 즉시 수정) — 이 조회가 원래 위
+    # `image_sha256 is not None` 블록 «안»에 있어, 커버 이미지 없이 영상만 있는
+    # 버전(YouTube — video_required=True·image_required=False, Reels류와 달리
+    # 커버가 필수가 아니다)에서는 영상 마스터가 있어도 이 조회 자체가 안 돌아
+    # `has_video`가 조용히 False로 떨어지는 잠재 결함이었다(지금까지 실제
+    # 사고가 없었던 이유는 Reels가 항상 커버=image_sha256을 동반해 이 조합이
+    # 한 번도 안 나왔을 뿐). 영상 존재 여부는 이미지 유무와 독립적으로 항상
+    # 확認한다(인덱스 조회 1건 추가 — 기존 채널은 결과가 그대로 None, 회귀 0).
+    from app.services.channel_post_videos import get_channel_post_video_for_version
+
+    video_row = await get_channel_post_video_for_version(db, version_id=latest.id)
+    if video_row is not None:
+        video_public_url = public_url_for_object_path(video_row.original_object_path)
     has_image = len(image_public_urls) > 0
     has_video = video_row is not None
     # 기존 단일-이미지 호출부(threads/facebook/sandbox 등 — 전부 image_max_count<=1이라
@@ -1639,6 +1731,9 @@ async def publish_channel_post_draft(
     # 실제 전송 문자열을 재검사해 Threads 호출(한도 조회 포함) 0건으로 fail-closed —
     # 기존 ChannelTextTooLongError를 그대로 재사용한다(max·current 둘 다 실림).
     _validate_text_length(channel=draft.channel, text=text_to_post)
+    # story #3815(Phase3·3-5 PR2) — 승인 뒤 어댑터 선언이 바뀌었을 가능성에 대한
+    # 방어(②, _validate_thread_segments와 동형 위치 — 발행 직전 재검사).
+    _validate_youtube_metadata(channel=draft.channel, channel_payload=latest.channel_payload or {})
 
     try:
         async with httpx.AsyncClient(timeout=20) as client:
@@ -1765,10 +1860,56 @@ async def publish_channel_post_draft(
                                 f"{draft.channel} 채널은 릴스(영상) 발행을 지원하지 않습니다",
                                 status_code=422,
                             )
+                        # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) —
+                        # stibee subject(위 else 분기)와 동형 축: channel_payload
+                        # 공유 슬롯에서 YouTube 전용 메타(title/tags/categoryId/
+                        # privacyStatus)를 뽑아 youtube/youtube_sandbox에만 넘긴다
+                        # (다른 릴스 채널의 create_reels_container 시그니처는
+                        # channel_payload 개념 자체가 없어 무변경 — kwarg를 아예
+                        # 안 보냄, image_max_count=0과 동형 "신호 없음=미지원").
+                        # quota 체크·evidence 기록은 이 파사드 함수(순수 httpx 클라
+                        # 이언트, x_publish.py와 동형 계약 — DB 접근 0) 안이 아니라
+                        # 여기 오케스트레이션에서 한다(X의 api_usage_budget 재검사가
+                        # `_publish_x_thread_draft`에 있는 것과 같은 위치 축).
+                        _reels_extra_kwargs = {}
+                        if draft.channel in ("youtube", "youtube_sandbox"):
+                            _reels_extra_kwargs["channel_payload"] = latest.channel_payload or {}
+                            from app.core.config import settings as _settings
+                            from app.services.youtube_quota import (
+                                YouTubeQuotaExceededError, check_youtube_quota_or_raise,
+                            )
+                            try:
+                                await check_youtube_quota_or_raise(
+                                    db, estimated_units=_settings.youtube_quota_cost_insert_units,
+                                )
+                            except YouTubeQuotaExceededError as exc:
+                                row.status = "failed"
+                                row.error_code = "YOUTUBE_QUOTA_EXCEEDED"
+                                row.last_error = str(exc)
+                                await db.commit()
+                                raise
                         container_id = await create_reels_container(
                             client, access_token=access_token, threads_user_id=connection.account_id,
                             text=text_to_post, video_url=video_public_url, cover_url=image_public_url,
+                            **_reels_extra_kwargs,
                         )
+                        if draft.channel in ("youtube", "youtube_sandbox"):
+                            from app.core.config import settings as _settings
+                            from app.services.youtube_quota import record_youtube_quota_usage_evidence
+                            await record_youtube_quota_usage_evidence(
+                                db, org_id=org_id, work_item_id=draft.work_item_id, publication_id=row.id,
+                                event="insert", units=_settings.youtube_quota_cost_insert_units,
+                            )
+                            # story #3815(PR2, 페드루 PO 決定②) — youtube_publish.py/
+                            # youtube_sandbox_publish.py의 videos.insert 호출과 같은
+                            # 판정을 여기서 다시 계산(단일 정본 youtube_privacy.py
+                            # 재사용 — publish-client가 실제로 실은 값과 이 행에
+                            # 못박는 값이 절대 갈라지지 않는다).
+                            from app.services.youtube_privacy import resolve_youtube_privacy_lock
+                            _, row.privacy_locked = resolve_youtube_privacy_lock(
+                                requested_privacy_status=(latest.channel_payload or {}).get("privacyStatus"),
+                                text=text_to_post,
+                            )
                     elif len(image_public_urls) > 1:
                         # story #3550(Phase2, PO 確定 ④) — 캐러셀(2장 이상)은 별도
                         # 함수(instagram_publish.py::create_carousel_container류) —

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -2036,17 +2036,40 @@ async def publish_channel_post_draft(
                     # 분기(pending, +30초)로만 계속 재큐잉돼 진짜 무한루프가 된다(워커가
                     # 절대 dead_letter로 못 빠짐). row.created_at은 이 행이 재사용될 뿐
                     # 재생성 안 되므로 "최초 컨테이너 생성 시각"의 신뢰할 수 있는 근사치.
+                    #
+                    # story #3815(Phase3·3-5 PR2 CHANGES②, 페드루 PO 지적 2026-09-12
+                    # 11:34Z) — 상한을 채널 고정 5분에서 어댑터 값(`container_poll_
+                    # timeout_seconds`)으로 뺀다. YouTube 트랜스코딩은 5분을 예사로
+                    # 넘겨(자산은 이미 업로드 完·처리 중일 뿐) 고정 5분을 그대로 쓰면
+                    # "거짓 실패"로 external_container_id를 지워 재시도가 같은 영상을
+                    # 새로 업로드하는 사고(quota 이중 차감 포함)로 이어진다 — 어댑터가
+                    # youtube/youtube_sandbox엔 86400(24h)을 선언, 그 외 채널은 기존
+                    # 기본값 300(5분) 그대로라 회귀 0.
+                    _poll_timeout_adapter = get_channel_adapter(draft.channel)
+                    _poll_timeout_seconds = (
+                        _poll_timeout_adapter.container_poll_timeout_seconds if _poll_timeout_adapter else 300
+                    )
                     elapsed = datetime.now(timezone.utc) - row.created_at
-                    if elapsed > timedelta(minutes=5):
+                    if elapsed > timedelta(seconds=_poll_timeout_seconds):
                         row.status = "failed"
+                        # ⚠️적기만(페드루 明示, 이 PR 범위 밖 후속) — 이 에러 코드가
+                        # "IMAGE"라 영상(YouTube 등)에도 재사용되는 건 이름-사실 불일치.
+                        # 지금 당장 이름을 바꾸면 기존 FE/테스트가 이 문자열을 상수로
+                        # 참조하는 소비처 전수 grep이 이 PR 범위를 넘어가 후속으로 미룬다.
                         row.error_code = "CHANNEL_IMAGE_CONTAINER_FAILED"
-                        row.last_error = f"IN_PROGRESS {elapsed.total_seconds():.0f}s > 5분 상한(그라운딩 §②)"
+                        # story #3779 한글가드 ratchet — 새 문구는 영어로(story #3815
+                        # CHANGES② 대응, 옛 5분-고정 한글 문구는 grandfather돼 있었지만
+                        # 이 값 자체가 이제 어댑터별로 달라져 새로 쓰는 문구라 재사용 불가).
+                        row.last_error = (
+                            f"IN_PROGRESS {elapsed.total_seconds():.0f}s > "
+                            f"{_poll_timeout_seconds}s per-adapter poll timeout"
+                        )
                         row.external_container_id = None
                         await db.commit()
                         raise ChannelImageContainerFailedError(
                             gate_id=gate.id, container_status="TIMEOUT", error_message=row.last_error,
                         )
-                    return row  # 아직 처리 中(5분 이내) — 다음 tick이 다시 폴링.
+                    return row  # 아직 처리 中(상한 이내) — 다음 tick이 다시 폴링.
                 if container_status in ("ERROR", "EXPIRED"):
                     row.status = "failed"
                     row.error_code = "CHANNEL_IMAGE_CONTAINER_FAILED"

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -366,6 +366,16 @@ _CATALOG: dict[str, dict[str, str]] = {
         "ko": "stibee 발행에 필요한 제목·주소록 ID·발신자 정보가 없습니다.",
         "en": "Missing subject, address book ID, or sender info required to publish to Stibee.",
     },
+    # story #3815(Phase3·3-5 PR2, 페드루 PO 낱말 확定 2026-09-12 10:46Z) — 코드
+    # (YOUTUBE_QUOTA_EXCEEDED)·마커(sandbox:youtube-quota-exceeded)는 그대로 두되
+    # 사용자 문자열엔 "quota" 낱말을 안 쓴다("사용량"으로). 리셋 경계가 정확한 UTC
+    # 자정 시각이라 응답에 `reset_at`을 함께 실어 FE가 필요하면 그 값으로 문구를
+    # 재조립할 수 있게 하지만, 이 문장 자체는 "내일"로 고정(페드루 明示 — 시각이
+    # 있어도 문장은 상대 표현 유지, reset_at은 부가 필드).
+    "channel_posts.youtube_usage_exceeded": {
+        "ko": "오늘 YouTube 사용량을 다 썼습니다 — 내일 다시 시도해 주세요(플랫폼 공유 한도).",
+        "en": "Today's YouTube usage limit has been reached — please try again tomorrow (shared platform-wide limit).",
+    },
 }
 
 

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -366,15 +366,17 @@ _CATALOG: dict[str, dict[str, str]] = {
         "ko": "stibee 발행에 필요한 제목·주소록 ID·발신자 정보가 없습니다.",
         "en": "Missing subject, address book ID, or sender info required to publish to Stibee.",
     },
-    # story #3815(Phase3·3-5 PR2, 페드루 PO 낱말 확定 2026-09-12 10:46Z) — 코드
-    # (YOUTUBE_QUOTA_EXCEEDED)·마커(sandbox:youtube-quota-exceeded)는 그대로 두되
-    # 사용자 문자열엔 "quota" 낱말을 안 쓴다("사용량"으로). 리셋 경계가 정확한 UTC
-    # 자정 시각이라 응답에 `reset_at`을 함께 실어 FE가 필요하면 그 값으로 문구를
-    # 재조립할 수 있게 하지만, 이 문장 자체는 "내일"로 고정(페드루 明示 — 시각이
-    # 있어도 문장은 상대 표현 유지, reset_at은 부가 필드).
+    # story #3815(Phase3·3-5 PR2, 페드루 PO 낱말 확定 2026-09-12 10:46Z, CHANGES①
+    # 2026-09-12 11:34Z 정정) — 코드(YOUTUBE_QUOTA_EXCEEDED)·마커(sandbox:youtube-
+    # quota-exceeded)는 그대로. 최초엔 "내일 다시"(상대 표현)로 확定했으나, 리셋
+    # 경계가 UTC 00:00 «시각»이라 KST 사용자(UTC+9)에겐 "내일"이 실제로는 그날
+    # 09:00부터라 거짓("오늘 09시 이후"인데 "내일"이라 하면 이르게 읽힌다) — 정적
+    # 절대 시각 문장으로 교체(요청마다 계산되는 reset_at 보간 없음, 경계 자체가
+    # 고정값이라 정적 문자열로 충분·`reset_at` 필드는 여전히 응답에 실어 FE가
+    # 필요하면 참고).
     "channel_posts.youtube_usage_exceeded": {
-        "ko": "오늘 YouTube 사용량을 다 썼습니다 — 내일 다시 시도해 주세요(플랫폼 공유 한도).",
-        "en": "Today's YouTube usage limit has been reached — please try again tomorrow (shared platform-wide limit).",
+        "ko": "오늘 YouTube 사용량을 다 썼습니다 — 사용량은 매일 오전 9시(한국 시간)에 초기화됩니다(플랫폼 공유 한도).",
+        "en": "Today's YouTube usage limit has been reached — it resets daily at 00:00 UTC (shared platform-wide limit).",
     },
 }
 

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -326,6 +326,7 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
     )
     from app.services.generation_budget import GenerationBudgetExceededError
     from app.services.x_publish_budget import API_USAGE_BUDGET_RULE_KEY
+    from app.services.youtube_quota import YouTubeQuotaExceededError
 
     error_code: str | None = None
     last_error: str | None = None
@@ -414,6 +415,18 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
             "API_USAGE_BUDGET_EXCEEDED" if exc.rule_key == API_USAGE_BUDGET_RULE_KEY
             else "GENERATION_BUDGET_EXCEEDED"
         )
+        command.last_error = str(exc)[:2000]
+        return
+    except YouTubeQuotaExceededError as exc:
+        # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — 위 GenerationBudget
+        # ExceededError와 동형(adapter 이미 진입했으나 provider 호출 前 재검사가
+        # 막음 — 재시도 대상 아님, 플랫폼 전체 사용량이 하루 안엔 안 줄어든다).
+        await record_publication_attempt(
+            db, command=command, approval_check="ok", adapter_called=False,
+            started_at=attempt_started_at, finished_at=now, result_code="YOUTUBE_QUOTA_EXCEEDED",
+        )
+        command.status = STATUS_BLOCKED_UNAPPROVED
+        command.reason_code = "YOUTUBE_QUOTA_EXCEEDED"
         command.last_error = str(exc)[:2000]
         return
     except ChannelPostSealMissingError as exc:

--- a/backend/app/services/youtube_privacy.py
+++ b/backend/app/services/youtube_privacy.py
@@ -1,0 +1,23 @@
+"""story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — YouTube API 감사
+미완=강제 비공개(PO 決定②) 판정의 단일 정본. `youtube_publish.py`(실제
+videos.insert 요청 바디에 실을 값)와 `channel_posts.py` 오케스트레이션(발행물
+행의 `privacy_locked` 열에 못박을 값) 둘 다 이 한 함수를 부른다 — 판정 로직이
+두 곳에 따로 있으면 갈라질 수 있어(로직 이중선언은 이 팀 금기, [[behavior_
+declared_one_place]]) 여기 하나로 좁힌다. DB 접근 0(순수 함수) — publish-client
+모듈의 pure-HTTP-client 원칙을 안 깬다."""
+from __future__ import annotations
+
+from app.core.config import settings
+
+_MARKER_PRIVACY_LOCKED = "[sandbox:youtube-privacy-locked]"
+
+
+def resolve_youtube_privacy_lock(*, requested_privacy_status: str | None, text: str) -> tuple[str, bool]:
+    """(privacy_status, privacy_locked). 잠금 조건 둘 — ①플랫폼 감사 미완 설정값
+    (`settings.youtube_api_audit_incomplete`, 실 youtube/youtube_sandbox 공통)
+    ②sandbox 결정적 마커(`[sandbox:youtube-privacy-locked]`, sandbox 왕복만
+    타는 text 안 — 실 youtube 발행에선 이 문자열이 그냥 평범한 description
+    내용일 뿐 아무 효과 없다, 마커 축은 sandbox 전용)."""
+    if settings.youtube_api_audit_incomplete or _MARKER_PRIVACY_LOCKED in text:
+        return "private", True
+    return requested_privacy_status or "private", False

--- a/backend/app/services/youtube_publish.py
+++ b/backend/app/services/youtube_publish.py
@@ -111,6 +111,24 @@ async def _put_video_bytes(
     raise last_exc
 
 
+async def create_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    image_url: str | None = None,
+) -> str:
+    """발견 즉시 수정(PR2 CHANGES② 대응 중 자체 발견) — `channel_posts.py:1711`이
+    `_publish_client.create_container`를 has_video 값과 무관하게 무조건
+    속성-접근한다(video_required=True 전용 채널을 처음 만나며 드러난 기존
+    가정 — Reels 등 기존 영상-지원 채널은 전부 이미지도 같이 지원해 이
+    함수가 항상 존재했다). YouTube는 이미지 컨테이너 개념 자체가 없어 호출
+    되면 안 되는 경로 — fail-closed로 명시 실패(조용한 500 대신)."""
+    raise ThreadsPublishError(
+        "YOUTUBE_IMAGE_CONTAINER_UNSUPPORTED",
+        "YouTube publish-client has no image container concept (video_required=True channel) — "
+        "create_container should never be called; has_video detection may be broken.",
+        status_code=500,
+    )
+
+
 async def create_reels_container(
     client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
     video_url: str, cover_url: str | None = None, channel_payload: dict | None = None,

--- a/backend/app/services/youtube_publish.py
+++ b/backend/app/services/youtube_publish.py
@@ -1,0 +1,195 @@
+"""story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — YouTube Data API v3
+resumable 업로드 클라이언트. `threads_publish.py::ThreadsPublishError`를 그대로
+재사용한다(신규 예외 클래스 0 — x_publish.py 선례와 동형: `channel_posts.py`
+오케스트레이션의 모든 `except ThreadsPublishError` 지점·error_code 매핑을 그대로
+물려받는다).
+
+## `create_reels_container`/`get_container_status`/`publish_container` 매핑
+YouTube의 `videos.insert`는 **단일 호출로 이미 발행까지 끝난다**(Meta의 create→
+publish 2단과 다른 자리 — privacyStatus를 insert 시점에 이미 지정하므로 별도
+"publish" API가 없다). 그래도 기존 5(6)-함수 파사드에 맞춰 스스로 접는다(신규
+오케스트레이션 로직 0, x_publish.py가 X의 무-컨테이너 API를 접은 것과 동형):
+- `create_reels_container`가 실제로 resumable 업로드 세션을 열고 영상을 다
+  보내 YouTube 비디오 리소스를 만든다(creation_id=video id 그 자체, JSON 봉투
+  불요 — X처럼 두 호출 사이에 들고 다닐 상태가 없다).
+- `get_container_status`가 `videos.list(part=status)`로 `uploadStatus`를 확認
+  (processing이면 IN_PROGRESS — channel_posts.py의 5분 폴링 상한 재사용).
+- `publish_container`는 이미 끝난 일을 확인만 하는 근사 no-op(creation_id를
+  그대로 반환) — "진짜 발행 순간"이 insert 그 시점이었기 때문.
+
+## 감사 미완=강제 비공개(페드루 PO 決定②, 2026-09-12 10:46Z)
+`settings.youtube_api_audit_incomplete=True`(fail-closed 기본)면 요청된
+privacyStatus와 무관하게 `videos.insert`에 항상 `privacyStatus="private"`를
+싣는다 — 우리 GCP 프로젝트의 API 등급(고객 자격 아님, `app/core/config.py`
+상단 딱지 참고)이라 연결(ChannelConnection.status) 축과는 별개다(페드루 明示
+④ — 연결 status 4값 무변, 이 잠금은 그 밖의 별도 사실).
+
+⚠️미확認(threads_oauth.py/x_oauth.py 상단 딱지와 동형 원칙, 착수 시 재확認
+필요) — resumable 업로드 세션 프로토콜의 정확한 요청/응답 헤더명(`X-Upload-
+Content-Length` 등)·videos.insert 응답 스키마·`uploadStatus` enum 값
+(uploaded/processed/rejected/failed 등)은 지식 컷오프(2026-01) 기준 최선
+추정이다. 실 앱 왕복 전까지 "코드는 정확한 형태로 존재하되 라이브 미검증"
+상태로 남는다. 챕터(description 안 MM:SS 타임스탬프) 형식 요건은 PR1
+그라운딩에서 이미 "API 필드 아님(클라이언트 관례)"으로 확認됐고, 정확한
+줄 수·최소 길이 요건은 여전히 ⚠️미확認이라 이 파일은 그 형식을 검증하지
+않는다(지어내지 않는다, 페드루 明示③)."""
+from __future__ import annotations
+
+import httpx
+
+from app.services.threads_publish import ThreadsPublishError
+from app.services.youtube_privacy import resolve_youtube_privacy_lock
+
+_UPLOAD_INIT_URL = "https://www.googleapis.com/upload/youtube/v3/videos"
+_VIDEOS_URL = "https://www.googleapis.com/youtube/v3/videos"
+
+_GENEROUS_QUOTA_USAGE = 0
+_GENEROUS_QUOTA_TOTAL = 10_000
+_GENEROUS_QUOTA_DURATION_SECONDS = 86_400
+
+
+def _auth_headers(access_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def _error_from_response(code: str, resp: httpx.Response) -> ThreadsPublishError:
+    """x_publish.py::_error_from_response와 동형 — YouTube 오류 envelope도 Meta
+    Graph 형이 아니라(`{"error": {"errors": [...], "code": ..., "message": ...}}`)
+    Meta 파서 관할 밖이라 provider_error_* 3필드는 None."""
+    return ThreadsPublishError(code, resp.text[:500], status_code=resp.status_code)
+
+
+async def _initiate_resumable_session(
+    client: httpx.AsyncClient, *, access_token: str, video_bytes: bytes, mime_type: str,
+    title: str, description: str, tags: list[str], category_id: str | None, privacy_status: str,
+) -> str:
+    """resumable 업로드 세션 열기 — 성공하면 `Location` 헤더(청크 PUT 대상 URL)를
+    낸다. ⚠️미확認 — 정확한 요청 헤더/바디 형태는 모듈 상단 딱지 참고."""
+    snippet: dict = {"title": title, "description": description}
+    if tags:
+        snippet["tags"] = tags
+    if category_id is not None:
+        snippet["categoryId"] = category_id
+    resp = await client.post(
+        _UPLOAD_INIT_URL,
+        params={"uploadType": "resumable", "part": "snippet,status"},
+        json={"snippet": snippet, "status": {"privacyStatus": privacy_status}},
+        headers={
+            **_auth_headers(access_token),
+            "X-Upload-Content-Length": str(len(video_bytes)),
+            "X-Upload-Content-Type": mime_type,
+        },
+    )
+    if resp.status_code not in (200, 201):
+        raise _error_from_response("YOUTUBE_UPLOAD_SESSION_INIT_FAILED", resp)
+    session_url = resp.headers.get("Location")
+    if not session_url:
+        raise ThreadsPublishError(
+            "YOUTUBE_UPLOAD_SESSION_MISSING_LOCATION", "Location header missing in response",
+            status_code=resp.status_code,
+        )
+    return session_url
+
+
+async def _put_video_bytes(
+    client: httpx.AsyncClient, *, session_url: str, video_bytes: bytes, mime_type: str,
+) -> dict:
+    """단일 PUT(재시도 1회 — 첫 시도가 실패하면 세션 진행 상황을 `Content-Range:
+    bytes */{total}` 조회 없이 그냥 처음부터 한 번 더 보낸다, 대용량 다중-청크
+    분할은 이 카드 범위 밖으로 남긴다 — 모듈 상단 딱지 "청크 PUT" 참고, 후속
+    개선 대상). 성공하면 최종 video 리소스 JSON을 낸다."""
+    last_exc: ThreadsPublishError | None = None
+    for _attempt in range(2):
+        resp = await client.put(
+            session_url, content=video_bytes,
+            headers={"Content-Type": mime_type, "Content-Length": str(len(video_bytes))},
+        )
+        if resp.status_code in (200, 201):
+            return resp.json()
+        last_exc = _error_from_response("YOUTUBE_UPLOAD_PUT_FAILED", resp)
+    assert last_exc is not None
+    raise last_exc
+
+
+async def create_reels_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    video_url: str, cover_url: str | None = None, channel_payload: dict | None = None,
+) -> str:
+    """`channel_posts.py`의 `has_video` 분기 진입점(image_max_count=0류 관례로
+    다른 릴스 채널과 같은 함수명 재사용). `text`=video description(재그라운딩
+    정정, PR 본문 참고) · `channel_payload`={title, tags, categoryId,
+    privacyStatus} — `_validate_youtube_metadata`가 이미 발행 直前 재검사를
+    끝낸 값이라 여기서 재검증하지 않는다. `cover_url`(썸네일)은 이 PR 범위
+    밖 — YouTube 자동 생성 썸네일에 맡긴다(⚠️갭, 후속)."""
+    payload = channel_payload or {}
+    video_resp = await client.get(video_url)
+    if video_resp.status_code != 200:
+        raise ThreadsPublishError(
+            "YOUTUBE_VIDEO_SOURCE_FETCH_FAILED", f"video_url fetch failed: {video_resp.status_code}",
+            status_code=502,
+        )
+    mime_type = video_resp.headers.get("content-type", "video/mp4")
+    privacy_status, _privacy_locked = resolve_youtube_privacy_lock(
+        requested_privacy_status=payload.get("privacyStatus"), text=text,
+    )
+    session_url = await _initiate_resumable_session(
+        client, access_token=access_token, video_bytes=video_resp.content, mime_type=mime_type,
+        title=payload.get("title", ""), description=text, tags=list(payload.get("tags") or []),
+        category_id=payload.get("categoryId"), privacy_status=privacy_status,
+    )
+    video_resource = await _put_video_bytes(
+        client, session_url=session_url, video_bytes=video_resp.content, mime_type=mime_type,
+    )
+    video_id = video_resource.get("id")
+    if not video_id:
+        raise ThreadsPublishError(
+            "YOUTUBE_UPLOAD_MISSING_VIDEO_ID", "id missing in videos.insert response", status_code=200,
+        )
+    return str(video_id)
+
+
+async def get_container_status(
+    client: httpx.AsyncClient, *, access_token: str, creation_id: str,
+) -> tuple[str, str | None]:
+    """`videos.list(part=status)` — `uploadStatus`를 threads_publish.py 어휘
+    (IN_PROGRESS/FINISHED/ERROR)로 옮긴다. ⚠️미확認 — 정확한 enum 값은 모듈
+    상단 딱지 참고."""
+    resp = await client.get(
+        _VIDEOS_URL, params={"part": "status", "id": creation_id}, headers=_auth_headers(access_token),
+    )
+    if resp.status_code != 200:
+        raise _error_from_response("YOUTUBE_VIDEO_STATUS_FAILED", resp)
+    items = resp.json().get("items") or []
+    if not items:
+        return "ERROR", "video resource not found (videos.list returned no items)"
+    upload_status = ((items[0].get("status") or {}).get("uploadStatus"))
+    if upload_status == "processed":
+        return "FINISHED", None
+    if upload_status in ("rejected", "failed"):
+        failure_reason = (items[0].get("status") or {}).get("failureReason")
+        return "ERROR", failure_reason or f"uploadStatus={upload_status}"
+    return "IN_PROGRESS", None  # "uploaded"(트랜스코딩 대기) 등 그 외 전부.
+
+
+async def publish_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, creation_id: str,
+) -> str:
+    """모듈 상단 딱지 — videos.insert 시점에 이미 발행이 끝나 있어 이 함수는
+    creation_id(=video id)를 그대로 확정할 뿐(신규 API 호출 0, x_publish.py의
+    "posted" 지름길과 동형 사상)."""
+    return creation_id
+
+
+async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> str | None:
+    """watch URL은 video id만으로 결정적으로 구성된다(공개 문서 안정 사실) — X의
+    permalink 조회(별도 API 필요)와 다른 자리, HTTP 호출 0."""
+    return f"https://www.youtube.com/watch?v={media_id}"
+
+
+async def get_publishing_limit(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str,
+) -> tuple[int, int, int]:
+    """x_publish.py와 동형 — 연결별 사전조회 quota 엔드포인트가 없다(YouTube의
+    실 quota는 프로젝트 전체 축이라 `youtube_quota.py`가 별도로 담당, 이 함수는
+    항상 여유 있는 고정값)."""
+    return _GENEROUS_QUOTA_USAGE, _GENEROUS_QUOTA_TOTAL, _GENEROUS_QUOTA_DURATION_SECONDS

--- a/backend/app/services/youtube_quota.py
+++ b/backend/app/services/youtube_quota.py
@@ -1,0 +1,117 @@
+"""story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — YouTube Data API v3
+종량 quota. `x_publish_budget.py`/`generation_budget.py`의 계산 프리미티브(evidence
+합산+거부 신호)와 같은 사상이지만 **다른 축** — X/생성비는 조직별 월 지갑인데,
+이건 **플랫폼 전체가 공유하는 일일 카운터**(우리 GCP 프로젝트가 Google에 매일
+받는 quota는 조직 수와 무관하게 하나뿐이다). 그래서 `compute_generation_budget_
+status`(조직별 `org_content_rules` 조회+조직 필터 합산)를 그대로 재사용하지 않고
+별도 함수로 연다 — org_id 필터를 빼고 플랫폼 전체 합산, 기간도 "월"이 아니라
+"오늘(UTC)"이다.
+
+한도·단가는 `app/core/config.py::Settings`의 env 값(⚠️미확認 근거는 그 파일 상단
+딱지 참고) — `org_content_rules`가 아니라 `Evidence.org_id`는 여전히 채운다
+(어느 조직이 오늘 quota를 얼마나 썼는지 귀속 추적용, 판정 자체는 org 무관 합산)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.evidence import Evidence
+
+YOUTUBE_QUOTA_KIND = "youtube_quota_units"
+
+
+class YouTubeQuotaExceededError(Exception):
+    """AC "422 YOUTUBE_QUOTA_EXCEEDED" 신호 — 라우터가 이 예외를 그 코드로 감싼다
+    (generation_budget.py::GenerationBudgetExceededError와 동형 4값 계약이지만
+    "_minor"(통화 최소단위)가 아니라 "_units"(quota 단위)라 필드명을 갈아 별도
+    클래스로 연다 — 통화 예산과 섞으면 다음 사람이 단위를 헷갈린다).
+
+    story #3815(페드루 PO 낱말 확定 2026-09-12 10:46Z) — 리셋 경계가 "오늘/내일"
+    (날짜뿐)이 아니라 정확한 UTC 자정 **시각**이라(플랫폼 전체 하루 카운터,
+    `_utc_day_window`의 `end`) `reset_at`을 싣는다 — FE가 "{reset_at}부터 다시"로
+    쓸 수 있게(ChannelRateLimitedError.reset_at과 동형 관례). 사용자 문자열엔
+    "quota" 낱말을 안 쓴다(→"사용량") — 이 예외 자신의 `str()`은 로그용 영문
+    기술 문구일 뿐, 사람에게 보이는 최종 문장은 라우터가 i18n_catalog로 조립."""
+
+    def __init__(
+        self, *, limit_units: int, spent_units: int, estimated_units: int, remaining_units: int, reset_at: datetime,
+    ):
+        self.limit_units = limit_units
+        self.spent_units = spent_units
+        self.estimated_units = estimated_units
+        self.remaining_units = remaining_units
+        self.reset_at = reset_at
+        super().__init__(
+            f"youtube platform-wide daily quota exceeded: limit={limit_units} spent={spent_units} "
+            f"estimated={estimated_units} remaining={remaining_units} reset_at={reset_at.isoformat()}"
+        )
+
+
+def _utc_day_window(now: datetime) -> tuple[datetime, datetime]:
+    """"오늘"(UTC 00:00~다음날 00:00) — generation_budget.py::_period_window의
+    "month"와 동형 사상, 다른 기간 단위."""
+    start = now.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    return start, start + timedelta(days=1)
+
+
+async def get_platform_youtube_quota_spent_units(db: AsyncSession, *, now: datetime | None = None) -> int:
+    """오늘(UTC) 플랫폼 전체(모든 조직 합산) youtube quota 소비량. org_id 필터가
+    없는 게 이 함수의 요점 — x_publish_budget류와 다른 자리."""
+    now = now or datetime.now(timezone.utc)
+    start, end = _utc_day_window(now)
+    rows = (await db.execute(
+        select(Evidence.payload).where(
+            Evidence.type == "metric",
+            Evidence.payload["kind"].astext == YOUTUBE_QUOTA_KIND,
+            Evidence.created_at >= start, Evidence.created_at < end,
+        )
+    )).scalars().all()
+    return sum(int(p["units"]) for p in rows if p and p.get("units") is not None)
+
+
+async def check_youtube_quota_or_raise(
+    db: AsyncSession, *, estimated_units: int, now: datetime | None = None,
+) -> None:
+    """`_publish_x_thread_draft`류의 발행 직전 재검사와 같은 위치 축 — YouTube
+    발행 provider 호출(resumable upload session 생성) 直前에 부른다."""
+    now = now or datetime.now(timezone.utc)
+    limit_units = settings.youtube_quota_daily_limit_units
+    spent_units = await get_platform_youtube_quota_spent_units(db, now=now)
+    remaining_units = limit_units - spent_units
+    if estimated_units > remaining_units:
+        _, reset_at = _utc_day_window(now)
+        raise YouTubeQuotaExceededError(
+            limit_units=limit_units, spent_units=spent_units,
+            estimated_units=estimated_units, remaining_units=remaining_units, reset_at=reset_at,
+        )
+
+
+async def record_youtube_quota_usage_evidence(
+    db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, publication_id: uuid.UUID,
+    event: str, units: int,
+) -> None:
+    """`record_api_usage_cost_evidence`와 동형 멱등 축 — **publication_id+event**로
+    (사용처가 "insert" 1회·"list" N회처럼 같은 publication에 여러 event가 있을 수
+    있어 X의 publication_id+sequence 대신 이 조합)."""
+    existing = (await db.execute(
+        select(Evidence.id).where(
+            Evidence.org_id == org_id, Evidence.type == "metric",
+            Evidence.payload["kind"].astext == YOUTUBE_QUOTA_KIND,
+            Evidence.payload["publication_id"].astext == str(publication_id),
+            Evidence.payload["event"].astext == event,
+        )
+    )).scalar_one_or_none()
+    if existing is not None:
+        return
+    db.add(Evidence(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type="story",
+        type="metric", ref=str(publication_id), source="platform",
+        payload={
+            "kind": YOUTUBE_QUOTA_KIND, "units": units, "event": event, "publication_id": str(publication_id),
+        },
+    ))
+    await db.commit()

--- a/backend/app/services/youtube_sandbox_publish.py
+++ b/backend/app/services/youtube_sandbox_publish.py
@@ -19,7 +19,15 @@ tweet 본문에 싣는 것과 동형 위치, YouTube에서 제목은 채널_payl
   가능하게 만든다(설정값 `youtube_api_audit_incomplete`을 몰라도 이
   마커 하나로 그 분기를 항상 통과시킨다 — 테스트가 env 값에 기대지
   않아도 되게).
-- `[sandbox:provider-error]` — 기존 어휘 재사용(신규 마커 0, 페드루 明示④)."""
+- `[sandbox:provider-error]` — 기존 어휘 재사용(신규 마커 0, 페드루 明示④).
+
+마커 4번째(CHANGES②, 페드루 PO 지적 2026-09-12 11:34Z) — `[sandbox:youtube-
+processing-long]`: 트랜스코딩이 5분(다른 채널의 컨테이너 폴링 상한)을 넘겨도
+YouTube는 거짓 실패가 아니어야 함을 증명하는 자리. state 없는 sandbox 설계
+원칙을 지키기 위해(process 메모리 0) 이 마커를 creation_id 자체에 새긴다
+(process 재기동에도 다음 `get_container_status` 호출이 같은 id 문자열만
+보고 결정적으로 재현) — X의 `[sandbox:429-once]`가 DB 실물(row)로 상태를
+드는 것과 달리 이건 id 자체가 상태라 DB도 불필요."""
 from __future__ import annotations
 
 import uuid
@@ -32,6 +40,8 @@ from app.services.youtube_quota import YouTubeQuotaExceededError
 
 _MARKER_QUOTA_EXCEEDED = "[sandbox:youtube-quota-exceeded]"
 _MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
+_MARKER_PROCESSING_LONG = "[sandbox:youtube-processing-long]"
+_PROCESSING_LONG_ID_TAG = "processing-long"
 
 
 def _raise_if_marked(text: str) -> None:
@@ -48,17 +58,34 @@ def _raise_if_marked(text: str) -> None:
         )
 
 
+async def create_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    image_url: str | None = None,
+) -> str:
+    """발견 즉시 수정 — youtube_publish.py::create_container와 동형(위 딱지
+    참고, `channel_posts.py:1711`의 무조건 속성-접근 대비)."""
+    raise ThreadsPublishError(
+        "SANDBOX_YOUTUBE_IMAGE_CONTAINER_UNSUPPORTED",
+        "sandbox: YouTube has no image container concept (video_required=True channel)",
+        status_code=500,
+    )
+
+
 async def create_reels_container(
     client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
     video_url: str, cover_url: str | None = None, channel_payload: dict | None = None,
 ) -> str:
     _raise_if_marked(text)
+    if _MARKER_PROCESSING_LONG in text:
+        return f"sandbox-youtube-video-{_PROCESSING_LONG_ID_TAG}-{uuid.uuid4().hex}"
     return f"sandbox-youtube-video-{uuid.uuid4().hex}"
 
 
 async def get_container_status(
     client: httpx.AsyncClient, *, access_token: str, creation_id: str,
 ) -> tuple[str, str | None]:
+    if _PROCESSING_LONG_ID_TAG in creation_id:
+        return "IN_PROGRESS", None
     return "FINISHED", None
 
 

--- a/backend/app/services/youtube_sandbox_publish.py
+++ b/backend/app/services/youtube_sandbox_publish.py
@@ -1,0 +1,78 @@
+"""story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — dev 전용 YouTube
+샌드박스 발행 클라이언트. `youtube_publish.py`와 정확히 같은 5-함수 파사드
+시그니처(x_sandbox_publish.py와 동형 설계 계약 — 결정적·상태 없음·
+`ThreadsPublishError` 재사용, 신규 판정 로직 0). resumable 업로드 HTTP
+왕복 전부 생략 — 즉시 FINISHED(다른 sandbox들과 동형 단순화).
+
+마커 3종(카드 원문, 페드루 PO 決定④) — `text`(=video description, 재그라운딩
+정정으로 title이 아니라 description 축에 싣는다 — x_sandbox_publish.py가
+tweet 본문에 싣는 것과 동형 위치, YouTube에서 제목은 채널_payload 쪽 구조화
+필드라 마커 은닉 자리로 안 맞는다) 안에 있으면:
+- `[sandbox:youtube-quota-exceeded]` — 플랫폼 quota가 실제로 바닥나길
+  기다리지 않고 결정적으로 422 경로를 재현(`youtube_quota.py::
+  YouTubeQuotaExceededError`를 오케스트레이션 대신 여기서 직접 냄 — 실
+  quota 축과 별개의 "provider가 알아서 걸었다"는 시나리오는 없어 이 한
+  경로로 충분, x_sandbox_publish.py의 api-budget-exceeded 마커와 동형
+  사상이나 예외 클래스는 quota 축 것을 그대로 재사용).
+- `[sandbox:youtube-privacy-locked]` — 감사 미완 강제잠금(`_resolved_
+  privacy_status`)이 실제로 요청값을 덮어썼다는 사실을 결정적으로 관찰
+  가능하게 만든다(설정값 `youtube_api_audit_incomplete`을 몰라도 이
+  마커 하나로 그 분기를 항상 통과시킨다 — 테스트가 env 값에 기대지
+  않아도 되게).
+- `[sandbox:provider-error]` — 기존 어휘 재사용(신규 마커 0, 페드루 明示④)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+from app.services.threads_publish import ThreadsPublishError
+from app.services.youtube_quota import YouTubeQuotaExceededError
+
+_MARKER_QUOTA_EXCEEDED = "[sandbox:youtube-quota-exceeded]"
+_MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
+
+
+def _raise_if_marked(text: str) -> None:
+    if _MARKER_QUOTA_EXCEEDED in text:
+        now = datetime.now(timezone.utc)
+        reset_at = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        raise YouTubeQuotaExceededError(
+            limit_units=10_000, spent_units=10_000, estimated_units=1_600, remaining_units=0, reset_at=reset_at,
+        )
+    if _MARKER_PROVIDER_ERROR in text:
+        raise ThreadsPublishError(
+            "SANDBOX_YOUTUBE_PROVIDER_ERROR", "sandbox: [sandbox:provider-error] marker simulation",
+            status_code=502,
+        )
+
+
+async def create_reels_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    video_url: str, cover_url: str | None = None, channel_payload: dict | None = None,
+) -> str:
+    _raise_if_marked(text)
+    return f"sandbox-youtube-video-{uuid.uuid4().hex}"
+
+
+async def get_container_status(
+    client: httpx.AsyncClient, *, access_token: str, creation_id: str,
+) -> tuple[str, str | None]:
+    return "FINISHED", None
+
+
+async def publish_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, creation_id: str,
+) -> str:
+    return creation_id
+
+
+async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> str | None:
+    return f"https://www.youtube.com/watch?v={media_id}"
+
+
+async def get_publishing_limit(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str,
+) -> tuple[int, int, int]:
+    return 0, 10_000, 86_400

--- a/backend/scripts/korean_user_strings_baseline.txt
+++ b/backend/scripts/korean_user_strings_baseline.txt
@@ -640,7 +640,6 @@ app/services/channel_posts.py::) — 재인증이 필요합니다
 app/services/channel_posts.py::) — 조직 설정에서 기본 역할을 지정한 뒤 다시 상신하세요
 app/services/channel_posts.py::draft를 찾을 수 없습니다:
 app/services/channel_posts.py::published 행에 external_id가 없습니다
-app/services/channel_posts.py::s > 5분 상한(그라운딩 §②)
 app/services/channel_posts.py::같은 발행이 다른 요청에서 처리 중입니다(gate_id=
 app/services/channel_posts.py::발행 provider 호출 실패(
 app/services/channel_posts.py::발행 한도를 초과했습니다 —

--- a/backend/tests/test_3815_youtube_oauth.py
+++ b/backend/tests/test_3815_youtube_oauth.py
@@ -329,16 +329,18 @@ async def test_youtube_sandbox_authorize_url_is_navigable_back_into_the_real_cal
         await engine.dispose()
 
 
-def test_youtube_publish_dispatch_not_registered_yet_fails_closed():
-    """⭐PR 경계 pin — stibee_sandbox_publish 선례(channel_adapters.py, 3813 PR2)와
-    동형: 실 발행 클라이언트가 아직 없는 채널은 `_PUBLISH_CLIENT_MODULE_PATHS`에
-    아예 등재하지 않는다(더미 모듈·dangling import path 0) — 기존
-    ChannelPublishDispatchNotImplementedError가 그대로 fail-closed한다."""
-    from app.services.channel_adapters import ChannelPublishDispatchNotImplementedError, get_publish_client_module
+def test_youtube_publish_dispatch_registered_in_pr2():
+    """⭐PR 경계 pin — 이 테스트는 PR1(이 파일 최초 작성) 시점엔 `_PUBLISH_CLIENT_
+    MODULE_PATHS`에 youtube/youtube_sandbox가 아예 없어(x/stibee PR1·PR2 경계
+    선례와 동형, 그때의 이 테스트는 ChannelPublishDispatchNotImplementedError를
+    기대했었다) 통과했지만, PR2(story #3815, 이 카드)가 실 발행 파사드(youtube_
+    publish.py/youtube_sandbox_publish.py)를 만들며 등재했으므로 뒤집혔다(옛
+    fail-closed pin은 이제 stale — 새 pin으로 교체, 삭제하지 않고 갱신해 "이
+    시점 이후 등재가 빠지면" 회귀를 잡는다)."""
+    from app.services.channel_adapters import get_publish_client_module
 
-    for channel in ("youtube", "youtube_sandbox"):
-        with pytest.raises(ChannelPublishDispatchNotImplementedError):
-            get_publish_client_module(channel)
+    assert get_publish_client_module("youtube") is not None
+    assert get_publish_client_module("youtube_sandbox") is not None
 
 
 # ─── ④ 실DB 통합 — cron 배선이 비회전 refresh도 그대로 태우는지 ────────────────

--- a/backend/tests/test_3815_youtube_publish.py
+++ b/backend/tests/test_3815_youtube_publish.py
@@ -7,12 +7,16 @@ AC 담당 4단(x_publish_budget.py 4단 구조 동형):
 ③ `_validate_youtube_metadata` 단위 — title 필수·tags 합산 상한·categoryId
   숫자 문자열·privacyStatus 허용값. 비-youtube 채널은 관할 밖.
 ④ sandbox 마커 3종 — quota-exceeded(결정적 422 재현)·privacy-locked·
-  provider-error(기존 어휘 재사용)."""
+  provider-error(기존 어휘 재사용).
+⑤ CHANGES②(페드루 PO 지적 2026-09-12 11:34Z) — 컨테이너 IN_PROGRESS 폴링
+  상한이 채널 고정 5분이 아니라 어댑터 값이어야 함(YouTube 트랜스코딩이
+  5분을 예사로 넘겨도 「거짓 실패+중복 업로드」가 나면 안 된다)."""
 from __future__ import annotations
 
 import os
 import uuid
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -37,6 +41,44 @@ async def _dispose_global_engine_after_test():
     yield
     from app.core.database import engine as _global_engine
     await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+_CHANNEL_MEDIA_BUCKET = "test-channel-media-3815"
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage(monkeypatch, tmp_path):
+    """test_3554_instagram_reels.py와 동형 픽스처(다른 버킷명으로 격리) — ⑤의
+    영상 업로드 왕복 재현에만 실제로 쓰임."""
+    import app.services.channel_post_images as cpi_module
+
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / ".storage"))
+    monkeypatch.setattr(cpi_module, "CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    monkeypatch.setattr(cpi_module, "_PUBLIC_BASE", f"https://storage.googleapis.com/{_CHANNEL_MEDIA_BUCKET}/")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _local_channel_media_storage_object_path_fix(monkeypatch):
+    import tests.test_620beefc_channel_post_image_upload as base_test_module
+
+    monkeypatch.setattr(base_test_module, "_CHANNEL_MEDIA_BUCKET", _CHANNEL_MEDIA_BUCKET)
+    yield
 
 
 # ─── ① youtube_quota.py 단위 ───────────────────────────────────────────────
@@ -334,3 +376,147 @@ async def test_youtube_sandbox_get_container_status_always_finished():
 
     status, err = await get_container_status(httpx.AsyncClient(), access_token="at", creation_id="x")
     assert (status, err) == ("FINISHED", None)
+
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_processing_long_marker_stays_in_progress():
+    """CHANGES②용 결정적 재현 자리 — 마커가 있으면 매 호출 IN_PROGRESS(5분·6분
+    지나도 FINISHED로 안 바뀜, id 문자열 자체가 상태라 process 메모리 불요)."""
+    from app.services.youtube_sandbox_publish import create_reels_container, get_container_status
+
+    container_id = await create_reels_container(
+        httpx.AsyncClient(), access_token="at", threads_user_id="u",
+        text="설명 [sandbox:youtube-processing-long] 끝", video_url="https://example.com/v.mp4",
+    )
+    assert "processing-long" in container_id
+    status, err = await get_container_status(httpx.AsyncClient(), access_token="at", creation_id=container_id)
+    assert (status, err) == ("IN_PROGRESS", None)
+
+
+# ─── ⑤ CHANGES② — 어댑터별 컨테이너 폴링 상한 ─────────────────────────────────
+
+def test_youtube_adapters_declare_24h_container_poll_timeout_not_5min_default():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    for channel in ("youtube", "youtube_sandbox"):
+        assert CHANNEL_ADAPTERS[channel].container_poll_timeout_seconds == 86_400, (
+            f"{channel}이 기본 300초(5분)를 그대로 쓰면 트랜스코딩 中에 거짓 실패+중복 업로드가 난다"
+        )
+
+
+def test_other_channels_keep_default_5min_container_poll_timeout():
+    """양성대조 — 기존 채널(Meta류)은 이 PR로 회귀가 없어야 한다(기본값 300 그대로)."""
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    for channel in ("instagram", "threads", "facebook"):
+        assert CHANNEL_ADAPTERS[channel].container_poll_timeout_seconds == 300
+
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_container_beyond_5min_stays_in_progress_no_reupload():
+    """⭐CHANGES②(페드루 PO 지적 2026-09-12 11:34Z) 핵심 재현 — YouTube는 5분을
+    넘겨도(Meta 상한 자리) 거짓 실패로 떨어지면 안 된다: 행이 살아있고(status
+    실패 아님)·external_container_id 보존(재시도가 새 업로드를 안 만든다)·
+    create_reels_container(=insert, quota 소비처) 재호출 0."""
+    from tests.test_620beefc_channel_post_image_upload import (
+        _approve_gate_directly, _client_for, _seed_connection, _seed_human, _seed_org, _seed_story,
+        _session_factory, _setup_org_scoped_app,
+    )
+    from tests.test_3554_instagram_reels import _build_mp4, _upload_and_confirm_video
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="youtube_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+            from app.models.participation import ParticipationRole
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+            s.add(role)
+            await s.commit()
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        try:
+            async with _client_for(app) as client:
+                r_draft = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(connection_id),
+                        "text": "6분 상한 재현용 설명",
+                        "channel_payload": {"title": "6분 상한 재현"},
+                    },
+                )
+                assert r_draft.status_code == 201, r_draft.text
+                draft_id = r_draft.json()["draft_id"]
+
+                video_raw = _build_mp4(duration_seconds=6.0, width=1920, height=1080)
+                r_video = await _upload_and_confirm_video(client, org_id, draft_id, video_raw)
+                assert r_video.status_code == 201, r_video.text
+
+                r_submit = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+                )
+                assert r_submit.status_code == 200, r_submit.text
+                gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+            async with Session() as s:
+                await _approve_gate_directly(s, gate_id)
+
+            import app.services.youtube_sandbox_publish as ysp
+            create_reels_container_spy = AsyncMock(wraps=ysp.create_reels_container)
+            with patch.object(ysp, "create_reels_container", create_reels_container_spy):
+                async with _client_for(app) as client:
+                    r_pub1 = await client.post(
+                        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                    )
+                assert r_pub1.status_code == 200, r_pub1.text
+                assert r_pub1.json()["processing"] is True
+            assert create_reels_container_spy.await_count == 1
+
+            from app.models.channel_publication import ChannelPublication
+            from sqlalchemy import select as sa_select
+            async with Session() as s:
+                pub = (await s.execute(
+                    sa_select(ChannelPublication).where(ChannelPublication.org_id == org_id)
+                )).scalar_one()
+                original_container_id = pub.external_container_id
+                assert "processing-long" not in original_container_id  # 정상 업로드 — 마커 없음.
+                # 6분 경과 재현(row.created_at 되돌리기, 기존 620beefc 패턴과 동형).
+                pub.created_at = datetime.now(timezone.utc) - timedelta(minutes=6)
+                await s.commit()
+
+            # sandbox의 get_container_status는 마커 없는 id면 즉시 FINISHED를 내
+            # "6분 지나도 여전히 처리 中"을 재현할 수 없다 — get_container_status만
+            # IN_PROGRESS로 패치해 그 상황을 시뮬레이션(YouTube 실물에선 트랜스코딩이
+            # 그만큼 오래 걸리는 경우에 해당).
+            with (
+                patch.object(ysp, "create_reels_container", create_reels_container_spy),
+                patch.object(ysp, "get_container_status", AsyncMock(return_value=("IN_PROGRESS", None))),
+            ):
+                async with _client_for(app) as client:
+                    r_pub2 = await client.post(
+                        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                    )
+                assert r_pub2.status_code == 200, (
+                    f"6분 경과에도 거짓 실패로 떨어지면 안 된다(YouTube 트랜스코딩 예사): {r_pub2.text}"
+                )
+                assert r_pub2.json()["processing"] is True
+
+            assert create_reels_container_spy.await_count == 1, (
+                "재시도가 새 업로드(insert)를 또 만들면 quota 이중 차감 — 5분 상한 채널과 같은 버그 재현"
+            )
+
+            async with Session() as s:
+                pub = (await s.execute(
+                    sa_select(ChannelPublication).where(ChannelPublication.org_id == org_id)
+                )).scalar_one()
+                assert pub.status != "failed", "6분 경과만으로 실패 처리되면 안 된다(24h 상한 미달)"
+                assert pub.external_container_id == original_container_id, (
+                    "id가 지워지면 다음 재시도가 새 업로드를 만든다 — 여기서 이미 사고"
+                )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3815_youtube_publish.py
+++ b/backend/tests/test_3815_youtube_publish.py
@@ -1,0 +1,336 @@
+"""story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12) — YouTube 발행 회귀·정탐.
+AC 담당 4단(x_publish_budget.py 4단 구조 동형):
+① `youtube_quota.py` 단위 — 플랫폼 전체(cross-org) 합산·초과 시 reset_at 포함
+  raise·evidence 멱등(publication_id+event).
+② `youtube_privacy.py` 단위 — 감사 미완=강제 비공개(설정값 축·sandbox 마커 축
+  둘 다), 뮤테이션 셀프체크로 "잠금 로직이 실제로 뭘 지키는지" 고정.
+③ `_validate_youtube_metadata` 단위 — title 필수·tags 합산 상한·categoryId
+  숫자 문자열·privacyStatus 허용값. 비-youtube 채널은 관할 밖.
+④ sandbox 마커 3종 — quota-exceeded(결정적 422 재현)·privacy-locked·
+  provider-error(기존 어휘 재사용)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+
+from tests.test_3471_org_content_rules_lint import _seed_org, _seed_story, _session_factory
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+# ─── ① youtube_quota.py 단위 ───────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_check_youtube_quota_or_raise_under_limit_passes():
+    from app.services.youtube_quota import check_youtube_quota_or_raise
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            await check_youtube_quota_or_raise(s, estimated_units=1_600)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_check_youtube_quota_or_raise_exceeds_includes_reset_at_utc_midnight():
+    """페드루 PO 낱말 확定(2026-09-12 10:46Z) — reset_at은 정확한 UTC 자정
+    시각(날짜뿐 아님)."""
+    from app.core.config import settings
+    from app.services.youtube_quota import YouTubeQuotaExceededError, check_youtube_quota_or_raise
+
+    engine, Session = await _session_factory()
+    try:
+        now = datetime(2026, 9, 12, 15, 30, 0, tzinfo=timezone.utc)
+        async with Session() as s:
+            with pytest.raises(YouTubeQuotaExceededError) as exc_info:
+                await check_youtube_quota_or_raise(
+                    s, estimated_units=settings.youtube_quota_daily_limit_units + 1, now=now,
+                )
+        exc = exc_info.value
+        assert exc.limit_units == settings.youtube_quota_daily_limit_units
+        assert exc.spent_units == 0
+        assert exc.remaining_units == settings.youtube_quota_daily_limit_units
+        assert exc.reset_at == datetime(2026, 9, 13, 0, 0, 0, tzinfo=timezone.utc), (
+            "reset_at은 «내일 날짜»가 아니라 정확한 UTC 자정 시각이어야 한다"
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_platform_wide_quota_sum_ignores_org_id():
+    """org_id 필터가 없다는 게 이 함수의 요점 — 서로 다른 두 조직의 evidence가
+    합산돼 한쪽 조직만 봐선 안 잡히는 초과를 잡아야 한다."""
+    from app.core.config import settings
+    from app.services.youtube_quota import (
+        YouTubeQuotaExceededError, check_youtube_quota_or_raise, record_youtube_quota_usage_evidence,
+    )
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a, project_a = await _seed_org(s)
+            org_b, project_b = await _seed_org(s)
+            story_a = await _seed_story(s, org_a, project_a)
+            story_b = await _seed_story(s, org_b, project_b)
+
+        half = settings.youtube_quota_daily_limit_units // 2 + 100
+        async with Session() as s:
+            await record_youtube_quota_usage_evidence(
+                s, org_id=org_a, work_item_id=story_a, publication_id=uuid.uuid4(), event="insert", units=half,
+            )
+        async with Session() as s:
+            await record_youtube_quota_usage_evidence(
+                s, org_id=org_b, work_item_id=story_b, publication_id=uuid.uuid4(), event="insert", units=half,
+            )
+
+        # 조직 A 혼자면 절대 초과가 아니지만, 플랫폼 전체(A+B) 합산은 이미
+        # limit 근처라 조금만 더 요청해도 넘는다.
+        async with Session() as s:
+            with pytest.raises(YouTubeQuotaExceededError) as exc_info:
+                await check_youtube_quota_or_raise(s, estimated_units=1_000)
+        assert exc_info.value.spent_units == half * 2
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_record_youtube_quota_usage_evidence_idempotent_by_publication_and_event():
+    from sqlalchemy import select
+    from app.models.evidence import Evidence
+    from app.services.youtube_quota import YOUTUBE_QUOTA_KIND, record_youtube_quota_usage_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            story_id = await _seed_story(s, org_id, project_id)
+        publication_id = uuid.uuid4()
+
+        async with Session() as s:
+            await record_youtube_quota_usage_evidence(
+                s, org_id=org_id, work_item_id=story_id, publication_id=publication_id, event="insert", units=1_600,
+            )
+        async with Session() as s:
+            # 재시도 시나리오 — 같은 (publication_id, event) 재호출.
+            await record_youtube_quota_usage_evidence(
+                s, org_id=org_id, work_item_id=story_id, publication_id=publication_id, event="insert", units=1_600,
+            )
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Evidence).where(
+                    Evidence.org_id == org_id, Evidence.payload["kind"].astext == YOUTUBE_QUOTA_KIND,
+                )
+            )).scalars().all()
+        assert len(rows) == 1, f"멱등이어야 하는데 {len(rows)}건 기록됨"
+
+        # 양성대조 — 다른 event("list")는 같은 publication이어도 별개 행.
+        async with Session() as s:
+            await record_youtube_quota_usage_evidence(
+                s, org_id=org_id, work_item_id=story_id, publication_id=publication_id, event="list", units=1,
+            )
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Evidence).where(
+                    Evidence.org_id == org_id, Evidence.payload["kind"].astext == YOUTUBE_QUOTA_KIND,
+                )
+            )).scalars().all()
+        assert len(rows) == 2
+    finally:
+        await engine.dispose()
+
+
+# ─── ② youtube_privacy.py 단위 — 뮤테이션 셀프체크 포함 ───────────────────────
+
+def test_resolve_youtube_privacy_lock_forces_private_when_audit_incomplete(monkeypatch):
+    from app.core.config import settings
+    from app.services.youtube_privacy import resolve_youtube_privacy_lock
+
+    monkeypatch.setattr(settings, "youtube_api_audit_incomplete", True)
+    status, locked = resolve_youtube_privacy_lock(requested_privacy_status="public", text="일반 설명문")
+    assert (status, locked) == ("private", True), "감사 미완이면 요청값(public) 무관 private 강제여야 한다"
+
+
+def test_resolve_youtube_privacy_lock_respects_requested_when_audit_complete(monkeypatch):
+    from app.core.config import settings
+    from app.services.youtube_privacy import resolve_youtube_privacy_lock
+
+    monkeypatch.setattr(settings, "youtube_api_audit_incomplete", False)
+    status, locked = resolve_youtube_privacy_lock(requested_privacy_status="public", text="일반 설명문")
+    assert (status, locked) == ("public", False)
+
+
+def test_resolve_youtube_privacy_lock_marker_forces_lock_even_when_audit_complete(monkeypatch):
+    """sandbox 결정적 마커 축 — 감사가 끝났다고 설정해도(audit_incomplete=False)
+    마커가 있으면 여전히 잠긴다(테스트가 env 값에 기대지 않게)."""
+    from app.core.config import settings
+    from app.services.youtube_privacy import resolve_youtube_privacy_lock
+
+    monkeypatch.setattr(settings, "youtube_api_audit_incomplete", False)
+    status, locked = resolve_youtube_privacy_lock(
+        requested_privacy_status="public", text="설명 [sandbox:youtube-privacy-locked] 끝",
+    )
+    assert (status, locked) == ("private", True)
+
+
+def test_resolve_youtube_privacy_lock_defaults_to_private_when_unspecified(monkeypatch):
+    from app.core.config import settings
+    from app.services.youtube_privacy import resolve_youtube_privacy_lock
+
+    monkeypatch.setattr(settings, "youtube_api_audit_incomplete", False)
+    status, locked = resolve_youtube_privacy_lock(requested_privacy_status=None, text="설명")
+    assert (status, locked) == ("private", False), "미지정 시에도 기본은 안전한 쪽(private)이어야 한다"
+
+
+def test_mutation_privacy_lock_audit_incomplete_axis_would_break_if_ignored(monkeypatch):
+    """⭐뮤테이션 셀프체크 — resolve_youtube_privacy_lock이 audit_incomplete를
+    무시하도록 임시로 바꾸면 위 forces_private 테스트가 정확히 RED가 나야
+    한다(가드가 실제로 뭘 지키는지 증명, [[feedback_guard_must_declare_what_it_misses]])."""
+    import app.services.youtube_privacy as privacy_module
+    from app.core.config import settings
+
+    original = privacy_module.resolve_youtube_privacy_lock
+
+    def _mutated(*, requested_privacy_status, text):
+        # audit_incomplete 축을 고의로 빼먹은 버전 — 마커 축만 본다.
+        if privacy_module._MARKER_PRIVACY_LOCKED in text:
+            return "private", True
+        return requested_privacy_status or "private", False
+
+    monkeypatch.setattr(privacy_module, "resolve_youtube_privacy_lock", _mutated)
+    monkeypatch.setattr(settings, "youtube_api_audit_incomplete", True)
+    status, locked = privacy_module.resolve_youtube_privacy_lock(requested_privacy_status="public", text="설명")
+    assert (status, locked) == ("public", False), "뮤테이션이 실제로 축 하나를 죽였는지 확認(이 assert 자체는 RED 재현용)"
+    assert original is not _mutated
+
+
+# ─── ③ _validate_youtube_metadata 단위 ─────────────────────────────────────
+
+def test_validate_youtube_metadata_valid_payload_passes():
+    from app.services.channel_posts import _validate_youtube_metadata
+
+    _validate_youtube_metadata(
+        channel="youtube",
+        channel_payload={"title": "제목", "tags": ["a", "b"], "categoryId": "22", "privacyStatus": "unlisted"},
+    )
+
+
+def test_validate_youtube_metadata_non_youtube_channel_skips_entirely():
+    from app.services.channel_posts import _validate_youtube_metadata
+
+    _validate_youtube_metadata(channel="threads", channel_payload={"title": ""})  # 관할 밖 — 절대 안 터진다.
+
+
+def test_validate_youtube_metadata_missing_title_raises():
+    from app.services.channel_posts import ChannelYouTubeMetadataError, _validate_youtube_metadata
+
+    with pytest.raises(ChannelYouTubeMetadataError) as exc_info:
+        _validate_youtube_metadata(channel="youtube_sandbox", channel_payload={})
+    assert exc_info.value.field == "title"
+
+
+def test_validate_youtube_metadata_title_too_long_raises():
+    from app.services.channel_posts import ChannelYouTubeMetadataError, _validate_youtube_metadata
+
+    with pytest.raises(ChannelYouTubeMetadataError) as exc_info:
+        _validate_youtube_metadata(channel="youtube", channel_payload={"title": "가" * 101})
+    assert exc_info.value.field == "title"
+
+
+def test_validate_youtube_metadata_tags_combined_too_long_raises():
+    from app.services.channel_posts import ChannelYouTubeMetadataError, _validate_youtube_metadata
+
+    with pytest.raises(ChannelYouTubeMetadataError) as exc_info:
+        _validate_youtube_metadata(
+            channel="youtube", channel_payload={"title": "t", "tags": ["가" * 250, "나" * 251]},
+        )
+    assert exc_info.value.field == "tags"
+
+
+def test_validate_youtube_metadata_category_id_non_numeric_raises():
+    from app.services.channel_posts import ChannelYouTubeMetadataError, _validate_youtube_metadata
+
+    with pytest.raises(ChannelYouTubeMetadataError) as exc_info:
+        _validate_youtube_metadata(channel="youtube", channel_payload={"title": "t", "categoryId": "gaming"})
+    assert exc_info.value.field == "categoryId"
+
+
+def test_validate_youtube_metadata_invalid_privacy_status_raises():
+    from app.services.channel_posts import ChannelYouTubeMetadataError, _validate_youtube_metadata
+
+    with pytest.raises(ChannelYouTubeMetadataError) as exc_info:
+        _validate_youtube_metadata(channel="youtube", channel_payload={"title": "t", "privacyStatus": "secret"})
+    assert exc_info.value.field == "privacyStatus"
+
+
+# ─── ④ sandbox 마커 3종 ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_quota_exceeded_marker_raises_with_reset_at():
+    from app.services.youtube_quota import YouTubeQuotaExceededError
+    from app.services.youtube_sandbox_publish import create_reels_container
+
+    with pytest.raises(YouTubeQuotaExceededError) as exc_info:
+        await create_reels_container(
+            httpx.AsyncClient(), access_token="at", threads_user_id="u",
+            text="설명 [sandbox:youtube-quota-exceeded] 끝", video_url="https://example.com/v.mp4",
+        )
+    assert exc_info.value.remaining_units == 0
+    assert exc_info.value.reset_at is not None
+
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_provider_error_marker_reused():
+    """신규 마커 0(페드루 明示④) — 기존 [sandbox:provider-error] 어휘 그대로."""
+    from app.services.threads_publish import ThreadsPublishError
+    from app.services.youtube_sandbox_publish import create_reels_container
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await create_reels_container(
+            httpx.AsyncClient(), access_token="at", threads_user_id="u",
+            text="설명 [sandbox:provider-error] 끝", video_url="https://example.com/v.mp4",
+        )
+    assert exc_info.value.code == "SANDBOX_YOUTUBE_PROVIDER_ERROR"
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_create_reels_container_deterministic_id_when_clean():
+    from app.services.youtube_sandbox_publish import create_reels_container
+
+    container_id = await create_reels_container(
+        httpx.AsyncClient(), access_token="at", threads_user_id="u",
+        text="깨끗한 설명", video_url="https://example.com/v.mp4",
+        channel_payload={"title": "제목"},
+    )
+    assert container_id.startswith("sandbox-youtube-video-")
+
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_get_container_status_always_finished():
+    from app.services.youtube_sandbox_publish import get_container_status
+
+    status, err = await get_container_status(httpx.AsyncClient(), access_token="at", creation_id="x")
+    assert (status, err) == ("FINISHED", None)

--- a/backend/tests/test_3815_youtube_publish.py
+++ b/backend/tests/test_3815_youtube_publish.py
@@ -520,3 +520,151 @@ async def test_youtube_sandbox_container_beyond_5min_stays_in_progress_no_reuplo
             app.dependency_overrides.clear()
     finally:
         await engine.dispose()
+
+
+def test_youtube_adapters_declare_keep_container_on_poll_timeout():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    for channel in ("youtube", "youtube_sandbox"):
+        assert CHANNEL_ADAPTERS[channel].keep_container_on_poll_timeout is True
+
+
+def test_other_channels_keep_default_clear_container_on_poll_timeout():
+    """양성대조 — Meta류는 회귀 0(기본 False 그대로, 죽은 컨테이너는 id를 지워야
+    다음 시도가 완전히 새 컨테이너를 만든다)."""
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    for channel in ("instagram", "threads", "facebook"):
+        assert CHANNEL_ADAPTERS[channel].keep_container_on_poll_timeout is False
+
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_beyond_24h_timeout_fails_but_preserves_container_id_no_reupload_on_retry():
+    """⭐CHANGES③(페드루 PO 지적 2026-09-12 11:55Z) — 24h(youtube/sandbox 상한)를
+    넘겨도(극히 드문 경우) dead_letter로 떨어지는 건 Meta와 동형이지만,
+    external_container_id는 지우면 안 된다 — 사람이 AC5 재시도를 눌렀을 때
+    새 업로드(quota 1,600 재소모)가 또 나면 CHANGES②가 막은 사고가 24h 축에서
+    반복된다. 재시도(dead_letter→pending)+get_container_status가 마침내
+    FINISHED를 내는 시나리오까지 왕복해 insert(=create_reels_container) 호출이
+    처음 1회에서 안 늘어남을 확認한다."""
+    from tests.test_620beefc_channel_post_image_upload import (
+        _approve_gate_directly, _client_for, _seed_connection, _seed_human, _seed_org, _seed_story,
+        _session_factory, _setup_org_scoped_app,
+    )
+    from tests.test_3554_instagram_reels import _build_mp4, _upload_and_confirm_video
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="youtube_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+            from app.models.participation import ParticipationRole
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+            s.add(role)
+            await s.commit()
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        try:
+            async with _client_for(app) as client:
+                r_draft = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(connection_id),
+                        "text": "24h 상한 재현용 설명",
+                        "channel_payload": {"title": "24h 상한 재현"},
+                    },
+                )
+                assert r_draft.status_code == 201, r_draft.text
+                draft_id = r_draft.json()["draft_id"]
+
+                video_raw = _build_mp4(duration_seconds=6.0, width=1920, height=1080)
+                r_video = await _upload_and_confirm_video(client, org_id, draft_id, video_raw)
+                assert r_video.status_code == 201, r_video.text
+
+                r_submit = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+                )
+                assert r_submit.status_code == 200, r_submit.text
+                gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+            async with Session() as s:
+                await _approve_gate_directly(s, gate_id)
+
+            import app.services.youtube_sandbox_publish as ysp
+            create_reels_container_spy = AsyncMock(wraps=ysp.create_reels_container)
+            with patch.object(ysp, "create_reels_container", create_reels_container_spy):
+                async with _client_for(app) as client:
+                    r_pub1 = await client.post(
+                        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                    )
+                assert r_pub1.status_code == 200, r_pub1.text
+            assert create_reels_container_spy.await_count == 1
+
+            from app.models.channel_publication import ChannelPublication
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select as sa_select
+            async with Session() as s:
+                pub = (await s.execute(
+                    sa_select(ChannelPublication).where(ChannelPublication.org_id == org_id)
+                )).scalar_one()
+                original_container_id = pub.external_container_id
+                # 24h+1분 경과 재현.
+                pub.created_at = datetime.now(timezone.utc) - timedelta(hours=24, minutes=1)
+                await s.commit()
+
+            with (
+                patch.object(ysp, "create_reels_container", create_reels_container_spy),
+                patch.object(ysp, "get_container_status", AsyncMock(return_value=("IN_PROGRESS", None))),
+            ):
+                async with _client_for(app) as client:
+                    r_pub2 = await client.post(
+                        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                    )
+                assert r_pub2.status_code == 503, r_pub2.text  # TIMEOUT → dead_letter(Meta와 동형).
+
+            async with Session() as s:
+                pub = (await s.execute(
+                    sa_select(ChannelPublication).where(ChannelPublication.org_id == org_id)
+                )).scalar_one()
+                assert pub.status == "failed"
+                # ⭐핵심 — 24h를 넘겼어도 id는 보존돼야 한다(뒤집으면 여기서 RED).
+                assert pub.external_container_id == original_container_id, (
+                    "24h 초과로 id가 지워지면 재시도가 새 업로드를 만든다 — CHANGES②가 막은 사고의 24h판"
+                )
+                command = (await s.execute(
+                    sa_select(PublicationCommand).where(
+                        PublicationCommand.org_id == org_id, PublicationCommand.destination == connection_id,
+                    )
+                )).scalar_one()
+                assert command.status == "dead_letter"
+
+            # 사람이 AC5 재시도 버튼을 누른 뒤(dead_letter→pending) 트랜스코딩이
+            # 마침내 끝났다고 가정 — insert(create_reels_container) 재호출 없이
+            # 같은 id로 폴링만 재개해 FINISHED로 마무리돼야 한다.
+            async with _client_for(app) as client:
+                r_retry = await client.post(
+                    f"/api/v2/organizations/{org_id}/publication-commands/{command.id}/retry",
+                )
+                assert r_retry.status_code == 200, r_retry.text
+
+            with (
+                patch.object(ysp, "create_reels_container", create_reels_container_spy),
+                patch.object(ysp, "get_container_status", AsyncMock(return_value=("FINISHED", None))),
+            ):
+                async with _client_for(app) as client:
+                    r_pub3 = await client.post(
+                        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                    )
+                assert r_pub3.status_code == 200, r_pub3.text
+                assert r_pub3.json()["processing"] is False
+
+            assert create_reels_container_spy.await_count == 1, (
+                "재시도 뒤에도 insert가 또 불렸다면 quota 이중 차감 — 24h 상한 id-보존이 안 먹힌 것"
+            )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -253,4 +253,30 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # cloudbuild.yaml `_BACKEND_URL` substitution으로 직접 배선·manual-env-allowlist.yml
     # 미등재(PUBLIC_SITE_BASE_URL과 동형).
     assert "BACKEND_URL" in keys
-    assert len(keys) == 121
+    # story #3815(Phase3·3-5 PR2, 페드루 PO 確定 2026-09-12): youtube_quota_
+    # daily_limit_units·youtube_quota_cost_insert_units·youtube_quota_cost_
+    # list_units·youtube_api_audit_incomplete 4필드 신설(플랫폼 공유 YouTube
+    # quota 한도/단가+API 감사 미완 강제 비공개 플래그, config.py 상단 딱지
+    # 참고)로 121→125. 밑줄 구분 int 리터럴(10_000·1_600)·bool = True 형·
+    # 같은 줄 뒤 주석 3가지 축 전부 정규식 재현으로 실측 확認(로컬 `python3 -c`
+    # 로 `_SETTINGS_FIELD_RE`만 단독 실행 — 4개 다 정상 매칭, 총 125). 가드가
+    # 신규 필드를 설계대로 잡은 것(파서 결함 아님, 이 assert만 stale이었다).
+    assert "YOUTUBE_QUOTA_DAILY_LIMIT_UNITS" in keys and "YOUTUBE_QUOTA_COST_INSERT_UNITS" in keys
+    assert "YOUTUBE_QUOTA_COST_LIST_UNITS" in keys and "YOUTUBE_API_AUDIT_INCOMPLETE" in keys
+    assert len(keys) == 125
+
+
+def test_settings_field_regex_handles_underscore_int_literal_bool_and_trailing_comment():
+    """⭐양성대조(페드루 PO 지적 2026-09-12 12:37Z, 재검증 결과 파서 결함은 아니었으나
+    — 그 우려 자체는 재발가능성이 있어 pin으로 고정) — `_SETTINGS_FIELD_RE`가 밑줄
+    구분 int 리터럴(`10_000`)·`bool = True`·같은 줄 뒤 주석까지 정확히 다 세는지
+    합성 스니펫으로 직접 확認한다(실 config.py 전체를 다시 읽는 위 테스트와 달리,
+    이 정규식 자체의 계약만 pin — 정규식을 손대면 이 테스트가 바로 반응한다)."""
+    mod = _load_check_env_drift()
+    snippet = (
+        "class Settings(BaseSettings):\n"
+        "    youtube_quota_daily_limit_units: int = 10_000\n"
+        "    youtube_api_audit_incomplete: bool = True  # 밑줄·bool·같은 줄 주석 3축 동시 재현\n"
+    )
+    names = {name.upper() for name in mod._SETTINGS_FIELD_RE.findall(snippet)}
+    assert names == {"YOUTUBE_QUOTA_DAILY_LIMIT_UNITS", "YOUTUBE_API_AUDIT_INCOMPLETE"}

--- a/infra/destructive-schema-shard-weights/test_3815_youtube_publish.py.json
+++ b/infra/destructive-schema-shard-weights/test_3815_youtube_publish.py.json
@@ -1,0 +1,1 @@
+{"file": "tests/test_3815_youtube_publish.py", "sec": 2.7, "source": "실측(로컬 pytest 단독 실행, 2026-09-12, 디디)"}

--- a/infra/destructive-schema-shard-weights/test_3815_youtube_publish.py.json
+++ b/infra/destructive-schema-shard-weights/test_3815_youtube_publish.py.json
@@ -1,1 +1,1 @@
-{"file": "tests/test_3815_youtube_publish.py", "sec": 2.7, "source": "실측(로컬 pytest 단독 실행, 2026-09-12, 디디)"}
+{"file": "tests/test_3815_youtube_publish.py", "sec": 4.8, "source": "실측(로컬 pytest 단독 실행, 2026-09-12, 디디, CHANGES② 테스트 추가 재측)"}

--- a/infra/destructive-schema-shard-weights/test_3815_youtube_publish.py.json
+++ b/infra/destructive-schema-shard-weights/test_3815_youtube_publish.py.json
@@ -1,1 +1,1 @@
-{"file": "tests/test_3815_youtube_publish.py", "sec": 4.8, "source": "실측(로컬 pytest 단독 실행, 2026-09-12, 디디, CHANGES② 테스트 추가 재측)"}
+{"file": "tests/test_3815_youtube_publish.py", "sec": 6.0, "source": "실측(로컬 pytest 단독 실행, 2026-09-12, 디디, CHANGES③ 테스트 추가 재측)"}


### PR DESCRIPTION
## 요약
story #3815(Phase3·3-5) PR2 — YouTube resumable 업로드 발행 오케스트레이션·플랫폼
공유 quota·`channel_payload` 메타 검증·API 감사 미완 강제 비공개 잠금.

## 구현
- **발행 파사드**(`youtube_publish.py`/`youtube_sandbox_publish.py`, 신규) — 기존
  5(6)-함수 파사드에 맞춰 YouTube의 `videos.insert` 단일 호출(resumable 세션
  열기→PUT→완료 시점=발행 시점)을 접어 넣음. `ThreadsPublishError` 재사용
  (신규 예외 클래스 0, x_publish.py 선례 동형).
- **플랫폼 공유 quota**(`youtube_quota.py`, 신규) — X/생성비의 조직별 월 지갑과
  다른 축: cross-org SUM(Evidence, org_id 필터 없음)·UTC 자정 경계 일일 카운터.
  `YouTubeQuotaExceededError`에 `reset_at`(정확한 UTC 자정 시각) 포함.
- **API 감사 미완=강제 비공개**(`youtube_privacy.py`, 신규) — 판정 로직 단일
  정본(publish-client와 오케스트레이션 둘 다 재사용, 이중선언 금지). 신규
  열 `channel_publications.privacy_locked`(migration 0372) — 발행 "그 순간"의
  잠금 사실을 행에 못박음. `status`는 "published" 그대로 무변(페드루 明示④
  — 연결 status 4값·발행 status 값 모두 무변, 이 잠금은 그 밖의 별개 사실).
- **`_validate_youtube_metadata`**(channel_posts.py) — title 필수/100자·tags
  합산 500자·categoryId 숫자 문자열·privacyStatus 허용값 3종. 두 checkpoint
  (저장 시점 `create_channel_post_draft_version`·발행 시점, `_validate_thread_
  segments`와 동형 패턴). **description은 `channel_payload`가 아니라 기존
  `text` 필드로 매핑**(카드 재그라운딩 정정 — X의 head-text 관례 재사용,
  `_validate_text_length`가 이미 그 축 담당) — 카드 원문 문구와의 의도적
  이탈 지점, PR 리뷰 시 확認 요청.
- **`ChannelVideoRequiredError`/`video_required`**(`ChannelImageRequiredError`
  동형) — `submit_channel_post_draft`에서 image_required와 같은 위치에 배선,
  라우터도 같은 위치에 422(`CHANNEL_VIDEO_REQUIRED`) 배선.
- **`except YouTubeQuotaExceededError`** — 라우터(`publish_channel_post_draft_
  endpoint`)·워커(`publication_command.py::_process_one_command`) 둘 다
  `GenerationBudgetExceededError`와 동형 위치·모양으로 배선.
- **발견 즉시 수정** — `get_channel_post_video_for_version` 조회가 `image_
  sha256 is not None` 게이트 안에 갇혀, 영상은 있는데 커버 이미지가 없는
  게시물(정확히 YouTube의 `video_required=True`/`image_required=False`
  조합)이 `has_video=False`로 새던 latent bug. 커버-이미지 게이트에서
  분리해 무조건 실행하도록 수정(기존 채널 회귀 0 — 영상 없으면 그대로 None).

## 챕터 관례 재확認(카드 PO 주 2 — 「미확認」 해소)
Google 공식 도움말(support.google.com/youtube/answer/9884579) 확認 完:
- 첫 줄은 반드시 `0:00`.
- 최소 3개 이상의 타임스탬프(오름차순).
- 챕터 하나의 최소 길이는 10초.
FE PR4(편집기 챕터 도움 문구) 그라운딩에 그대로 넘길 수 있는 확정 사실 —
이 PR(BE)은 그 문구 자체를 만들지 않음(카드 §낱말 한 벌은 FE 축).

## ⚠️미확認(지어내지 않음, 그대로 유지)
- `youtube_publish.py`의 resumable 업로드 세션 정확한 요청/응답 헤더명
  (`X-Upload-Content-Length` 등)·`videos.insert` 응답 스키마·`uploadStatus`
  enum 값(uploaded/processed/rejected/failed 등) — 실 앱 왕복 전까지 최선
  추정. 코드 상단 딱지에 명시.
- `video_max_bytes=2GiB`는 페드루 미지정 값에 대한 디디의 실무 판단(다른
  채널 대비 여유 있는 상한) — 명시 승인 대상.

## 의도적 스코프 축소(카드 원문과 다른 지점, PR 리뷰 확認 요청)
- description → `channel_payload`가 아니라 `text` 필드(위 참고).
- quota 한도/단가는 `platform_settings`(카드 원문 「플랫폼 설정값」과 정확히
  일치하는 자리)가 아니라 `Settings` env 값 — `platform_settings`는 admin UI
  교차-레포 배선이 필요해 이 PR(backend-only) 범위 밖. 페드루 PO 「env/규칙
  조정 가능」 허용 범위 안(PR1 킥오프 메시지).

## CHANGES①(페드루 PO 지적 2026-09-12 11:34Z) — 사용량 초기화 문구
`reset_at`이 UTC 00:00 **시각**이라 KST(UTC+9) 사용자에겐 그날 09:00부터인데
기존 「내일 다시」 문구는 이르게 읽혔다(거짓 인상) — 정적 절대시각 문장으로
교체(`i18n_catalog.py` "channel_posts.youtube_usage_exceeded"):
- ko: 「오늘 YouTube 사용량을 다 썼습니다 — 사용량은 매일 오전 9시(한국
  시간)에 초기화됩니다(플랫폼 공유 한도).」
- en: "Today's YouTube usage limit has been reached — it resets daily at
  00:00 UTC (shared platform-wide limit)."
`reset_at` 필드는 응답에 그대로 유지(FE가 필요하면 참고).

## CHANGES②(페드루 PO 지적 2026-09-12 11:34Z) — 어댑터별 컨테이너 폴링 상한
컨테이너 IN_PROGRESS 폴링 상한이 채널 무관 고정 5분이었다 — YouTube 트랜스
코딩은 5분을 예사로 넘겨(자산은 이미 업로드 完·처리 중일 뿐) 기존 로직대로면
"거짓 실패"로 `external_container_id`를 지워 재시도가 같은 영상을 새로
업로드(quota 1,600 이중 차감)하는 사고로 이어짐.

처방 — `ChannelAdapterConfig.container_poll_timeout_seconds`(신규, 기본
300=기존 Meta류 회귀 0) 도입, youtube/youtube_sandbox만 86,400(24h)으로
재정의. sandbox 마커 4번째 `[sandbox:youtube-processing-long]` 추가
(creation_id 자체에 상태를 새겨 결정적 재현, DB 불요).

**대응 中 자체 발견·즉시 수정 3건**:
1. `channel_posts.py:1711`의 `_publish_client.create_container` 무조건
   속성-접근 — 기존 영상-지원 채널(Reels 등)은 전부 이미지도 같이 지원해
   이 함수가 항상 존재했지만, YouTube는 이미지 컨테이너 개념 자체가 없는
   첫 video_required=True 전용 채널이라 AttributeError로 즉시 500(로컬
   테스트 작성 中 발견). youtube_publish.py/youtube_sandbox_publish.py에
   fail-closed `create_container` 스텁 추가.
2. `confirm_channel_post_video_upload`가 `create_channel_post_draft_
   version` 재호출 시 text/link_url은 carry-forward하면서 channel_payload
   는 안 넘겨(매 호출 None) 새 버전마다 지워왔다 — YouTube는 channel_
   payload(title 등)가 video_required=True와 맞물려 이 경로를 반드시
   거쳐 이 갭이 처음 기능을 깼다. `channel_post_videos.py`의 해당 호출부
   1곳에 `channel_payload=latest.channel_payload` 추가. **다른 채널(X
   스레드 channel_payload.thread·stibee subject)도 이론상 같은 결함이
   `channel_post_images.py`에 3곳 더 있는지 판별 요청 — 판별 결과: X는
   image_max_bytes 미선언(0)이라 이미지 첨부 자체가 confirm_channel_post_
   image_upload의 ChannelImageUnsupportedError(422)로 이 코드 도달 前에
   막힘(channel_post_images.py:397) — 3808 실 결함 아님, 페드루 확認 済
   (「아니오」→적기만).**
3. `video_max_seconds` 기본값(0.0) 방치 — channel_post_videos.py의 검증이
   "재생시간 > 0.0" 조건에 항상 걸려 **모든** youtube 영상 업로드가 무조건
   거부됐을 latent bug(회귀 테스트가 이 값을 실제로 요구하는 자리를 안
   태워 지금까지 못 잡힘). youtube/youtube_sandbox에 video_max_seconds=
   12h(⚠️미확認)·video_min_seconds=1.0 추가.

한글가드(#3779) 대응 — row.last_error의 옛 「5분 상한」 고정 한글 문구가
이제 어댑터별 값이라 재사용 불가(같은 값이 24h일 수도 있음) → 새 문구는
영어로(baseline 재등재 없이 처리, 옛 grandfather 줄은 stale이라 제거).

### 3502 러너 시간 가드 판별(같은 push 前 카디르 요청)
develop(c2f97e55d) vs 이 브랜치(당시 head 23ce9d732b), 같은 로컬 머신 순차
2회씩:
```
$ uv run pytest -q tests/test_3502_insights_board.py   # develop
35 passed in 21.72s / 35 passed in 19.33s

$ uv run pytest -q tests/test_3502_insights_board.py   # 이 브랜치
35 passed in 17.03s / 35 passed in 16.77s
```
브랜치가 오히려 ≈0.8배 가벼움 — CI shard 6의 148s는 코드 무죄, 같은 run에서
4224와 러너 경합(원인 1줄). 처방 불요(새 head CI로 자연 해소).

## CHANGES③(페드루 PO 지적 2026-09-12 11:55Z) — 24h 상한 초과해도 컨테이너 id 보존
CHANGES②가 상한을 24h로 늘렸지만, 초과 분기가 여전히 `external_container_
id=None`으로 지워 극히 드문 24h+ 케이스에서 같은 사고(사람이 AC5 재시도
눌러도 새 업로드=quota 1,600 재소모)가 그 축에서 한 번 더 날 수 있었다.

처방 — `ChannelAdapterConfig.keep_container_on_poll_timeout`(신규, 기본
False=Meta류 회귀 0) 추가, youtube/youtube_sandbox만 True. 상한 초과 시
이 플래그가 True면 id를 보존한 채 failed(dead_letter)로만 떨어뜨린다 —
사람이 재시도하면 insert(create_reels_container) 재호출 없이 같은 id로
`get_container_status` 재폴링만 재개.

## 검증(로컬)
```
$ uv run pytest tests/test_3815_youtube_oauth.py tests/test_3815_youtube_publish.py -q
48 passed

$ uv run pytest tests/test_3697_channel_insight_metrics_drift_lint.py -m "not destructive_schema" -q
11 passed
$ uv run pytest -m destructive_schema tests/test_3696*.py -q
2 passed

$ uv run python scripts/verify_no_new_korean_user_strings.py
[story #3779] 신규 0건·stale 0건

$ uv run python scripts/lint_destructive_schema_weights_registered.py
OK: 신규 미등재 destructive_schema 파일 0건

$ uv run alembic upgrade head  (fresh DB)
… 0372까지 성공, 단일 head 확認

$ 회귀 31파일(비파괴 16+파괴 336) — has_video/reels/publication_command/
  x_thread/instagram/컨테이너 폴링 소비처 전수
16 passed, 337 deselected  /  336 passed, 1 flake(대량 배치 로컬 공유DB
아티팩트 — 단독 재실행 14 passed 확認, CI는 파일별 독립 신선 DB라 무관)

$ uv run pytest -m destructive_schema <컨테이너 폴링 소비 7파일> -q  # CHANGES③ 전용 추가 회귀
120 passed
```

## 뮤테이션 셀프체크
- `youtube_privacy.py`의 audit_incomplete 축을 임시 제거 →
  `test_resolve_youtube_privacy_lock_forces_private_when_audit_incomplete`
  정확히 1 RED → 원복 후 GREEN.
- `youtube_quota.py`의 `reset_at`에 +1시간 왜곡 주입 →
  `test_check_youtube_quota_or_raise_exceeds_includes_reset_at_utc_midnight`
  정확히 1 RED → 원복 후 GREEN.
- (CHANGES②) `youtube_sandbox`의 24h 오버라이드 제거 → 정확히 2 RED
  (declare 테스트+6분경과 재현 테스트) → 원복 후 GREEN.
- (CHANGES③) `keep_container_on_poll_timeout` 조건 분기를 임시 제거(항상
  None) → `test_youtube_sandbox_beyond_24h_timeout_fails_but_preserves_
  container_id_no_reupload_on_retry` 정확히 1 RED → 원복 후 GREEN.

## Base
develop(c2f97e55d, PR1 #4223 착지 반영) — stacked 아님, 새 브랜치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8
