### PR TITLE
[SID:3815] 실 결함 — ChannelYouTubeMetadataError 라우터 미매핑으로 코드 없는 500

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -51,6 +51,7 @@ from app.services.channel_posts import (
     ChannelTokenExpiredError,
     ChannelUnpublishUnsupportedError,
     ChannelVideoRequiredError,
+    ChannelYouTubeMetadataError,
     ContentRuleViolationError,
     ExternalPublishGateNotApprovedError,
     PublicationCommandNotCancellableError,
@@ -590,10 +591,16 @@ async def post_channel_post_draft_version(
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
+    # story #3815(Phase3·3-5, 미르코 PR4 그라운딩 발견 2026-09-12) —
+    # YOUTUBE_METADATA_INVALID 사용자 문장을 i18n_catalog로 조립하기 위한
+    # 최소 추가(publish 엔드포인트의 locale DI 관례 그대로).
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
 ) -> ChannelPostDraftVersionResponse:
     """AC1 — 고객 에이전트·휴먼 공용 초안 제출/수정 API. `channel`은 요청 본문에 없다 —
     `connection_id`에서 서버가 조회해 derive한다(클라이언트가 실제와 다른 channel을 주장할
     표면 자체를 없앤다, PO 정정: channel은 connection_id의 파생값이지 독립 축이 아니다)."""
+    resolved_locale = resolve_locale_from_request(locale, accept_language)
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
@@ -636,6 +643,19 @@ async def post_channel_post_draft_version(
             detail={
                 "code": "CHANNEL_TEXT_TOO_LONG", "message": str(exc),
                 "max_length": exc.max_length, "current_length": exc.current_length,
+            },
+        ) from exc
+    except ChannelYouTubeMetadataError as exc:
+        # story #3815(Phase3·3-5, 미르코 PR4 그라운딩 발견 → 페드루 PO 지적 2026-09-12
+        # 14:37Z) — 실 결함 처방: 이 예외가 라우터 어디서도 안 잡혀 사용자에게
+        # 코드 없는 500이 나갔다(4225 리뷰 miss). ChannelTextTooLongError와 동형
+        # 위치·모양(field/reason 추가) — 저장 시점 checkpoint.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "YOUTUBE_METADATA_INVALID",
+                "message": t("channel_posts.youtube_metadata_invalid", resolved_locale),
+                "field": exc.field, "reason": exc.reason,
             },
         ) from exc
 
@@ -2051,6 +2071,26 @@ async def publish_channel_post_draft_endpoint(
             detail=_with_command_state({
                 "code": "CHANNEL_TEXT_TOO_LONG", "message": str(exc),
                 "max_length": exc.max_length, "current_length": exc.current_length,
+            }),
+        ) from exc
+    except ChannelYouTubeMetadataError as exc:
+        # story #3815(Phase3·3-5, 미르코 PR4 그라운딩 발견 → 페드루 PO 지적 2026-09-12
+        # 14:37Z) — 실 결함 처방(발행 시점 checkpoint, 저장 시점 checkpoint는 위
+        # post_channel_post_draft_version에 동형으로 배선). `_validate_youtube_
+        # metadata`는 channel_posts.py:1643 부근 `_validate_text_length` 直後
+        # 호출(Threads에 아무 HTTP도 안 나간 시점) — ChannelTextTooLongError와
+        # 같은 adapter_called=False 축.
+        await _record_this_attempt(approval_check="ok", adapter_called=False, result_code="YOUTUBE_METADATA_INVALID")
+        await apply_command_failure(
+            db, command, error_code="YOUTUBE_METADATA_INVALID", last_error=str(exc), now=now,
+        )
+        await db.commit()
+        raise HTTPException(
+            status_code=422,
+            detail=_with_command_state({
+                "code": "YOUTUBE_METADATA_INVALID",
+                "message": t("channel_posts.youtube_metadata_invalid", resolved_locale),
+                "field": exc.field, "reason": exc.reason,
             }),
         ) from exc
     except ChannelPostSealMissingError as exc:

