### PR TITLE
[SID:3816][SID:3815] 클래스 정정 — wordpress 마크다운→HTML+사용량 문구 드리프트 가드

### DIFF
--- a/backend/app/services/markdown_render.py
+++ b/backend/app/services/markdown_render.py
@@ -1,14 +1,17 @@
 """story #3816(Phase3·3-6 PR2, 페드루 PO 確定 2026-09-12) — 공용 마크다운→HTML
 변환. Ghost Admin API `?source=html`이 HTML 계약이라(마크다운 문법을 그대로
-넘기면 글에 문법이 노출된다, wordpress_publish.py가 raw body_md를 그대로
-`content`로 보내는 것도 같은 클래스의 잔존 결함이지만 이 PR 범위 밖 — 손대지
-않는다) 새로 도입한다. 표준 Python-Markdown(`markdown` PyPI 패키지) 하나만
-쓴다(신규 판정 로직 0, 라이브러리 위임) — `fenced_code` 확장으로 코드 블록
-(```)을 지원하고, 라이브러리 기본 동작이 이미 원본에 섞인 raw HTML 블록을
-그대로 통과시킨다(별도 처리 불요, Ghost가 최종적으로 자체 sanitize한다).
+넘기면 글에 문법이 노출된다) 새로 도입했다. 표준 Python-Markdown(`markdown`
+PyPI 패키지) 하나만 쓴다(신규 판정 로직 0, 라이브러리 위임) — `fenced_code`
+확장으로 코드 블록(```)을 지원하고, 라이브러리 기본 동작이 이미 원본에 섞인
+raw HTML 블록을 그대로 통과시킨다(별도 처리 불요, Ghost가 최종적으로 자체
+sanitize한다).
 
-이 함수는 BE 공용이라 이름에 채널을 안 붙인다 — 지금은 Ghost 하나만 쓰지만
-후속(예: wordpress의 같은 결함 처방)이 재사용할 수 있게."""
+이 함수는 BE 공용이라 이름에 채널을 안 붙인다 — 클래스 정정(같은 커밋,
+페드루 PO 지적 2026-09-12 14:21Z)으로 wordpress_publish.py도 이 함수를
+재사용한다(WordPress REST의 `content`도 같은 HTML 계약 — raw body_md를
+그대로 보내던 잔존 결함이었다). webhook_publish.py는 손대지 않는다(그쪽
+`content`는 고객이 직접 소비하는 payload 계약 축이라 이 스토리의 "우리
+provider가 HTML을 기대한다" 축과 다른 성격)."""
 from __future__ import annotations
 
 import markdown

--- a/backend/app/services/wordpress_publish.py
+++ b/backend/app/services/wordpress_publish.py
@@ -29,6 +29,7 @@ import os
 import httpx
 
 from app.services.destination_url_safety import DestinationURLUnsafeError, assert_destination_url_safe
+from app.services.markdown_render import render_markdown_html
 
 _POSTS_PATH = "/wp-json/wp/v2/posts"
 
@@ -92,7 +93,14 @@ async def publish(
     응답 JSON의 `id`(정수, 문자열로 캐스팅)·`link`."""
     base = await _validate_https(site_url)
     path = f"{_POSTS_PATH}/{external_id}" if external_id else _POSTS_PATH
-    payload = {"title": title, "content": body_md, "excerpt": summary, "slug": slug, "status": "publish"}
+    # 클래스 정정(story #3816 PR2, markdown_render.py 도입으로 드러남) — WordPress
+    # REST의 `content`도 Ghost와 같은 HTML 계약이라(마크다운 문법을 그대로 넘기면
+    # 글에 문법이 노출된다), raw body_md를 그대로 보내던 것을 같은 공용 변환기로
+    # 바꾼다(신규 판정 로직 0, markdown_render.render_markdown_html 재사용).
+    payload = {
+        "title": title, "content": render_markdown_html(body_md), "excerpt": summary,
+        "slug": slug, "status": "publish",
+    }
     resp = await client.post(
         f"{base}{path}", json=payload, auth=httpx.BasicAuth(username, app_password), timeout=20,
     )

--- a/backend/tests/test_3815_youtube_publish.py
+++ b/backend/tests/test_3815_youtube_publish.py
@@ -121,6 +121,34 @@ async def test_check_youtube_quota_or_raise_exceeds_includes_reset_at_utc_midnig
         await engine.dispose()
 
 
+def test_youtube_usage_exceeded_wording_matches_actual_utc_day_window_boundary():
+    """⭐드리프트 가드(story #3815, 페드루 PO 지적 2026-09-12 14:21Z) — i18n_catalog의
+    정적 문장 「매일 오전 9시(한국 시간)」/"00:00 UTC"가 실제 `_utc_day_window`
+    경계와 갈리면 안 된다. 경계를 UTC 자정에서 계산해 KST(UTC+9)로 환산한
+    시(hour)가 9가 아니면 이 테스트가 RED — 그 시점이 이 카탈로그 문장도 같이
+    고쳐야 한다는 신호다(문장 자체는 계산식과 무관한 리터럴이라 자동 동기화가
+    안 되므로, 이 pin이 유일한 안전망)."""
+    from datetime import timedelta
+
+    from app.services.i18n_catalog import t
+    from app.services.youtube_quota import _utc_day_window
+
+    now = datetime(2026, 9, 12, 15, 30, 0, tzinfo=timezone.utc)
+    _, boundary_utc = _utc_day_window(now)
+    assert (boundary_utc.hour, boundary_utc.minute, boundary_utc.second) == (0, 0, 0), (
+        "경계가 UTC 자정이 아니게 바뀌었다 — 아래 카탈로그 문장도 같이 고칠 것"
+    )
+    kst_hour = (boundary_utc + timedelta(hours=9)).hour
+    assert kst_hour == 9, (
+        f"UTC 자정의 KST 환산이 9시가 아님({kst_hour}시) — 「매일 오전 9시(한국 시간)」 문구 갱신 필요"
+    )
+
+    ko = t("channel_posts.youtube_usage_exceeded", "ko")
+    en = t("channel_posts.youtube_usage_exceeded", "en")
+    assert "오전 9시(한국 시간)" in ko
+    assert "00:00 UTC" in en
+
+
 @pytest.mark.anyio
 async def test_platform_wide_quota_sum_ignores_org_id():
     """org_id 필터가 없다는 게 이 함수의 요점 — 서로 다른 두 조직의 evidence가

--- a/backend/tests/test_e4fc29fa_wordpress_publish_adapter.py
+++ b/backend/tests/test_e4fc29fa_wordpress_publish_adapter.py
@@ -55,7 +55,9 @@ async def test_publish_creates_post_returns_external_id_and_permalink(dns_stub):
     assert captured["url"] == "https://customer-blog.example.com/wp-json/wp/v2/posts"
     assert captured["auth_header"] is not None and captured["auth_header"].startswith("Basic ")
     assert captured["body"] == {
-        "title": "제목", "content": "# 본문", "excerpt": "요약", "slug": "my-slug", "status": "publish",
+        # 클래스 정정(story #3816, 2026-09-12) — content는 이제 HTML(markdown_
+        # render.render_markdown_html 경유), raw body_md 그대로가 아니다.
+        "title": "제목", "content": "<h1>본문</h1>", "excerpt": "요약", "slug": "my-slug", "status": "publish",
     }
 
 
@@ -76,6 +78,32 @@ async def test_publish_with_external_id_updates_existing_post(dns_stub):
 
     assert external_id == "42"
     assert captured["url"] == "https://customer-blog.example.com/wp-json/wp/v2/posts/42"
+
+
+@pytest.mark.anyio
+async def test_publish_renders_markdown_to_html_headings_lists_and_links(dns_stub):
+    """⭐클래스 정정(story #3816, 페드루 PO 지적 2026-09-12 14:21Z) — Ghost PR2가
+    도입한 markdown_render.render_markdown_html을 wordpress_publish.py도
+    재사용해야 한다(WordPress REST의 content도 같은 HTML 계약, raw body_md
+    그대로 보내면 마크다운 문법이 글에 그대로 노출된다). h2·ul·a 3태그 실측
+    — 변환기를 걷으면(raw body_md 그대로 보내면) 이 assert가 RED가 난다."""
+    captured = {}
+    body_md = "## 제목\n\n- 첫째\n- 둘째\n\n[링크](https://example.com)\n"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(201, json={"id": 1, "link": "https://customer-blog.example.com/2026/09/x/"})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        await publish(
+            client, site_url="https://customer-blog.example.com", username="editor",
+            app_password="app-pw", title="제목", body_md=body_md, summary="요약", slug="x",
+        )
+
+    content = captured["body"]["content"]
+    assert "<h2>제목</h2>" in content
+    assert "<ul>" in content and "<li>첫째</li>" in content and "<li>둘째</li>" in content
+    assert '<a href="https://example.com">링크</a>' in content
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 요약
기존 카드 2건의 「적기만」 항목을 닫는 소 PR(새 카드 0) — 페드루 PO 지적
2026-09-12 14:21Z.

## 구현

### ① [SID:3816] wordpress도 markdown→HTML 클래스 정정
`wordpress_publish.py`가 raw `body_md`를 WordPress REST `content`에 그대로
보내고 있었다 — Ghost PR2(#4226)가 도입한 `markdown_render.render_markdown_
html`(그 모듈 자신의 docstring이 "wordpress도 같은 결함이지만 이 PR 범위
밖"이라 명시적으로 남겨뒀던 자리)을 이제 재사용한다. 신규 판정 로직 0(공용
변환기 재사용 그대로).

`webhook_publish.py`는 손대지 않음 — 그쪽 `content`는 우리 provider가
기대하는 HTML 계약이 아니라 고객이 직접 소비하는 payload 계약 축이라 이
클래스 정정과 성격이 다르다(페드루 明示).

### ② [SID:3815] 사용량 초기화 문구 드리프트 가드
`i18n_catalog.py`의 정적 문장(「매일 오전 9시(한국 시간)」/"00:00 UTC")이
실제 `youtube_quota.py::_utc_day_window`의 UTC 자정 경계와 갈리면 안 된다
— 계산식과 하드코딩 리터럴 문장은 자동으로 동기화되지 않으므로, 경계를
KST(UTC+9)로 환산한 시(hour)가 9인지 확認하는 pin 테스트를 신설했다(경계가
바뀌면 이 테스트가 RED로 "카탈로그 문장도 같이 고칠 것"을 알린다).

## 검증(로컬)
```
$ uv run pytest -m "not destructive_schema" tests/test_3816_blog_publish_error_code.py tests/test_3816_markdown_render.py tests/test_e4fc29fa_destination_url_safety.py tests/test_e4fc29fa_wordpress_publish_adapter.py -q
31 passed

$ uv run pytest -m destructive_schema tests/test_3513_unpublish_absent_idempotent.py tests/test_e4fc29fa_destination_axis.py tests/test_e4fc29fa_site_post_orchestration.py -q
35 passed(라이브 wordpress stub 왕복 포함 — test_worker_publishes_site_post_command_against_live_wordpress_stub)

$ uv run pytest tests/test_3815_youtube_publish.py -q
28 passed

$ uv run python scripts/verify_no_new_korean_user_strings.py
신규 0건

$ uv run python scripts/lint_destructive_schema_weights_registered.py
OK: 신규 destructive 파일 0건(기존 파일에 테스트만 추가, 새 파일 없음)
```

## 뮤테이션 셀프체크
- `wordpress_publish.py`의 `render_markdown_html` 호출을 raw `body_md`로
  되돌림 → 기존 content assert 1건 + 신규 h2/ul/a 태그 테스트 1건 정확히
  2 RED → 원복 후 GREEN.
- `youtube_quota.py::_utc_day_window`의 경계를 UTC 01:00으로 왜곡 →
  드리프트 가드 테스트 + 기존 reset_at 테스트 정확히 2 RED → 원복 후 GREEN.

## Base
develop(ba3349df6, PR2/PR3 #4225/#4227 착지 반영) — 새 브랜치, stacked 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8