### PR TITLE
[SID:3816] Ghost PR2 — 발행 파사드(publish/unpublish)+마크다운→HTML

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2402,6 +2402,7 @@
     "errorChannelPublishProviderError": "The channel couldn't process the request — retrying automatically. If it keeps failing, we'll show it on the connection.",
     "errorStibeePlanRestricted": "Plan restriction · The email API requires the Pro plan or higher.",
     "errorStibeeSenderNotVerified": "Your sender email isn't verified with Stibee — please verify it in your Stibee sender settings.",
+    "errorGhostAuthFailed": "Your Admin API key isn't valid — check it in your Ghost settings.",
     "errorUnpublishHumanOnly": "Only human members can unpublish.",
     "errorUnpublishOwnerOrAdminOnly": "Only the organization owner or an admin can unpublish.",
     "errorGateAlreadyHeld": "Another draft («{title}» · {lang}) is already in approval — only one draft per item can be submitted at a time.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2402,6 +2402,7 @@
     "errorChannelPublishProviderError": "채널이 요청을 처리하지 못했습니다 — 자동으로 다시 시도하고 있습니다. 계속 실패하면 연결 상태에 표시됩니다.",
     "errorStibeePlanRestricted": "요금제 제한 · 이메일 API는 Pro 요금제부터 사용할 수 있습니다.",
     "errorStibeeSenderNotVerified": "발신자 이메일이 스티비에서 인증되지 않았습니다 · 스티비 발신자 설정에서 인증해 주세요.",
+    "errorGhostAuthFailed": "Admin API 키가 유효하지 않습니다 · Ghost 설정에서 다시 확인해 주세요.",
     "errorUnpublishHumanOnly": "발행 취소는 휴먼 멤버만 할 수 있습니다.",
     "errorUnpublishOwnerOrAdminOnly": "발행 취소는 조직 owner 또는 admin만 할 수 있습니다.",
     "errorGateAlreadyHeld": "이 항목은 다른 초안(«{title}» · {lang})이 승인 절차 중입니다 — 한 항목에 한 초안만 상신할 수 있습니다.",

--- a/apps/web/src/components/content/api-error.test.ts
+++ b/apps/web/src/components/content/api-error.test.ts
@@ -184,6 +184,17 @@ describe('parseSitePostApiError (story #3368, doc phase0-post-manager-screen-des
       },
     );
 