--- a/backend/app/services/i18n_catalog.py
+++ b/backend/app/services/i18n_catalog.py
@@ -407,6 +407,16 @@ _CATALOG: dict[str, dict[str, str]] = {
         "ko": "오늘 YouTube 사용량을 다 썼습니다 — 사용량은 매일 오전 9시(한국 시간)에 초기화됩니다(플랫폼 공유 한도).",
         "en": "Today's YouTube usage limit has been reached — it resets daily at 00:00 UTC (shared platform-wide limit).",
     },
+    # story #3815(Phase3·3-5, 미르코 PR4 그라운딩 발견 → 페드루 PO 지적 2026-09-12
+    # 14:37Z) — `_validate_youtube_metadata`가 던지는 `ChannelYouTubeMetadataError`
+    # 를 라우터 어디서도 안 잡아 사용자에게 코드 없는 500이 나가던 실 결함. 이
+    # 문장은 4필드(title/tags/categoryId/privacyStatus) 중 어느 게 틀렸는지
+    # 구체적으로 말하지 않는다(field/reason은 detail의 별도 키로 실림, 문장 자체는
+    # 그 4필드 전체를 가리키는 안내).
+    "channel_posts.youtube_metadata_invalid": {
+        "ko": "YouTube 제목·태그·카테고리·공개 범위 값을 확인해 주세요.",
+        "en": "Check the YouTube title, tags, category, and privacy values.",
+    },
 }
 
 

--- a/backend/tests/test_3815_youtube_publish.py
+++ b/backend/tests/test_3815_youtube_publish.py
@@ -668,3 +668,124 @@ async def test_youtube_sandbox_beyond_24h_timeout_fails_but_preserves_container_
             app.dependency_overrides.clear()
     finally:
         await engine.dispose()
