### PR TITLE
[SID:3815] 실 결함 — channel_publications.privacy_locked 어느 응답에도 미노출

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -325,6 +325,15 @@ class ChannelPostDraftListItem(BaseModel):
     permalink: str | None = None
     external_id: str | None = None
     error_code: str | None = None
+    # story #3815(Phase3·3-5, 미르코 시드 中 발견 → 페드루 PO 지적 2026-09-13) —
+    # migration 0372가 신설했지만 어느 응답에도 안 실려 온 실 결함. FE가 이
+    # 값을 못 읽으면 연결 레벨의 "지금" 감사-미완 플래그(ChannelConnectionResponse.
+    # privacy_locked)로 대리 판정할 수밖에 없는데, 그건 감사가 끝나 플래그가
+    # 꺼지면 "그때 잠겼던 과거 발행물"이 안 잠겼던 것처럼 보이는 — 정확히 0372가
+    # 막으려던 사고. `published_pub`(이 행 자체, "가장 최근 published" 기준)의
+    # 값을 그대로 노출 — publication_status와 같은 소스(다른 채널은 항상 False,
+    # server_default 그대로).
+    privacy_locked: bool = False
     # story #3415(#3414 범위 절단 후속) — publication_commands(story #3414)의 예약·재시도
     # 상태를 목록/단건에 노출. 필드명은 유나 §17-2·§11-5(공통 어휘 정본) 그대로:
     # `next_retry_at`은 DB 컬럼명(`PublicationCommand.next_attempt_at`)과 다르다 — 화면