+    // story #3816(Phase3·3-6 PR2, 페드루 PO §낱말 정정 2, 2026-09-12) — Ghost
+    // JWT 401(재서명 1회 재시도까지 실패)도 kind=token_expired(재연결로 풀리는
+    // 세계) — 단 문구는 CHANNEL_TOKEN_EXPIRED의 일반 문구가 아니라 저장 시
+    // GHOST_ADMIN_KEY_INVALID와 같은 전용 문구를 재사용한다(새 labelKey).
+    test('GHOST_AUTH_FAILED — kind=token_expired·전용 문구 재사용(일반 CHANNEL_TOKEN_EXPIRED 문구 아님)', () => {
+      const result = parseSitePostApiError({ error: { code: 'GHOST_AUTH_FAILED', message: 'invalid' } });
+      expect(result.kind).toBe('token_expired');
+      expect(result.humanMessageKey).toBe('errorGhostAuthFailed');
+      expect(result.humanMessageKey).not.toBe('errorChannelTokenExpired');
+    });
+
     test('CHANNEL_CONNECTION_NOT_ACTIVE — kind=connection_not_active', () => {
       const result = parseSitePostApiError({ error: { code: 'CHANNEL_CONNECTION_NOT_ACTIVE', message: '연결 비활성' } });
       expect(result.kind).toBe('connection_not_active');

--- a/apps/web/src/components/content/api-error.test.ts
+++ b/apps/web/src/components/content/api-error.test.ts
@@ -1,4 +1,6 @@
 import { describe, test, expect } from 'vitest';
+import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
 import { parseSitePostApiError } from './api-error';
 
 describe('parseSitePostApiError (story #3368, doc phase0-post-manager-screen-design §4-1)', () => {
@@ -193,6 +195,18 @@ describe('parseSitePostApiError (story #3368, doc phase0-post-manager-screen-des
       expect(result.kind).toBe('token_expired');
       expect(result.humanMessageKey).toBe('errorGhostAuthFailed');
       expect(result.humanMessageKey).not.toBe('errorChannelTokenExpired');
+    });
+
+    // story #3816 PR2 CHANGES 1(유나 관찰·PO 지목 2026-09-12) — `content.
+    // errorGhostAuthFailed`와 `channelConnect.channelConnectErrorGhostAdminKeyInvalid`
+    // 는 의도적으로 같은 값(값이 같은 두 키 — 저장 시 키 오류와 발행 시 인증
+    // 실패가 같은 문장을 말한다는 §낱말 정본). 공유 키로 합치는 대신 드리프트
+    // 가드로 싸게 고정한다 — 한쪽만 고치면 이 테스트가 RED여야 한다.
+    test('⭐errorGhostAuthFailed === channelConnectErrorGhostAdminKeyInvalid(ko·en 둘 다, 의도된 문구 중복 고정)', () => {
+      const ko = koMessages as { content: Record<string, string>; channelConnect: Record<string, string> };
+      const en = enMessages as { content: Record<string, string>; channelConnect: Record<string, string> };
+      expect(ko.content.errorGhostAuthFailed).toBe(ko.channelConnect.channelConnectErrorGhostAdminKeyInvalid);
+      expect(en.content.errorGhostAuthFailed).toBe(en.channelConnect.channelConnectErrorGhostAdminKeyInvalid);
     });
 
     test('CHANNEL_CONNECTION_NOT_ACTIVE — kind=connection_not_active', () => {

--- a/apps/web/src/components/content/api-error.ts
+++ b/apps/web/src/components/content/api-error.ts
@@ -230,6 +230,13 @@ const KNOWN_ERRORS: Record<string, KnownError> = {
   // 고쳐야 하는 문제(요금제 업그레이드·발신자 인증)라는 걸 문구가 말한다.
   STIBEE_PLAN_RESTRICTED: { labelKey: 'errorStibeePlanRestricted', kind: 'provider_error' },
   STIBEE_SENDER_NOT_VERIFIED: { labelKey: 'errorStibeeSenderNotVerified', kind: 'provider_error' },
+  // story #3816(Phase3·3-6 PR2, 페드루 PO §낱말 정정 2, 2026-09-12) — Ghost JWT
+  // 401(재서명 1회 재시도까지 실패)은 위 stibee 2종과 반대 세계다 — 키를 다시
+  // 붙여넣으면(재연결) 실제로 풀리는 오류라 kind='token_expired'(재연결 세계).
+  // 문구는 저장 시 GHOST_ADMIN_KEY_INVALID와 같은 낱말을 재사용(전용 키로 새로
+  // 등재 — errorChannelTokenExpired의 일반 "연결이 끊겼습니다" 문구를 쓰면
+  // "무엇을 다시 입력해야 하는지"가 사라진다).
+  GHOST_AUTH_FAILED: { labelKey: 'errorGhostAuthFailed', kind: 'token_expired' },
   // story #3426(BE #3419, PR#3774) — 예약 취소·회수 6종(그라운딩 확認·2026-09-04 07:5x).
   // CANCEL_UNPUBLISH_HUMAN_ONLY/OWNER_OR_ADMIN_ONLY는 site-posts의 UNPUBLISH_* 항목을
   // 그대로 재사용한다(같은 "발행 취소·회수는 이 역할만" 개념 공유, 문구도 동일).

--- a/backend/app/services/blog_destinations.py
+++ b/backend/app/services/blog_destinations.py
@@ -55,4 +55,8 @@ def get_blog_destination_module(
     if channel == "webhook":
         from app.services import webhook_publish
         return webhook_publish
+    # story #3816(Phase3·3-6 PR2, 페드루 PO 確定 2026-09-12) — Ghost 발행 배선.
+    if channel == "ghost":
+        from app.services import ghost_publish
+        return ghost_publish
     raise BlogDestinationNotImplementedError(connection_id=connection_id)

--- a/backend/app/services/blog_destinations.py
+++ b/backend/app/services/blog_destinations.py
@@ -59,4 +59,10 @@ def get_blog_destination_module(
     if channel == "ghost":
         from app.services import ghost_publish
         return ghost_publish
+    # story #3816(Phase3·3-6 PR2 CHANGES 1, 페드루 PO 지목 2026-09-12) — 실
+    # Ghost 사이트 없이도 dev-app 라이브 회차가 발행 축을 결정적으로 재현할
+    # 수 있게 4호 구현체를 더한다(ghost_publish.py와 같은 시그니처).
+    if channel == "ghost_sandbox":
+        from app.services import ghost_sandbox_publish
+        return ghost_sandbox_publish
     raise BlogDestinationNotImplementedError(connection_id=connection_id)

--- a/backend/app/services/ghost_publish.py
+++ b/backend/app/services/ghost_publish.py
@@ -1,0 +1,162 @@
+"""story #3816(Phase3·3-6 PR2, 페드루 PO 確定 2026-09-12) — Ghost 발행(publish)/
+회수(unpublish). `blog_destinations.py::BlogDestinationModule` Protocol 구현체 —
+wordpress_publish.py/webhook_publish.py와 동형(publish/unpublish 두 async
+callable) — site_url+admin_api_key로 Ghost Admin API를 직접 친다.
+
+**이미지 재업로드→URL 치환은 이 PR 범위 밖**(페드루 PO 決定 2026-09-12 12:20Z)
+— `site_post_versions`에 이미지 필드 자체가 없고, body_md 안 인라인 이미지
+URL은 HTML로 그대로 넘기면 Ghost가 외부 URL을 그대로 렌더해 기능 갭이 아니다.
+`/images/upload/`(Ghost 내부 저장이 필요해질 때 후속, 필요성 자체가 미확認)·
+`ghost-image-too-large` 마커는 지금 등재하지 않는다(적기만).
+
+글 생성/갱신은 `?source=html`(HTML 계약) — `markdown_render.render_markdown_html`
+로 body_md를 HTML로 변환해 보낸다(마크다운 문법이 그대로 노출되는 결함 처방,
+PO 決定 — wordpress의 같은 클래스 잔존 결함은 이 PR에서 안 건드린다). 갱신
+(external_id 있음)은 Ghost Admin API의 낙관적 잠금 계약대로 먼저 GET으로 현재
+`updated_at`을 읽어 PUT 페이로드에 실어야 한다(⚠️미확認·실 사이트 왕복 前 —
+공개 문서 그라운딩 그대로, stibee의 여러 self-correction 선례처럼 조정 여지).
+
+봉인 시각(scheduled_at)이 있으면 status="scheduled"+published_at=그 시각(UTC
+ISO8601), 없으면 status="published"(즉시 게시).
+
+JWT 401은 시계 어긋남(clock skew)일 수 있어 재서명 1회만 재시도한다(같은
+admin_api_key로 새 iat/exp 재발급 — `sign_admin_jwt`는 캐싱하지 않는 설계라
+그냥 한 번 더 부르면 된다). 그래도 401이면 자격 자체가 틀렸다는 뜻 — 연결
+「다시 연결 필요」 세계(`GhostPublishError.status_code == 401`을 site_posts.py::
+_blog_publish_error_code가 `GHOST_AUTH_FAILED`로 승격, CHANNEL_PUBLISH_AUTH_
+REJECTED와 다른 코드를 쓰는 이유는 저장 시 GHOST_ADMIN_KEY_INVALID와 같은
+문구를 재사용해야 해서다, PO §낱말 정정 2)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+
+from app.services.destination_url_safety import DestinationURLUnsafeError, assert_destination_url_safe
+from app.services.ghost_client import ghost_stub_enabled, sign_admin_jwt
+from app.services.markdown_render import render_markdown_html
+
+_POSTS_PATH = "/ghost/api/admin/posts/"
+
+
+class GhostSiteURLInsecureError(ValueError):
+    """site_url이 안전하지 않음(destination_url_safety.py 판정 그대로 감쌈) —
+    wordpress_publish.py::WordPressSiteURLInsecureError와 동형 사상. 메시지는
+    영문(#3779 가드 — 이 예외는 내부 분류 전용이라 사람 화면엔 code로만 닿는다,
+    최근 채널 등록의 영문 관례와 동형 — wordpress의 한글 메시지는 가드 시행 前
+    baseline 잔존)."""
+
+    def __init__(self, *, site_url: str):
+        self.site_url = site_url
+        super().__init__(f"Ghost site_url is not safe: {site_url!r}")
+
+
+class GhostPublishError(Exception):
+    """Ghost Admin API가 2xx 밖 응답을 줌 — status_code·응답 본문(길이 컷)을 실어
+    failure_kind 분류에 쓴다(wordpress_publish.py::WordPressPublishError와 동형).
+    `.status_code == 401`은 재서명 1회 재시도까지 실패한 뒤에만 여기 도달한다
+    (site_posts.py가 이 값으로 GHOST_AUTH_FAILED를 고른다)."""
+
+    _BODY_MAX_CHARS = 500
+
+    def __init__(self, *, status_code: int, body: str):
+        self.status_code = status_code
+        self.body = body[: self._BODY_MAX_CHARS]
+        super().__init__(f"Ghost Admin API error(status={status_code}): {self.body}")
+
+
+async def _validate_site_url(site_url: str) -> str:
+    try:
+        return await assert_destination_url_safe(site_url, allow_loopback=ghost_stub_enabled())
+    except DestinationURLUnsafeError as exc:
+        raise GhostSiteURLInsecureError(site_url=site_url) from exc
+
+
+async def _request_with_retry(
+    client: httpx.AsyncClient, method: str, url: str, *, admin_api_key: str, json_body: dict | None = None,
+) -> httpx.Response:
+    """JWT 401 재서명 1회 재시도(모듈 docstring 그대로) — 이 모듈의 모든 Admin API
+    호출(GET·POST·PUT)이 이 헬퍼 하나를 거친다(재시도 로직 중복 0)."""
+    token = sign_admin_jwt(admin_api_key)
+    resp = await client.request(method, url, headers={"Authorization": f"Ghost {token}"}, json=json_body, timeout=20)
+    if resp.status_code == 401:
+        token = sign_admin_jwt(admin_api_key)
+        resp = await client.request(method, url, headers={"Authorization": f"Ghost {token}"}, json=json_body, timeout=20)
+    return resp
+
+
+def _post_status_and_published_at(scheduled_at: datetime | None) -> dict:
+    if scheduled_at is None:
+        return {"status": "published"}
+    at = scheduled_at if scheduled_at.tzinfo else scheduled_at.replace(tzinfo=timezone.utc)
+    return {"status": "scheduled", "published_at": at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")}
+
+
+async def publish(
+    client: httpx.AsyncClient,
+    *,
+    site_url: str,
+    admin_api_key: str,
+    title: str,
+    body_md: str,
+    summary: str,
+    tags: list,
+    slug: str,
+    external_id: str | None = None,
+    scheduled_at: datetime | None = None,
+) -> tuple[str, str | None]:
+    """external_id가 없으면 생성(POST), 있으면 갱신(PUT) — wordpress_publish.py의
+    upsert 사상과 동형(재발행이 새 글을 또 안 만든다). 반환은 (external_id,
+    permalink) — 응답 JSON의 `posts[0].id`(문자열)·`posts[0].url`."""
+    base = await _validate_site_url(site_url)
+    html = render_markdown_html(body_md)
+    post_fields: dict = {
+        "title": title, "html": html, "custom_excerpt": summary, "slug": slug,
+        "tags": [{"name": tag} for tag in tags],
+        **_post_status_and_published_at(scheduled_at),
+    }
+
+    if external_id is None:
+        url = f"{base}{_POSTS_PATH}?source=html"
+        resp = await _request_with_retry(
+            client, "POST", url, admin_api_key=admin_api_key, json_body={"posts": [post_fields]},
+        )
+    else:
+        # Ghost Admin API 갱신은 낙관적 잠금(현재 updated_at을 그대로 되돌려 보내야
+        # 함) — 먼저 GET으로 그 값을 읽는다(⚠️미확認, 공개 문서 그라운딩).
+        get_resp = await _request_with_retry(
+            client, "GET", f"{base}{_POSTS_PATH}{external_id}/", admin_api_key=admin_api_key,
+        )
+        if get_resp.status_code // 100 != 2:
+            raise GhostPublishError(status_code=get_resp.status_code, body=get_resp.text)
+        current_updated_at = get_resp.json()["posts"][0]["updated_at"]
+        post_fields["updated_at"] = current_updated_at
+        url = f"{base}{_POSTS_PATH}{external_id}/?source=html"
+        resp = await _request_with_retry(
+            client, "PUT", url, admin_api_key=admin_api_key, json_body={"posts": [post_fields]},
+        )
+
+    if resp.status_code // 100 != 2:
+        raise GhostPublishError(status_code=resp.status_code, body=resp.text)
+    post = resp.json()["posts"][0]
+    return str(post["id"]), post.get("url")
+
+
+async def unpublish(
+    client: httpx.AsyncClient, *, site_url: str, admin_api_key: str, external_id: str,
+) -> None:
+    """行 삭제가 아니라 status=draft 전환(wordpress_publish.unpublish()와 동형
+    비파괴 사상) — 재발행(publish() 재호출)으로 되돌릴 수 있다."""
+    base = await _validate_site_url(site_url)
+    get_resp = await _request_with_retry(
+        client, "GET", f"{base}{_POSTS_PATH}{external_id}/", admin_api_key=admin_api_key,
+    )
+    if get_resp.status_code // 100 != 2:
+        raise GhostPublishError(status_code=get_resp.status_code, body=get_resp.text)
+    current_updated_at = get_resp.json()["posts"][0]["updated_at"]
+    resp = await _request_with_retry(
+        client, "PUT", f"{base}{_POSTS_PATH}{external_id}/?source=html", admin_api_key=admin_api_key,
+        json_body={"posts": [{"status": "draft", "updated_at": current_updated_at}]},
+    )
+    if resp.status_code // 100 != 2:
+        raise GhostPublishError(status_code=resp.status_code, body=resp.text)

--- a/backend/app/services/ghost_sandbox_publish.py
+++ b/backend/app/services/ghost_sandbox_publish.py
@@ -1,0 +1,79 @@
+"""story #3816(Phase3·3-6 PR2 CHANGES 1, 페드루 PO 지목 2026-09-12) — Ghost 발행
+sandbox 미러. `blog_destinations.py::BlogDestinationModule` 4호 구현체 —
+ghost_publish.py와 같은 시그니처(publish/unpublish)지만 **네트워크 0·JWT 서명
+0**(credential_kind="none" 샌드박스 연결이라 admin_api_key는 더미값
+"sandbox-dummy-access-token" — 실제로 안 쓴다). 실 Ghost 사이트 없이도(dev-app
+라이브 회차) 발행 축(성공·재서명-후-성공 모양·인증 실패 승격)을 결정적으로
+재현한다 — sandbox_publish.py/facebook_sandbox_publish.py 등 기존 마커 관례
+그대로(title·body_md 어디든 부분일치로 스캔).
+
+마커 4갈래:
+- `[sandbox:provider-error]` → `GhostPublishError(status_code=503)`(일시적,
+  CHANNEL_PUBLISH_PROVIDER_ERROR — 백오프 재시도 대상).
+- `[sandbox:ghost-jwt-expired]` → ghost_publish.py의 재서명 1회 재시도가 실제
+  Ghost 사이트에서 성공하는 모양을 결정적으로 재현(첫 시도 401→재서명→둘째
+  시도 성공, 이 모듈 안에서 흉내만 낸다 — 실 JWT 재서명은 없다). 최종 결과는
+  published지만 external_id 접두사(`sandbox-ghost-jwtretry-`)로 이 경로를 탔음을
+  구분한다(지어낸 구분이지만 테스트·라이브 캡처가 "그 경로가 실행됐다"를 확認할
+  유일한 방법 — 최종 상태만 보면 마커 없음과 구별이 안 된다).
+- `[sandbox:ghost-auth-failed]` → `GhostPublishError(status_code=401)`(재서명
+  재시도까지 실패한 것과 같은 최종 상태 — site_posts.py::_blog_publish_error_code
+  가 `GHOST_AUTH_FAILED`로 승격, 연결 「다시 연결 필요」).
+- 마커 없음 → 성공. external_id=`sandbox-ghost-<uuid4>`·permalink=
+  `https://ghost-sandbox.invalid/p/<external_id>/`(실물 도메인이 아닌 `.invalid`
+  TLD — RFC 2606, 실 도메인 노출 0 규율과 동형).
+
+unpublish — 항상 성공(멱등, 상태 보존 없음 — sandbox_publish.py의 결정적 성공
+관례와 동형)."""
+from __future__ import annotations
+
+import uuid
+
+from app.services.ghost_publish import GhostPublishError
+
+_MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
+_MARKER_JWT_EXPIRED = "[sandbox:ghost-jwt-expired]"
+_MARKER_AUTH_FAILED = "[sandbox:ghost-auth-failed]"
+
+_SANDBOX_URL_BASE = "https://ghost-sandbox.invalid/p"
+
+
+def _has_marker(marker: str, *texts: str) -> bool:
+    return any(marker in text for text in texts if text)
+
+
+async def publish(
+    client,
+    *,
+    site_url: str,
+    admin_api_key: str,
+    title: str,
+    body_md: str,
+    summary: str,
+    tags: list,
+    slug: str,
+    external_id: str | None = None,
+    scheduled_at=None,
+) -> tuple[str, str | None]:
+    """ghost_publish.publish()와 같은 시그니처(BlogDestinationModule Protocol,
+    site_posts.py::_call_blog_module_publish가 채널 무관하게 kwargs를 그대로
+    넘긴다) — `client`는 이 모듈에서 실제로 쓰지 않는다(네트워크 0, 시그니처
+    호환 목적으로만 받는다)."""
+    if _has_marker(_MARKER_PROVIDER_ERROR, title, body_md):
+        raise GhostPublishError(status_code=503, body="sandbox: [sandbox:provider-error] marker simulation")
+    if _has_marker(_MARKER_AUTH_FAILED, title, body_md):
+        raise GhostPublishError(status_code=401, body="sandbox: [sandbox:ghost-auth-failed] marker simulation")
+
+    if _has_marker(_MARKER_JWT_EXPIRED, title, body_md):
+        new_id = external_id or f"sandbox-ghost-jwtretry-{uuid.uuid4()}"
+        return new_id, f"{_SANDBOX_URL_BASE}/{new_id}/"
+
+    new_id = external_id or f"sandbox-ghost-{uuid.uuid4()}"
+    return new_id, f"{_SANDBOX_URL_BASE}/{new_id}/"
+
+
+async def unpublish(client, *, site_url: str, admin_api_key: str, external_id: str) -> None:
+    """항상 성공 — 실 상태를 보존하지 않는 결정적 sandbox 관례(재발행으로도
+    되돌릴 "진짜" 상태가 없다, wordpress/webhook과 달리 이 모듈은 처음부터
+    비영속적 응답만 낸다)."""
+    return None

--- a/backend/app/services/markdown_render.py
+++ b/backend/app/services/markdown_render.py
@@ -1,0 +1,23 @@
+"""story #3816(Phase3·3-6 PR2, 페드루 PO 確定 2026-09-12) — 공용 마크다운→HTML
+변환. Ghost Admin API `?source=html`이 HTML 계약이라(마크다운 문법을 그대로
+넘기면 글에 문법이 노출된다, wordpress_publish.py가 raw body_md를 그대로
+`content`로 보내는 것도 같은 클래스의 잔존 결함이지만 이 PR 범위 밖 — 손대지
+않는다) 새로 도입한다. 표준 Python-Markdown(`markdown` PyPI 패키지) 하나만
+쓴다(신규 판정 로직 0, 라이브러리 위임) — `fenced_code` 확장으로 코드 블록
+(```)을 지원하고, 라이브러리 기본 동작이 이미 원본에 섞인 raw HTML 블록을
+그대로 통과시킨다(별도 처리 불요, Ghost가 최종적으로 자체 sanitize한다).
+
+이 함수는 BE 공용이라 이름에 채널을 안 붙인다 — 지금은 Ghost 하나만 쓰지만
+후속(예: wordpress의 같은 결함 처방)이 재사용할 수 있게."""
+from __future__ import annotations
+
+import markdown
+
+# fenced_code — ``` 코드 블록 지원(기본 markdown은 4-space 들여쓰기 블록만 인식).
+_EXTENSIONS = ["fenced_code"]
+
+
+def render_markdown_html(body_md: str) -> str:
+    """마크다운 원문을 HTML로 변환한다. 빈 문자열 입력은 빈 문자열을 그대로
+    반환(Python-Markdown 자체가 이미 이렇게 동작 — 특별 분기 불요)."""
+    return markdown.markdown(body_md, extensions=_EXTENSIONS)

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -66,6 +66,13 @@ _CONNECTION_BLOCKED_CODES = frozenset({
     # connection.status가 첫 실패에도 즉시 승격되지 않고 재시도 상한까지 기다리는
     # 결함이었다 — CHANNEL_TOKEN_EXPIRED와 대칭이 안 맞았다).
     "CHANNEL_CONNECTION_REVOKED", "CHANNEL_CONNECTION_AUTH_ERROR",
+    # story #3816(Phase3·3-6 PR2, 페드루 PO §낱말 정정 2, 2026-09-12) — Ghost
+    # JWT 401(재서명 1회 재시도까지 실패)은 CHANNEL_PUBLISH_AUTH_REJECTED와 같은
+    # 축(자격 자체가 틀림·연결 「다시 연결 필요」)이지만 저장 시 GHOST_ADMIN_KEY_
+    # INVALID와 같은 문구를 재사용하려고 별도 코드를 쓴다(site_posts.py::
+    # _blog_publish_error_code) — 승격 로직은 여기 등재 하나로 CHANNEL_PUBLISH_
+    # AUTH_REJECTED와 동일해진다.
+    "GHOST_AUTH_FAILED",
 })
 # story 620beefc(PO 決定, 2026-09-04) — IMAGE 컨테이너가 Threads 쪽에서 ERROR/EXPIRED로
 # 끝났다. 폴링을 몇 번 더 반복해도 같은 결과이므로(결정적) transient 백오프가 아니라

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -1144,12 +1144,13 @@ def _blog_destination_exception_classes() -> tuple[tuple[type[Exception], ...], 
     공개 예외 타입을 갖는다(호출자 계약 유지, 모듈 재사용 원칙) — 오케스트레이션
     계층은 둘 다 잡아야 하므로 여기서 한 곳에 모은다(새 모듈이 추가되면 여기 한 줄만
     늘면 된다)."""
+    from app.services.ghost_publish import GhostPublishError, GhostSiteURLInsecureError
     from app.services.webhook_publish import WebhookPublishError, WebhookTargetURLInsecureError
     from app.services.wordpress_publish import WordPressPublishError, WordPressSiteURLInsecureError
 
     return (
-        (WordPressSiteURLInsecureError, WebhookTargetURLInsecureError),
-        (WordPressPublishError, WebhookPublishError),
+        (WordPressSiteURLInsecureError, WebhookTargetURLInsecureError, GhostSiteURLInsecureError),
+        (WordPressPublishError, WebhookPublishError, GhostPublishError),
     )
 
 
@@ -1162,6 +1163,17 @@ def _blog_publish_error_code(exc: Exception) -> str:
     대상: 이 분기를 지우면 401도 CHANNEL_PUBLISH_PROVIDER_ERROR(transient)로 떨어져
     고쳐지지 않는 자격으로 무한 백오프 재시도만 반복한다(webhook 라이브 테스트가
     실제로 이 경로를 잡았다)."""
+    # story #3816(Phase3·3-6 PR2, 페드루 PO §낱말 정정 2, 2026-09-12) — Ghost의
+    # 401은 ghost_publish.py가 이미 재서명 1회 재시도까지 거친 뒤에만 여기 온다
+    # (자격 자체가 틀렸다는 뜻). CHANNEL_PUBLISH_AUTH_REJECTED와 다른 코드를 쓰는
+    # 이유는 저장 시 GHOST_ADMIN_KEY_INVALID와 같은 문구를 재사용해야 해서다 —
+    # 둘 다 결과(연결 「다시 연결 필요」 승격)는 같다(_CONNECTION_BLOCKED_CODES
+    # 등재, publication_command.py). 뮤테이션 대상 — 이 분기를 지우면 Ghost 401도
+    # CHANNEL_PUBLISH_AUTH_REJECTED로 떨어져(틀린 문구는 아니지만) 회귀로 잡는다.
+    from app.services.ghost_publish import GhostPublishError
+
+    if isinstance(exc, GhostPublishError) and exc.status_code == 401:
+        return "GHOST_AUTH_FAILED"
     if getattr(exc, "status_code", None) in (401, 403):
         return "CHANNEL_PUBLISH_AUTH_REJECTED"
     return "CHANNEL_PUBLISH_PROVIDER_ERROR"
@@ -1169,7 +1181,7 @@ def _blog_publish_error_code(exc: Exception) -> str:
 
 async def _call_blog_module_publish(
     module, client, *, channel: str, connection, app_password: str, title: str, body_md: str,
-    summary: str, tags: list, slug: str, external_id: str | None,
+    summary: str, tags: list, slug: str, external_id: str | None, scheduled_at: datetime | None = None,
 ) -> tuple[str, str | None]:
     """story e4fc29fa(조각④) — wordpress/webhook 모듈은 이름(publish)은 같아도
     파라미터 모양이 다르다(BlogDestinationModule Protocol 明示 — 목적지마다 자격
@@ -1186,6 +1198,19 @@ async def _call_blog_module_publish(
             client, target_url=connection.account_id, secret=app_password, title=title, body_md=body_md,
             summary=summary, tags=tags, slug=slug, external_id=external_id,
         )
+    if channel == "ghost":
+        # story #3816(Phase3·3-6 PR2) — scheduled_at은 command.scheduled_at을
+        # 그대로 넘긴다. ⚠️site_post는 아직 scheduled_at 개념이 없어(그라운딩
+        # 확認 — 모든 site_post 커맨드가 scheduled_at=None으로 생성된다, 위
+        # publish_site_post_external_command 호출부 참고) 이 분기는 오늘 코드상
+        # 항상 None(=published)만 실행된다 — API 계약·테스트는 갖췄으나 살아있는
+        # 스케줄 호출 경로는 아직 없다(site_post 스케줄 기능이 생기면 그때 값이
+        # 실린다, 지어내지 않는다).
+        return await module.publish(
+            client, site_url=connection.account_id, admin_api_key=app_password, title=title,
+            body_md=body_md, summary=summary, tags=tags, slug=slug, external_id=external_id,
+            scheduled_at=scheduled_at,
+        )
     raise SitePostExternalPublishError(
         error_code="SITE_POST_DRAFT_NOT_FOUND", message=f"알 수 없는 blog 채널: {channel!r}",
     )
@@ -1200,6 +1225,11 @@ async def _call_blog_module_unpublish(module, client, *, channel: str, connectio
         return
     if channel == "webhook":
         await module.unpublish(client, target_url=connection.account_id, secret=app_password, external_id=external_id)
+        return
+    if channel == "ghost":
+        await module.unpublish(
+            client, site_url=connection.account_id, admin_api_key=app_password, external_id=external_id,
+        )
         return
     raise SitePostExternalPublishError(
         error_code="SITE_POST_DRAFT_NOT_FOUND", message=f"알 수 없는 blog 채널: {channel!r}",
@@ -1417,7 +1447,7 @@ async def publish_site_post_external_command(db: AsyncSession, command: "Publica
             external_id, permalink = await _call_blog_module_publish(
                 module, client, channel=connection.channel, connection=connection, app_password=app_password,
                 title=version.title, body_md=version.body_md, summary=version.summary, tags=version.tags,
-                slug=draft.slug, external_id=prior_external_id,
+                slug=draft.slug, external_id=prior_external_id, scheduled_at=command.scheduled_at,
             )
     except _BLOG_DESTINATION_INSECURE_ERRORS as exc:
         raise SitePostExternalPublishError(error_code="SITE_POST_DESTINATION_INSECURE", message=str(exc)) from exc

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -1198,8 +1198,10 @@ async def _call_blog_module_publish(
             client, target_url=connection.account_id, secret=app_password, title=title, body_md=body_md,
             summary=summary, tags=tags, slug=slug, external_id=external_id,
         )
-    if channel == "ghost":
-        # story #3816(Phase3·3-6 PR2) — scheduled_at은 command.scheduled_at을
+    if channel in ("ghost", "ghost_sandbox"):
+        # story #3816(Phase3·3-6 PR2) — ghost_sandbox_publish.py는 ghost_publish.py와
+        # 같은 시그니처라(4호 구현체, CHANGES 1) kwargs 조립을 그대로 공유한다.
+        # scheduled_at은 command.scheduled_at을
         # 그대로 넘긴다. ⚠️site_post는 아직 scheduled_at 개념이 없어(그라운딩
         # 확認 — 모든 site_post 커맨드가 scheduled_at=None으로 생성된다, 위
         # publish_site_post_external_command 호출부 참고) 이 분기는 오늘 코드상
@@ -1226,7 +1228,7 @@ async def _call_blog_module_unpublish(module, client, *, channel: str, connectio
     if channel == "webhook":
         await module.unpublish(client, target_url=connection.account_id, secret=app_password, external_id=external_id)
         return
-    if channel == "ghost":
+    if channel in ("ghost", "ghost_sandbox"):
         await module.unpublish(
             client, site_url=connection.account_id, admin_api_key=app_password, external_id=external_id,
         )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -76,6 +76,12 @@ dependencies = [
     # IANA DB를 담아 OS 설치 없이도 zoneinfo가 그걸 찾게 한다(stdlib가 자동으로 우선
     # 시도) — apt-get 없이 uv 의존성만으로 해소.
     "tzdata>=2025.1",
+    # story #3816(Phase3·3-6 PR2, 페드루 PO 確定 2026-09-12) — Ghost Admin API
+    # `?source=html`은 HTML 계약이라 body_md(마크다운)를 그대로 보내면 마크다운
+    # 문법이 글에 그대로 노출된다. 표준 markdown→HTML 변환용 최소 의존성 1개
+    # 신규 도입(그라운딩 확認 — 이 전까지 코드베이스에 markdown 렌더 라이브러리
+    # 0건, pillow 도입 때와 동형 판단).
+    "markdown>=3.7",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_3816_blog_publish_error_code.py
+++ b/backend/tests/test_3816_blog_publish_error_code.py
@@ -1,0 +1,25 @@
+"""story #3816(Phase3·3-6 PR2, 페드루 PO §낱말 정정 2, 2026-09-12) —
+`site_posts.py::_blog_publish_error_code`의 Ghost 분기 단위 테스트. DB 불요(순수
+함수, 예외 인스턴스만 넣어 본다)."""
+from __future__ import annotations
+
+from app.services.ghost_publish import GhostPublishError
+from app.services.site_posts import _blog_publish_error_code
+from app.services.wordpress_publish import WordPressPublishError
+
+
+def test_ghost_401_maps_to_ghost_auth_failed():
+    assert _blog_publish_error_code(GhostPublishError(status_code=401, body="x")) == "GHOST_AUTH_FAILED"
+
+
+def test_ghost_5xx_maps_to_generic_provider_error_not_auth_failed():
+    """뮤테이션 대상(스토리 본문 明示) — GhostPublishError 판정을 status_code
+    무관하게 적용하도록 되돌리면 이 테스트가 RED여야 한다(5xx까지 GHOST_AUTH_
+    FAILED로 잘못 승격돼 연결이 불필요하게 「다시 연결 필요」로 뜬다)."""
+    assert _blog_publish_error_code(GhostPublishError(status_code=500, body="x")) == "CHANNEL_PUBLISH_PROVIDER_ERROR"
+
+
+def test_wordpress_401_still_maps_to_channel_publish_auth_rejected_unaffected():
+    """회귀 0 — Ghost 전용 분기 추가가 wordpress/webhook의 기존 401/403 분류를
+    안 건드린다."""
+    assert _blog_publish_error_code(WordPressPublishError(status_code=401, body="x")) == "CHANNEL_PUBLISH_AUTH_REJECTED"

--- a/backend/tests/test_3816_ghost_publish.py
+++ b/backend/tests/test_3816_ghost_publish.py
@@ -1,0 +1,186 @@
+"""story #3816(Phase3·3-6 PR2, 페드루 PO 確定 2026-09-12) — `ghost_publish.py` 직접
+단위 테스트. DB 불요 — `httpx.MockTransport`로 Ghost Admin API 응답을 흉내낸다
+(test_3816_ghost_client.py와 동형 관례)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from app.services.ghost_publish import (
+    GhostPublishError,
+    GhostSiteURLInsecureError,
+    publish,
+    unpublish,
+)
+
+_FAKE_ADMIN_KEY = "64f1a2b3c4d5e6f7a8b9c0d1:0123456789abcdef0123456789abcdef"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.anyio
+async def test_publish_create_sends_html_converted_body_and_source_html_query(dns_stub):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["body"] = request.content
+        return httpx.Response(201, json={"posts": [{"id": "42", "url": "https://blog.example.com/p/42/"}]})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        external_id, permalink = await publish(
+            client, site_url="https://blog.example.com", admin_api_key=_FAKE_ADMIN_KEY,
+            title="제목", body_md="# 제목\n\n본문입니다.", summary="요약", tags=["a", "b"], slug="my-post",
+        )
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://blog.example.com/ghost/api/admin/posts/?source=html"
+    import json as _json
+    body = _json.loads(captured["body"])
+    post = body["posts"][0]
+    assert "<h1>제목</h1>" in post["html"]
+    assert post["status"] == "published"
+    assert post["tags"] == [{"name": "a"}, {"name": "b"}]
+    assert external_id == "42"
+    assert permalink == "https://blog.example.com/p/42/"
+
+
+@pytest.mark.anyio
+async def test_publish_with_scheduled_at_sets_scheduled_status_and_published_at(dns_stub):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.content
+        return httpx.Response(201, json={"posts": [{"id": "1", "url": None}]})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        await publish(
+            client, site_url="https://blog.example.com", admin_api_key=_FAKE_ADMIN_KEY,
+            title="t", body_md="b", summary="s", tags=[], slug="slug-1",
+            scheduled_at=datetime(2026, 12, 25, 9, 0, 0, tzinfo=timezone.utc),
+        )
+
+    import json as _json
+    post = _json.loads(captured["body"])["posts"][0]
+    assert post["status"] == "scheduled"
+    assert post["published_at"] == "2026-12-25T09:00:00Z"
+
+
+@pytest.mark.anyio
+async def test_publish_update_reads_current_updated_at_then_puts_with_it(dns_stub):
+    """story #3816 — Ghost 갱신은 낙관적 잠금 계약(현재 updated_at을 그대로
+    되돌려 보내야 함). GET(조회)→PUT(갱신) 순서를 뮤테이션 대상으로 고정한다."""
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.method)
+        if request.method == "GET":
+            assert str(request.url) == "https://blog.example.com/ghost/api/admin/posts/existing-42/"
+            return httpx.Response(200, json={"posts": [{"id": "existing-42", "updated_at": "2026-09-01T00:00:00.000Z"}]})
+        assert str(request.url) == "https://blog.example.com/ghost/api/admin/posts/existing-42/?source=html"
+        import json as _json
+        body = _json.loads(request.content)
+        assert body["posts"][0]["updated_at"] == "2026-09-01T00:00:00.000Z"
+        return httpx.Response(200, json={"posts": [{"id": "existing-42", "url": "https://blog.example.com/p/x/"}]})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        external_id, permalink = await publish(
+            client, site_url="https://blog.example.com", admin_api_key=_FAKE_ADMIN_KEY,
+            title="t", body_md="b", summary="s", tags=[], slug="slug-1", external_id="existing-42",
+        )
+
+    assert calls == ["GET", "PUT"]
+    assert external_id == "existing-42"
+    assert permalink == "https://blog.example.com/p/x/"
+
+
+@pytest.mark.anyio
+async def test_publish_retries_once_on_401_then_succeeds(dns_stub):
+    """뮤테이션 대상(스토리 본문 明示) — 재서명 1회 재시도 분기를 지우면 이
+    테스트가 RED여야 한다(첫 401에서 바로 실패로 끝난다)."""
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return httpx.Response(401, json={"errors": [{"message": "token expired"}]})
+        return httpx.Response(201, json={"posts": [{"id": "1", "url": None}]})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        external_id, _ = await publish(
+            client, site_url="https://blog.example.com", admin_api_key=_FAKE_ADMIN_KEY,
+            title="t", body_md="b", summary="s", tags=[], slug="slug-1",
+        )
+
+    assert attempts["count"] == 2
+    assert external_id == "1"
+
+
+@pytest.mark.anyio
+async def test_publish_raises_ghost_publish_error_401_after_retry_exhausted(dns_stub):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"errors": [{"message": "invalid"}]})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(GhostPublishError) as exc_info:
+            await publish(
+                client, site_url="https://blog.example.com", admin_api_key=_FAKE_ADMIN_KEY,
+                title="t", body_md="b", summary="s", tags=[], slug="slug-1",
+            )
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_publish_raises_ghost_publish_error_on_5xx(dns_stub):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="internal error")
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(GhostPublishError) as exc_info:
+            await publish(
+                client, site_url="https://blog.example.com", admin_api_key=_FAKE_ADMIN_KEY,
+                title="t", body_md="b", summary="s", tags=[], slug="slug-1",
+            )
+
+    assert exc_info.value.status_code == 500
+
+
+@pytest.mark.anyio
+async def test_publish_rejects_insecure_site_url():
+    async with httpx.AsyncClient(transport=_transport(lambda r: httpx.Response(200))) as client:
+        with pytest.raises(GhostSiteURLInsecureError):
+            await publish(
+                client, site_url="http://blog.example.com", admin_api_key=_FAKE_ADMIN_KEY,
+                title="t", body_md="b", summary="s", tags=[], slug="slug-1",
+            )
+
+
+@pytest.mark.anyio
+async def test_unpublish_reads_updated_at_then_sets_status_draft(dns_stub):
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.method)
+        if request.method == "GET":
+            return httpx.Response(200, json={"posts": [{"id": "42", "updated_at": "2026-09-01T00:00:00.000Z"}]})
+        import json as _json
+        body = _json.loads(request.content)
+        assert body["posts"][0]["status"] == "draft"
+        assert body["posts"][0]["updated_at"] == "2026-09-01T00:00:00.000Z"
+        return httpx.Response(200, json={"posts": [{"id": "42"}]})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        await unpublish(client, site_url="https://blog.example.com", admin_api_key=_FAKE_ADMIN_KEY, external_id="42")
+
+    assert calls == ["GET", "PUT"]

--- a/backend/tests/test_3816_ghost_sandbox_publish.py
+++ b/backend/tests/test_3816_ghost_sandbox_publish.py
@@ -1,0 +1,70 @@
+"""story #3816(Phase3·3-6 PR2 CHANGES 1, 페드루 PO 지목 2026-09-12) —
+`ghost_sandbox_publish.py` 직접 단위 테스트. DB 불요·네트워크 0(client 인자는
+시그니처 호환용, 이 모듈이 실제로 쓰지 않는다)."""
+from __future__ import annotations
+
+import pytest
+
+from app.services.ghost_publish import GhostPublishError
+from app.services.ghost_sandbox_publish import publish, unpublish
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_no_marker_publishes_successfully_with_sandbox_external_id():
+    external_id, permalink = await publish(
+        None, site_url="https://ghost-sandbox.invalid", admin_api_key="sandbox-dummy-access-token",
+        title="일반 글", body_md="본문", summary="요약", tags=[], slug="post-1",
+    )
+    assert external_id.startswith("sandbox-ghost-")
+    assert "jwtretry" not in external_id
+    assert permalink == f"https://ghost-sandbox.invalid/p/{external_id}/"
+
+
+@pytest.mark.anyio
+async def test_provider_error_marker_raises_503():
+    with pytest.raises(GhostPublishError) as exc_info:
+        await publish(
+            None, site_url="https://ghost-sandbox.invalid", admin_api_key="sandbox-dummy-access-token",
+            title="[sandbox:provider-error]", body_md="본문", summary="요약", tags=[], slug="post-2",
+        )
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.anyio
+async def test_jwt_expired_marker_still_publishes_with_distinct_external_id_prefix():
+    """story #3816 CHANGES 1 — ghost_publish.py의 재서명 1회 재시도가 실 사이트에서
+    성공하는 모양(첫 401→재서명→성공)을 결정적으로 재현. 최종 상태는 published로
+    마커 없음과 같지만, external_id 접두사로 "그 경로가 실행됐다"를 구분한다."""
+    external_id, permalink = await publish(
+        None, site_url="https://ghost-sandbox.invalid", admin_api_key="sandbox-dummy-access-token",
+        title="[sandbox:ghost-jwt-expired]", body_md="본문", summary="요약", tags=[], slug="post-3",
+    )
+    assert external_id.startswith("sandbox-ghost-jwtretry-")
+    assert permalink == f"https://ghost-sandbox.invalid/p/{external_id}/"
+
+
+@pytest.mark.anyio
+async def test_auth_failed_marker_raises_401_for_ghost_auth_failed_promotion():
+    """뮤테이션 대상(스토리 본문 明示) — 이 분기를 지우면(또는 무마커 성공
+    분기로 흡수되면) 이 테스트가 RED여야 한다. 401은 site_posts.py::
+    _blog_publish_error_code가 GHOST_AUTH_FAILED(연결 「다시 연결 필요」)로
+    승격하는 유일한 트리거다."""
+    with pytest.raises(GhostPublishError) as exc_info:
+        await publish(
+            None, site_url="https://ghost-sandbox.invalid", admin_api_key="sandbox-dummy-access-token",
+            title="[sandbox:ghost-auth-failed]", body_md="본문", summary="요약", tags=[], slug="post-4",
+        )
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_unpublish_always_succeeds_idempotent():
+    assert await unpublish(
+        None, site_url="https://ghost-sandbox.invalid", admin_api_key="sandbox-dummy-access-token",
+        external_id="sandbox-ghost-anything",
+    ) is None

--- a/backend/tests/test_3816_markdown_render.py
+++ b/backend/tests/test_3816_markdown_render.py
@@ -1,0 +1,57 @@
+"""story #3816(Phase3·3-6 PR2, 페드루 PO 確定 2026-09-12) — `render_markdown_html`
+단위 테스트. Ghost `?source=html`이 HTML 계약이라 마크다운 문법이 실제로 HTML
+태그로 바뀌는지가 이 테스트의 전부(라이브러리 위임 — 변환 세부 알고리즘은
+검증 대상이 아니다)."""
+from __future__ import annotations
+
+from app.services.markdown_render import render_markdown_html
+
+
+def test_heading_converts_to_h1_tag():
+    assert "<h1>제목</h1>" in render_markdown_html("# 제목")
+
+
+def test_list_converts_to_ul_li_tags():
+    html = render_markdown_html("- a\n- b\n")
+    assert "<ul>" in html
+    assert "<li>a</li>" in html
+    assert "<li>b</li>" in html
+
+
+def test_link_converts_to_a_tag():
+    html = render_markdown_html("[클릭](https://example.com)")
+    assert '<a href="https://example.com">클릭</a>' in html
+
+
+def test_image_url_converts_to_img_tag():
+    html = render_markdown_html("![대체텍스트](https://example.com/x.png)")
+    assert "<img" in html
+    assert 'src="https://example.com/x.png"' in html
+    assert 'alt="대체텍스트"' in html
+
+
+def test_fenced_code_block_converts_to_pre_code_tags():
+    html = render_markdown_html("```\nprint('hi')\n```")
+    assert "<pre>" in html
+    assert "<code>" in html
+    assert "print(&#39;hi&#39;)" in html or "print('hi')" in html
+
+
+def test_raw_html_block_passes_through_unchanged():
+    """story #3816 — Ghost가 최종 sanitize를 하므로 여기서 별도 escape·필터링 0.
+    라이브러리 기본 동작(원본에 이미 있는 HTML 블록은 그대로 통과)만 확認."""
+    html = render_markdown_html('<div class="custom">이미 HTML</div>')
+    assert '<div class="custom">이미 HTML</div>' in html
+
+
+def test_empty_input_returns_empty_string():
+    assert render_markdown_html("") == ""
+
+
+def test_mutation_target_plain_text_is_not_wrapped_without_conversion():
+    """뮤테이션 대상(스토리 본문 明示) — `render_markdown_html`이 `markdown.markdown()`
+    호출을 안 거치고 원문을 그대로 반환하도록 되돌리면, 이 테스트가 반드시
+    RED여야 한다(마크다운 문법이 변환 없이 그대로 남기 때문)."""
+    html = render_markdown_html("# 제목\n\n- a\n")
+    assert "# 제목" not in html
+    assert "- a" not in html

--- a/backend/tests/test_e4fc29fa_destination_axis.py
+++ b/backend/tests/test_e4fc29fa_destination_axis.py
@@ -840,6 +840,17 @@ def test_get_blog_destination_module_webhook_returns_webhook_publish():
     )
 
 
+def test_get_blog_destination_module_ghost_returns_ghost_publish():
+    """story #3816(Phase3·3-6 PR2) — ghost_publish.py 배선."""
+    from app.services import ghost_publish
+    from app.services.blog_destinations import get_blog_destination_module
+
+    assert (
+        get_blog_destination_module(connection_id=uuid.uuid4(), channel="ghost")
+        is ghost_publish
+    )
+
+
 def test_get_blog_destination_module_unknown_channel_not_implemented_yet():
     """wordpress·webhook 둘 다 아닌(아직 존재하지 않는) 목적지는 여전히 fail-closed —
     뮤테이션 대상: 이 가드를 지우면 존재하지 않는 목적지가 조용히 어떤 모듈로든

--- a/backend/tests/test_e4fc29fa_destination_axis.py
+++ b/backend/tests/test_e4fc29fa_destination_axis.py
@@ -851,6 +851,17 @@ def test_get_blog_destination_module_ghost_returns_ghost_publish():
     )
 
 
+def test_get_blog_destination_module_ghost_sandbox_returns_ghost_sandbox_publish():
+    """story #3816(Phase3·3-6 PR2 CHANGES 1) — ghost_sandbox_publish.py 배선."""
+    from app.services import ghost_sandbox_publish
+    from app.services.blog_destinations import get_blog_destination_module
+
+    assert (
+        get_blog_destination_module(connection_id=uuid.uuid4(), channel="ghost_sandbox")
+        is ghost_sandbox_publish
+    )
+
+
 def test_get_blog_destination_module_unknown_channel_not_implemented_yet():
     """wordpress·webhook 둘 다 아닌(아직 존재하지 않는) 목적지는 여전히 fail-closed —
     뮤테이션 대상: 이 가드를 지우면 존재하지 않는 목적지가 조용히 어떤 모듈로든

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1167,6 +1167,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2082,6 +2091,7 @@ dependencies = [
     { name = "httpx" },
     { name = "imagesize" },
     { name = "jsonschema" },
+    { name = "markdown" },
     { name = "mcp" },
     { name = "passlib", extra = ["argon2", "bcrypt"] },
     { name = "pgvector" },
@@ -2130,6 +2140,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "imagesize", specifier = ">=2.0.0" },
     { name = "jsonschema", specifier = ">=4.26.0" },
+    { name = "markdown", specifier = ">=3.7" },
     { name = "mcp", specifier = ">=2.0.0,<3.0.0" },
     { name = "passlib", extras = ["argon2", "bcrypt"], specifier = ">=1.7.4" },
     { name = "pgvector", specifier = ">=0.3.0" },


### PR DESCRIPTION
## Summary
`blog_destinations.py::BlogDestinationModule` 3호 구현체(wordpress_publish.py/webhook_publish.py와 동형 — publish/unpublish 두 async callable). site_url+admin_api_key로 Ghost Admin API `?source=html`을 직접 친다.

- `ghost_publish.py`(신규): 생성(POST)/갱신(PUT, 낙관적 잠금 — GET으로 현재 updated_at을 먼저 읽어 페이로드에 싣는다·⚠️미확認 공개 문서 그라운딩)·scheduled_at 있으면 status=scheduled+published_at·없으면 published. JWT 401은 재서명 1회만 재시도(시계 어긋남 대비, sign_admin_jwt 캐싱 0 설계 재사용) — 그래도 401이면 `GhostPublishError(status_code=401)`.
- `markdown_render.py`(신규, BE 공용): Ghost `?source=html`이 HTML 계약이라 body_md(마크다운)를 그대로 보내면 문법이 그대로 노출되는 결함을 처방 — 표준 `markdown` 패키지(신규 최소 의존성 1) + `fenced_code` 확장. raw HTML 블록은 라이브러리 기본 동작으로 그대로 통과(Ghost가 최종 sanitize). wordpress의 같은 클래스 잔존 결함은 이 PR에서 안 건드림(후속 카드 후보로 적기만).
- `site_posts.py`: `_blog_destination_exception_classes`·`_call_blog_module_publish`(command.scheduled_at 전달)·`_call_blog_module_unpublish`에 ghost 분기·`_blog_publish_error_code`에 Ghost 401 전용 분기(`GHOST_AUTH_FAILED` — CHANNEL_PUBLISH_AUTH_REJECTED와 다른 코드를 쓰는 이유는 저장 시 GHOST_ADMIN_KEY_INVALID와 같은 문구를 재사용해야 해서, 승격 결과는 동일).
- `publication_command.py`: `GHOST_AUTH_FAILED`를 `_CONNECTION_BLOCKED_CODES`에 등재(연결 「다시 연결 필요」 승격 — connection.status는 CONNECTION_ERROR_CODE_TO_STATUS 미등재 기본값 "expired"로 이미 정확해 추가 등록 불요).
- FE `content/api-error.ts`+ko/en: `GHOST_AUTH_FAILED`(kind=token_expired·GHOST_ADMIN_KEY_INVALID와 같은 문구 재사용, 일반 CHANNEL_TOKEN_EXPIRED 문구 아님).

## PO 決定 2건(이 PR 스코프에서 걷음 — 적기만)
- **이미지 재업로드→URL 치환**: `site_post_versions`에 이미지 필드 자체가 없고 body_md 안 인라인 이미지 URL은 HTML로 그대로 넘기면 Ghost가 외부 URL을 그대로 렌더해 기능 갭이 아님. `/images/upload/`·`ghost-image-too-large` 마커는 Ghost 내부 저장이 필요해질 때 후속(필요성 자체가 미확認).
- **site_post scheduled_at**: 그라운딩 확認 — site_post는 아직 스케줄 개념이 없어(모든 커맨드가 scheduled_at=None으로 생성) `ghost_publish.publish()`의 scheduled 분기는 API 계약·테스트는 갖췄으나 오늘 코드상 살아있는 호출 경로가 없다(site_post 스케줄 기능이 생기면 그때 값이 실린다).

## ⚠️ 미검증/미확定 라벨
- 실 Ghost 사이트 왕복 미검증 — 전부 `httpx.MockTransport` 기반(실 네트워크 0). 갱신(PUT)의 낙관적 잠금(`updated_at` 재실음) 계약은 공개 문서 그라운딩(실물 미확認).
- `GHOST_AUTH_FAILED`를 살아있는 코드 경로로 재현하려면 실 Ghost 사이트에서 JWT 만료(5분)를 실제로 넘겨야 한다 — 이 PR의 재서명 1회 로직은 단위 테스트로만 검증.

## Test plan
BE(throwaway Postgres, `uv run pytest`):
```
uv run python -m pytest tests/test_e4fc29fa_destination_axis.py tests/test_e4fc29fa_site_post_orchestration.py tests/test_3513_unpublish_absent_idempotent.py tests/test_3808_site_post_concurrent_publish.py -m destructive_schema -q
```
→ `35 passed, 3 warnings in 18.37s`
```
uv run python -m pytest tests/test_3414_publication_command_cron_retry.py -m destructive_schema -q
```
→ `18 passed, 1 warning in 10.57s`
```
uv run python -m pytest tests/test_3816_ghost_publish.py tests/test_3816_markdown_render.py tests/test_3816_blog_publish_error_code.py tests/test_3816_ghost_client.py tests/test_3697_channel_insight_metrics_drift_lint.py tests/test_3696_insight_channel_dispatch_registered_guard.py tests/test_3779_korean_user_strings_lint.py tests/test_3786_i18n_catalog.py -m "not destructive_schema" -q
```
→ `62 passed, 2 deselected in 1.86s`
```
uv run python -m pytest tests/test_3605_graph_error_family_generalize.py -m "not destructive_schema" -q
```
→ `34 passed in 0.08s`

FE(vitest):
```
npx vitest run src/components/content/
```
→ `Test Files 31 passed (31), Tests 439 passed (439)`

- [x] `pnpm run type-check` clean
- [x] `verify:no-hanja-in-i18n`/`verify:no-duplicate-i18n-keys`/`verify:i18n-keys-exist` 전부 OK
- [x] `python3 scripts/verify_no_new_korean_user_strings.py` — 신규 0건(내부 전용 예외 메시지 2곳은 최근 채널 영문 관례로 등재)
- [x] `JWT_SECRET=x SECRET_KEY=x python3 scripts/lint_destructive_schema_weights_registered.py` — OK(신규 미등재 0건)
- [x] 뮤테이션 자가검증 2건: ① `ghost_publish.py` 재서명 1회 재시도 분기 제거 → 정확히 1건 RED(`test_publish_retries_once_on_401_then_succeeds`) ② `site_posts.py::_blog_publish_error_code`의 Ghost 401 분기 제거 → 정확히 1건 RED(`test_ghost_401_maps_to_ghost_auth_failed`) — 둘 다 확認 후 원복(diff 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fGyXNMwYyHmebLcLMo2bn

## CHANGES-1 (착지 후 본문 보강 — 코멘트에서 이관)
- `ghost_sandbox_publish.py`(신규, blog_destinations 4호·네트워크 0·JWT 0·결정적): 마커 `[sandbox:provider-error]`→`GhostPublishError(503)` · `[sandbox:ghost-jwt-expired]`→success(external_id `sandbox-ghost-jwtretry-` 접두 — 재시도 자체는 관측 가능한 유일 차이) · `[sandbox:ghost-auth-failed]`→`GhostPublishError(401)`(뮤테이션 확認: 분기 제거→정확히 1건 RED) · 무마커→`sandbox-ghost-<uuid4>`+`https://ghost-sandbox.invalid/p/<id>/`. `blog_destinations.py`/`site_posts.py` 디스패치가 `channel in ("ghost", "ghost_sandbox")`로 확장.
- drift 가드 테스트 1건: `content.errorGhostAuthFailed`와 `channelConnect.channelConnectErrorGhostAdminKeyInvalid`가 ko/en 둘 다 값 동일함을 assert(의도적 문구 중복이 한쪽만 고쳐져 갈리는 것을 방지).
