### PR TITLE
[SID:3816] sandbox expired 칩 낱말 「만료됨」(다시 연결 필요 거짓 약속 정정)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2041,6 +2041,7 @@
     "channelStatusConnected": "Connected",
     "channelStatusExpiringSoon": "Expiring soon",
     "channelStatusReauthRequired": "Reconnect needed",
+    "channelStatusExpiredSandbox": "Expired",
     "channelStatusProviderError": "Provider error",
     "channelStatusStibeePlanRestricted": "Plan restricted",
     "channelStatusStibeeSenderNotVerified": "Sender not verified",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2041,7 +2041,7 @@
     "channelStatusConnected": "Connected",
     "channelStatusExpiringSoon": "Expiring soon",
     "channelStatusReauthRequired": "Reconnect needed",
-    "channelStatusExpiredSandbox": "Expired",
+    "channelStatusReconnectUnavailable": "Reconnect unavailable",
     "channelStatusProviderError": "Provider error",
     "channelStatusStibeePlanRestricted": "Plan restricted",
     "channelStatusStibeeSenderNotVerified": "Sender not verified",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2041,7 +2041,7 @@
     "channelStatusConnected": "연결됨",
     "channelStatusExpiringSoon": "만료 임박",
     "channelStatusReauthRequired": "다시 연결 필요",
-    "channelStatusExpiredSandbox": "만료됨",
+    "channelStatusReconnectUnavailable": "다시 연결 불가",
     "channelStatusProviderError": "제공자 오류",
     "channelStatusStibeePlanRestricted": "요금제 제한",
     "channelStatusStibeeSenderNotVerified": "발신자 미인증",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2041,6 +2041,7 @@
     "channelStatusConnected": "연결됨",
     "channelStatusExpiringSoon": "만료 임박",
     "channelStatusReauthRequired": "다시 연결 필요",
+    "channelStatusExpiredSandbox": "만료됨",
     "channelStatusProviderError": "제공자 오류",
     "channelStatusStibeePlanRestricted": "요금제 제한",
     "channelStatusStibeeSenderNotVerified": "발신자 미인증",

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -742,6 +742,39 @@ describe('OrganizationChannelsPage — 헤더 rollup 칩 임계값(story dd29e6d
   });
 });
 