@@ -1341,6 +1350,7 @@ def _to_draft_list_item(
         permalink=published_pub.permalink if published_pub else None,
         external_id=published_pub.external_id if published_pub else None,
         error_code=latest_pub.error_code if latest_pub else None,
+        privacy_locked=bool(published_pub.privacy_locked) if published_pub else False,
         failure_kind=latest_command.failure_kind if latest_command else None,
         next_retry_at=(
             latest_command.next_attempt_at.isoformat()
@@ -1877,6 +1887,9 @@ class PublishChannelPostResponse(BaseModel):
     # processing=True(컨테이너 비동기 대기)면 아직 최종 published 행이 없어 그 세
     # 필드처럼 null 그대로.
     publication_id: uuid.UUID | None = None
+    # story #3815(Phase3·3-5, 페드루 PO 지적 2026-09-13) — ChannelPostDraftListItem
+    # 과 동형 이유·같은 소스(row.privacy_locked, "지금 이 발행 그 순간"의 사실).
+    privacy_locked: bool = False
 
 
 @router.post(
@@ -2252,6 +2265,7 @@ async def publish_channel_post_draft_endpoint(
         permalink=row.permalink, external_id=row.external_id,
         published_at=row.published_at.isoformat(), version_id=row.version_id,
         scheduled=False, command_id=command.id, publication_id=row.id,
+        privacy_locked=bool(row.privacy_locked),
     )
 
 

--- a/backend/tests/test_3815_youtube_publish.py
+++ b/backend/tests/test_3815_youtube_publish.py
@@ -817,3 +817,146 @@ async def test_youtube_metadata_invalid_maps_to_422_not_500_at_publish_time():
             app.dependency_overrides.clear()
     finally:
         await engine.dispose()
+
+
+# ─── ⑦ privacy_locked 노출(미르코 시드 中 발견 실 결함) ────────────────────────
+
+@pytest.mark.anyio
+async def test_privacy_locked_exposed_true_on_publish_response_and_draft_list(monkeypatch):
+    """⭐실 결함 재현(페드루 PO 지적 2026-09-13) — migration 0372가 신설한
+    `channel_publications.privacy_locked`가 어느 응답에도 안 실려 왔다. FE가
+    이 값을 못 읽으면 연결 레벨의 "지금" 감사-미완 플래그로 대리 판정할
+    수밖에 없는데, 감사가 끝나 그 플래그가 꺼지면 "그때 잠겼던 과거
+    발행물"이 안 잠겼던 것처럼 보인다 — 정확히 0372가 막으려던 사고."""
+    from app.core.config import settings
+    from tests.test_620beefc_channel_post_image_upload import (
+        _approve_gate_directly, _client_for, _seed_connection, _seed_human, _seed_org, _seed_story,
+        _session_factory, _setup_org_scoped_app,
+    )
+    from tests.test_3554_instagram_reels import _build_mp4, _upload_and_confirm_video
+    from app.main import app
+
+    monkeypatch.setattr(settings, "youtube_api_audit_incomplete", True)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="youtube_sandbox")
+            story_id = await _seed_story(s, org_id, project_id)
+            from app.models.participation import ParticipationRole
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+            s.add(role)
+            await s.commit()
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        try:
+            async with _client_for(app) as client:
+                r_draft = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json={
+                        "work_item_id": str(story_id), "connection_id": str(connection_id),
+                        "text": "잠금 노출 재현", "channel_payload": {"title": "잠금 노출 재현"},
+                    },
+                )
+                assert r_draft.status_code == 201, r_draft.text
+                draft_id = r_draft.json()["draft_id"]
+
+                video_raw = _build_mp4(duration_seconds=6.0, width=1920, height=1080)
+                r_video = await _upload_and_confirm_video(client, org_id, draft_id, video_raw)
+                assert r_video.status_code == 201, r_video.text
+
+                r_submit = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+                )
+                assert r_submit.status_code == 200, r_submit.text
+                gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+            async with Session() as s:
+                await _approve_gate_directly(s, gate_id)
+
+            async with _client_for(app) as client:
+                # 첫 호출은 컨테이너 생성만(비동기 관례 — 막 만든 컨테이너를 곧바로
+                # poll하지 않는다, processing=true) — 두 번째 호출이 실제 "published"
+                # 로 마무리한다(sandbox는 결정적으로 즉시 FINISHED).
+                r_pub1 = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                )
+                assert r_pub1.status_code == 200, r_pub1.text
+                assert r_pub1.json()["processing"] is True
+
+                r_pub2 = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                )
+                assert r_pub2.status_code == 200, r_pub2.text
+                assert r_pub2.json()["processing"] is False
+                assert r_pub2.json()["privacy_locked"] is True, "publish 완료 응답에 privacy_locked이 안 실림"
+
+                r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+                assert r_list.status_code == 200, r_list.text
+                item = next(row for row in r_list.json() if row["draft_id"] == draft_id)
+                assert item["privacy_locked"] is True, "목록/단건 응답에 privacy_locked이 안 실림"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_privacy_locked_false_for_non_youtube_channel():
+    """양성대조 — youtube/youtube_sandbox 축이 없는 채널(threads)은 privacy_locked
+    이 항상 False(server_default 그대로, 새 열이 기존 채널 회귀 0)."""
+    from tests.test_620beefc_channel_post_image_upload import (
+        _approve_gate_directly, _client_for, _create_draft, _seed_connection, _seed_human, _seed_org,
+        _seed_story, _session_factory, _setup_org_scoped_app,
+    )
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id, channel="threads")
+            story_id = await _seed_story(s, org_id, project_id)
+            from app.models.participation import ParticipationRole
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+            s.add(role)
+            await s.commit()
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+
+        try:
+            async with _client_for(app) as client:
+                draft_id = await _create_draft(client, org_id=org_id, connection_id=connection_id, story_id=story_id)
+                r_submit = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+                )
+                assert r_submit.status_code == 200, r_submit.text
+                gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+            async with Session() as s:
+                await _approve_gate_directly(s, gate_id)
+
+            import app.services.threads_publish as tp
+            with (
+                patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(0, 100, 3600))),
+                patch.object(tp, "create_container", AsyncMock(return_value="container-1")),
+                patch.object(tp, "publish_container", AsyncMock(return_value="media-1")),
+                patch.object(tp, "get_permalink", AsyncMock(return_value="https://threads.net/p/1")),
+            ):
+                async with _client_for(app) as client:
+                    r_pub = await client.post(
+                        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish",
+                    )
+            assert r_pub.status_code == 200, r_pub.text
+            assert r_pub.json()["privacy_locked"] is False
+
+            async with _client_for(app) as client:
+                r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+            item = next(row for row in r_list.json() if row["draft_id"] == draft_id)
+            assert item["privacy_locked"] is False
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
미르코 시드 中 발견된 실 결함 처방 — 페드루 PO 지적 2026-09-13. migration
0372가 신설한 `channel_publications.privacy_locked`가 목록/단건/발행 완료
어느 응답에도 안 실려 왔다. FE가 이 값을 못 읽으면 연결 레벨의 "지금"
감사-미완 플래그(`ChannelConnectionResponse.privacy_locked`)로 대리
판정할 수밖에 없는데, 감사가 끝나 그 플래그가 꺼지면 "그때 잠겼던 과거
발행물"이 안 잠겼던 것처럼 보인다 — 정확히 0372가 막으려던 사고.