+
+
+# ─── ⑥ ChannelYouTubeMetadataError 라우터 매핑(미르코 PR4 그라운딩 발견 실 결함) ──
+
+@pytest.mark.anyio
+async def test_youtube_metadata_invalid_maps_to_422_not_500_at_save_time():
+    """⭐실 결함 재현(페드루 PO 지적 2026-09-12 14:37Z) — `ChannelYouTubeMetadataError`
+    를 라우터가 안 잡아 사용자에게 코드 없는 500이 나가던 것. 저장 시점
+    (create_channel_post_draft_version) checkpoint 재현 — title 누락."""
+    from tests.test_620beefc_channel_post_image_upload import (
+        _client_for, _seed_connection, _seed_human, _seed_org, _seed_story, _session_factory,
+        _setup_org_scoped_app,
+    )
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="youtube_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        try:
+            async with _client_for(app) as client:
+                r = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(connection_id),
+                        "text": "설명", "channel_payload": {"tags": ["a"]},  # title 누락.
+                    },
+                )
+            assert r.status_code == 422, r.text
+            body = r.json()["error"]
+            assert body["code"] == "YOUTUBE_METADATA_INVALID"
+            assert body["field"] == "title"
+            assert body["message"]  # i18n_catalog 문구, 빈 문자열 아님.
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_youtube_metadata_invalid_maps_to_422_not_500_at_publish_time():
+    """발행 시점 checkpoint 재현 — 저장 시점엔 유효했던 channel_payload가(승인
+    뒤 값이 조용히 나빠질 수 있는 시나리오, 예: 어댑터/상수가 그 사이 바뀜)
+    발행 直前 재검사에서 걸려도 500이 아니라 422여야 한다. DB를 직접 헝클어
+    (privacyStatus를 허용값 밖으로) 그 시나리오를 재현한다 — API로는 애초에
+    이 상태를 만들 수 없다는 게 이 재현의 요점(저장 시점 게이트가 이미 막으므로)."""
+    from sqlalchemy import select as sa_select
+    from tests.test_620beefc_channel_post_image_upload import (
+        _approve_gate_directly, _client_for, _seed_connection, _seed_human, _seed_org, _seed_story,
+        _session_factory, _setup_org_scoped_app,
+    )
+    from tests.test_3554_instagram_reels import _build_mp4, _upload_and_confirm_video
+    from app.main import app
+    from app.models.channel_post_version import ChannelPostVersion
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="youtube_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+            from app.models.participation import ParticipationRole
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+            s.add(role)
+            await s.commit()
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        try:
+            async with _client_for(app) as client:
+                r_draft = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(connection_id),
+                        "text": "설명", "channel_payload": {"title": "정상 제목"},
+                    },
+                )
+                assert r_draft.status_code == 201, r_draft.text
+                draft_id = r_draft.json()["draft_id"]
+
+                video_raw = _build_mp4(duration_seconds=6.0, width=1920, height=1080)
+                r_video = await _upload_and_confirm_video(client, org_id, draft_id, video_raw)
+                assert r_video.status_code == 201, r_video.text
+
+                r_submit = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+                )
+                assert r_submit.status_code == 200, r_submit.text
+                gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+            async with Session() as s:
+                await _approve_gate_directly(s, gate_id)
+                # API로는 만들 수 없는 상태를 직접 주입 — 승인 뒤 값이 나빠진
+                # 시나리오 재현(위 docstring 참고).
+                latest = (await s.execute(
+                    sa_select(ChannelPostVersion)
+                    .where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+                    .order_by(ChannelPostVersion.version.desc())
+                    .limit(1)
+                )).scalar_one()
+                latest.channel_payload = {"title": "정상 제목", "privacyStatus": "not-a-real-value"}
+                await s.commit()
+
+            async with _client_for(app) as client:
+                r_pub = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                )
+            assert r_pub.status_code == 422, r_pub.text
+            body = r_pub.json()["error"]
+            assert body["code"] == "YOUTUBE_METADATA_INVALID"
+            assert body["field"] == "privacyStatus"
+            assert body["message"]
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
미르코 PR4(FE) 그라운딩에서 발견된 실 결함 처방 — 페드루 PO 지적 2026-09-12
14:37Z(4225 리뷰 miss). `_validate_youtube_metadata`가 던지는
`ChannelYouTubeMetadataError`를 라우터 어디서도 안 잡아 사용자에게 코드
없는 500이 나가고 있었다. 파일 겹침 0(PR #4228과 병렬, stacked 아님).

## 구현
`ChannelTextTooLongError`와 동형 위치·모양(422 매핑)으로 두 checkpoint 배선:
- 저장 시점 — `post_channel_post_draft_version` 엔드포인트
  (`create_channel_post_draft_version` 호출을 감싸는 try/except).
- 발행 시점 — `publish_channel_post_draft_endpoint`(`_record_this_attempt`
  + `apply_command_failure` + commit 뒤 raise, 다른 필드-검증 에러들과 동형).

두 자리 다 `{code: "YOUTUBE_METADATA_INVALID", message, field, reason}`
422로 응답. `message`는 `i18n_catalog.py`의 새 키
`"channel_posts.youtube_metadata_invalid"`(ko/en, 한자 0)로 조립 — 두
엔드포인트 다 기존 `resolve_locale_from_request` DI 관례를 그대로 사용
(발행 엔드포인트는 이미 있었고, 저장 엔드포인트엔 이번에 추가).

FE 매핑(코드→화면 문구)은 미르코 PR4 몫(1줄) — 이 PR은 BE 계약만.

## 검증(로컬)
```
$ uv run pytest tests/test_3815_youtube_publish.py -q
29 passed

$ uv run python scripts/verify_no_new_korean_user_strings.py
신규 0건
```

## 뮤테이션 셀프체크
두 `except ChannelYouTubeMetadataError` 블록을 모두 제거(실 결함 재현 —
예외가 라우터를 그대로 통과해 500) → 신규 테스트 2건(저장 시점·발행 시점
각각) 정확히 2 RED → 원복 후 GREEN.

## Base
develop(ba3349df6, PR2/PR3 #4225/#4227 착지 반영) — 새 브랜치, stacked
아님, PR #4228과 파일 겹침 0(병렬 진행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8