### PR TITLE
[SID:3815] PR3 — YouTube 1d/7d 인사이트+사용량 GET+연결 능력 플래그

### DIFF
--- a/apps/web/src/components/insights-board/channel-declared-metrics.ts
+++ b/apps/web/src/components/insights-board/channel-declared-metrics.ts
@@ -51,6 +51,13 @@ export const CHANNEL_DECLARED_METRICS: Record<string, readonly BoardMetric[]> = 
   // METRIC_KEYS)엔 아직 없다(PR4 몫) — 이 맵은 "선택기 노출"이 아니라 "이 채널이
   // 이 지표를 declare하는가"의 BE 미러라 선택기 상태와 무관하게 실값 그대로 채운다.
   stibee_sandbox: ['opens', 'delivered', 'clicks'],
+  // story #3815(Phase3·3-5 PR3, 페드루 PO 決定) — views=viewCount·engagements=
+  // likeCount+commentCount(합산). PR1/PR2 시점엔 BE 미선언이라 이 맵에 없었다
+  // (그때는 그게 옳은 값 — 위 wordpress/webhook 주석과 동형 원칙), PR3이
+  // dispatch+선언을 같은 커밋에 추가하며 여기도 짝을 맞춘다.
+  youtube: ['views', 'engagements'],
+  // channel_adapters.py — youtube와 동형(x_sandbox 선례 그대로).
+  youtube_sandbox: ['views', 'engagements'],
 };
 
 /** 이 채널이 declare한 지표 목록. 등록되지 않은 채널(모르는 값·wordpress·webhook 등)은

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -16,6 +16,7 @@ import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 
+from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.services.channel_adapters import can_auto_refresh, get_channel_adapter
@@ -167,6 +168,20 @@ class ChannelConnectionResponse(BaseModel):
     # 스레드 이어쓰기 미지원", FE가 이 값으로 편집기의 「스레드 이어쓰기」 목록 UI
     # 노출 여부를 판단한다, 채널 이름 하드코딩 목록 금지).
     thread_max_segments: int = 0
+    # story #3815(Phase3·3-5 PR3, 미르코 PR4 그라운딩 갭 → 페드루 PO 계약 확定
+    # 2026-09-12) — image_required와 동형 관례(영상판, 이미 어댑터엔 있었으나
+    # 이 응답엔 안 실렸던 갭). 미선언 채널(어댑터 None 포함)은 False.
+    video_required: bool = False
+    # 이 채널의 발행 편집기가 channel_payload(title/tags/categoryId/
+    # privacyStatus) 4필드를 요구하는가 — 채널 이름 하드코딩 금지 관례
+    # (thread_max_segments·image_required와 동형): FE가 "youtube"/"youtube_
+    # sandbox" 문자열을 직접 비교하지 않고 이 플래그로 편집기 폼 분기.
+    youtube_metadata_required: bool = False
+    # API 감사 미완 강제 비공개(`settings.youtube_api_audit_incomplete`, 페드루
+    # PO 決定②) — 플랫폼 전체 값이라 모든 youtube/youtube_sandbox 연결이 항상
+    # 같은 값을 본다(연결별 상태 아님, ChannelConnection.status 4값과 무관).
+    # video_required=False인 채널은 이 축 자체가 없어 항상 False.
+    privacy_locked: bool = False
     # story #3492 — 붙여넣기(pasted_secret) 재방문 표시(§2 규격 3, app_id_suffix와
     # 동형). oauth 채널은 항상 null(secret_hint 자체를 안 씀).
     secret_hint: str | None = None
@@ -244,6 +259,14 @@ def _to_response(row, *, reconnect_mismatch_target_id: uuid.UUID | None = None) 
         video_aspect_tolerance=adapter.video_aspect_tolerance if adapter is not None else 0.0,
         video_codecs=list(adapter.video_codecs) if adapter is not None else [],
         thread_max_segments=adapter.thread_max_segments if adapter is not None else 0,
+        video_required=adapter.video_required if adapter is not None else False,
+        # story #3815(PR3) — 지금은 video_required=True(YouTube)인 채널만 이
+        # 메타 4필드를 요구한다(채널명 하드코딩 대신 이 축으로 판정 — 다음
+        # video_required 채널이 이 메타를 안 쓰게 되면 그때 별도 필드로 승격).
+        youtube_metadata_required=bool(adapter is not None and adapter.video_required),
+        privacy_locked=bool(
+            adapter is not None and adapter.video_required and settings.youtube_api_audit_incomplete
+        ),
         secret_hint=row.secret_hint,
         reconnect_mismatch_target_id=reconnect_mismatch_target_id,
         sender_email=(row.provider_config or {}).get("sender_email"),
@@ -317,6 +340,20 @@ class TestConnectionResponse(BaseModel):
     ok: bool
     account: dict | None = None
     error: str | None = None
+
+
+class YouTubeUsageResponse(BaseModel):
+    """story #3815(Phase3·3-5 PR3, 미르코 PR4 FE 그라운딩 갭 → 페드루 PO 계약 확定
+    2026-09-12) — 연결 카드 「오늘 사용량 {used}/{limit} · 플랫폼 공유」 줄의 BE 계약.
+    `scope="platform"`이 이 값의 성격을 명시한다 — connection_id는 인가(그 채널에
+    접근 권한이 있는지)에만 쓰이고, 값 자체는 org 무관(플랫폼 전체 공유 카운터,
+    `youtube_quota.py`가 이미 그렇게 계산). evidence를 새로 쓰지 않는 순수 읽기
+    (youtube_quota.py::get_platform_youtube_quota_spent_units 재사용)."""
+    used_units: int
+    limit_units: int
+    remaining_units: int
+    reset_at: str
+    scope: Literal["platform"] = "platform"
 
 
 class AppCredentialsRequest(BaseModel):
@@ -1709,6 +1746,43 @@ async def test_channel_connection(
             return TestConnectionResponse(ok=False, error=exc.message)
     del access_token  # ⛔즉시 소비 후 폐기 — 더 들고 있지 않는다.
     return TestConnectionResponse(ok=True, account=account)
+
+
+@router.get(
+    "/{org_id}/channel-connections/{connection_id}/youtube-usage", response_model=YouTubeUsageResponse,
+)
+async def get_youtube_usage(
+    org_id: uuid.UUID,
+    connection_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> YouTubeUsageResponse:
+    """story #3815(Phase3·3-5 PR3, 미르코 PR4 그라운딩 갭 → 페드루 PO 계약 확定
+    2026-09-12) — 연결 카드 사용량 줄. `/test`와 동형 인가(member 이상, owner
+    제한 없음 — 조회뿐). connection_id는 "이 채널을 볼 권한이 있는가"만 확인하고,
+    반환값 자체는 org 무관 플랫폼 전체 카운터(`YouTubeUsageResponse.scope`
+    딱지 참고) — evidence를 새로 쓰지 않는 순수 읽기."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    await _require_human(db, auth, org_id)
+
+    row = await get_channel_connection(db, org_id=org_id, connection_id=connection_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="channel connection not found")
+    if row.channel not in ("youtube", "youtube_sandbox"):
+        raise HTTPException(status_code=422, detail=f"youtube-usage unsupported for channel: {row.channel}")
+
+    from app.services.youtube_quota import _utc_day_window, get_platform_youtube_quota_spent_units
+
+    now = datetime.now(timezone.utc)
+    limit_units = settings.youtube_quota_daily_limit_units
+    spent_units = await get_platform_youtube_quota_spent_units(db, now=now)
+    _, reset_at = _utc_day_window(now)
+    return YouTubeUsageResponse(
+        used_units=spent_units, limit_units=limit_units,
+        remaining_units=max(0, limit_units - spent_units), reset_at=reset_at.isoformat(),
+    )
 
 
 @router.put("/{org_id}/channel-connections/{channel}/app-credentials", response_model=AppCredentialsPutResponse)

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -650,6 +650,12 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         video_codecs=("avc1", "hvc1", "hev1"),
         container_poll_timeout_seconds=86_400,  # 24h — 페드루 PO 지적 2026-09-12 11:34Z.
         keep_container_on_poll_timeout=True,  # CHANGES③ — 페드루 PO 지적 2026-09-12 11:55Z.
+        # story #3815(Phase3·3-5 PR3, 페드루 PO 決定) — views=viewCount·
+        # engagements=likeCount+commentCount(합산, PO 決定 그대로). PR1/PR2
+        # 시점엔 이 열이 미선언이었다(수집 배선이 이 PR 몫이라 §2(d) 관례대로
+        # 미룸) — 이제 dispatch가 생겨 선언(3696 가드 짝 맞춤, 3697
+        # EXPECTED_BACKEND_CHANNELS 주석도 같이 갱신).
+        insight_metrics=("views", "engagements"),
     ),
     "youtube_sandbox": ChannelAdapterConfig(
         authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
@@ -673,6 +679,10 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         video_codecs=("avc1", "hvc1", "hev1"),
         container_poll_timeout_seconds=86_400,  # 24h — 페드루 PO 지적 2026-09-12 11:34Z.
         keep_container_on_poll_timeout=True,  # CHANGES③ — 페드루 PO 지적 2026-09-12 11:55Z.
+        # story #3815(PR3) — x_sandbox와 동형(실 API 호출 0, 위 "youtube" 선언과
+        # 짝 맞춤 — declared_metrics 필터가 제네릭 _fetch_sandbox의 7키 중
+        # 2키만 통과시킨다).
+        insight_metrics=("views", "engagements"),
     ),
 }
 

--- a/backend/app/services/insight_snapshots.py
+++ b/backend/app/services/insight_snapshots.py
@@ -658,6 +658,76 @@ async def _fetch_x(client: "httpx.AsyncClient", *, access_token: str, tweet_id: 
     return {"raw": body, "values": values}
 
 
+_YOUTUBE_ENGAGEMENT_STATISTICS_FIELDS = ("likeCount", "commentCount")
+
+
+async def _fetch_youtube(client: "httpx.AsyncClient", *, access_token: str, video_id: str) -> dict[str, Any]:  # noqa: F821
+    """story #3815(Phase3·3-5 PR3, 페드루 PO 決定) — `_fetch_x`/`_fetch_threads`와
+    동형. `videos.list(part=statistics)` — viewCount→views(threads/x의 views
+    자리와 동형, YouTube는 자체가 "views"라는 이름을 씀)·likeCount+commentCount
+    합산→engagements(PO 決定, 카드 원문 "engagements = likeCount + commentCount"
+    — dislikeCount는 YouTube가 공개 API에서 이미 안 냄, §2(d) 7키류 "개별 반응
+    종류 없음" 관례와 다른 축: 아예 API에 없는 값이라 합산 후보에서 자동 제외).
+    통계값은 Google이 문자열로 준다(예: "1234") — int() 변환 필요."""
+    from app.services.youtube_publish import _VIDEOS_URL, _auth_headers
+
+    resp = await client.get(
+        _VIDEOS_URL, params={"part": "statistics", "id": video_id}, headers=_auth_headers(access_token),
+    )
+    # story #3779 BE 한글 사용자 문장 재발 가드 — 신규 코드는 영문(_fetch_x 선례 그대로).
+    if resp.status_code == 401:
+        raise InsightFetchError(error_code="CHANNEL_TOKEN_EXPIRED", message="YouTube access token expired")
+    if resp.status_code == 429:
+        raise InsightFetchError(error_code="CHANNEL_RATE_LIMITED", message="YouTube insights API rate limit exceeded")
+    if resp.status_code >= 500:
+        raise InsightFetchError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=f"YouTube server error: {resp.status_code}")
+    if resp.status_code >= 400:
+        raise InsightFetchError(error_code="CHANNEL_PUBLISH_AUTH_REJECTED", message=f"YouTube insights request rejected: {resp.status_code}")
+
+    body = resp.json()
+    items = body.get("items") or []
+    statistics = (items[0].get("statistics") or {}) if items else {}
+    values: dict[str, int] = {}
+    if "viewCount" in statistics:
+        values["views"] = int(statistics["viewCount"])
+    engagement_total = sum(
+        int(statistics[k]) for k in _YOUTUBE_ENGAGEMENT_STATISTICS_FIELDS if k in statistics
+    )
+    if any(k in statistics for k in _YOUTUBE_ENGAGEMENT_STATISTICS_FIELDS):
+        values["engagements"] = engagement_total
+    return {"raw": body, "values": values}
+
+
+async def _fetch_youtube_via_connection(db: AsyncSession, snapshot: InsightSnapshot) -> dict[str, Any]:
+    """`_fetch_x_via_connection`과 동형 — quota evidence(list=1) 기록은 여기가
+    아니라 `process_due_insight_snapshots`(x_sandbox의 read-cost 기록과 같은
+    위치 축, 아래 참고) — fetch 함수 자신은 순수 조회 계층 유지(DB 접근은
+    connection/publication 조회뿐, evidence write 0)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_connection import decrypt_for_use
+
+    pub = (await db.execute(
+        select(ChannelPublication).where(ChannelPublication.id == snapshot.publication_id)
+    )).scalar_one_or_none()
+    if pub is None or pub.external_id is None:
+        raise InsightFetchError(
+            error_code="INSIGHT_PUBLICATION_NOT_FOUND", message=f"channel_publication을 찾을 수 없습니다: {snapshot.publication_id}",
+        )
+    connection = await db.get(ChannelConnection, pub.connection_id)
+    if connection is None or connection.status != "active":
+        raise InsightFetchError(
+            error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message=f"연결이 활성 상태가 아닙니다: {pub.connection_id}",
+        )
+    access_token = decrypt_for_use(connection)
+    if access_token is None:
+        raise InsightFetchError(error_code="CHANNEL_CONNECTION_NOT_ACTIVE", message="연결에 자격이 없습니다")
+
+    import httpx
+
+    async with httpx.AsyncClient() as client:
+        return await _fetch_youtube(client, access_token=access_token, video_id=pub.external_id)
+
+
 async def _fetch_x_via_connection(db: AsyncSession, snapshot: InsightSnapshot) -> dict[str, Any]:
     from app.models.channel_connection import ChannelConnection
     from app.models.channel_publication import ChannelPublication
@@ -711,6 +781,14 @@ async def _fetch_for_snapshot(db: AsyncSession, snapshot: InsightSnapshot, *, li
     if snapshot.channel == "x":
         return await _fetch_x_via_connection(db, snapshot)
     if snapshot.channel == "x_sandbox":
+        return await _fetch_sandbox(db, publication_id=snapshot.publication_id, live=live)
+    # story #3815(Phase3·3-5 PR3, 페드루 PO 決定) — youtube_sandbox는 x_sandbox와
+    # 동형으로 제네릭 `_fetch_sandbox()` 재사용(신규 로직 0, insight_metrics
+    # 선언이 declared_metrics 필터를 통해 자동으로 views·engagements 2키만
+    # 통과시킨다 — _normalize 참고).
+    if snapshot.channel == "youtube":
+        return await _fetch_youtube_via_connection(db, snapshot)
+    if snapshot.channel == "youtube_sandbox":
         return await _fetch_sandbox(db, publication_id=snapshot.publication_id, live=live)
     # story #3696(Phase2·BE·funnel 갭, 디디 e2e 그라운딩 발견 2026-09-08) — 이전
     # 주석("instagram_sandbox와 달리 facebook_sandbox는 dispatch가 없으면...")이
@@ -982,6 +1060,19 @@ async def process_due_insight_snapshots(db: AsyncSession, *, now: datetime | Non
                     db, org_id=snapshot.org_id, work_item_id=snapshot.work_item_id,
                     publication_id=snapshot.publication_id, snapshot_kind=snapshot_kind,
                     cost_minor=insights_unit_cost_minor,
+                )
+            if snapshot.channel == "youtube":
+                # story #3815(Phase3·3-5 PR3, 페드루 PO 決定 — quota evidence
+                # insert 1,600·list 1) — X read-cost 기록과 같은 위치 축(성공
+                # fetch 뒤·_finalize_snapshot_write 前). event=snapshot.id로
+                # 좁혀 같은 스냅샷의 워커 재시도만 멱등(1d·7d 두 스냅샷은 서로
+                # 다른 id라 각자 따로 집계 — youtube_sandbox는 실 API 호출이
+                # 없어(제네릭 _fetch_sandbox) 기록 대상 아님).
+                from app.services.youtube_quota import record_youtube_quota_usage_evidence
+
+                await record_youtube_quota_usage_evidence(
+                    db, org_id=snapshot.org_id, work_item_id=snapshot.work_item_id,
+                    publication_id=snapshot.publication_id, event=str(snapshot.id), units=1,
                 )
             if await _finalize_snapshot_write(db, snapshot, new_status="captured"):
                 counts["captured"] += 1

--- a/backend/scripts/lint_channel_insight_metrics_drift.py
+++ b/backend/scripts/lint_channel_insight_metrics_drift.py
@@ -74,9 +74,9 @@ EXPECTED_BACKEND_CHANNELS = frozenset({
     # 0(신규 FE 등재 불요, PR3에서 stibee_sandbox만 채움).
     "stibee", "stibee_sandbox",
     # story #3815(Phase3·3-5 PR1, 페드루 PO 確定 2026-09-12) — youtube/youtube_
-    # sandbox도 같은 이유로 이 PR 시점엔 insight_metrics 미선언(빈 튜플 기본값)
-    # — 통계 수집(views/likeCount+commentCount→engagements) 배선은 후속 PR
-    # 몫. x/stibee와 동형으로 drift 0(신규 FE 등재 불요).
+    # sandbox 등재(PR1 시점엔 insight_metrics 미선언이었으나 PR3(views·
+    # engagements=likeCount+commentCount 합산)이 채움 — FE 미러(channel-
+    # declared-metrics.ts)도 PR3에서 같이 등재해 drift 0).
     "youtube", "youtube_sandbox",
     # story #3816(Phase3·3-6 PR1, 페드루 PO 確定 2026-09-12) — ghost/ghost_sandbox도
     # 같은 이유로 insight_metrics 미선언(빈 튜플 기본값 — Ghost Admin API에 통계

--- a/backend/tests/test_3815_youtube_insights.py
+++ b/backend/tests/test_3815_youtube_insights.py
@@ -1,0 +1,330 @@
+"""story #3815(Phase3·3-5 PR3, 페드루 PO 決定) — YouTube 헤드 영상 1d/7d 인사이트
+스냅샷(organic) + quota evidence(list=1). `test_3808_x_insights.py`와 동형 구조 —
+①실 youtube 200(views·engagements=likeCount+commentCount 합산)②401 승격
+③quota evidence 멱등(1d·7d 각자 별도 event)④youtube_sandbox 양성대조(declared
+2키만)⑤1d/7d 예약 동형.
+
+세팅 헬퍼는 test_3497_insight_snapshots.py(_patch_threads_transport는 httpx.
+AsyncClient 자체를 감싸 채널 무관 재사용 가능·_seed_channel_connection·
+_seed_channel_publication)·test_e4fc29fa_site_post_orchestration.py(_seed_org)
+재사용(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import _seed_org, _session_factory
+from tests.test_3497_insight_snapshots import (
+    _patch_threads_transport,
+    _seed_channel_connection,
+    _seed_channel_publication,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+# ─── ① 단위 — _fetch_youtube 정규화 ────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_fetch_youtube_sums_like_and_comment_count_into_engagements():
+    import httpx
+    from app.services.insight_snapshots import _fetch_youtube
+
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={
+        "items": [{"statistics": {"viewCount": "500", "likeCount": "10", "commentCount": "3"}}],
+    }))
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await _fetch_youtube(client, access_token="at", video_id="v1")
+    assert result["values"] == {"views": 500, "engagements": 13}
+
+
+@pytest.mark.anyio
+async def test_fetch_youtube_missing_statistics_leaves_values_empty():
+    """items가 비어있으면(예: 삭제된 영상) 지어내지 않고 빈 values — _normalize가
+    null로 채운다(이 스토리의 척추 원칙)."""
+    import httpx
+    from app.services.insight_snapshots import _fetch_youtube
+
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={"items": []}))
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await _fetch_youtube(client, access_token="at", video_id="v1")
+    assert result["values"] == {}
+
+
+# ─── ② 실 youtube 200/401 ──────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_youtube_200_captures_views_and_engagements(monkeypatch):
+    import httpx
+
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="youtube")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="youtube")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="youtube", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            _patch_threads_transport(monkeypatch, lambda request: httpx.Response(200, json={
+                "items": [{"statistics": {"viewCount": "1000", "likeCount": "40", "commentCount": "5"}}],
+            }))
+            counts = await process_due_insight_snapshots(s)
+
+            assert counts["captured"] == 2, counts
+            snaps = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == pub.id)
+            )).scalars().all()
+            for snap in snaps:
+                assert snap.normalized["views"] == 1000
+                assert snap.normalized["engagements"] == 45  # 40+5
+                # YouTube가 선언 안 한 5축은 null(지어내지 않는다).
+                assert snap.normalized["impressions"] is None
+                assert snap.normalized["reach"] is None
+                assert snap.normalized["clicks"] is None
+                assert snap.normalized["spend"] is None
+                assert snap.normalized["conversions"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_youtube_401_promotes_connection_and_marks_snapshot_failed(monkeypatch):
+    import httpx
+
+    from app.models.channel_connection import ChannelConnection
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="youtube")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="youtube")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="youtube", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            _patch_threads_transport(monkeypatch, lambda request: httpx.Response(401, json={"error": {"message": "expired"}}))
+            counts = await process_due_insight_snapshots(s)
+
+            assert counts["failed"] == 2, counts
+            conn_row = await s.get(ChannelConnection, connection.id)
+            assert conn_row.status != "active"
+    finally:
+        await engine.dispose()
+
+
+# ─── ③ quota evidence(list=1) — 1d·7d 각자 별도 event, 재시도는 멱등 ───────────
+
+@pytest.mark.anyio
+async def test_youtube_insight_fetch_records_one_list_unit_evidence_per_snapshot(monkeypatch):
+    import httpx
+    from sqlalchemy import select
+    from app.models.evidence import Evidence
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from app.services.youtube_quota import YOUTUBE_QUOTA_KIND
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="youtube")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="youtube")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="youtube", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            _patch_threads_transport(monkeypatch, lambda request: httpx.Response(200, json={
+                "items": [{"statistics": {"viewCount": "1", "likeCount": "1", "commentCount": "0"}}],
+            }))
+            counts = await process_due_insight_snapshots(s)
+            assert counts["captured"] == 2, counts
+
+            rows = (await s.execute(
+                select(Evidence).where(
+                    Evidence.org_id == org_id, Evidence.payload["kind"].astext == YOUTUBE_QUOTA_KIND,
+                )
+            )).scalars().all()
+            # 1d·7d 두 스냅샷 각자 1 unit — 합쳐서 2건(같은 publication이어도
+            # snapshot.id가 달라 서로 안 겹친다).
+            assert len(rows) == 2, [r.payload for r in rows]
+            assert all(r.payload["units"] == 1 for r in rows)
+    finally:
+        await engine.dispose()
+
+
+# ─── ④ youtube_sandbox 양성대조 — declared 2키만 ──────────────────────────────
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_captures_only_declared_two_keys():
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="youtube_sandbox")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=connection.id, channel="youtube_sandbox",
+            )
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="youtube_sandbox", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+
+            counts = await process_due_insight_snapshots(s)
+
+            assert counts["captured"] == 2, counts
+            snaps = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == pub.id)
+            )).scalars().all()
+            for snap in snaps:
+                assert snap.normalized["views"] is not None
+                assert snap.normalized["engagements"] is not None
+                assert snap.normalized["impressions"] is None
+                assert snap.normalized["reach"] is None
+                assert snap.normalized["clicks"] is None
+                assert snap.normalized["spend"] is None
+                assert snap.normalized["conversions"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_youtube_sandbox_records_no_quota_evidence():
+    """sandbox는 실 API 호출이 없다(제네릭 _fetch_sandbox, DB 접근 0) — quota
+    evidence를 기록하면 실제로 쓰지도 않은 quota를 소비한 것처럼 거짓 기록하는
+    셈이라 반드시 0건이어야 한다."""
+    from sqlalchemy import select
+    from app.models.evidence import Evidence
+    from app.services.insight_snapshots import process_due_insight_snapshots, schedule_insight_snapshots
+    from app.services.youtube_quota import YOUTUBE_QUOTA_KIND
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="youtube_sandbox")
+            pub = await _seed_channel_publication(
+                s, org_id=org_id, connection_id=connection.id, channel="youtube_sandbox",
+            )
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="youtube_sandbox", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc) - timedelta(days=8),
+            )
+            await s.commit()
+            await process_due_insight_snapshots(s)
+
+            rows = (await s.execute(
+                select(Evidence).where(
+                    Evidence.org_id == org_id, Evidence.payload["kind"].astext == YOUTUBE_QUOTA_KIND,
+                )
+            )).scalars().all()
+            assert rows == []
+    finally:
+        await engine.dispose()
+
+
+# ─── ⑤ 1d/7d 예약 동형 ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_youtube_schedules_both_1d_and_7d_rows():
+    from app.models.insight_snapshot import InsightSnapshot
+    from app.services.insight_snapshots import schedule_insight_snapshots
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            connection = await _seed_channel_connection(s, org_id, channel="youtube")
+            pub = await _seed_channel_publication(s, org_id=org_id, connection_id=connection.id, channel="youtube")
+            work_item_id = uuid.uuid4()
+
+            await schedule_insight_snapshots(
+                s, org_id=org_id, work_item_id=work_item_id, publication_id=pub.id,
+                publication_kind="channel_publication", channel="youtube", external_id=pub.external_id,
+                anchor_at=datetime.now(timezone.utc),
+            )
+            await s.commit()
+
+            rows = (await s.execute(
+                select(InsightSnapshot).where(InsightSnapshot.publication_id == pub.id).order_by(InsightSnapshot.due_at)
+            )).scalars().all()
+        assert len(rows) == 2
+        assert (rows[1].due_at - rows[0].due_at) == timedelta(days=6)
+    finally:
+        await engine.dispose()
+
+
+# ─── ⑥ 어댑터·드리프트 가드 등록 확認 ───────────────────────────────────────────
+
+def test_youtube_adapters_declare_views_and_engagements():
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    for channel in ("youtube", "youtube_sandbox"):
+        assert CHANNEL_ADAPTERS[channel].insight_metrics == ("views", "engagements")

--- a/backend/tests/test_3815_youtube_oauth.py
+++ b/backend/tests/test_3815_youtube_oauth.py
@@ -258,9 +258,12 @@ def test_youtube_and_youtube_sandbox_adapters_registered_with_reused_refresh_mod
         assert cfg.kind == "social"
         assert "youtube.upload" in cfg.scope
         assert "youtube.readonly" in cfg.scope
-        # PR1은 OAuth만 — 발행/인사이트 능력은 아직 선언하지 않는다(§3696 가드가
-        # 요구하는 "선언=dispatch 존재" 계약을 어길 자리 자체를 안 만든다).
-        assert cfg.insight_metrics == ()
+        # ⭐PR 경계 pin — PR1(이 파일 최초 작성) 시점엔 OAuth만이라 insight_metrics
+        # 미선언(빈 튜플)이었다. PR3(story #3815, views·engagements=likeCount+
+        # commentCount 합산)이 선언+dispatch를 같은 커밋에 추가하며 뒤집혔다(youtube_
+        # publish dispatch pin이 PR2에서 뒤집힌 것과 동형 — 옛 pin은 stale이라 갱신,
+        # 삭제 아님).
+        assert cfg.insight_metrics == ("views", "engagements")
     assert can_auto_refresh("refresh_token") is True
 
 

--- a/backend/tests/test_3815_youtube_usage_endpoint.py
+++ b/backend/tests/test_3815_youtube_usage_endpoint.py
@@ -1,0 +1,303 @@
+"""story #3815(Phase3·3-5 PR3, 미르코 PR4 FE 그라운딩 갭 → 페드루 PO 계약 확定
+2026-09-12 12:53Z) — BE 조각 2건:
+① `GET /channel-connections/{connection_id}/youtube-usage` — 연결 카드 사용량
+  줄 계약(`used_units`/`limit_units`/`remaining_units`/`reset_at`/
+  `scope:"platform"`). 값은 org 무관(플랫폼 전체 공유 카운터), evidence
+  소비 0(순수 읽기), connection_id는 인가에만 쓰임.
+② `ChannelConnectionResponse`의 어댑터 능력 노출에 `video_required`·
+  `youtube_metadata_required`·`privacy_locked`(Settings `youtube_api_audit_
+  incomplete` 반영) 추가 — `thread_max_segments`/`image_required`와 동형
+  관례(채널 이름 하드코딩 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_3471_org_content_rules_lint import (
+    _client_for, _seed_org, _seed_human, _session_factory, _setup_org_scoped_app,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _seed_youtube_connection(session, org_id, *, owner_id, channel="youtube_sandbox"):
+    from app.services.channel_connection import upsert_channel_connection
+
+    return await upsert_channel_connection(
+        session, org_id=org_id, channel=channel, account_id=f"{channel}-usage-1",
+        account_label="usage_user", credential_kind="oauth",
+        access_token="plain-access-token", refresh_token="plain-refresh-token",
+        token_expires_at=datetime.now(timezone.utc), refresh_mode="refresh_token",
+        scopes=["https://www.googleapis.com/auth/youtube.upload"], connected_by=owner_id,
+    )
+
+
+# ─── ① GET youtube-usage ───────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_youtube_usage_endpoint_returns_platform_scope_contract():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            connection = await _seed_youtube_connection(s, org_id, owner_id=owner_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(
+                    f"/api/v2/organizations/{org_id}/channel-connections/{connection.id}/youtube-usage",
+                )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["scope"] == "platform"
+            assert body["limit_units"] > 0
+            assert body["remaining_units"] == body["limit_units"] - body["used_units"]
+            assert body["reset_at"]  # ISO 문자열, UTC 자정 경계.
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_youtube_usage_endpoint_value_is_org_agnostic_platform_counter():
+    """⭐핵심 계약 — 값 자체가 org 무관(플랫폼 전체 공유). 서로 다른 두 조직이
+    같은 시각에 조회하면 완전히 같은 used_units/limit_units를 봐야 한다(연결이
+    다른 org 소속이어도 카운터는 하나)."""
+    from app.main import app
+    from app.services.youtube_quota import record_youtube_quota_usage_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a, _ = await _seed_org(s)
+            owner_a = await _seed_human(s, org_a)
+            connection_a = await _seed_youtube_connection(s, org_a, owner_id=owner_a)
+            org_b, _ = await _seed_org(s)
+            owner_b = await _seed_human(s, org_b)
+            connection_b = await _seed_youtube_connection(s, org_b, owner_id=owner_b)
+            # org_a에서만 사용량 발생 — 그래도 org_b가 조회하는 값도 그 사용량을 반영해야 한다.
+            await record_youtube_quota_usage_evidence(
+                s, org_id=org_a, work_item_id=uuid.uuid4(), publication_id=uuid.uuid4(),
+                event="insert", units=1_600,
+            )
+
+        _setup_org_scoped_app(app, Session, org_a, user_id=owner_a)
+        try:
+            async with _client_for(app) as client:
+                r_a = await client.get(
+                    f"/api/v2/organizations/{org_a}/channel-connections/{connection_a.id}/youtube-usage",
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        _setup_org_scoped_app(app, Session, org_b, user_id=owner_b)
+        try:
+            async with _client_for(app) as client:
+                r_b = await client.get(
+                    f"/api/v2/organizations/{org_b}/channel-connections/{connection_b.id}/youtube-usage",
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert r_a.status_code == 200 and r_b.status_code == 200
+        assert r_a.json()["used_units"] == r_b.json()["used_units"] == 1_600
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_youtube_usage_endpoint_rejects_non_youtube_channel():
+    from app.main import app
+    from app.services.channel_connection import upsert_channel_connection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            connection = await upsert_channel_connection(
+                s, org_id=org_id, channel="threads", account_id="threads-usage-1",
+                account_label="threads_user", credential_kind="oauth",
+                access_token="plain-access-token", refresh_token=None, token_expires_at=None,
+                refresh_mode="reissue_from_access_token", scopes=[], connected_by=owner_id,
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(
+                    f"/api/v2/organizations/{org_id}/channel-connections/{connection.id}/youtube-usage",
+                )
+            assert r.status_code == 422, r.text
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_youtube_usage_endpoint_records_no_evidence():
+    """순수 읽기 — 조회 자체가 quota를 소비한 것으로 잘못 기록되면 안 된다."""
+    from sqlalchemy import select
+    from app.main import app
+    from app.models.evidence import Evidence
+    from app.services.youtube_quota import YOUTUBE_QUOTA_KIND
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            connection = await _seed_youtube_connection(s, org_id, owner_id=owner_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                for _ in range(3):
+                    r = await client.get(
+                        f"/api/v2/organizations/{org_id}/channel-connections/{connection.id}/youtube-usage",
+                    )
+                    assert r.status_code == 200, r.text
+        finally:
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Evidence).where(
+                    Evidence.org_id == org_id, Evidence.payload["kind"].astext == YOUTUBE_QUOTA_KIND,
+                )
+            )).scalars().all()
+        assert rows == []
+    finally:
+        await engine.dispose()
+
+
+# ─── ② ChannelConnectionResponse 능력 노출 ─────────────────────────────────
+
+@pytest.mark.anyio
+async def test_connection_response_exposes_youtube_capability_flags(monkeypatch):
+    from app.core.config import settings
+    from app.main import app
+
+    monkeypatch.setattr(settings, "youtube_api_audit_incomplete", True)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            await _seed_youtube_connection(s, org_id, owner_id=owner_id, channel="youtube_sandbox")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+            assert r.status_code == 200, r.text
+            row = r.json()[0]
+            assert row["video_required"] is True
+            assert row["youtube_metadata_required"] is True
+            assert row["privacy_locked"] is True
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_connection_response_privacy_locked_false_when_audit_complete(monkeypatch):
+    from app.core.config import settings
+    from app.main import app
+
+    monkeypatch.setattr(settings, "youtube_api_audit_incomplete", False)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            await _seed_youtube_connection(s, org_id, owner_id=owner_id, channel="youtube_sandbox")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+            assert r.status_code == 200, r.text
+            row = r.json()[0]
+            assert row["video_required"] is True  # 어댑터 축은 감사 상태와 무관하게 그대로.
+            assert row["privacy_locked"] is False
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_connection_response_capability_flags_false_for_unsupported_channel():
+    """양성대조 — video_required 미선언 채널(threads)은 3플래그 전부 False."""
+    from app.main import app
+    from app.services.channel_connection import upsert_channel_connection
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id)
+            await upsert_channel_connection(
+                s, org_id=org_id, channel="threads", account_id="threads-cap-1",
+                account_label="threads_user", credential_kind="oauth",
+                access_token="plain-access-token", refresh_token=None, token_expires_at=None,
+                refresh_mode="reissue_from_access_token", scopes=[], connected_by=owner_id,
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+        try:
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+            assert r.status_code == 200, r.text
+            row = r.json()[0]
+            assert row["video_required"] is False
+            assert row["youtube_metadata_required"] is False
+            assert row["privacy_locked"] is False
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights/test_3815_youtube_insights.py.json
+++ b/infra/destructive-schema-shard-weights/test_3815_youtube_insights.py.json
@@ -1,0 +1,1 @@
+{"file": "tests/test_3815_youtube_insights.py", "sec": 3.3, "source": "실측(로컬 pytest 단독 실행, 2026-09-12, 디디)"}

--- a/infra/destructive-schema-shard-weights/test_3815_youtube_usage_endpoint.py.json
+++ b/infra/destructive-schema-shard-weights/test_3815_youtube_usage_endpoint.py.json
@@ -1,0 +1,1 @@
+{"file": "tests/test_3815_youtube_usage_endpoint.py", "sec": 6.0, "source": "실측(로컬 pytest 단독 실행, 2026-09-12, 디디)"}


### PR DESCRIPTION
## 요약
story #3815(Phase3·3-5) PR3 — YouTube 헤드 영상 1d/7d 인사이트 스냅샷(organic)·
quota evidence(list=1)·연결 카드 사용량 GET 계약·`ChannelConnectionResponse`
능력 플래그 3종(미르코 PR4 FE 그라운딩 갭 대응 포함).

## 구현

### ① 인사이트 스냅샷(카드 AC5)
- `_fetch_youtube`/`_fetch_youtube_via_connection`(insight_snapshots.py, 신규)
  — `_fetch_x`와 동형: `videos.list(part=statistics)`. views=viewCount·
  engagements=likeCount+commentCount(합산, PO 決定). `_fetch_for_snapshot`
  dispatch에 youtube(실 연결 조회)·youtube_sandbox(x_sandbox와 동형 — 제네릭
  `_fetch_sandbox()` 재사용, declared_metrics 필터가 7키 중 2키만 통과) 등록.
- `channel_adapters.py` — youtube/youtube_sandbox에 `insight_metrics=
  ("views","engagements")` 선언(PR1/PR2 시점엔 미선언, 3696/3697 가드 짝을
  이 커밋에서 같이 맞춤).
- `channel-declared-metrics.ts`(FE 미러) — 같은 2키 등재(#3697 drift 0, 이
  파일 자체 컨벤션이 "같은 커밋에서 BE+FE 같이" 명시).
- quota evidence(list=1, 워커 레벨, `process_due_insight_snapshots`) — X의
  read-cost 기록과 같은 위치 축(성공 fetch 뒤·`_finalize_snapshot_write` 前).
  `event=str(snapshot.id)`로 1d·7d 두 스냅샷을 서로 다른 event로 분리(같은
  publication이어도 안 겹침), 재시도만 멱등. youtube_sandbox는 기록 대상
  아님(실 API 호출 0).
- 성과 보드 organic 귀속 — `organic_snapshots_only`/`paid_snapshots_only`
  필터가 채널 무관(snapshot 출처 축)이라 organic 스케줄러로 생성된 YouTube
  스냅샷은 신규 배선 0으로 자동 귀속.

### ② BE 조각 2(미르코 PR4 FE 그라운딩 갭 → 페드루 PO 계약 확定 2026-09-12 12:53Z)
- `GET /channel-connections/{connection_id}/youtube-usage`(신규) —
  `{used_units, limit_units, remaining_units, reset_at, scope:"platform"}`.
  connection_id는 인가에만 쓰임 — 값 자체는 org 무관 플랫폼 전체 카운터
  (`youtube_quota.py::get_platform_youtube_quota_spent_units` 재사용,
  evidence 소비 0인 순수 읽기). `/test`와 동형 인가(member 이상).
- `ChannelConnectionResponse`에 `video_required`·`youtube_metadata_required`·
  `privacy_locked` 3필드 추가 — `thread_max_segments`/`image_required`와
  동형 관례(채널 이름 하드코딩 금지, 어댑터 선언이 코드 변경 0으로 노출).
  `privacy_locked`는 `settings.youtube_api_audit_incomplete` 반영(플랫폼
  전체 값 — 연결별 상태 아님, `ChannelConnection.status` 4값과 무관).

### ⭐PR 경계 pin 갱신
`test_3815_youtube_oauth.py`의 PR1 시점 pin(`insight_metrics == ()`)이 이
PR의 views/engagements 선언으로 뒤집혀 stale화 → `("views", "engagements")`
로 갱신(youtube_publish dispatch pin이 PR2에서 뒤집힌 것과 동형 패턴, 삭제
아닌 갱신).

## ⚠️미확認
- YouTube `videos.list` 응답의 `statistics` 필드 정확한 스키마(문자열 숫자
  형 등)는 지식 컷오프 기준 최선 추정 — 실 앱 왕복 전까지 코드 상단 딱지에
  명시 그대로.

## 검증(로컬)
```
$ uv run pytest tests/test_3815_youtube_insights.py tests/test_3815_youtube_usage_endpoint.py tests/test_3815_youtube_oauth.py -q
30 passed

$ uv run pytest tests/test_3697_channel_insight_metrics_drift_lint.py -m "not destructive_schema" -q
11 passed
$ uv run python scripts/lint_channel_insight_metrics_drift.py
OK: insight_metrics 19개 채널 전부 BE↔FE 일치

$ uv run python scripts/verify_no_new_korean_user_strings.py
신규 0건·stale 0건

$ uv run python scripts/lint_destructive_schema_weights_registered.py
OK: 신규 미등재 destructive_schema 파일 0건

$ uv run alembic upgrade head  (fresh DB)
… 0372까지 성공, 단일 head 확認

$ 회귀 8파일(insight_snapshots/x_insights/stibee/3696 가드/channel_connections
  인증/facebook 연결/x thread/youtube_publish) — dispatch·응답 스키마 영향권 전수
118 passed, 9 deselected
```

## 뮤테이션 셀프체크
- engagements 합산에서 commentCount 누락(likeCount만 남김) →
  `test_fetch_youtube_sums_like_and_comment_count_into_engagements`·
  `test_youtube_200_captures_views_and_engagements` 정확히 2 RED → 원복 후 GREEN.
- quota evidence 기록 분기(`if snapshot.channel == "youtube":`)를 임시 비활성화 →
  `test_youtube_insight_fetch_records_one_list_unit_evidence_per_snapshot`
  정확히 1 RED → 원복 후 GREEN.
- `privacy_locked`를 `audit_incomplete` 반영 없이 항상 False로 고정 →
  `test_connection_response_exposes_youtube_capability_flags` 정확히 1 RED
  → 원복 후 GREEN.

## Base
develop(2071717d2, PR2 #4225·Ghost PR1/PR2 #4224/#4226 착지 반영) — stacked
아님, 새 브랜치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8