## 구현
- `ChannelPostDraftListItem`(목록·단건 공유 응답)에 `privacy_locked: bool`
  추가 — `published_pub`(그 draft의 "가장 최근 published" 행)에서 직접.
- `PublishChannelPostResponse`(발행 완료 응답)에도 같은 필드 추가 —
  `row`(방금 완료된 그 ChannelPublication 행)에서 직접.
- 둘 다 "지금 이 발행 그 순간"의 사실을 그대로 노출(연결 레벨 현재 상태가
  아니라 발행 시점에 못박힌 값) — 다른 채널(youtube 축이 없는)은
  server_default False 그대로, 회귀 0.

## Rebase 이력(페드루 PO 지시 2026-09-12 15:21Z)
PR #4230이 먼저 착지(develop c6c74aa0a)하며 이 PR이 CONFLICTING으로
전환(둘 다 `app/routers/channel_posts.py` 건드림, 서로 다른 자리) —
develop c6c74aa0a 위 rebase 뒤 force-push. git rebase/cherry-pick 자동
3-way merge가 근접 줄을 여러 조각으로 쪼개 자동해소가 지저분해져,
원 커밋(옛 head 13931c2f3c)의 정본 diff를 앵커 기준으로 수동 재적용해
깨끗하게 재현(삽입 줄 수 157로 원본과 정확히 일치 확認). 새 head
5dd13692c.

## 검증(로컬, develop c6c74aa0a 기준 rebase 뒤)
```
$ uv run pytest tests/test_3815_youtube_publish.py -q
32 passed(29 기존+이 PR 2건, PR #4230의 metadata-422 2건과 자연 병합 확認)

$ uv run pytest -m destructive_schema tests/test_3554_instagram_reels.py tests/test_620beefc_channel_post_image_lifecycle.py tests/test_f8f7cb0f_channel_post_publish.py tests/test_3808_x_thread_publish.py tests/test_3813_stibee_publish.py -q
57 passed

$ uv run python scripts/verify_no_new_korean_user_strings.py
신규 0건
```

## 뮤테이션 셀프체크
두 노출 지점(목록/단건, 발행 완료 응답)을 모두 하드코딩 `False`로 되돌림
(실 결함 재현) → `test_privacy_locked_exposed_true_on_publish_response_and_
draft_list` 정확히 1 RED(양성대조 `test_privacy_locked_false_for_non_
youtube_channel`은 원래 False를 기대하는 테스트라 그대로 GREEN) → 원복
후 GREEN.

## Base
develop(c6c74aa0a, PR #4230 착지 반영·rebase 完) — stacked 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8