+// story #3816(Phase3·3-6, 페드루 PO 지적 2026-09-12·배포 81 라이브 회차 유나 판정
+// CHANGES 1) — sandbox(credential_kind==='none') 연결의 expired는 재연결 경로가
+// 구조적으로 없다(ReauthNote 옆 분기가 버튼 대신 「테스트용 연결은 다시 연결할
+// 수 없습니다」 문장을 낸다) — 그런데 칩은 여전히 공용 「다시 연결 필요」를 내
+// 같은 행 안에서 칩·문장이 반대 뜻을 말했다(4222 축 재현).
+describe('OrganizationChannelsPage — sandbox expired 칩 낱말(story #3816)', () => {
+  const AVAILABLE_WITH_SANDBOX = [
+    { channel: 'threads', display_name: 'Threads', credential_kind: 'oauth', kind: 'social' },
+    { channel: 'sandbox', display_name: 'Sandbox', credential_kind: 'none', kind: 'social' },
+  ];
+
+  it('⭐sandbox(credential_kind=none) expired — 칩이 「만료됨」(재연결 경로 없음, 「다시 연결 필요」는 거짓 약속)', async () => {
+    stubFetch({
+      connections: [{ ...CONNECTION_ACTIVE, id: 'conn-sandbox-1', channel: 'sandbox', credential_kind: 'none', status: 'expired' }],
+      availableChannels: AVAILABLE_WITH_SANDBOX,
+    });
+    await mount('owner');
+    await expandChannelRow({ viaMenuLabel: koMessages.channelConnect.channelManageConnectionsAction, rowChannel: koMessages.channelConnect.channelLabelSandbox });
+    const chip = container.querySelector('[data-testid="channel-section"] [data-status-chip="reauth_required"]');
+    expect(chip?.textContent).toBe(koMessages.channelConnect.channelStatusExpiredSandbox);
+    expect(chip?.textContent).not.toBe(koMessages.channelConnect.channelStatusReauthRequired);
+    // 같은 행 안의 문장(버튼 대신)과 뜻이 어긋나면 안 된다 — 둘 다 "재연결 불가" 쪽.
+    expect(container.textContent).toContain('다시 연결할 수 없습니다');
+  });
+
+  it('⭐양성대조 — oauth(재연결 가능) expired는 그대로 「다시 연결 필요」(회귀 0)', async () => {
+    stubFetch({ connections: [{ ...CONNECTION_ACTIVE, status: 'expired' }] });
+    await mount('owner');
+    const chip = container.querySelector('[data-status-chip="reauth_required"]');
+    expect(chip?.textContent).toBe(koMessages.channelConnect.channelStatusReauthRequired);
+  });
+});
+
 describe('OrganizationChannelsPage — 앱 자격(AC2, story #3376)', () => {
   // story #3743 CHANGES — AppCredentialsCard는 이제 펼친 상세 안에만 있다. connections=[]
   // +effectiveSource!=='none'이면 다음 발은 「연결하기」라 카드는 ⋯의 「{channel} 앱 자격」

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -743,17 +743,24 @@ describe('OrganizationChannelsPage — 헤더 rollup 칩 임계값(story dd29e6d
 });
 
 // story #3816(Phase3·3-6, 페드루 PO 지적 2026-09-12·배포 81 라이브 회차 유나 판정
-// CHANGES 1) — sandbox(credential_kind==='none') 연결의 expired는 재연결 경로가
-// 구조적으로 없다(ReauthNote 옆 분기가 버튼 대신 「테스트용 연결은 다시 연결할
-// 수 없습니다」 문장을 낸다) — 그런데 칩은 여전히 공용 「다시 연결 필요」를 내
-// 같은 행 안에서 칩·문장이 반대 뜻을 말했다(4222 축 재현).
-describe('OrganizationChannelsPage — sandbox expired 칩 낱말(story #3816)', () => {
+// CHANGES 1) — sandbox(credential_kind==='none') 연결은 재연결 경로가 구조적으로
+// 없다(ReauthNote 옆 분기가 버튼 대신 「테스트용 연결은 다시 연결할 수 없습니다」
+// 문장을 낸다) — 그런데 칩은 여전히 공용 「다시 연결 필요」를 내 같은 행 안에서
+// 칩·문장이 반대 뜻을 말했다(4222 축 재현).
+//
+// CHANGES(페드루 PO 확認 1, 2026-09-12 15:48Z) — reason 분기 없음(reason 무관
+// «재연결 불가 세계» 라벨). BE grep 실측: sandbox 연결도 `/disconnect`가
+// credential_kind 무관·owner 전용이라(FE 「해제」 버튼도 동일 무조건) reason=
+// 'revoked' 도달 가능(사람이 그 버튼을 누르면 즉시) — 아래 두 번째 테스트가
+// 그 경로를 pin한다. reason='error'는 오늘 자동 경로 0(주석 참고, page.tsx의
+// reauthChipLabel 옆)이지만 라벨은 reason 무관이라 그 경로가 생겨도 안전.
+describe('OrganizationChannelsPage — sandbox 재연결 불가 칩 낱말(story #3816)', () => {
   const AVAILABLE_WITH_SANDBOX = [
     { channel: 'threads', display_name: 'Threads', credential_kind: 'oauth', kind: 'social' },
     { channel: 'sandbox', display_name: 'Sandbox', credential_kind: 'none', kind: 'social' },
   ];
 
-  it('⭐sandbox(credential_kind=none) expired — 칩이 「만료됨」(재연결 경로 없음, 「다시 연결 필요」는 거짓 약속)', async () => {
+  it('⭐sandbox(credential_kind=none) expired — 칩이 「다시 연결 불가」(재연결 경로 없음, 「다시 연결 필요」는 거짓 약속)', async () => {
     stubFetch({
       connections: [{ ...CONNECTION_ACTIVE, id: 'conn-sandbox-1', channel: 'sandbox', credential_kind: 'none', status: 'expired' }],
       availableChannels: AVAILABLE_WITH_SANDBOX,
@@ -761,14 +768,36 @@ describe('OrganizationChannelsPage — sandbox expired 칩 낱말(story #3816)',
     await mount('owner');
     await expandChannelRow({ viaMenuLabel: koMessages.channelConnect.channelManageConnectionsAction, rowChannel: koMessages.channelConnect.channelLabelSandbox });
     const chip = container.querySelector('[data-testid="channel-section"] [data-status-chip="reauth_required"]');
-    expect(chip?.textContent).toBe(koMessages.channelConnect.channelStatusExpiredSandbox);
+    expect(chip?.textContent).toBe(koMessages.channelConnect.channelStatusReconnectUnavailable);
     expect(chip?.textContent).not.toBe(koMessages.channelConnect.channelStatusReauthRequired);
     // 같은 행 안의 문장(버튼 대신)과 뜻이 어긋나면 안 된다 — 둘 다 "재연결 불가" 쪽.
     expect(container.textContent).toContain('다시 연결할 수 없습니다');
   });
 
+  // story #3816 CHANGES(페드루 PO 확認 1) — sandbox 연결도 「해제」(disconnect)를
+  // 누르면 status='revoked'가 된다(BE `/disconnect`가 credential_kind 무관).
+  // 「만료됨」처럼 reason별 낱말을 썼다면 이 행엔 "시간이 지나 저절로"라는 새
+  // 거짓이 붙었을 것 — reason 무관 라벨이라 여기서도 정확하다.
+  it('⭐sandbox(credential_kind=none) revoked(해제 뒤) — 칩이 그대로 「다시 연결 불가」(reason 무관, 「만료됨」류 시간-기반 낱말 아님)', async () => {
+    stubFetch({
+      connections: [{ ...CONNECTION_ACTIVE, id: 'conn-sandbox-1', channel: 'sandbox', credential_kind: 'none', status: 'revoked' }],
+      availableChannels: AVAILABLE_WITH_SANDBOX,
+    });
+    await mount('owner');
+    await expandChannelRow({ viaMenuLabel: koMessages.channelConnect.channelManageConnectionsAction, rowChannel: koMessages.channelConnect.channelLabelSandbox });
+    const chip = container.querySelector('[data-testid="channel-section"] [data-status-chip="reauth_required"]');
+    expect(chip?.textContent).toBe(koMessages.channelConnect.channelStatusReconnectUnavailable);
+  });
+
   it('⭐양성대조 — oauth(재연결 가능) expired는 그대로 「다시 연결 필요」(회귀 0)', async () => {
     stubFetch({ connections: [{ ...CONNECTION_ACTIVE, status: 'expired' }] });
+    await mount('owner');
+    const chip = container.querySelector('[data-status-chip="reauth_required"]');
+    expect(chip?.textContent).toBe(koMessages.channelConnect.channelStatusReauthRequired);
+  });
+
+  it('⭐양성대조 — oauth(재연결 가능) revoked도 그대로 「다시 연결 필요」(회귀 0, reason 무관 라벨이 credential_kind 축을 안 넘는다)', async () => {
+    stubFetch({ connections: [{ ...CONNECTION_ACTIVE, status: 'revoked' }] });
     await mount('owner');
     const chip = container.querySelector('[data-status-chip="reauth_required"]');
     expect(chip?.textContent).toBe(koMessages.channelConnect.channelStatusReauthRequired);

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -480,10 +480,31 @@ function providerErrorChipLabel(lastErrorCode: string | null | undefined, t: Ret
 // 문자열이 아니라 "재연결 액션이 그려지는가"와 같은 조건(credential_kind===
 // 'none') — 재연결 가능한 연결(oauth·pasted_secret)은 회귀 0(undefined 반환 →
 // 기존 공용 라벨 그대로).
+//
+// CHANGES(페드루 PO 확認 1 요청, 2026-09-12 15:48Z) — reason 분기는 없앤다(reason
+// 무관 «재연결 불가 세계» 라벨). 근거(BE grep 실측): sandbox(credential_kind=
+// 'none') 연결도 `/disconnect`(revoke_channel_connection)가 credential_kind
+// 무관·owner 전용으로 걸려 있어(FE 「해제」 버튼도 동일 무조건) reason='revoked'
+// 도달 가능(사람이 그 버튼을 누르면 즉시) — reason='expired'만 막으면 그 행은
+// 칩·문장 모순이 그대로 남는다. reason='error'는 오늘 어떤 sandbox 마커도
+// (threads/ig/fb/x류는 401만 시뮬레이트→classify_graph_error_code가 provider_
+// error_code 없으면 항상 CHANNEL_TOKEN_EXPIRED로만 떨어짐·stibee_sandbox 마커
+// 둘 다 CONNECTION_ERROR_CODE_TO_STATUS 밖·ghost_sandbox의 GHOST_AUTH_FAILED는
+// publication_command.py 표시축(FAILURE_KIND_CONNECTION)만 건드리고 ChannelConnection.
+// status는 안 건드림) 자동으로는 못 내지만, 시드/직접 세팅(오늘 관측된 expired도
+// 같은 축)으로는 항상 가능 — reason 분기를 남겨두면 그 경로가 열리는 순간 같은
+// 모순이 재발한다. reason 무관 오버라이드로 미리 닫는다.
+//
+// 낱말은 「만료됨」이 아니라 「다시 연결 불가」로 골랐다 — reason='revoked'(사람이
+// 방금 「해제」를 눌러 만든 상태)에 「만료됨」을 붙이면 "시간이 지나 저절로
+// 그렇게 됐다"는 새 거짓을 만든다(이번에 고치려는 것과 같은 클래스의 오류).
+// 「다시 연결 불가」는 reason 무관하게 항상 참(sandbox엔 애초에 재연결 개념이
+// 없다) — 옆 문장(channelSandboxReauthUnavailableNote, 같은 "다시 연결" 낱말)과
+// 뜻이 정확히 겹친다.
 function reauthChipLabel(
-  reason: 'expired' | 'revoked' | 'error' | undefined, credentialKind: string, t: ReturnType<typeof useTranslations>,
+  _reason: 'expired' | 'revoked' | 'error' | undefined, credentialKind: string, t: ReturnType<typeof useTranslations>,
 ): string | undefined {
-  return reason === 'expired' && credentialKind === 'none' ? t('channelStatusExpiredSandbox') : undefined;
+  return credentialKind === 'none' ? t('channelStatusReconnectUnavailable') : undefined;
 }
 
 function ExpiringSoonNote({

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -471,6 +471,21 @@ function providerErrorChipLabel(lastErrorCode: string | null | undefined, t: Ret
   return undefined;
 }
 
+// story #3816(Phase3·3-6, 페드루 PO 지적 2026-09-12·배포 81 라이브 회차 유나 판정
+// CHANGES 1) — sandbox(credential_kind==='none')는 재연결 경로가 구조적으로 없다
+// (위 ReauthNote 옆 분기 참고 — 버튼 대신 「테스트용 연결은 다시 연결할 수
+// 없습니다」 문장). 그런데 칩은 여전히 공용 라벨 channelStatusReauthRequired
+// (「다시 연결 필요」)를 냈다 — 같은 행 안에서 칩(필요)·문장(불가)이 반대 뜻을
+// 말하는 모순(4222 축 재현: 칩은 실 행동/상태를 따라야 한다). 판별축은 status
+// 문자열이 아니라 "재연결 액션이 그려지는가"와 같은 조건(credential_kind===
+// 'none') — 재연결 가능한 연결(oauth·pasted_secret)은 회귀 0(undefined 반환 →
+// 기존 공용 라벨 그대로).
+function reauthChipLabel(
+  reason: 'expired' | 'revoked' | 'error' | undefined, credentialKind: string, t: ReturnType<typeof useTranslations>,
+): string | undefined {
+  return reason === 'expired' && credentialKind === 'none' ? t('channelStatusExpiredSandbox') : undefined;
+}
+
 function ExpiringSoonNote({
   isAutoRefreshInfo, tokenExpiresAt, t,
 }: {
@@ -581,7 +596,11 @@ function ConnectionRow({
         {showStatusChip ? (
           <ChannelStatusChip
             status={derived.status}
-            label={derived.status === 'provider_error' ? providerErrorChipLabel(conn.last_error_code, t) : undefined}
+            label={
+              derived.status === 'provider_error' ? providerErrorChipLabel(conn.last_error_code, t)
+                : derived.status === 'reauth_required' ? reauthChipLabel(derived.reauthReason, conn.credential_kind, t)
+                : undefined
+            }
           />
         ) : null}
       </div>
@@ -918,7 +937,11 @@ function ChannelSection({
               // 문구를 낸다(2개 이상이면 어느 계정 얘기인지 한 낱말로 못 줄인다 —
               // subtitle의 "지어내지 않는다" 원칙과 동형, ChannelStatusChip 제네릭
               // 폴백에 맡긴다).
-              label={channelStatus === 'provider_error' && single ? providerErrorChipLabel(single.last_error_code, t) : undefined}
+              label={
+                channelStatus === 'provider_error' && single ? providerErrorChipLabel(single.last_error_code, t)
+                  : channelStatus === 'reauth_required' && single ? reauthChipLabel(singleDerived?.reauthReason, single.credential_kind, t)
+                  : undefined
+              }
             />
           )}
           // story #3743 CHANGES Ⓓ(페드루 PO, 2026-09-09 12:41Z) — 채운 파랑은 헤더


### PR DESCRIPTION
## 요약
배포 81 라이브 회차 유나 판정 CHANGES 1 — 페드루 PO 지적 2026-09-12. Ghost
Sandbox 연결(및 credential_kind='none'인 모든 sandbox류 연결)이 expired
상태일 때, 채널 행(dev-app `/organization/channels`)의 칩이 「다시 연결
필요」인데 같은 행 문장은 「테스트용 연결은 다시 연결할 수 없습니다 — 「{채널}
연결 만들기」로 새로 만들어 주세요.」— 같은 낱말 «다시 연결»이 칩(필요)·문장
(불가) 반대 뜻(story #4222 축 재현: 칩은 실 행동/상태를 따라야 한다).

## 구현
- `reauthChipLabel()`(신규, `providerErrorChipLabel`과 동형 패턴) —
  `credentialKind==='none'`이면 `channelStatusReconnectUnavailable`("다시
  연결 불가"/"Reconnect unavailable")로 칩 라벨을 오버라이드. 판별축은
  status 문자열이 아니라 **재연결 액션이 그려지는 조건**과 같은 축
  (`credential_kind==='none'`, 재연결 버튼 대신 안내 문장이 뜨는 그 분기와
  동일 조건) — 재연결 가능한 연결(oauth·pasted_secret)은 `undefined` 반환
  → 기존 공용 라벨 그대로(회귀 0).
- **CHANGES(PO 확認 1, 09-12 15:48Z)** — reason 분기 없음(reason 무관).
  BE grep 실측: sandbox 연결도 `/disconnect`(credential_kind 무관·owner
  전용)로 `reason='revoked'`가 실제로 도달 가능(사람이 「해제」 버튼을
  누르면 즉시) — reason='expired'만 막으면 그 행엔 모순이 그대로 남는다.
  `reason='error'`는 오늘 자동 경로 0(threads/ig/fb/x sandbox 마커는 401만
  시뮬레이트→classify_graph_error_code가 CHANNEL_TOKEN_EXPIRED로만 떨어짐·
  stibee_sandbox 마커는 CONNECTION_ERROR_CODE_TO_STATUS 밖·ghost_sandbox의
  GHOST_AUTH_FAILED는 ChannelConnection.status를 안 건드림)이지만 라벨은
  reason 무관이라 안전. 동시에 라벨 자체를 「만료됨」→「다시 연결 불가」로
  교체 — 「만료됨」을 revoked 행에 재사용하면 "시간이 지나 저절로"라는 새
  거짓이 생긴다(이번에 고치려는 것과 같은 클래스의 오류, 자체 발견·즉시
  수정). 「다시 연결 불가」는 reason 무관 항상 참·옆 문장과 낱말·뜻이 겹친다.
- 두 `ChannelStatusChip` 호출부(펼친 행별 칩 `ConnectionRow`·섹션 헤더
  요약 칩) 둘 다 적용 — `status` enum 자체는 무변(`reauth_required` 그대로,
  톤도 destructive 그대로).
- i18n 키 `channelStatusReconnectUnavailable`(ko: "다시 연결 불가"/en:
  "Reconnect unavailable") — `channelStatusReauthRequired` 바로 아래 등재.

## 검증(로컬)
```
$ npx vitest run "src/app/(authenticated)/organization/channels/page.test.tsx"
122 passed(신규 2 — sandbox expired·sandbox revoked, 양성대조 2 — oauth
expired·oauth revoked 회귀 0)

$ npm run type-check
clean

$ i18n 가드 6종(phrase-collision·hardcoded-korean·duplicate-keys·hanja·
keys-exist·repeated-row-action-names)
전부 신규 0건
```

## 뮤테이션 셀프체크
`reauthChipLabel()`을 항상 `undefined` 반환하도록 되돌림(실 결함 재현) →
sandbox 2건(expired·revoked) 정확히 RED, 양성대조 2건(oauth expired·
revoked) 그대로 GREEN → 원복 후 GREEN.

## 캡처 대기(유나 최종 Design PASS 앵커용, 페드루 PO 요청)
로컬 스택에 시드 준비 中 — ① Ghost Sandbox expired 행(칩 「다시 연결
불가」+재생성 문장) ② 재연결 가능 expired 행(X 테스트용 등, 칩 「다시 연결
필요」+버튼 회귀 0). 준비되면 포트·org id·데모 로그인 파일 경로를 코멘트로.

## Base
develop(c6c74aa0a, PR #4225/#4227/#4228/#4230 착지 반영) — 새 브랜치,
stacked 아님. 3815 트랙 PR들과 파일 겹침 0(FE 전용, 다른 story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvADboiMTX5sUNfQ9qRbK8